### PR TITLE
feat: hook system and plugin support design spec

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,823 @@
+# Praxis Hook System and Plugin Support
+
+Status: draft
+
+This document specifies the hook system and plugin runtime for Praxis. Hooks complement the existing `HttpFilter` / `TcpFilter` surface with typed, capability-gated plugins that observe or enforce policy at well-defined lifecycle points. The runtime is CPEX (ContextForge Plugin Extensibility), embedded in-process.
+
+## 1. Scope
+
+2. [Goals and Non-Goals](#2-goals-and-non-goals).
+3. [Integration architecture](#3-integration-architecture).
+4. [Layering model](#4-layering-model).
+5. [Hook catalog: startup, TLS, TCP, HTTP lifecycle](#5-hook-catalog-lifecycle-hooks).
+6. [Typed payloads per hook](#6-hook-payloads) (full signatures in [Appendix A](#appendix-a-payload-type-sketches)).
+7. [Dispatch semantics: phase scheduling, failure modes, timeouts, tighten-only composition](#7-dispatch-semantics).
+8. [Plugin ABI](#8-plugin-abi).
+9. [YAML configuration](#9-configuration) (full example in [Appendix B](#appendix-b-configuration-examples)).
+10. [Observability](#10-observability), [security boundary mapping](#11-security-invariants-and-hook-mapping), [staged rollout](#12-staged-rollout), [open questions](#13-open-questions).
+
+Out of scope:
+
+- CPEX internals (payload dispatch, capability gating, CMF extension format). See the CPEX spec.
+- Protocol-semantic hooks for MCP, A2A, or LLM payloads. [How protocol-semantic hooks ship later](#43-how-protocol-semantic-hooks-ship-later) explains why they are deferred and where they belong instead.
+- Hot-swapping plugins at runtime. Plugins are loaded at startup and released on shutdown.
+- The Python plugin host. CPEX supports it; Praxis does not, for latency reasons.
+
+## 2. Goals and Non-Goals
+
+### 2.1 Goals
+
+- **A second extension surface.** `HttpFilter` / `TcpFilter` handle per-request transformation well. They are insufficient for lifecycle observation (TLS handshake, connect, session end), policy enforcement at security boundaries the pipeline does not expose, and out-of-process dispatch. Hooks fill those gaps.
+- **A common runtime for extensibility.** CPEX is the runtime; Praxis is a host. Plugins that target Praxis hooks can also target other hosts where payload types overlap.
+- **Latency-budgeted.** Hooks run on the request hot path. Native plugin overhead must stay in single-digit microseconds per hook; WASM plugins under 100 µs. [Failure modes and timeouts](#73-failure-modes-and-timeouts) enumerates enforceable budgets.
+- **Tighten-only composition.** Policy hooks may strengthen any of the 18 security boundaries catalogued in [Security Invariants and Hook Mapping](#11-security-invariants-and-hook-mapping). They must not silently weaken any. The dispatcher enforces this structurally (see [Tighten-only composition](#74-tighten-only-composition)).
+- **Zero cost when unused.** Deployments without a `plugins:` section in YAML pay a single `AtomicBool` check at each call site. No dispatcher traversal, no allocations.
+
+### 2.2 Non-Goals
+
+- **Replacing filters.** Filters remain the right abstraction for per-request transformation. Hooks wrap filters, not the other way around.
+- **Hot reload.** Startup-only loading keeps the trust model simple. Reload-without-restart is deferred.
+- **Arbitrary cross-hook ordering.** Within a hook point, plugins run in CPEX's 5-phase order at configured priority. Across hook points, order is set by the request lifecycle.
+- **Semantic payload parsing in the HTTP filter layer.** See [How protocol-semantic hooks ship later](#43-how-protocol-semantic-hooks-ship-later).
+
+## 3. Integration Architecture
+
+### 3.1 CPEX as runtime, Praxis as host
+
+Praxis embeds the CPEX `PluginManager` in-process. A plugin call is a function call, not an IPC hop. CPEX provides the typed dispatcher, phase executor, payload policy enforcement, and host loaders (`native`, `wasm`). Praxis provides lifecycle call sites, payload construction, and the tighten-only composition monoid.
+
+### 3.2 Crate layout
+
+A single new crate joins the Praxis workspace.
+
+```
+praxis/
+  hooks/                          NEW: praxis-hooks crate
+    src/
+      lib.rs                      register_hooks!, public types
+      payloads/{startup,tls,tcp,http}.rs
+      dispatcher/{mod,http,tcp,tls,tighten}.rs
+      config.rs                   YAML → CPEX config adapter
+      metrics.rs                  praxis_hook_* emitters
+      policy.rs                   HookPayloadPolicy builders
+  server/                         depends on praxis-hooks
+  protocol/                       depends on praxis-hooks
+  tls/                            depends on praxis-hooks
+```
+
+Workspace dependencies:
+
+```toml
+cpex-core  = { version = "0.2", default-features = false }
+cpex-hosts = { version = "0.2", default-features = false,
+               features = ["native", "wasm"] }
+cpex-sdk   = { version = "0.2" }   # dev-dep, for test plugins only
+```
+
+The `plugins-native` and `plugins-wasm` Cargo features are on by default. Building with `--no-default-features --features plugins-native` produces a binary that rejects WASM plugins at load time.
+
+### 3.3 Lifecycle integration
+
+The `PluginManager` is owned by `server::run_server`, built after pipelines are resolved and before `server.run_forever()`.
+
+```
+server/src/server.rs::run_server
+  enforce_root_check
+  warn_insecure_key_permissions
+  build_health_registry
+  resolve_pipelines
+  HookDispatcher::from_config(&config)            NEW
+    register_all_praxis_hook_types                (HookTypeDefs)
+    load_plugins_from_config
+    validate_subscriptions
+    run S1 on_config_loaded                       (fail-closed)
+  PingoraServerRuntime::new(..., dispatcher)
+  PingoraHttp.register(..., dispatcher)
+  PingoraTcp.register(..., dispatcher)
+  run S3 on_listeners_bound                       (fail-open)
+  server.run_forever()
+```
+
+Protocol handlers receive the dispatcher as `Arc<HookDispatcher>`, parallel to how they receive `Arc<FilterPipeline>` today. A `None` dispatcher (no `plugins:` section) collapses every call site to a single `Option::is_some()` branch.
+
+### 3.4 Call-site contract
+
+Every call site in the [hook catalog](#5-hook-catalog-lifecycle-hooks) must:
+
+1. Fast-path check `dispatcher.is_enabled(HOOK_ID)`: a compile-time-indexed `[AtomicBool; 29]`.
+2. If enabled, build the typed payload from local context.
+3. Invoke via `dispatcher.invoke::<HookId>(payload, ctx).await`, or the sync variant for L1 and L4.
+4. Apply the returned `PipelineResult` per the hook's interaction class (see [Interaction enforcement](#72-interaction-enforcement)).
+5. Emit the per-site metric (see [Observability](#10-observability)).
+
+Call sites use the `praxis_hooks::invoke_hook!` macro to keep boilerplate out of the request path.
+
+### 3.5 What CPEX provides
+
+| CPEX feature | Praxis usage |
+|---|---|
+| `Plugin` trait (lifecycle) | Startup and shutdown of plugin-owned resources. |
+| `HookTypeDef` | Praxis hook types, zero-cost borrow dispatch for native plugins. |
+| `HookHandler<H>::handle` | The user-visible plugin surface. |
+| `PluginRef.trusted_config` | Praxis reads priority, mode, and capabilities from the loader, never from plugin-reported values. |
+| Plugin executor | Plugin [dispatching modes](#71-phase-selection). |
+| `HookPayloadPolicy` | Declares field-level writability per hook (see [HookPayloadPolicy](#75-hookpayloadpolicy)). |
+| `OnError` | Surfaced verbatim in YAML: `fail` / `ignore` / `disable`. |
+| Capability gating on extensions | Reserved for v2 (see [Extensions](#65-extensions-reserved-for-v2)). |
+
+Praxis does not rely on CPEX `SessionStore` (no cross-request plugin state in v1) nor on CPEX's own route/policy config loader.
+
+## 4. Layering Model
+
+The hardest design question for this system is where content-aware logic lives. One approach is to dispatch MCP, A2A, and LLM hooks from inside a single `HttpFilter`. That choice has two costs large enough to warrant an explicit layering model.
+
+### 4.1 Why content hooks do not belong in `HttpFilter`
+
+**Cost 1: the streaming model collapses.** Praxis ranks body modes `Buffer > StreamBuffer > SizeLimit > Stream` precisely so that streaming stays the default. A filter that forces `BodyMode::Buffer { max_bytes: 1 MiB }` on every request promotes the entire listener to buffered mode, adding per-request latency equal to upstream-body-arrival time and up to 1 MiB of residency per in-flight request. A feature touched by a narrow minority of requests should not pay this cost on every request.
+
+**Cost 2: abstraction inversion.** An `HttpFilter` parsing JSON-RPC method names and dispatching per-tool hooks bakes protocol knowledge into the HTTP layer. That is the wrong home for it. The HTTP layer should know headers, methods, URIs, and bodies-as-bytes. Protocol semantics belong in whatever component routes the protocol.
+
+### 4.2 Two hook categories, one deferred
+
+**Lifecycle hooks (this spec).** Startup, TLS, TCP, and HTTP lifecycle points. Operate on HTTP and TCP primitives: methods, URIs, headers, client addresses, TLS info, upstream selection, connect failures, response headers, byte counters. Header-level identity and authorization (JWT decoding, DPoP, external authz) fit naturally here: they attach to H2, H4, H7, or H10 and read or inject headers without parsing bodies. Body access is opt-in per plugin via H6 and H13 and participates in the existing `BodyCapabilities` budget.
+
+**Protocol-semantic hooks (deferred).** MCP `tools/call`, A2A tasks, LLM inputs and outputs, prompt and resource fetches. These require parsing a structured body into a protocol-typed message before they can fire. They belong in a protocol-native host that parses once during routing, not in an HTTP filter that buffers speculatively. This spec names no such hooks. [How protocol-semantic hooks ship later](#43-how-protocol-semantic-hooks-ship-later) describes the path.
+
+### 4.3 How protocol-semantic hooks ship later
+
+Protocol-semantic hooks are unblocked when Praxis grows protocol-native proxy services peered with `ProxyHttp`. Plausible shapes:
+
+- An `McpProxy` service recognizes JSON-RPC over HTTP POST, parses methods and parameters once, and dispatches `praxis.mcp.tool_pre_invoke` / `praxis.mcp.tool_post_invoke` from inside the service loop. Bodies are buffered only for methods known to carry semantic payloads (`tools/call`, `prompts/get`, `resources/read`). Methods like `ping` or `initialize` stream through.
+- An `A2aProxy` service models the task lifecycle and dispatches `praxis.a2a.task_created`, `_updated`, `_completed`.
+- An LLM-aware service (OpenAI-compatible or Bedrock-compatible) dispatches `praxis.llm.input` and `praxis.llm.output` with proper streaming semantics for SSE response bodies.
+
+Each of these would register its own `HookTypeDef`s with the same CPEX dispatcher Praxis already owns. Plugins that target MCP or A2A today can continue to target them tomorrow without code changes; only the host module changes. Until those services land, protocol-semantic hook names are reserved (namespace `praxis.mcp.*`, `praxis.a2a.*`, `praxis.llm.*`) but unregistered.
+
+This split keeps the spec shippable, the hot path streaming, and the semantic surface evolvable.
+
+## 5. Hook Catalog (lifecycle hooks)
+
+### 5.1 Conventions
+
+- **ID** is a stable short identifier: `S` startup, `L` TLS, `T` TCP, `H` HTTP. IDs are stable across the API lifetime; payload types evolve under semver.
+- **Name** is the string CPEX registers under and the value operators write in YAML `subscribe:` blocks.
+- **Interaction** is `observe`, `mutating`, or `policy`, mapped to phases in [Dispatch Semantics](#7-dispatch-semantics).
+- **Sync?** filled circle for hooks that must run synchronously (rustls path); open circle for async.
+
+### 5.2 Startup hooks
+
+| ID | Name | Call site | Interaction | Default phase | Sync? | Rationale |
+|---|---|---|---|---|---|---|
+| S1 | `praxis.startup.config_loaded` | `server.rs` after `Config::load` | policy | sequential | ○ | Validate or veto config before pipelines are built. Failing here aborts startup. |
+| S2 | `praxis.startup.pipelines_built` | after `resolve_pipelines` | policy | sequential | ○ | Inspect assembled pipelines; reject inconsistent compositions. |
+| S3 | `praxis.startup.listeners_bound` | before `server.run_forever` | observe | audit | ○ | Publish to service discovery, warm caches, open watchers. |
+| S4 | `praxis.startup.shutdown` | on SIGTERM path | observe | sequential | ○ | Flush buffered state, deregister. Bounded by `shutdown_timeout_secs`. |
+
+Example: an S1 plugin rejects startup if any `insecure_options` flag is set in a production environment. An S2 plugin enforces "every listener has `rate_limit` before `router`".
+
+### 5.3 TLS hooks
+
+| ID | Name | Call site | Interaction | Default phase | Sync? | Rationale |
+|---|---|---|---|---|---|---|
+| L1 | `praxis.tls.client_hello` | `tls/src/setup/sni.rs` in `ResolvesServerCert::resolve` | policy | sequential | ● | Pre-handshake SNI gating. Rustls calls `resolve` synchronously. |
+| L2 | `praxis.tls.cert_resolved` | same, after successful match | observe | audit | ● | Audit trail: which cert served which SNI. |
+| L3 | `praxis.tls.cert_reloaded` | `tls/src/reload.rs::reload` | observe | audit | ○ | Fires on success and failure paths of cert rotation. |
+| L4 | `praxis.tls.mtls_client_cert` | rustls `ClientCertVerifier::verify_client_cert` adapter | policy | sequential | ● | Custom chain validation beyond rustls default. |
+
+L1 and L4 run on the rustls blocking thread. Their plugin hosts are restricted to `native` (always) and `wasm` with fuel-bounded execution (see [Failure modes and timeouts](#73-failure-modes-and-timeouts)). Sidecar plugins are rejected at startup for these hooks.
+
+### 5.4 TCP hooks
+
+| ID | Name | Call site | Interaction | Default phase | Rationale |
+|---|---|---|---|---|---|
+| T1 | `praxis.tcp.accept` | `protocol/src/tcp/proxy.rs` after `extract_addrs` | policy | sequential | Cheap IP gating before any byte is read. |
+| T2 | `praxis.tcp.sni_peeked` | after `peek_sni` | policy | sequential | SNI allowlist and tenant routing. |
+| T3 | `praxis.tcp.pre_connect` | before `run_connect_filters` | policy | sequential | Short-circuit the TCP filter chain (e.g., maintenance mode). |
+| T4 | `praxis.tcp.upstream_selected` | after `run_connect_filters` | policy | sequential | Veto the filter-chosen upstream. |
+| T5 | `praxis.tcp.upstream_connected` | after `connect_upstream` | observe | audit | Upstream TCP is live. |
+| T6 | `praxis.tcp.session_end` | after `forward`, before disconnect filters | observe | fire_and_forget | Non-blocking session audit with final byte counts. |
+| T7 | `praxis.tcp.post_disconnect` | after disconnect filters | observe | fire_and_forget | Terminal; publish derived metrics. |
+
+All TCP hooks are async. The TCP lifecycle has no sync bridge.
+
+### 5.5 HTTP lifecycle hooks
+
+| ID | Name | Call site | Interaction | Default phase | Notes |
+|---|---|---|---|---|---|
+| H1 | `praxis.http.early_request` | `early_request_filter` | observe | audit | Raw request line decoded; Host / Max-Forwards not yet validated. |
+| H2 | `praxis.http.host_validated` | after `validate_host_header` | observe | audit | Canonicalised Host available. |
+| H3 | `praxis.http.max_forwards_handled` | after terminal `handle_max_forwards` | observe | audit | Fires only for TRACE/OPTIONS at count 0. |
+| H4 | `praxis.http.pre_request_pipeline` | `request_filter/mod.rs:98` before `execute_http_request` | policy | sequential | Short-circuit before filters run. |
+| H5 | `praxis.http.post_request_pipeline` | `request_filter/mod.rs:146` after `run_pipeline` | policy | sequential | Cluster, upstream, rewritten_path known. |
+| H6 | `praxis.http.request_body_chunk` | `request_body_filter.rs` per mode | mutating | transform | Opt-in; participates in `BodyCapabilities`. |
+| H7 | `praxis.http.pre_upstream_select` | just before `upstream_peer::execute` | policy | sequential | Final pre-select gate. |
+| H8 | `praxis.http.upstream_selected` | `upstream_peer.rs` after `build_peer` | observe | audit | Last view before upstream I/O. |
+| H9 | `praxis.http.upstream_connect_failure` | `handle_connect_failure` | policy (voting) | sequential | Returns `RetryVote`. |
+| H10 | `praxis.http.pre_upstream_request_write` | after strip + rewrite + Via | mutating | transform | Final shape of upstream request. |
+| H11 | `praxis.http.upstream_response_header` | `response_filter.rs` after `strip_hop_by_hop_response` | policy | sequential | First look at upstream response. May veto 5xx. |
+| H12 | `praxis.http.post_response_pipeline` | after `execute_http_response`, before Via | mutating | transform | Response after filters ran. |
+| H13 | `praxis.http.response_body_chunk` | `response_body_filter.rs` per mode | mutating | transform | Sync from Pingora's perspective; bounded deadline. |
+| H14 | `praxis.http.session_logged` | `handler/mod.rs:186` after `logging_cleanup` | observe | fire_and_forget | Terminal; fires exactly once per request. |
+
+Header-level identity and authorization fit here without new hook kinds:
+
+- JWT decoding attaches to H2 or H4 and sets per-request state that downstream plugins read.
+- External authz dispatches at H4 (for pipeline preemption) or H7 (for upstream-specific policy).
+- Delegated token injection attaches to H10.
+
+None of these require body buffering.
+
+### 5.6 Summary
+
+| Family | Count | Sync mix | Phase mix (default) |
+|---|---|---|---|
+| Startup | 4 | async | 3 sequential, 1 audit |
+| TLS | 4 | 3 sync, 1 async | 2 sequential, 2 audit |
+| TCP | 7 | async | 4 sequential, 1 audit, 2 fire_and_forget |
+| HTTP | 14 | async (H13 sync context) | 5 sequential, 5 transform, 3 audit, 1 fire_and_forget |
+| **Total** | **29** | | |
+
+## 6. Hook Payloads
+
+CPEX binds each hook type to a payload and a result:
+
+```rust
+pub trait HookTypeDef: Send + Sync + 'static {
+    type Payload: PluginPayload + Clone;
+    type Result: Clone;
+    const NAME: &'static str;
+}
+```
+
+Every hook in the [catalog](#5-hook-catalog-lifecycle-hooks) has one `HookTypeDef` in `praxis_hooks::payloads::*`. Payload structs borrow request-scoped data rather than clone it; plugins that need to retain anything clone explicitly. Full signatures are in [Appendix A](#appendix-a-payload-type-sketches).
+
+The shared HTTP context view is:
+
+```rust
+pub struct HttpHookCtx<'a> {
+    pub client_addr: Option<IpAddr>,
+    pub client_http_version: http::Version,
+    pub listener: &'a str,
+    pub request_start: Instant,
+    pub request_id: Option<&'a str>,
+    pub cluster: Option<&'a str>,           // None before H5/H7
+    pub upstream: Option<&'a Upstream>,     // None before H7
+    pub rewritten_path: Option<&'a str>,
+    pub retries: u32,
+}
+```
+
+The context grows richer as the lifecycle progresses. Fields `cluster`, `upstream`, and `rewritten_path` are `None` at H1 through H4, populated at H5 and later.
+
+H9 is the one hook returning a custom vote type:
+
+```rust
+pub enum RetryVote { Retry, NoRetry, NoOpinion }
+```
+
+The [tighten-only monoid](#74-tighten-only-composition) composes plugin votes with the built-in idempotency check.
+
+### 6.5 Extensions (reserved for v2)
+
+CPEX supports capability-gated `Extensions` on payloads. Praxis v1 attaches none. v2 candidates include `SecurityLabels` (monotonic set) and a `DelegationChain`. Reserved until a concrete consumer lands.
+
+## 7. Dispatch Semantics
+
+### 7.1 Phase selection
+
+For each hook in the [catalog](#5-hook-catalog-lifecycle-hooks) the dispatcher enforces:
+
+1. **Allowed modes.** Plugin YAML `mode:` must match the interaction class. Violations abort startup.
+2. **Default mode.** Omitted `mode:` falls back to the "Default phase" column in the [catalog](#5-hook-catalog-lifecycle-hooks).
+3. **Ordering within a phase.** By ascending `priority:`, then YAML position.
+4. **Phase order.** Canonical CPEX order `sequential → transform → audit → concurrent → fire_and_forget`.
+
+Interaction-class to allowed-phase mapping:
+
+| Interaction | Allowed `mode:` values |
+|---|---|
+| observe | `audit`, `fire_and_forget` |
+| mutating | `transform` |
+| policy | `sequential`, `concurrent` |
+
+`concurrent` is offered only where plugin ordering is irrelevant (e.g., parallel audit lookups that all must agree).
+
+### 7.2 Interaction enforcement
+
+After the CPEX executor returns a `PipelineResult`, the call site applies it per class:
+
+| Class | `allowed` | `denied` | `modified_payload` |
+|---|---|---|---|
+| observe | proceed | log at error, proceed | discarded |
+| mutating | proceed | log at error, proceed | replace payload, re-validate via `HookPayloadPolicy` |
+| policy | proceed | abort per [Short-circuit behavior](#76-short-circuit-behavior) | accepted in `sequential` only; `concurrent` cannot mutate |
+
+A plugin returning a modified payload whose forbidden fields differ fails per its `on_error:` setting.
+
+### 7.3 Failure modes and timeouts
+
+Each plugin has `on_error:` (from CPEX: `fail`, `ignore`, `disable`) and `timeout_ms:` (passed through as `tokio::time::timeout`). Defaults:
+
+| Class | Default `on_error` | Default `timeout_ms` |
+|---|---|---|
+| observe | ignore | 50 |
+| mutating | fail | 20 |
+| policy | fail | 100 |
+| body chunk (H6, H13) | fail | 10 per chunk |
+
+**Synchronous hooks (L1, L4).** These run on the rustls blocking thread and cannot `await`. The dispatcher exposes `dispatch_tls_hook_sync` which:
+
+- Rejects non-`native` and non-`wasm` plugin kinds at startup.
+- Runs native plugins on the current thread with a hard deadline (default 2 ms) checked after each plugin.
+- Runs WASM plugins with wasmtime fuel-bounded execution (default 100 000 fuel units, roughly 1 ms on typical workloads).
+
+### 7.4 Tighten-only composition
+
+For every `policy` hook, plugin results compose with the built-in check via a monoid that can only tighten:
+
+```rust
+pub trait Tighten { fn tighten(self, other: Self) -> Self; }
+
+// AllowVote: Continue < Reject. Reject wins.
+// RetryVote: Retry < NoOpinion < NoRetry. NoRetry wins.
+```
+
+This is enforced in the dispatcher's reduce step, not per call site. A plugin voting `Continue` never overrides a built-in `Reject`. A plugin voting `Retry` on a non-idempotent request is rejected at startup as a `HookError::BoundaryViolation` and the plugin is disabled.
+
+### 7.5 HookPayloadPolicy
+
+CPEX's `HookPayloadPolicy` declares writable fields for `transform` and `sequential` phases. Praxis ships one policy per mutating or policy hook:
+
+| Hook | Writable | Forbidden |
+|---|---|---|
+| H6 | `chunk` in place | changing `end_of_stream`, exceeding body ceiling |
+| H10 | header insert / remove on `upstream_request` | altering `:path` (owned by `rewritten_path`), reintroducing stripped hop-by-hop headers |
+| H11 | `upstream_response` status and headers, or a rejection | response bodies exceeding write capacity |
+| H12 | response headers | changing status (already committed), reintroducing hop-by-hop |
+| H13 | `chunk` in place | same as H6 |
+
+Violations are treated per the plugin's `on_error:`.
+
+### 7.6 Short-circuit behavior
+
+| Hook | What "short-circuit" does |
+|---|---|
+| S1 | `run_server` returns `Err`, non-zero exit before any listener binds. |
+| L1 | `resolve` returns `None`; rustls aborts with `unrecognised_name`. |
+| L4 | Verifier returns `Err(BadCertificate)`; rustls aborts. |
+| T1 through T4 | Connection closes before `forward`; peeked bytes discarded. |
+| H4, H5, H7 | `send_rejection(session, rejection)` emits a response from the plugin violation. |
+| H9 | `err.set_retry(false)`. Built-in idempotency check already handled. |
+| H11 | Replace upstream response with the plugin-provided response; downstream sees the sanitized version. |
+
+## 8. Plugin ABI
+
+### 8.1 Supported hosts
+
+| Host | CPEX feature | Praxis default | Notes |
+|---|---|---|---|
+| Native (`.so` / `.dylib`) | `cpex-hosts::native` | on | Primary path. Zero marshalling. |
+| WASM (`.wasm`) | `cpex-hosts::wasm` | on | wasmtime sandbox. 20 to 50 µs marshalling per hook. |
+| Python (PyO3) | `cpex-hosts::python` | **off, unsupported** | Incompatible with Praxis latency budget. |
+| Sidecar (UDS gRPC) | future | off | Reserved for async non-policy hooks. |
+
+### 8.2 Plugin declaration
+
+A Praxis plugin is a crate that depends on `cpex-sdk`, implements one or more `HookHandler<H>` for Praxis hook types, and compiles to `cdylib` (native) or `wasm32-wasip1`. No other formats are supported.
+
+### 8.3 Trust boundary
+
+All plugins run with Praxis process privileges except the WASM sandbox. Consequences:
+
+- Native plugins can crash Praxis, leak memory, or call syscalls. Plugin provenance is the operator's responsibility.
+- WASM plugins cannot escape the sandbox; they can exhaust fuel and time out.
+- No plugin can widen a boundary from [Security Invariants and Hook Mapping](#11-security-invariants-and-hook-mapping). Attempts fail at startup or fire a `BoundaryViolation` at dispatch (see [Tighten-only composition](#74-tighten-only-composition)).
+- `insecure_options` flags are visible to S1 plugins so a policy plugin can reject startup if any flag is set.
+
+### 8.4 Load order
+
+1. Praxis builds the CPEX `PluginManager` and registers all `HookTypeDef`s.
+2. For each plugin in YAML order, select the host from the `kind:` scheme, load the binary, call `Plugin::initialize`.
+3. For each `subscribe:` entry, look up the hook and register the handler with mode, priority, and `on_error`.
+4. Run S1 `config_loaded` across all plugins. Any failure aborts startup.
+
+### 8.5 Unload
+
+Plugins are released on SIGTERM via `Plugin::shutdown`, bounded by `shutdown_timeout_secs`. Runtime reload is deferred; when added it will follow the cert-reload pattern (`ArcSwap<PluginManager>`).
+
+## 9. Configuration
+
+### 9.1 YAML surface
+
+`praxis.yaml` gains one top-level section, `plugins:`. All existing sections are unchanged. A small example:
+
+```yaml
+plugins:
+  - name: sni-allowlist
+    kind: native:///opt/praxis/plugins/libsniallow.so
+    subscribe:
+      - hook: praxis.tls.client_hello       # L1, synchronous
+        on_error: fail
+        timeout_ms: 2
+    config:
+      allowlist_path: /etc/praxis/sni_allowed.txt
+
+  - name: audit-log
+    kind: wasm:///opt/praxis/plugins/audit.wasm
+    subscribe:
+      - hook: praxis.http.session_logged    # H14
+        mode: fire_and_forget
+    config:
+      sink: https://audit.internal/v1/events
+```
+
+A broader configuration spanning multiple hook families is in [Appendix B](#appendix-b-configuration-examples).
+
+### 9.2 Field semantics
+
+| Field | Required | Meaning |
+|---|---|---|
+| `name` | yes | Unique plugin identifier; used in logs and metrics. |
+| `kind` | yes | Scheme-prefixed location: `native://`, `wasm://`, `builtin:<name>`. Selects the host. |
+| `version` | no | Advisory string, logged at startup. |
+| `subscribe[].hook` | yes | Hook name from the [catalog](#5-hook-catalog-lifecycle-hooks). |
+| `subscribe[].mode` | no | CPEX mode; default from the [catalog](#5-hook-catalog-lifecycle-hooks); validated against interaction class. |
+| `subscribe[].priority` | no | Ordering within a phase; default 100. |
+| `subscribe[].on_error` | no | Default per class (see [Failure modes and timeouts](#73-failure-modes-and-timeouts)). |
+| `subscribe[].timeout_ms` | no | Default per class (see [Failure modes and timeouts](#73-failure-modes-and-timeouts)). |
+| `config` | no | Opaque plugin-specific YAML; handed to `Plugin::initialize` as JSON. |
+
+### 9.3 Startup validation
+
+Startup fails when:
+
+- Two plugins share a `name`.
+- A `subscribe[].hook` is not a registered Praxis hook.
+- A `subscribe[].mode` is not allowed for the hook's interaction class.
+- A synchronous hook (L1, L4) subscribes to a plugin whose `kind` is `sidecar://`.
+- WASM host is disabled at compile time and a plugin requests `wasm://`.
+- A plugin's `Plugin::initialize` returns `Err` with `on_error: fail`.
+- Any S1 plugin rejects the config.
+
+Unknown fields under a plugin entry are rejected, consistent with Praxis' `deny_unknown_fields` convention elsewhere.
+
+### 9.4 `insecure_options` interplay
+
+Plugins cannot flip `insecure_options`: they observe config, not mutate it. An S1 plugin can, however, reject startup when any `insecure_*` flag is set. Teams use this to enforce production-hardening policies.
+
+### 9.5 Environment interpolation
+
+Existing `${ENV_VAR}` resolution in `core/src/config/parse.rs` applies to `plugins[].config`. Secrets should flow through env vars, not YAML literals.
+
+## 10. Observability
+
+Three metric series per plugin-hook pair:
+
+```
+praxis_hook_invocations_total{plugin, hook, outcome}        continue | reject | error | timeout
+praxis_hook_duration_seconds{plugin, hook}                  histogram
+praxis_hook_last_error_timestamp_seconds{plugin, hook}
+```
+
+Aggregate counters:
+
+```
+praxis_hook_dispatch_cache_hits_total        AtomicBool fast path
+praxis_hook_dispatch_cache_misses_total
+praxis_plugins_loaded_total{host}
+praxis_plugins_disabled_total{reason}
+```
+
+Tracing integrates with Praxis' existing `tracing` output: each dispatch emits a `trace!` at invocation and a `debug!` at result, and the request span gains a `plugins.invoked` counter plus a `plugins.rejected_by` attribute populated on policy denial.
+
+Plugin-owned metrics flow through `PluginContext::metadata` and surface under `praxis_plugin_user_<plugin_name>_<metric_name>`.
+
+## 11. Security Invariants and Hook Mapping
+
+### 11.1 Built-in boundary catalogue
+
+Praxis enforces 18 load-bearing invariants today. The hook system lets plugins strengthen any without silently weakening any. Escape hatches listed; all default off.
+
+| # | Boundary | Enforced at | Escape hatch |
+|---|---|---|---|
+| 1 | Refuse UID 0 | `server.rs::check_root_privilege` | `allow_root` |
+| 2 | TLS key perms ≤ 0600 (advisory) | `server.rs::warn_insecure_key_permissions` | (warn) |
+| 3 | Host header present, single-valued | `request_filter/validation.rs` (RFC 9112 §3.2) | — |
+| 4 | Max-Forwards TRACE redaction | same | — |
+| 5 | Request hop-by-hop strip | `handler/hop_by_hop.rs` | — |
+| 6 | Response hop-by-hop strip | same | — |
+| 7 | Via header injection | `handler/via.rs` | — |
+| 8 | Rewritten path validation | `handler/upstream_request.rs` | — |
+| 9 | Upstream SNI required for TLS | `handler/upstream_peer.rs::derive_sni` | `allow_tls_without_sni` |
+| 10 | Idempotent-only retries, max 3 | `handler/mod.rs::handle_connect_failure` | — |
+| 11 | Body size ceilings | `filter/src/pipeline/mod.rs::apply_body_limits` | `allow_unbounded_body` |
+| 12 | Pipeline ordering validation | `server/src/pipelines.rs::validate_pipeline` | `skip_pipeline_validation` |
+| 13 | Health probe allowlist | `config/validate/cluster/endpoints.rs` | `allow_private_health_checks` |
+| 14 | Admin not on 0.0.0.0 / :: | `config/validate/listener/address.rs` | `allow_public_admin` |
+| 15 | Duplicate SNI cert rejection | `tls/setup/sni.rs::build_sni_resolver` | — |
+| 16 | SNI parser rejects IP literals | `tls/sni.rs` (RFC 6066 §3) | — |
+| 17 | Cert reload fail-safe | `tls/reload.rs::reload` | — |
+| 18 | YAML ingest safety | `config/parse.rs::check_yaml_safety` | — |
+
+### 11.2 Hook mapping
+
+| # | Boundary | Hook(s) | Direction |
+|---|---|---|---|
+| 1 | Refuse UID 0 | S1 | observe + startup veto |
+| 2 | TLS key perms | S1 | observe + startup veto |
+| 3 | Host validation | H2 | observe (non-bypassable) |
+| 4 | TRACE redaction | H3 | observe |
+| 5 | Request hop-by-hop strip | H10 (post-strip) | observe |
+| 6 | Response hop-by-hop strip | H11, H12 | observe |
+| 7 | Via injection | H10, H12 | observe |
+| 8 | Rewritten path | H10 | observe |
+| 9 | Upstream SNI required | H7 | tighten |
+| 10 | Idempotent-only retries | H9 | tighten (`RetryVote::NoRetry`) |
+| 11 | Body size ceilings | H6, H13 | observe |
+| 12 | Pipeline ordering | S2 | tighten |
+| 13 | Health probe allowlist | S1 | tighten |
+| 14 | Admin not public | S1 | tighten |
+| 15 | Duplicate SNI cert | S2, L2 | observe |
+| 16 | SNI IP literals | L1 | observe |
+| 17 | Cert reload fail-safe | L3 | observe + alert |
+| 18 | YAML ingest safety | S1 | observe |
+
+Every "tighten" row maps to a specific monoid instance (see [Tighten-only composition](#74-tighten-only-composition)). No code path lets a plugin widen any boundary.
+
+## 12. Staged Rollout
+
+Each phase is independently shippable.
+
+**Phase 0, crate skeleton.** `praxis-hooks` crate, CPEX dependency pinned, CI-only. Publishes [Goals and Non-Goals](#2-goals-and-non-goals) types and [Hook Payloads](#6-hook-payloads) sketches.
+
+**Phase 1, startup and TLS observation (S1 through S4, L2, L3).** Wire the dispatcher into `run_server`. Ship `cert_rotation_alert` as the first `builtin:` plugin. Acceptance: rotation events visible end-to-end; startup-rejects-root example plugin passes.
+
+**Phase 2, HTTP observation (H1, H2, H3, H8, H14).** All observer-only, fail-open. Validates dispatcher fast path, metrics, and tracing at production rates. Acceptance: audit-log plugin at 50k RPS with <1% tail-latency impact.
+
+**Phase 3, TLS policy (L1, L4).** Sync dispatcher variant; fuel-bounded wasmtime for WASM plugins on this path. Ship `sni_allowlist` as reference. Acceptance: 1000-entry allowlist adds <10 µs p99 per handshake.
+
+**Phase 4, HTTP policy (H4, H5, H7, H9, H11).** Tighten-only monoid and `RetryVote` plumbing. Acceptance: ext-authz plugin denies within budget; integration test verifies a plugin can force `NoRetry` on a GET but not `Retry` on a POST.
+
+**Phase 5, TCP hooks (T1 through T7).** Linear lifecycle, no sync context. Acceptance: T1 IP denylist adds <5 µs per accepted connection.
+
+**Phase 6, mutating HTTP (H6, H10, H12, H13).** Requires `HookPayloadPolicy` enforcement and body-mode participation in `BodyCapabilities`. Acceptance: DLP plugin at H13 redacts bodies correctly; H10 injects mTLS-derived headers; body ceiling regressions remain green.
+
+**Phase 7, protocol-native services (optional).** If and when `McpProxy`, `A2aProxy`, or LLM-aware services land, they expose `praxis.mcp.*`, `praxis.a2a.*`, `praxis.llm.*` hook types against the same dispatcher. Not scheduled; driven by demand.
+
+**Phase 8, sidecar host (optional).** UDS gRPC to a local sidecar, limited to async non-policy hooks.
+
+## 13. Open Questions
+
+1. **CPEX version pinning.** CPEX PR #13 is Phase 1a and unreleased. Options: wait for CPEX 0.2 before starting Praxis Phase 0, or vendor the Rust core as a git submodule during Phase 0 and un-vendor on release. Preference: wait.
+
+2. **WASM on synchronous hooks.** [Failure modes and timeouts](#73-failure-modes-and-timeouts) allows fuel-bounded WASM on L1 and L4. Keeping handshake paths unambiguously in-process argues for native-only here. Decision deferred; leaning native-only for v1.
+
+3. **Body-chunk back-pressure.** H6 and H13 default to 10 ms per chunk. A slow plugin stalls HTTP/1.1 connections and HTTP/2 streams. A per-request cumulative budget (e.g., 50 ms across all chunks) in addition to per-chunk deadlines is likely required. To be confirmed in Phase 6.
+
+4. **Hook-filter ordering.** Filters run between H4 and H5 in the request path, so H5 plugins see post-filter state. H10 and H12 hooks run after filters in their respective directions. Worth a dedicated example in the developer guide.
+
+5. **Per-plugin CPU accounting.** Tokio has no cheap per-task accounting. A `sequential` plugin within its timeout but burning CPU stays invisible. Options: process-level quota, push expensive plugins to `fire_and_forget`, require WASM for untrusted plugins (fuel accounts for work). Revisit after Phase 4.
+
+6. **Cross-hook state.** A WAF-style plugin needs shared state between H4 (decision) and H14 (audit). CPEX's `PluginContext::local_state` is per-invocation. A `praxis-hooks::PerRequestState<T>` helper keyed by `request_id` and pruned at H14 likely fills the gap. Design in Phase 4.
+
+7. **Protocol-semantic hooks design work.** The MCP and A2A protocol-native services described in [How protocol-semantic hooks ship later](#43-how-protocol-semantic-hooks-ship-later) are speculative. A design doc for at least one (probably `McpProxy` first) is a prerequisite for Phase 7 and should be started in parallel with Phase 2, independent of the dispatcher work.
+
+## Appendix A: Payload type sketches
+
+```rust
+// Startup
+
+pub struct ConfigLoadedPayload<'a> { pub config: &'a Config }
+
+pub struct PipelinesBuiltPayload<'a> {
+    pub config: &'a Config,
+    pub pipelines: &'a ListenerPipelines,
+    pub health_registry: &'a HealthRegistry,
+}
+
+pub struct ListenersBoundPayload<'a> { pub listeners: &'a [ListenerBinding] }
+
+pub struct ShutdownPayload { pub deadline: Instant }
+
+// TLS
+
+pub struct ClientHelloPayload<'a> {
+    pub sni: Option<&'a str>,
+    pub cipher_suites: &'a [u16],
+    pub alpn_protocols: &'a [&'a [u8]],
+    pub remote_addr: IpAddr,
+    pub listener: &'a str,
+}
+
+pub struct CertResolvedPayload<'a> {
+    pub sni: Option<&'a str>,
+    pub cert_fingerprint: CertFingerprint,    // sha256, 32 bytes
+    pub listener: &'a str,
+}
+
+pub struct CertReloadedPayload<'a> {
+    pub cert_path: &'a str,
+    pub outcome: Result<CertFingerprint, &'a TlsError>,
+}
+
+pub struct MtlsClientCertPayload<'a> {
+    pub chain: &'a [CertificateDer<'a>],
+    pub sni: Option<&'a str>,
+    pub remote_addr: IpAddr,
+}
+
+// TCP
+
+pub struct TcpConnInfo<'a> {
+    pub remote_addr: SocketAddr,
+    pub local_addr: SocketAddr,
+    pub listener: &'a str,
+    pub accepted_at: Instant,
+}
+
+pub struct TcpAcceptPayload<'a> { pub conn: TcpConnInfo<'a> }
+
+pub struct TcpSniPeekedPayload<'a> {
+    pub conn: TcpConnInfo<'a>,
+    pub sni: Option<&'a str>,
+    pub peeked_bytes: &'a [u8],
+}
+
+pub struct TcpUpstreamCandidatePayload<'a> {
+    pub conn: TcpConnInfo<'a>,
+    pub sni: Option<&'a str>,
+    pub upstream_addr: Option<Cow<'a, str>>,
+}
+
+pub struct TcpUpstreamConnectedPayload<'a> {
+    pub conn: TcpConnInfo<'a>,
+    pub upstream_addr: &'a str,
+    pub upstream_peer: SocketAddr,
+}
+
+pub struct TcpSessionEndPayload<'a> {
+    pub conn: TcpConnInfo<'a>,
+    pub upstream_addr: Option<&'a str>,
+    pub bytes_in: u64,
+    pub bytes_out: u64,
+    pub duration: Duration,
+    pub close_reason: TcpCloseReason,
+}
+
+// HTTP
+
+pub struct HttpHookCtx<'a> {
+    pub client_addr: Option<IpAddr>,
+    pub client_http_version: http::Version,
+    pub listener: &'a str,
+    pub request_start: Instant,
+    pub request_id: Option<&'a str>,
+    pub cluster: Option<&'a str>,
+    pub upstream: Option<&'a Upstream>,
+    pub rewritten_path: Option<&'a str>,
+    pub retries: u32,
+}
+
+pub struct EarlyRequestPayload<'a> {
+    pub ctx: HttpHookCtx<'a>,
+    pub request_header: &'a pingora_http::RequestHeader,
+}
+
+pub struct HttpRequestPipelinePayload<'a> {
+    pub ctx: HttpHookCtx<'a>,
+    pub request: &'a praxis_filter::Request,
+    pub pre_read_body: Option<&'a [Bytes]>,
+}
+
+pub struct UpstreamSelectedPayload<'a> {
+    pub ctx: HttpHookCtx<'a>,
+    pub upstream: &'a Upstream,
+    pub peer: &'a pingora_load_balancing::prelude::HttpPeer,
+}
+
+pub struct UpstreamConnectFailurePayload<'a> {
+    pub ctx: HttpHookCtx<'a>,
+    pub err: &'a pingora_core::Error,
+    pub retry_count: u32,
+    pub is_idempotent: bool,
+}
+pub enum RetryVote { Retry, NoRetry, NoOpinion }
+
+pub struct PreUpstreamRequestWritePayload<'a> {
+    pub ctx: HttpHookCtx<'a>,
+    pub upstream_request: &'a mut pingora_http::RequestHeader,
+}
+
+pub struct UpstreamResponseHeaderPayload<'a> {
+    pub ctx: HttpHookCtx<'a>,
+    pub upstream_response: &'a mut pingora_http::ResponseHeader,
+}
+
+pub struct PostResponsePipelinePayload<'a> {
+    pub ctx: HttpHookCtx<'a>,
+    pub response: &'a mut praxis_filter::Response,
+}
+
+pub struct BodyChunkPayload<'a> {
+    pub ctx: HttpHookCtx<'a>,
+    pub chunk: Option<&'a mut Bytes>,
+    pub end_of_stream: bool,
+}
+
+pub struct SessionLoggedPayload<'a> {
+    pub ctx: HttpHookCtx<'a>,
+    pub status: http::StatusCode,
+    pub request_bytes: u64,
+    pub response_bytes: u64,
+    pub duration: Duration,
+    pub outcome: SessionOutcome,
+}
+```
+
+## Appendix B: Configuration examples
+
+A `plugins:` block covering multiple hook families:
+
+```yaml
+plugins:
+  - name: ext-authz
+    kind: native:///opt/praxis/plugins/libextauthz.so
+    version: "1.0.2"
+    subscribe:
+      - hook: praxis.http.pre_upstream_select       # H7
+        mode: sequential
+        priority: 10
+        on_error: fail
+        timeout_ms: 50
+    config:
+      grpc_url: unix:///var/run/authz.sock
+      cache_ttl_ms: 5000
+
+  - name: audit-log
+    kind: wasm:///opt/praxis/plugins/audit.wasm
+    version: "0.3.0"
+    subscribe:
+      - hook: praxis.http.session_logged            # H14
+        mode: fire_and_forget
+        priority: 100
+        on_error: ignore
+        timeout_ms: 200
+      - hook: praxis.tcp.session_end                # T6
+        mode: fire_and_forget
+    config:
+      sink: https://audit.internal/v1/events
+
+  - name: cert-rotation-alert
+    kind: builtin:cert_rotation_alert               # ships in praxis
+    subscribe:
+      - hook: praxis.tls.cert_reloaded              # L3
+        mode: audit
+    config:
+      pagerduty_routing_key: ${PD_KEY}
+
+  - name: sni-allowlist
+    kind: native:///opt/praxis/plugins/libsniallow.so
+    subscribe:
+      - hook: praxis.tls.client_hello               # L1 synchronous
+        mode: sequential
+        on_error: fail
+        timeout_ms: 2
+    config:
+      allowlist_path: /etc/praxis/sni_allowed.txt
+
+  - name: prod-hardening
+    kind: builtin:insecure_options_guard
+    subscribe:
+      - hook: praxis.startup.config_loaded          # S1
+        on_error: fail
+    config:
+      forbid_flags:
+        - allow_root
+        - allow_public_admin
+        - allow_unbounded_body
+        - skip_pipeline_validation
+        - allow_tls_without_sni
+        - allow_private_health_checks
+```
+
+## Appendix C: Reserved protocol-semantic hook names
+
+These names are reserved but unregistered. They become live hook points when the corresponding protocol-native services (see [How how protocol-semantic hooks ship later](#43-how-protocol-semantic-hooks-ship-later)) land.
+
+```
+praxis.mcp.tool_pre_invoke
+praxis.mcp.tool_post_invoke
+praxis.mcp.prompt_pre_fetch
+praxis.mcp.prompt_post_fetch
+praxis.mcp.resource_pre_fetch
+praxis.mcp.resource_post_fetch
+
+praxis.a2a.task_created
+praxis.a2a.task_updated
+praxis.a2a.task_completed
+
+praxis.llm.input
+praxis.llm.output
+```
+
+Plugins must not `subscribe:` to these names in v1; the loader will reject any subscription to an unregistered hook. Authors designing MCP or A2A plugins today target the HTTP hooks (H4, H7, H10, H11) and re-target to protocol-semantic names once the corresponding service ships.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -2,49 +2,64 @@
 
 Status: draft
 
-This document specifies the hook system and plugin runtime for Praxis. Hooks complement the existing `HttpFilter` / `TcpFilter` surface with typed, capability-gated plugins that observe or enforce policy at well-defined lifecycle points. The runtime is CPEX (ContextForge Plugin Extensibility), embedded in-process.
+This document specifies the hook system and plugin runtime for Praxis. Hooks complement the existing `HttpFilter` / `TcpFilter` surface with typed, capability-gated plugins that observe or enforce policy at well-defined lifecycle (e.g., startup, auth) and protocol-semantic (e.g., MCP, A2A) points. The runtime is [CPEX](https://github.com/contextforge-org/contextforge-plugins-framework), embedded in-process.
 
-## 1. Scope
+## Contents
 
-2. [Goals and Non-Goals](#2-goals-and-non-goals).
-3. [Integration architecture](#3-integration-architecture).
-4. [Layering model](#4-layering-model).
-5. [Hook catalog: startup, TLS, TCP, HTTP lifecycle](#5-hook-catalog-lifecycle-hooks).
-6. [Typed payloads per hook](#6-hook-payloads) (full signatures in [Appendix A](#appendix-a-payload-type-sketches)).
-7. [Dispatch semantics: phase scheduling, failure modes, timeouts, tighten-only composition](#7-dispatch-semantics).
-8. [Plugin ABI](#8-plugin-abi).
-9. [YAML configuration](#9-configuration) (full example in [Appendix B](#appendix-b-configuration-examples)).
-10. [Observability](#10-observability), [security boundary mapping](#11-security-invariants-and-hook-mapping), [staged rollout](#12-staged-rollout), [open questions](#13-open-questions).
+1. [Scope (v1)](#1-scope-v1)
+2. [Goals and non-goals](#2-goals-and-non-goals)
+3. [Integration architecture](#3-integration-architecture)
+4. [Protocol hook design](#4-protocol-hook-design)
+5. [Hook catalog (v1)](#5-hook-catalog-v1)
+6. [Plugin runtime model](#6-plugin-runtime-model)
+7. [Plugin authoring and loading](#7-plugin-authoring-and-loading)
+8. [Configuration](#8-configuration)
+9. [Security invariants and hook mapping](#9-security-invariants-and-hook-mapping)
+10. [Staged rollout](#10-staged-rollout)
+11. [Open questions](#11-open-questions)
+12. [Appendix A: Full hook catalog and payload sketches](#appendix-a-full-hook-catalog-and-payload-sketches)
+13. [Appendix B: Configuration example](#appendix-b-configuration-example)
 
-Out of scope:
+## 1. Scope (v1)
 
-- CPEX internals (payload dispatch, capability gating, CMF extension format). See the CPEX spec.
-- Protocol-semantic hooks for MCP, A2A, or LLM payloads. [How protocol-semantic hooks ship later](#43-how-protocol-semantic-hooks-ship-later) explains why they are deferred and where they belong instead.
-- Hot-swapping plugins at runtime. Plugins are loaded at startup and released on shutdown.
-- The Python plugin host. CPEX supports it; Praxis does not, for latency reasons.
+The hook system v1 includes:
 
-## 2. Goals and Non-Goals
+1. One new Praxis crate, `praxis-hooks`, plus one new builtin filter at `filter/src/builtins/http/mcp/`. One external dependency, `cpex-core`.
+2. CPEX `PluginManager` wired through `run_server`. All hooks flow through the same dispatcher: lifecycle and protocol-semantic hooks. See the [CPEX Rust spec](https://github.com/contextforge-org/contextforge-plugins-framework/blob/dev/docs/specs/cpex-rust-spec.md).
+3. Initial set of 12 hooks registered, including lifecycle hooks, identity hooks (`praxis.identity.resolve`, `praxis.identity.delegate`), and MCP tool hooks (`praxis.mcp.tool_pre_invoke`, `praxis.mcp.tool_post_invoke`).
+4. Tool hooks ship via the MCP gateway filter described in §4.4 with _route-driven body mode_ (§4.3). A protocol-native `McpProxy` service (§4.2) is described as an upgrade path if the filter approach under-performs. Hook names are stable across options; plugin code does not change.
+5. Plugins are Rust crates registered programmatically (`register_handler` / `register_handler_for_names`). Dynamic loading via `cdylib` plus `libloading` is in the spec and ships as a parallel phase.
+6. Mutation flows through CPEX `Extensions` and capability-gated `WriteToken`s. Field-level write authority uses type-system enforcement (`Sealed<T>`, `MutabilityTier`, `Guarded<T>`) when needed; v1's capability-gated Extensions and WriteTokens are sufficient.
+
+Out of scope in v1:
+
+- A2A, LLM, prompt, and resource protocol-semantic hooks. Planned; names reserved in [Appendix A](#appendix-a-full-hook-catalog-and-payload-sketches).
+- WASM, Python, and sidecar plugin hosts. It will be possible through future releases of CPEX, but need to consider use case and performance requirements.
+- Hot reload. Plugins load at startup and release on shutdown.
+
+## 2. Goals and non-goals
 
 ### 2.1 Goals
 
-- **A second extension surface.** `HttpFilter` / `TcpFilter` handle per-request transformation well. They are insufficient for lifecycle observation (TLS handshake, connect, session end), policy enforcement at security boundaries the pipeline does not expose, and out-of-process dispatch. Hooks fill those gaps.
-- **A common runtime for extensibility.** CPEX is the runtime; Praxis is a host. Plugins that target Praxis hooks can also target other hosts where payload types overlap.
-- **Latency-budgeted.** Hooks run on the request hot path. Native plugin overhead must stay in single-digit microseconds per hook; WASM plugins under 100 µs. [Failure modes and timeouts](#73-failure-modes-and-timeouts) enumerates enforceable budgets.
-- **Tighten-only composition.** Policy hooks may strengthen any of the 18 security boundaries catalogued in [Security Invariants and Hook Mapping](#11-security-invariants-and-hook-mapping). They must not silently weaken any. The dispatcher enforces this structurally (see [Tighten-only composition](#74-tighten-only-composition)).
-- **Zero cost when unused.** Deployments without a `plugins:` section in YAML pay a single `AtomicBool` check at each call site. No dispatcher traversal, no allocations.
+- **A second extension surface.** `HttpFilter` and `TcpFilter` handle per-request transformation well. They are insufficient for lifecycle observation (TLS handshake, connect, session end), policy enforcement at security boundaries the pipeline does not expose, and policy targeted at protocol-semantic events rather than HTTP primitives. Hooks fill those gaps.
+- **A common runtime.** CPEX provides a common runtime for configuring, registering, and dispatching plugins at hook points; Praxis is the host owning the hook points and a reference to CPEX `PluginManager` (the hook dispatcher). Plugins targeting Praxis hooks can also target other CPEX hosts where payload types overlap. CPEX `MessagePayload` (CMF) payloads (the tool hooks) are the clearest example.
+- **Latency-budgeted.** Hooks run on the request hot path. Native AFIT in CPEX means a `HookHandler::handle` with no `.await` compiles to a ready future with no scheduler interaction; the cost is a direct call.
+- **Tighten-only composition.** Plugins may strengthen the security boundaries catalogued in [§9](#9-security-invariants-and-hook-mapping). They cannot silently weaken any. The dispatcher enforces this structurally.
+- **Zero cost when unused.** A deployment without a `plugins:` block pays a single `PluginManager::has_hooks_for` lookup at each call site. No dispatcher traversal, no allocations.
 
-### 2.2 Non-Goals
+### 2.2 Non-goals
 
 - **Replacing filters.** Filters remain the right abstraction for per-request transformation. Hooks wrap filters, not the other way around.
-- **Hot reload.** Startup-only loading keeps the trust model simple. Reload-without-restart is deferred.
-- **Arbitrary cross-hook ordering.** Within a hook point, plugins run in CPEX's 5-phase order at configured priority. Across hook points, order is set by the request lifecycle.
-- **Semantic payload parsing in the HTTP filter layer.** See [How protocol-semantic hooks ship later](#43-how-protocol-semantic-hooks-ship-later).
+- **Hot reload.** Startup-only loading keeps the trust model simple.
+- **Arbitrary cross-hook ordering.** Within a hook point, plugins run in CPEX's [execution order](https://contextforge-org.github.io/contextforge-plugins-framework/docs/execution-modes/) at configured priority. Across hook points, order is set by the request lifecycle.
+- **Field-level payload write policy.** Not needed in v1. The `Guarded<T>` / `WriteToken` mechanism enforces write authority at the type level. Future tightening beyond `WriteToken` will use `Sealed<T>` / `MutabilityTier` type-system enforcement, not a runtime policy mechanism.
+- **Policy evaluation language ([APL](https://github.com/contextforge-org/contextforge-plugins-framework/blob/eaedce7af05ec3f63ef48fa469035bb5948b38e3/docs/specs/apl-dsl-spec.md)).** Praxis hosts CPEX hooks; policy-evaluation integration via APL or `PolicyEvaluator` is out of scope for v1. May land as a Phase 5+ item if a concrete consumer warrants it.
 
-## 3. Integration Architecture
+## 3. Integration architecture
 
-### 3.1 CPEX as runtime, Praxis as host
+### 3.1 CPEX runtime
 
-Praxis embeds the CPEX `PluginManager` in-process. A plugin call is a function call, not an IPC hop. CPEX provides the typed dispatcher, phase executor, payload policy enforcement, and host loaders (`native`, `wasm`). Praxis provides lifecycle call sites, payload construction, and the tighten-only composition monoid.
+Praxis embeds the CPEX `PluginManager` in-process. A plugin call is a function call, not an IPC hop. CPEX provides the typed dispatcher, phase executor, capability-gated extensions, plugin lifecycle, and registration. Praxis provides lifecycle call sites, payload construction, protocol gateway filters (e.g., MCP), and the tighten-only composition rules for its policy hooks.
 
 ### 3.2 Crate layout
 
@@ -55,26 +70,25 @@ praxis/
   hooks/                          NEW: praxis-hooks crate
     src/
       lib.rs                      register_hooks!, public types
-      payloads/{startup,tls,tcp,http}.rs
-      dispatcher/{mod,http,tcp,tls,tighten}.rs
-      config.rs                   YAML → CPEX config adapter
+      payloads/{startup,tls,tcp,http,mcp}.rs
+      dispatcher/{mod,http,tcp,tls,mcp,tighten}.rs
+      config.rs                   YAML to CPEX config adapter
       metrics.rs                  praxis_hook_* emitters
-      policy.rs                   HookPayloadPolicy builders
+  filter/src/builtins/http/mcp/   NEW: MCP gateway filter (§4.4)
   server/                         depends on praxis-hooks
   protocol/                       depends on praxis-hooks
   tls/                            depends on praxis-hooks
 ```
 
-Workspace dependencies:
+Workspace dependency:
 
 ```toml
-cpex-core  = { version = "0.2", default-features = false }
-cpex-hosts = { version = "0.2", default-features = false,
-               features = ["native", "wasm"] }
-cpex-sdk   = { version = "0.2" }   # dev-dep, for test plugins only
+cpex-core = { git = "https://github.com/contextforge-org/contextforge-plugins-framework", branch = "dev" }
 ```
 
-The `plugins-native` and `plugins-wasm` Cargo features are on by default. Building with `--no-default-features --features plugins-native` produces a binary that rejects WASM plugins at load time.
+`branch = "dev"` indicates the source branch. In practice, Praxis pins to a specific commit or dev tag (see [§11 Open Question 1](#11-open-questions)). The lockfile records the exact resolved commit.
+
+`cpex-sdk` can be imported when implementing out-of-tree plugins without importing the entire `cpex-core` machinery. WASM, Python, and sidecar hosts are not in cpex-core today; when they ship, they enter via additive `cpex-hosts::*` crates without changing the Praxis surface.
 
 ### 3.3 Lifecycle integration
 
@@ -86,158 +100,188 @@ server/src/server.rs::run_server
   warn_insecure_key_permissions
   build_health_registry
   resolve_pipelines
-  HookDispatcher::from_config(&config)            NEW
-    register_all_praxis_hook_types                (HookTypeDefs)
-    load_plugins_from_config
-    validate_subscriptions
-    run S1 on_config_loaded                       (fail-closed)
-  PingoraServerRuntime::new(..., dispatcher)
-  PingoraHttp.register(..., dispatcher)
-  PingoraTcp.register(..., dispatcher)
-  run S3 on_listeners_bound                       (fail-open)
+  PluginManager::new(ManagerConfig::default())
+  register_handler::<H, _>(...) for each compiled-in plugin
+  load_config(plugins_yaml)                          (dynamic plugins, when shipped)
+  manager.initialize().await                         (calls Plugin::initialize on each)
+  invoke S1 praxis.startup.config_loaded             (fail-closed)
+  PingoraServerRuntime::new(..., manager)
+  PingoraHttp.register(..., manager)
+  PingoraTcp.register(..., manager)
+  // S3 praxis.startup.listeners_bound               (reserved; no-op until promoted)
   server.run_forever()
 ```
 
-Protocol handlers receive the dispatcher as `Arc<HookDispatcher>`, parallel to how they receive `Arc<FilterPipeline>` today. A `None` dispatcher (no `plugins:` section) collapses every call site to a single `Option::is_some()` branch.
+Protocol handlers receive the manager as `Arc<PluginManager>`, parallel to how they receive `Arc<FilterPipeline>` today. A manager with no registered handlers for a hook short-circuits `invoke::<H>` to a zero-cost path, so a Praxis deployment without plugins pays one registry lookup per call site.
 
 ### 3.4 Call-site contract
 
-Every call site in the [hook catalog](#5-hook-catalog-lifecycle-hooks) must:
+Every call site in the [hook catalog](#5-hook-catalog-v1) must:
 
-1. Fast-path check `dispatcher.is_enabled(HOOK_ID)`: a compile-time-indexed `[AtomicBool; 29]`.
-2. If enabled, build the typed payload from local context.
-3. Invoke via `dispatcher.invoke::<HookId>(payload, ctx).await`, or the sync variant for L1 and L4.
-4. Apply the returned `PipelineResult` per the hook's interaction class (see [Interaction enforcement](#72-interaction-enforcement)).
-5. Emit the per-site metric (see [Observability](#10-observability)).
+1. Fast-path check `manager.has_hooks_for(H::NAME)`. CPEX's registry uses `ArcSwap` for lock-free reads; a miss is one atomic load.
+2. If hooks exist, build the typed payload from local context.
+3. Invoke via `manager.invoke::<H>(payload, extensions, ctx_table).await`, which returns `(PipelineResult, BackgroundTasks)`.
+4. Apply the returned `PipelineResult` per the hook's interaction class (see [§6.7](#67-interaction-enforcement)).
+5. Emit the per-site metric (see [§8.6](#86-observability)).
 
 Call sites use the `praxis_hooks::invoke_hook!` macro to keep boilerplate out of the request path.
 
-### 3.5 What CPEX provides
+### 3.5 What CPEX provides (public API)
 
 | CPEX feature | Praxis usage |
 |---|---|
-| `Plugin` trait (lifecycle) | Startup and shutdown of plugin-owned resources. |
-| `HookTypeDef` | Praxis hook types, zero-cost borrow dispatch for native plugins. |
-| `HookHandler<H>::handle` | The user-visible plugin surface. |
-| `PluginRef.trusted_config` | Praxis reads priority, mode, and capabilities from the loader, never from plugin-reported values. |
-| Plugin executor | Plugin [dispatching modes](#71-phase-selection). |
-| `HookPayloadPolicy` | Declares field-level writability per hook (see [HookPayloadPolicy](#75-hookpayloadpolicy)). |
-| `OnError` | Surfaced verbatim in YAML: `fail` / `ignore` / `disable`. |
-| Capability gating on extensions | Reserved for v2 (see [Extensions](#65-extensions-reserved-for-v2)). |
+| `Plugin` trait | Plugin lifecycle (`initialize`, `shutdown`). |
+| `HookTypeDef` | Praxis hook types; typed dispatch via `invoke::<H>`. |
+| `HookHandler<H>::handle` | The plugin-author surface. Async by default; AFIT makes sync bodies free. |
+| `PluginManager` | Owned by `run_server`. One instance per process. |
+| `PluginConfig` | YAML schema; trusted source of priority, mode, capabilities. |
+| `PluginMode` | Sequential, Transform, Audit, Concurrent, FireAndForget, Disabled (YAML: `sequential`, `transform`, `audit`, `concurrent`, `fire_and_forget`, `disabled`). |
+| `OnError` | Surfaced verbatim in YAML: `fail`, `ignore`, `disable`. |
+| `Extensions` | Capability-gated sidecar data for headers, identity, MCP entity metadata. |
+| `PluginContext` | `local_state` (per-plugin, cross-hook) and `global_state` (cross-plugin, per-invoke). |
+| `MessagePayload` (CMF) | Tool hook payload. Reused without modification. |
+| `register_handler_for_names` | CMF-style multi-name registration. |
+| `invoke_named::<H>` | Tool hook dispatch (one type, multiple names). |
 
-Praxis does not rely on CPEX `SessionStore` (no cross-request plugin state in v1) nor on CPEX's own route/policy config loader.
+Finer-grained field-level write authority beyond `WriteToken` will use type-system enforcement (`Sealed<T>`, `MutabilityTier`) when needed. Praxis v1 does not require it. Capability-gated `Extensions` cover header mutation; full-payload `modify_payload` covers the rest.
 
-## 4. Layering Model
+## 4. Protocol hook design
 
-The hardest design question for this system is where content-aware logic lives. One approach is to dispatch MCP, A2A, and LLM hooks from inside a single `HttpFilter`. That choice has two costs large enough to warrant an explicit layering model.
+Hooks fall into two families: **lifecycle** (operate on HTTP/TCP primitives — headers, methods, URIs, client addresses, TLS info, upstream selection; no body access needed) and **protocol-semantic** (operate on parsed protocol payloads like MCP `tools/call`; require body buffering). Lifecycle hooks are cheap by construction. The design challenge is delivering protocol-semantic hooks without imposing buffering costs on unrelated traffic or inverting Praxis's layering.
 
-### 4.1 Why content hooks do not belong in `HttpFilter`
+In v1, tool hooks (`praxis.mcp.tool_pre_invoke`, `praxis.mcp.tool_post_invoke`) ship through the MCP gateway filter (§4.4). Bodies buffer only for routes the operator marks as MCP-aware (§4.3). Non-`tools/call` MCP methods stream through. Future protocol-semantic hooks (A2A, LLM, prompts, resources) are reserved in [Appendix A](#appendix-a-full-hook-catalog-and-payload-sketches); promoted when a concrete consumer warrants it.
 
-**Cost 1: the streaming model collapses.** Praxis ranks body modes `Buffer > StreamBuffer > SizeLimit > Stream` precisely so that streaming stays the default. A filter that forces `BodyMode::Buffer { max_bytes: 1 MiB }` on every request promotes the entire listener to buffered mode, adding per-request latency equal to upstream-body-arrival time and up to 1 MiB of residency per in-flight request. A feature touched by a narrow minority of requests should not pay this cost on every request.
+### 4.1 Why protocol-semantic hooks cost something
 
-**Cost 2: abstraction inversion.** An `HttpFilter` parsing JSON-RPC method names and dispatching per-tool hooks bakes protocol knowledge into the HTTP layer. That is the wrong home for it. The HTTP layer should know headers, methods, URIs, and bodies-as-bytes. Protocol semantics belong in whatever component routes the protocol.
+Praxis ranks body modes `StreamBuffer > SizeLimit > Stream`. Streaming is the default. Recent versions of Praxis addressed the "listener-wide collapse" failure mode where one filter forcing `Buffer` promoted the whole listener: `Buffer` is gone, and filters opt into buffering per request via `ctx.set_request_body_mode(...)` and `ctx.set_response_body_mode(...)` (commit `0f0f656`).
 
-### 4.2 Two hook categories, one deferred
+The surviving failure mode is _indiscriminate per-request buffering_. A content-aware filter that does not predicate body access by route or method still pays buffering cost on every request its filter chain matches. The cost is narrower than before but not free, and naive content-type sniffing inside a filter is the easy way to fall into it.
 
-**Lifecycle hooks (this spec).** Startup, TLS, TCP, and HTTP lifecycle points. Operate on HTTP and TCP primitives: methods, URIs, headers, client addresses, TLS info, upstream selection, connect failures, response headers, byte counters. Header-level identity and authorization (JWT decoding, DPoP, external authz) fit naturally here: they attach to H2, H4, H7, or H10 and read or inject headers without parsing bodies. Body access is opt-in per plugin via H6 and H13 and participates in the existing `BodyCapabilities` budget.
+A second cost is _abstraction inversion_. A filter that parses JSON-RPC method names and dispatches per-tool hooks bakes protocol knowledge into the HTTP layer. The HTTP layer should know headers, methods, URIs, and bodies-as-bytes. Protocol semantics belong in the component that routes the protocol.
 
-**Protocol-semantic hooks (deferred).** MCP `tools/call`, A2A tasks, LLM inputs and outputs, prompt and resource fetches. These require parsing a structured body into a protocol-typed message before they can fire. They belong in a protocol-native host that parses once during routing, not in an HTTP filter that buffers speculatively. This spec names no such hooks. [How protocol-semantic hooks ship later](#43-how-protocol-semantic-hooks-ship-later) describes the path.
+Both costs survive the gateway filter approach. Sections §4.2 and §4.3 introduce mechanisms that make them bounded and explicit.
 
-### 4.3 How protocol-semantic hooks ship later
+### 4.2 Protocol hooks: gateway filter vs. protocol-native service
 
-Protocol-semantic hooks are unblocked when Praxis grows protocol-native proxy services peered with `ProxyHttp`. Plausible shapes:
+Two implementation paths for protocol-semantic hooks. Both dispatch against the same `Arc<PluginManager>`. Hook names are stable across both. Plugin code does not change between them.
 
-- An `McpProxy` service recognizes JSON-RPC over HTTP POST, parses methods and parameters once, and dispatches `praxis.mcp.tool_pre_invoke` / `praxis.mcp.tool_post_invoke` from inside the service loop. Bodies are buffered only for methods known to carry semantic payloads (`tools/call`, `prompts/get`, `resources/read`). Methods like `ping` or `initialize` stream through.
-- An `A2aProxy` service models the task lifecycle and dispatches `praxis.a2a.task_created`, `_updated`, `_completed`.
-- An LLM-aware service (OpenAI-compatible or Bedrock-compatible) dispatches `praxis.llm.input` and `praxis.llm.output` with proper streaming semantics for SSE response bodies.
+**Protocol gateway filters (v1).** For MCP hooks, v1 defines a builtin filter under `filter/src/builtins/http/mcp/`. The filter runs only on routes that opt in via the route-level `body_mode:` declaration (§4.3). On matched routes, the filter consumes the buffered body, parses JSON-RPC (using `filter/src/builtins/http/payload_processing/json_rpc/`), constructs `MessagePayload` for `tools/call` methods, and dispatches `praxis.mcp.tool_pre_invoke` and `_post_invoke`. This works today with no new architectural pieces beyond the route field. The §4.1 costs apply: bounded buffering on matched routes, protocol parsing in the filter layer. See §4.4 for the full filter spec.
 
-Each of these would register its own `HookTypeDef`s with the same CPEX dispatcher Praxis already owns. Plugins that target MCP or A2A today can continue to target them tomorrow without code changes; only the host module changes. Until those services land, protocol-semantic hook names are reserved (namespace `praxis.mcp.*`, `praxis.a2a.*`, `praxis.llm.*`) but unregistered.
+**Protocol-native services (future option).** Using MCP as an example, this approach defines a new crate sibling to `protocol/src/http/` and `protocol/src/tcp/`, registered as a new `ProtocolKind::Mcp` listener. It owns its accept loop, parses JSON-RPC at the head, buffers selectively only for methods that carry payloads (`tools/call`, `prompts/get`, `resources/read`), and dispatches `praxis.mcp.*` against the same `Arc<PluginManager>`. This is the long-term home. It removes the abstraction-inversion cost and lets the buffering decision live with the protocol parser. Significantly more work: listener wiring, lifecycle parity with HTTP, SSE-aware response streaming, integration tests.
 
-This split keeps the spec shippable, the hot path streaming, and the semantic surface evolvable.
+> **Decision.** Ship the gateway filter in v1 to validate the hook payload shapes, the `filter_metadata` plumbing, and operator-facing config against real plugins. Promote to the protocol-native service when the filter-layer parsing becomes a bottleneck or when abstraction inversion bites in practice. Plugins written against the gateway filter retarget to the protocol-native service without code changes. Hook names are the stable contract.
 
-## 5. Hook Catalog (lifecycle hooks)
+### 4.3 Route-driven body mode
+
+This proposed mechanism makes the gateway filter operator-friendly and provides a canonical way to enable buffering for protocol-aware routes.
+
+**Assumption.** Praxis routes have shape `path_match: PathMatch` plus `cluster: Arc<str>` (`core/src/config/route.rs`). The cluster is resolved before body chunks flow. The pipeline knows, pre-body, whether the request is destined for a protocol-aware backend.
+
+**Mechanism.** A route gains an optional `body_mode:` block:
+
+```yaml
+routes:
+  - path_prefix: /mcp/
+    cluster: mcp-backend
+    body_mode:
+      request:
+        stream_buffer:
+          max_bytes: 65536
+      response:
+        stream_buffer:
+          max_bytes: 262144
+```
+
+The pipeline applies the declared `BodyMode` to the request context immediately after route resolution, before pipeline filters run. The MCP filter then runs unconditionally on matched routes and is a true no-op on unmatched ones. No content-type sniffing in code. No per-request branching for the common case.
+
+**Why this beats in-filter sniffing.**
+
+- *Declarative.* The operator decides which backends are MCP-aware in YAML.
+- *Cheap.* Routing already happens. One extra `cluster` to `BodyMode` lookup. The MCP filter's hot path is "is metadata set, dispatch hook; else fall through."
+- *Decoupled.* The filter carries no protocol-detection logic.
+- *Upgrade-safe.* When the protocol-native service lands, the route still names the cluster. Operator config does not change.
+
+**Praxis change required.** `core/src/config/route.rs` gains an optional `body_mode: Option<RouteBodyMode>`, where `RouteBodyMode { request: Option<BodyMode>, response: Option<BodyMode> }`. The pipeline calls `ctx.set_request_body_mode(...)` and `ctx.set_response_body_mode(...)` from the route binding before filters execute. Route-declared `body_mode` participates in `apply_body_limits` ceilings; an unbounded `StreamBuffer { max_bytes: None }` at the route level is rejected unless `allow_unbounded_body` is set, matching the existing filter-declared invariant.
+
+**Fallback.** Filters retain the right to call `ctx.set_request_body_mode(...)` per request when route-driven config is not appropriate (a filter that decides based on a header the route does not see). Both paths converge on the same context API.
+
+### 4.4 The MCP gateway filter
+
+The single piece of Praxis-side code beyond `praxis-hooks` that v1 adds.
+
+**Location.** `filter/src/builtins/http/mcp/`.
+
+**Activation.** Operator opts in by adding `mcp_gateway` to a listener's filter chain. The filter only takes work for requests where the route declared a buffered body mode (§4.3) and the JSON-RPC payload classifies as `tools/call`. All other paths fall through as no-ops.
+
+**Behavior.**
+
+1. On request, check whether the route enabled buffering (§4.3). If not, fall through.
+2. On buffered routes, after body-done, run the JSON-RPC parser at `filter/src/builtins/http/payload_processing/json_rpc/` to extract `method`, `id`, `params`.
+3. If `method == "tools/call"`, construct a `MessagePayload` with the parsed tool name and arguments and dispatch `praxis.mcp.tool_pre_invoke` via the `PluginManager` handle the pipeline already holds.
+4. If `PipelineResult.is_denied()`, emit a JSON-RPC error response without contacting upstream. If `modified_payload.is_some()`, write the redacted arguments back into the buffered request body before forwarding. If `modified_extensions.is_some()`, merge extension changes (header writes, label appends) back into the request context before forwarding; the merge follows CPEX's copy-on-write semantics with `WriteToken` authority preserved.
+5. For JSON-RPC batch requests (array of method calls), the filter dispatches tool hooks per individual call within the batch. Batch identity (array index, batch request ID) is carried in `PluginContext::local_state` so plugins can correlate calls. If any call is denied, only that call's response is replaced with a JSON-RPC error; other calls in the batch proceed independently.
+6. On response, if the original request was a `tools/call`, parse the JSON-RPC response, build the post-payload, dispatch `praxis.mcp.tool_post_invoke`. Thread the `PluginContextTable` from M1 into M2 so `local_state` carries through. Apply `modified_payload` back into the response body if any plugin redacted output. If `modified_extensions.is_some()`, merge post-invoke extension mutations into the response context before forwarding to client.
+7. Non-`tools/call` methods bypass hook dispatch. The JSON-RPC parse runs once on buffered routes; the dispatch is gated on method.
+8. Per-request metadata (parsed method, tool name, JSON-RPC id) goes into `filter_metadata` so it survives to H14 / `session_logged` for audit plugins downstream.
+
+**What the filter does not do.**
+
+- It does not own protocol routing. Praxis routing already does.
+- It does not own buffering policy. The route declares it (§4.3).
+- It does not own plugin invocation semantics. CPEX does.
+- It does not validate tool argument schemas. Plugins do.
+
+**Acknowledged cost.** The abstraction-inversion cost from §4.1 remains. The protocol-native service (§4.2) is the upgrade. Hook names are stable across both approaches; plugins do not change.
+
+**Tests.** Unit tests for JSON-RPC method classification. Integration tests using `examples/configs/protocols/mcp/` with a fake MCP upstream that exercises `tools/call` end-to-end, including plugin-driven denial and argument or response redaction.
+
+## 5. Hook catalog (v1)
+
+This section covers the 12 hooks registered in v1. "Status: v1" means the hook is registered and usable by the end of the initial release sequence (Phases 1–4 in [§10](#10-staged-rollout)); it does not imply all hooks ship in the same phase. The full catalog (including reserved hooks and their payload sketches) is in [Appendix A](#appendix-a-full-hook-catalog-and-payload-sketches).
 
 ### 5.1 Conventions
 
-- **ID** is a stable short identifier: `S` startup, `L` TLS, `T` TCP, `H` HTTP. IDs are stable across the API lifetime; payload types evolve under semver.
-- **Name** is the string CPEX registers under and the value operators write in YAML `subscribe:` blocks.
-- **Interaction** is `observe`, `mutating`, or `policy`, mapped to phases in [Dispatch Semantics](#7-dispatch-semantics).
-- **Sync?** filled circle for hooks that must run synchronously (rustls path); open circle for async.
+- **ID** is a stable short identifier: `S` startup, `L` TLS, `T` TCP, `H` HTTP, `M` MCP.
+- **Name** is the string CPEX registers under and the value operators write in YAML `hooks:` lines.
+- **Interaction** is `observe`, `mutating`, or `policy`, mapped to allowed modes in [§6.6](#66-mode-constraints).
 
-### 5.2 Startup hooks
+### 5.2 Lifecycle hooks
 
-| ID | Name | Call site | Interaction | Default phase | Sync? | Rationale |
-|---|---|---|---|---|---|---|
-| S1 | `praxis.startup.config_loaded` | `server.rs` after `Config::load` | policy | sequential | ○ | Validate or veto config before pipelines are built. Failing here aborts startup. |
-| S2 | `praxis.startup.pipelines_built` | after `resolve_pipelines` | policy | sequential | ○ | Inspect assembled pipelines; reject inconsistent compositions. |
-| S3 | `praxis.startup.listeners_bound` | before `server.run_forever` | observe | audit | ○ | Publish to service discovery, warm caches, open watchers. |
-| S4 | `praxis.startup.shutdown` | on SIGTERM path | observe | sequential | ○ | Flush buffered state, deregister. Bounded by `shutdown_timeout_secs`. |
-
-Example: an S1 plugin rejects startup if any `insecure_options` flag is set in a production environment. An S2 plugin enforces "every listener has `rate_limit` before `router`".
-
-### 5.3 TLS hooks
-
-| ID | Name | Call site | Interaction | Default phase | Sync? | Rationale |
-|---|---|---|---|---|---|---|
-| L1 | `praxis.tls.client_hello` | `tls/src/setup/sni.rs` in `ResolvesServerCert::resolve` | policy | sequential | ● | Pre-handshake SNI gating. Rustls calls `resolve` synchronously. |
-| L2 | `praxis.tls.cert_resolved` | same, after successful match | observe | audit | ● | Audit trail: which cert served which SNI. |
-| L3 | `praxis.tls.cert_reloaded` | `tls/src/reload.rs::reload` | observe | audit | ○ | Fires on success and failure paths of cert rotation. |
-| L4 | `praxis.tls.mtls_client_cert` | rustls `ClientCertVerifier::verify_client_cert` adapter | policy | sequential | ● | Custom chain validation beyond rustls default. |
-
-L1 and L4 run on the rustls blocking thread. Their plugin hosts are restricted to `native` (always) and `wasm` with fuel-bounded execution (see [Failure modes and timeouts](#73-failure-modes-and-timeouts)). Sidecar plugins are rejected at startup for these hooks.
-
-### 5.4 TCP hooks
-
-| ID | Name | Call site | Interaction | Default phase | Rationale |
+| ID | Name | Interaction | Default mode | Call site | Rationale |
 |---|---|---|---|---|---|
-| T1 | `praxis.tcp.accept` | `protocol/src/tcp/proxy.rs` after `extract_addrs` | policy | sequential | Cheap IP gating before any byte is read. |
-| T2 | `praxis.tcp.sni_peeked` | after `peek_sni` | policy | sequential | SNI allowlist and tenant routing. |
-| T3 | `praxis.tcp.pre_connect` | before `run_connect_filters` | policy | sequential | Short-circuit the TCP filter chain (e.g., maintenance mode). |
-| T4 | `praxis.tcp.upstream_selected` | after `run_connect_filters` | policy | sequential | Veto the filter-chosen upstream. |
-| T5 | `praxis.tcp.upstream_connected` | after `connect_upstream` | observe | audit | Upstream TCP is live. |
-| T6 | `praxis.tcp.session_end` | after `forward`, before disconnect filters | observe | fire_and_forget | Non-blocking session audit with final byte counts. |
-| T7 | `praxis.tcp.post_disconnect` | after disconnect filters | observe | fire_and_forget | Terminal; publish derived metrics. |
+| S1 | `praxis.startup.config_loaded` | policy | sequential | `server.rs` after `Config::load` | Validate or veto config before pipelines are built. Failing here aborts startup. |
+| S4 | `praxis.startup.shutdown` | observe | audit | on SIGTERM path | Flush buffered state, deregister. Bounded by `shutdown_timeout_secs`. |
+| L3 | `praxis.tls.cert_reloaded` | observe | audit | `tls/src/reload.rs::reload` | Fires on success and failure of cert rotation. |
+| I1 | `praxis.identity.resolve` | policy | sequential | `request_filter/mod.rs` at H4, before pipeline | Identity resolution via CPEX `IdentityResolve`. Slot collision rejection at config load; identity sealed immutable post-resolution. |
+| I2 | `praxis.identity.delegate` | mutating | transform | after route resolution, at H10 site | Token delegation via CPEX `TokenDelegate`. Framework-enforced scope narrowing, raw-credential boundary, `(subject, audience, scopes, mode)`-keyed cache. |
+| H4 | `praxis.http.pre_request_pipeline` | policy | sequential | `request_filter/mod.rs` before pipeline | Short-circuit before filters run. Ext-authz home. |
+| H7 | `praxis.http.pre_upstream_select` | policy | sequential | just before `upstream_peer::execute` | Final pre-select gate. |
+| H9 | `praxis.http.upstream_connect_failure` | policy | sequential | `handle_connect_failure` | Deny to suppress retry; built-in idempotency check applies independently. |
+| H11 | `praxis.http.upstream_response_header` | policy | sequential | `response_filter.rs` after hop-by-hop strip | First look at upstream response. May veto. |
+| H14 | `praxis.http.session_logged` | observe | fire_and_forget | `handler/mod.rs` after `logging_cleanup` | Terminal; fires exactly once per request. |
 
-All TCP hooks are async. The TCP lifecycle has no sync bridge.
+Praxis hosts the CPEX `IdentityResolve` and `TokenDelegate` framework hooks (I1, I2) to get structural guarantees that ad-hoc H4/H10 plugins cannot provide: slot collision rejection at config load (no two resolvers write the same identity slot), immutable sealing post-resolution (mid-pipeline plugins cannot overwrite `security.subject`), capability-gated writes (`write_subject`, `write_client`, `write_workload`), a raw-credential boundary (`Zeroizing<String>`, `#[serde(skip)]`), and a token cache with invalidation API. Plugins authored against either CPEX or Praxis work on both hosts.
 
-### 5.5 HTTP lifecycle hooks
+### 5.3 Protocol-semantic hooks
 
-| ID | Name | Call site | Interaction | Default phase | Notes |
+| ID | Name | Interaction | Default mode | Payload | Rationale |
 |---|---|---|---|---|---|
-| H1 | `praxis.http.early_request` | `early_request_filter` | observe | audit | Raw request line decoded; Host / Max-Forwards not yet validated. |
-| H2 | `praxis.http.host_validated` | after `validate_host_header` | observe | audit | Canonicalised Host available. |
-| H3 | `praxis.http.max_forwards_handled` | after terminal `handle_max_forwards` | observe | audit | Fires only for TRACE/OPTIONS at count 0. |
-| H4 | `praxis.http.pre_request_pipeline` | `request_filter/mod.rs:98` before `execute_http_request` | policy | sequential | Short-circuit before filters run. |
-| H5 | `praxis.http.post_request_pipeline` | `request_filter/mod.rs:146` after `run_pipeline` | policy | sequential | Cluster, upstream, rewritten_path known. |
-| H6 | `praxis.http.request_body_chunk` | `request_body_filter.rs` per mode | mutating | transform | Opt-in; participates in `BodyCapabilities`. |
-| H7 | `praxis.http.pre_upstream_select` | just before `upstream_peer::execute` | policy | sequential | Final pre-select gate. |
-| H8 | `praxis.http.upstream_selected` | `upstream_peer.rs` after `build_peer` | observe | audit | Last view before upstream I/O. |
-| H9 | `praxis.http.upstream_connect_failure` | `handle_connect_failure` | policy (voting) | sequential | Returns `RetryVote`. |
-| H10 | `praxis.http.pre_upstream_request_write` | after strip + rewrite + Via | mutating | transform | Final shape of upstream request. |
-| H11 | `praxis.http.upstream_response_header` | `response_filter.rs` after `strip_hop_by_hop_response` | policy | sequential | First look at upstream response. May veto 5xx. |
-| H12 | `praxis.http.post_response_pipeline` | after `execute_http_response`, before Via | mutating | transform | Response after filters ran. |
-| H13 | `praxis.http.response_body_chunk` | `response_body_filter.rs` per mode | mutating | transform | Sync from Pingora's perspective; bounded deadline. |
-| H14 | `praxis.http.session_logged` | `handler/mod.rs:186` after `logging_cleanup` | observe | fire_and_forget | Terminal; fires exactly once per request. |
+| M1 | `praxis.mcp.tool_pre_invoke` | policy | sequential | `MessagePayload` | Gate or redact tool arguments before upstream. |
+| M2 | `praxis.mcp.tool_post_invoke` | mutating | transform | `MessagePayload` | Redact or transform tool results before the client. |
 
-Header-level identity and authorization fit here without new hook kinds:
+Dispatch site is the MCP gateway filter (§4.4). The filter runs only on routes that opt in via `body_mode:` (§4.3). Non-`tools/call` MCP methods bypass hook dispatch.
 
-- JWT decoding attaches to H2 or H4 and sets per-request state that downstream plugins read.
-- External authz dispatches at H4 (for pipeline preemption) or H7 (for upstream-specific policy).
-- Delegated token injection attaches to H10.
+Plugin authors register both names against a single `CmfHook` handler with `register_handler_for_names`. The filter calls `manager.invoke_named::<CmfHook>("praxis.mcp.tool_pre_invoke", ...)` and `..._post_invoke`. `PluginContext::local_state` threads per-tool state from M1 to M2 (a timer, a redaction decision).
 
-None of these require body buffering.
+### 5.4 Identity and authorization patterns
 
-### 5.6 Summary
+Identity and authorization use the dedicated framework hooks (I1, I2) rather than ad-hoc H4/H10 plugin patterns:
 
-| Family | Count | Sync mix | Phase mix (default) |
-|---|---|---|---|
-| Startup | 4 | async | 3 sequential, 1 audit |
-| TLS | 4 | 3 sync, 1 async | 2 sequential, 2 audit |
-| TCP | 7 | async | 4 sequential, 1 audit, 2 fire_and_forget |
-| HTTP | 14 | async (H13 sync context) | 5 sequential, 5 transform, 3 audit, 1 fire_and_forget |
-| **Total** | **29** | | |
+- **Identity resolution (I1).** JWT decoding, mTLS subject extraction, or API-key lookup registers as an `IdentityResolve` handler. The framework populates `SecurityExtension` slots (`subject`, `client`, `caller_workload`) and seals them immutable before the pipeline runs. Downstream plugins read identity via `read_subject` / `read_client` capabilities.
+- **External authz.** Dispatches at H4 (for pipeline preemption) or H7 (for upstream-specific policy), reading the sealed identity from `SecurityExtension`.
+- **Token delegation (I2).** Outbound token minting (OAuth token exchange, SPIFFE SVID, scoped API key) registers as a `TokenDelegate` handler at the H10 call site. The framework enforces scope narrowing (delegated token cannot exceed the inbound subject's authority), maintains a `(subject, audience, scopes, mode)`-keyed cache, and isolates raw credentials behind `RawCredentialsExtension` with `Zeroizing<String>` and `#[serde(skip)]`.
 
-## 6. Hook Payloads
+## 6. Plugin runtime model
 
 CPEX binds each hook type to a payload and a result:
 
@@ -249,50 +293,145 @@ pub trait HookTypeDef: Send + Sync + 'static {
 }
 ```
 
-Every hook in the [catalog](#5-hook-catalog-lifecycle-hooks) has one `HookTypeDef` in `praxis_hooks::payloads::*`. Payload structs borrow request-scoped data rather than clone it; plugins that need to retain anything clone explicitly. Full signatures are in [Appendix A](#appendix-a-payload-type-sketches).
+Every registered Praxis hook has one `HookTypeDef` in `praxis_hooks::payloads::*`. Payload structs borrow request-scoped data rather than clone it; plugins that need to retain anything clone explicitly. Full signatures for v1 hooks are in [Appendix A](#appendix-a-full-hook-catalog-and-payload-sketches).
 
-The shared HTTP context view is:
+### 6.1 The shared HTTP context
+
+Every HTTP-family hook (H4–H14) receives an `HttpHookCtx<'a>` carrying client address, HTTP version, listener name, timing, request ID, and routing state. The context grows richer as the lifecycle progresses: `cluster`, `upstream`, and `rewritten_path` are `None` at H4 and earlier, populated after route resolution. Full struct definition in [Appendix A](#appendix-a-full-hook-catalog-and-payload-sketches).
+
+### 6.2 Extensions
+
+`Extensions` is a separate parameter, never folded into the payload. CPEX uses capabilities and `WriteToken`s to enforce read and write authority:
 
 ```rust
-pub struct HttpHookCtx<'a> {
-    pub client_addr: Option<IpAddr>,
-    pub client_http_version: http::Version,
-    pub listener: &'a str,
-    pub request_start: Instant,
-    pub request_id: Option<&'a str>,
-    pub cluster: Option<&'a str>,           // None before H5/H7
-    pub upstream: Option<&'a Upstream>,     // None before H7
-    pub rewritten_path: Option<&'a str>,
-    pub retries: u32,
+pub struct Extensions {
+    pub http: Option<Arc<HttpExtension>>,               // request / response headers
+    pub security: Option<Arc<SecurityExtension>>,       // subject, client, workload, labels
+    pub request: Option<Arc<RequestExtension>>,         // request-id, trace-id, timing
+    pub agent: Option<Arc<AgentExtension>>,             // session / conversation context
+    pub delegation: Option<Arc<DelegationExtension>>,   // monotonic delegation chain
+    pub raw_credentials: Option<Arc<RawCredentialsExtension>>,  // capability-gated, serde-skipped
+    pub mcp: Option<Arc<MCPExtension>>,                 // MCP entity metadata (Praxis-defined)
 }
 ```
 
-The context grows richer as the lifecycle progresses. Fields `cluster`, `upstream`, and `rewritten_path` are `None` at H1 through H4, populated at H5 and later.
+`SecurityExtension` carries: `subject` (authenticated user), `client` (OAuth client / gateway), `caller_workload` (inbound SPIFFE), `this_workload` (our outbound SPIFFE), and `labels` (monotonic append-only). `AgentExtension` carries session/conversation context (`agent_id`, `parent_agent_id`, `session_id`, `conversation_id`, `turn`) — distinct from security credentials. `DelegationExtension` carries the monotonic delegation chain (`hops`, `depth`, `origin_subject_id`, `actor_subject_id`, `age_seconds`); written by the framework, read-only for plugins. `RawCredentialsExtension` holds inbound tokens and delegated tokens behind per-slot capabilities, with `Zeroizing<String>` storage and `#[serde(skip)]` to prevent leakage into logs or traces. `MCPExtension` is Praxis-defined and carries tool server metadata for hook dispatch.
 
-H9 is the one hook returning a custom vote type:
+Common Praxis capabilities:
+
+| Capability | Grants |
+|---|---|
+| `read_headers` | `HttpExtension.request_headers` (read) |
+| `write_headers` | `HttpExtension.response_headers` (read plus write token) |
+| `read_subject` | `SecurityExtension.subject` (read) |
+| `write_subject` | `SecurityExtension.subject` (write; identity resolvers only) |
+| `read_client` | `SecurityExtension.client` (read) |
+| `write_client` | `SecurityExtension.client` (write; identity resolvers only) |
+| `read_workload` | `SecurityExtension.caller_workload` / `this_workload` (read) |
+| `read_labels` | `SecurityExtension.labels` (read) |
+| `write_labels` | `SecurityExtension.labels` (append-only) |
+| `read_classification` | `SecurityExtension.classification` (read) |
+| `read_agent` | `AgentExtension` (read) |
+| `write_agent` | `AgentExtension` (write) |
+| `read_delegation` | `DelegationExtension` (read; framework writes) |
+| `read_inbound_credentials` | `RawCredentialsExtension.inbound_tokens` (read) |
+| `read_delegated_tokens` | `RawCredentialsExtension.delegated_tokens` (read) |
+
+Header writes go through a copy-on-write token. `OwnedExtensions.http` is `Option<Guarded<HttpExtension>>`. The `Guarded` wrapper enforces write authority at the type level:
 
 ```rust
-pub enum RetryVote { Retry, NoRetry, NoOpinion }
+async fn handle(
+    &self,
+    payload: &CompletedRequest,
+    extensions: &Extensions,
+    _ctx: &mut PluginContext,
+) -> PluginResult<CompletedRequest> {
+    let mut owned = extensions.cow_copy();
+    if let Some(token) = &owned.http_write_token {
+        if let Some(guarded_http) = owned.http.as_mut() {
+            guarded_http.write(token).set_response_header("X-Audit-Plugin", "true");
+        }
+    }
+    PluginResult::modify_extensions(owned)
+}
 ```
 
-The [tighten-only monoid](#74-tighten-only-composition) composes plugin votes with the built-in idempotency check.
+A plugin without `write_headers` sees `http_write_token == None` and silently cannot write. The token is the type-system enforcement of the YAML capability. Plugins do not need to check capabilities at runtime.
 
-### 6.5 Extensions (reserved for v2)
+### 6.3 PluginContext
 
-CPEX supports capability-gated `Extensions` on payloads. Praxis v1 attaches none. v2 candidates include `SecurityLabels` (monotonic set) and a `DelegationChain`. Reserved until a concrete consumer lands.
+Every `HookHandler::handle` call receives `&mut PluginContext`:
 
-## 7. Dispatch Semantics
+```rust
+pub struct PluginContext {
+    pub local_state: HashMap<String, Value>,    // per-plugin, persists across hooks in one request
+    pub global_state: HashMap<String, Value>,   // shared across plugins, scoped to one invoke chain
+}
+```
 
-### 7.1 Phase selection
+The plugin's identity (`Uuid`) is tracked externally in `PluginContextTable`, which indexes each plugin's `local_state` by ID.
 
-For each hook in the [catalog](#5-hook-catalog-lifecycle-hooks) the dispatcher enforces:
+`local_state` is the cross-hook state mechanism. A plugin that registers against both M1 and M2 stashes per-tool data (a timer, a redaction decision) in `local_state` at M1 and reads it at M2. The embedder threads the `PluginContextTable` returned from M1's `PipelineResult` into M2's `invoke_named` call, and CPEX populates each plugin's `local_state` from the table.
 
-1. **Allowed modes.** Plugin YAML `mode:` must match the interaction class. Violations abort startup.
-2. **Default mode.** Omitted `mode:` falls back to the "Default phase" column in the [catalog](#5-hook-catalog-lifecycle-hooks).
-3. **Ordering within a phase.** By ascending `priority:`, then YAML position.
-4. **Phase order.** Canonical CPEX order `sequential → transform → audit → concurrent → fire_and_forget`.
+`global_state` is cross-plugin. An identity-resolving plugin at H4 writes `user_id` to `global_state`; downstream plugins read it.
 
-Interaction-class to allowed-phase mapping:
+### 6.4 Handler signature
+
+```rust
+pub trait HookHandler<H: HookTypeDef>: Plugin + Send + Sync {
+    fn handle(
+        &self,
+        payload: &H::Payload,
+        extensions: &Extensions,
+        ctx: &mut PluginContext,
+    ) -> impl std::future::Future<Output = H::Result> + Send;
+}
+```
+
+Plugin authors write `async fn handle(...) -> PluginResult<P>`. Native AFIT means handlers with no `.await` compile to a ready future with no scheduler interaction. Handlers that need to await (a JWKS refresh, an authz RPC, a dynamic policy lookup) just use `.await` inside the body.
+
+The latency budget reflects two plugin shapes:
+
+| Shape | Per-hook cost |
+|---|---|
+| Sync body (no `.await`) | Single-digit microseconds; equivalent to a direct call. |
+| Async body (with `.await`) | Plus the cost of whatever was awaited, plus one boxed future at the `AnyHookHandler` boundary. |
+
+### 6.5 CMF payloads and the tool hooks
+
+Tool hooks reuse CPEX's `MessagePayload` directly. No new Praxis payload type. The MCP gateway filter constructs a `MessagePayload` whose `Message.content` carries a `ContentPart::ToolCall { tool_call_id, name, arguments, .. }` parsed from the JSON-RPC body.
+
+Plugin authors:
+
+```rust
+manager.register_handler_for_names::<CmfHook, _>(
+    Arc::clone(&plugin),
+    config,
+    &[
+        "praxis.mcp.tool_pre_invoke",
+        "praxis.mcp.tool_post_invoke",
+    ],
+)?;
+```
+
+The gateway filter dispatches:
+
+```rust
+let (result, _bg) = manager.invoke_named::<CmfHook>(
+    "praxis.mcp.tool_pre_invoke",
+    message_payload,
+    extensions,
+    Some(prev_ctx_table),  // None on M1; threaded into M2
+).await;
+```
+
+Identity flows through `SecurityExtension`, so the plugin sees the same subject Praxis sees at H4 and H7. The MCP entity metadata (tool server ID, registry coordinates) flows through `MCPExtension`.
+
+### 6.6 Mode constraints
+
+Plugin YAML `mode:` must match the hook's interaction class; violations abort startup. Omitted `mode:` falls back to the hook's default. Within a phase, plugins run by ascending `priority:`, then YAML position. Phase execution order follows CPEX's [5-phase model](https://contextforge-org.github.io/contextforge-plugins-framework/docs/execution-modes/).
+
+Interaction class to allowed mode:
 
 | Interaction | Allowed `mode:` values |
 |---|---|
@@ -300,294 +439,464 @@ Interaction-class to allowed-phase mapping:
 | mutating | `transform` |
 | policy | `sequential`, `concurrent` |
 
-`concurrent` is offered only where plugin ordering is irrelevant (e.g., parallel audit lookups that all must agree).
+`concurrent` is offered only where plugin ordering is irrelevant (parallel audit lookups that all must agree). Disagreement semantics: deny-wins — if any concurrent policy plugin returns `deny`, the aggregate result is `deny`. The first violation message is preserved as the primary; others are attached to `PipelineResult.errors` for observability. Plugins cannot mutate payload in `concurrent` mode.
 
-### 7.2 Interaction enforcement
+### 6.7 Interaction enforcement
 
 After the CPEX executor returns a `PipelineResult`, the call site applies it per class:
 
-| Class | `allowed` | `denied` | `modified_payload` |
+| Class | `continue_processing` | `is_denied` | `modified_payload` / `modified_extensions` |
 |---|---|---|---|
 | observe | proceed | log at error, proceed | discarded |
-| mutating | proceed | log at error, proceed | replace payload, re-validate via `HookPayloadPolicy` |
-| policy | proceed | abort per [Short-circuit behavior](#76-short-circuit-behavior) | accepted in `sequential` only; `concurrent` cannot mutate |
+| mutating | proceed | log at error, proceed | apply payload replacement; apply extension changes via `WriteToken` merge |
+| policy | proceed | abort per [§6.11](#611-short-circuit-behavior) | applied in `sequential` only; `concurrent` cannot mutate |
 
-A plugin returning a modified payload whose forbidden fields differ fails per its `on_error:` setting.
+### 6.8 Failure modes and timeouts
 
-### 7.3 Failure modes and timeouts
-
-Each plugin has `on_error:` (from CPEX: `fail`, `ignore`, `disable`) and `timeout_ms:` (passed through as `tokio::time::timeout`). Defaults:
+Each plugin has `on_error:` (`fail`, `ignore`, `disable`) and `timeout_ms:` (passed through as `tokio::time::timeout`). Defaults:
 
 | Class | Default `on_error` | Default `timeout_ms` |
 |---|---|---|
 | observe | ignore | 50 |
 | mutating | fail | 20 |
 | policy | fail | 100 |
-| body chunk (H6, H13) | fail | 10 per chunk |
+| tool hooks (M1, M2)* | fail | 100 |
 
-**Synchronous hooks (L1, L4).** These run on the rustls blocking thread and cannot `await`. The dispatcher exposes `dispatch_tls_hook_sync` which:
+*Tool hooks override class defaults; JSON-RPC parsing and payload construction justify the higher budget.
 
-- Rejects non-`native` and non-`wasm` plugin kinds at startup.
-- Runs native plugins on the current thread with a hard deadline (default 2 ms) checked after each plugin.
-- Runs WASM plugins with wasmtime fuel-bounded execution (default 100 000 fuel units, roughly 1 ms on typical workloads).
+`Ignore` and `Disable` failures land in `PipelineResult.errors` as `PluginErrorRecord`. `Fail` failures populate `PipelineResult.violation` and set `continue_processing = false`.
 
-### 7.4 Tighten-only composition
+L1 and L4 are reserved in v1, so the sync-dispatch story is deferred. When promoted, they require a dedicated `dispatch_tls_hook_sync` design.
 
-For every `policy` hook, plugin results compose with the built-in check via a monoid that can only tighten:
+### 6.9 Tighten-only composition
 
-```rust
-pub trait Tighten { fn tighten(self, other: Self) -> Self; }
+The tighten-only guarantee from [§2.1](#2-goals-and-non-goals) is enforced structurally by CPEX: once any plugin in a sequential or concurrent phase returns `PluginResult::deny(...)`, `PipelineResult.continue_processing` is `false` and no subsequent plugin can revert it. Praxis's built-in security invariants ([§9](#9-security-invariants-and-hook-mapping)) run independently of plugins and enforce all 18 boundaries regardless of plugin decisions.
 
-// AllowVote: Continue < Reject. Reject wins.
-// RetryVote: Retry < NoOpinion < NoRetry. NoRetry wins.
-```
+### 6.10 Mutation surface
 
-This is enforced in the dispatcher's reduce step, not per call site. A plugin voting `Continue` never overrides a built-in `Reject`. A plugin voting `Retry` on a non-idempotent request is rejected at startup as a `HookError::BoundaryViolation` and the plugin is disabled.
+Plugins mutate one of:
 
-### 7.5 HookPayloadPolicy
+- **Headers.** Through `Extensions` with `write_headers` capability and `WriteToken`. The executor merges modified extensions back at phase boundaries.
+- **Payload.** Through `PluginResult::modify_payload(p)` in `sequential` or `transform` mode. The call site applies the replacement before forwarding.
 
-CPEX's `HookPayloadPolicy` declares writable fields for `transform` and `sequential` phases. Praxis ships one policy per mutating or policy hook:
+Field-level write restriction beyond full-payload replacement is not enforced in v1. The cost is that a misbehaving plugin can rewrite parts of a payload it should not touch. Mitigations: plugin provenance is the operator's responsibility (the trust model is the same as for built-in code). Future tightening will use type-system enforcement (`Sealed<T>`, `MutabilityTier`) rather than a runtime policy mechanism.
 
-| Hook | Writable | Forbidden |
-|---|---|---|
-| H6 | `chunk` in place | changing `end_of_stream`, exceeding body ceiling |
-| H10 | header insert / remove on `upstream_request` | altering `:path` (owned by `rewritten_path`), reintroducing stripped hop-by-hop headers |
-| H11 | `upstream_response` status and headers, or a rejection | response bodies exceeding write capacity |
-| H12 | response headers | changing status (already committed), reintroducing hop-by-hop |
-| H13 | `chunk` in place | same as H6 |
-
-Violations are treated per the plugin's `on_error:`.
-
-### 7.6 Short-circuit behavior
+### 6.11 Short-circuit behavior
 
 | Hook | What "short-circuit" does |
 |---|---|
 | S1 | `run_server` returns `Err`, non-zero exit before any listener binds. |
-| L1 | `resolve` returns `None`; rustls aborts with `unrecognised_name`. |
-| L4 | Verifier returns `Err(BadCertificate)`; rustls aborts. |
-| T1 through T4 | Connection closes before `forward`; peeked bytes discarded. |
-| H4, H5, H7 | `send_rejection(session, rejection)` emits a response from the plugin violation. |
-| H9 | `err.set_retry(false)`. Built-in idempotency check already handled. |
+| H4, H7 | `send_rejection(session, rejection)` emits a response from the plugin violation. |
+| H9 | `err.set_retry(false)`. Suppresses the retry; built-in idempotency check still applies independently. |
 | H11 | Replace upstream response with the plugin-provided response; downstream sees the sanitized version. |
+| M1 | MCP gateway filter emits a JSON-RPC error response without contacting upstream. |
+| M2 | Response body is replaced with the plugin-provided body before forwarding to the client. |
 
-## 8. Plugin ABI
+## 7. Plugin authoring and loading
 
-### 8.1 Supported hosts
+Two coexisting loading paths. Static loading is the primary v1 path. Dynamic loading is in the spec; it lands as a parallel phase without changing the static-plugin surface.
 
-| Host | CPEX feature | Praxis default | Notes |
-|---|---|---|---|
-| Native (`.so` / `.dylib`) | `cpex-hosts::native` | on | Primary path. Zero marshalling. |
-| WASM (`.wasm`) | `cpex-hosts::wasm` | on | wasmtime sandbox. 20 to 50 µs marshalling per hook. |
-| Python (PyO3) | `cpex-hosts::python` | **off, unsupported** | Incompatible with Praxis latency budget. |
-| Sidecar (UDS gRPC) | future | off | Reserved for async non-policy hooks. |
+### 7.1 Static plugins (primary v1 path)
 
-### 8.2 Plugin declaration
+A static plugin is a Rust crate depending on `cpex-sdk` (or `cpex-core` directly for in-tree plugins). It implements `Plugin` and one or more `HookHandler<H>` impls. It compiles into the Praxis binary as a regular workspace member or external crate dependency.
 
-A Praxis plugin is a crate that depends on `cpex-sdk`, implements one or more `HookHandler<H>` for Praxis hook types, and compiles to `cdylib` (native) or `wasm32-wasip1`. No other formats are supported.
+Registration:
 
-### 8.3 Trust boundary
+```rust
+manager.register_handler::<H, _>(Arc::clone(&plugin), config)?;
+// or, for one plugin handling many CMF hook names:
+manager.register_handler_for_names::<CmfHook, _>(
+    Arc::clone(&plugin),
+    config,
+    &["praxis.mcp.tool_pre_invoke", "praxis.mcp.tool_post_invoke"],
+)?;
+```
 
-All plugins run with Praxis process privileges except the WASM sandbox. Consequences:
+Trust boundary: runs with Praxis process privileges. Plugin provenance is the operator's responsibility. Cross-version compatibility: plugin and Praxis are built from the same workspace lockfile, so Rust ABI instability does not apply.
 
-- Native plugins can crash Praxis, leak memory, or call syscalls. Plugin provenance is the operator's responsibility.
-- WASM plugins cannot escape the sandbox; they can exhaust fuel and time out.
-- No plugin can widen a boundary from [Security Invariants and Hook Mapping](#11-security-invariants-and-hook-mapping). Attempts fail at startup or fire a `BoundaryViolation` at dispatch (see [Tighten-only composition](#74-tighten-only-composition)).
-- `insecure_options` flags are visible to S1 plugins so a policy plugin can reject startup if any flag is set.
+### 7.2 Dynamic plugins (forthcoming, parallel phase)
 
-### 8.4 Load order
+A dynamic plugin is a Rust crate compiled to `cdylib`, loaded at startup via `libloading` (which uses `dlopen` underneath). The plugin exports a registration entry point:
 
-1. Praxis builds the CPEX `PluginManager` and registers all `HookTypeDef`s.
-2. For each plugin in YAML order, select the host from the `kind:` scheme, load the binary, call `Plugin::initialize`.
-3. For each `subscribe:` entry, look up the hook and register the handler with mode, priority, and `on_error`.
-4. Run S1 `config_loaded` across all plugins. Any failure aborts startup.
+```rust
+#[no_mangle]
+pub extern "C" fn praxis_plugin_register(
+    host: &PluginManager,
+) -> Result<(), Box<PluginError>>
+```
 
-### 8.5 Unload
+Inside that function, the plugin constructs its own `TypedHandlerAdapter<H, P>` and registers via `PluginManager::register_raw::<H>(plugin, config, handler)` (CPEX §5.1). The `register_raw` API already exists in cpex-core; the missing piece is the `cpex-hosts::native` loader.
 
-Plugins are released on SIGTERM via `Plugin::shutdown`, bounded by `shutdown_timeout_secs`. Runtime reload is deferred; when added it will follow the cert-reload pattern (`ArcSwap<PluginManager>`).
-
-## 9. Configuration
-
-### 9.1 YAML surface
-
-`praxis.yaml` gains one top-level section, `plugins:`. All existing sections are unchanged. A small example:
+YAML wires dynamic plugins via a `dylib` factory kind:
 
 ```yaml
 plugins:
-  - name: sni-allowlist
-    kind: native:///opt/praxis/plugins/libsniallow.so
-    subscribe:
-      - hook: praxis.tls.client_hello       # L1, synchronous
-        on_error: fail
-        timeout_ms: 2
+  - name: sni-filter
+    kind: dylib
+    hooks: [praxis.tls.client_hello]
     config:
-      allowlist_path: /etc/praxis/sni_allowed.txt
-
-  - name: audit-log
-    kind: wasm:///opt/praxis/plugins/audit.wasm
-    subscribe:
-      - hook: praxis.http.session_logged    # H14
-        mode: fire_and_forget
-    config:
-      sink: https://audit.internal/v1/events
+      path: /opt/praxis/plugins/libsnifilter.so
 ```
 
-A broader configuration spanning multiple hook families is in [Appendix B](#appendix-b-configuration-examples).
+The `dylib` factory is registered by Praxis at startup when the dynamic-loading phase ships. Trust boundary: same as static (process privileges). Cross-version: plugin and host must be built with the same `rustc` and the same `cpex-core` version; the loader rejects mismatched ABIs at startup with a clear error. Panic isolation: every `AnyHookHandler::invoke` is wrapped in `catch_unwind` at the host adapter, same rule the FFI path already follows.
 
-### 9.2 Field semantics
+When dynamic loading ships, no migration is required for static plugins. The registration call shape inside the plugin's entry point is identical to what a static plugin already does.
+
+### 7.3 Future hosts
+
+Out of scope for v1, listed so authors know what to expect:
+
+- **WASM.** Waits on `cpex-hosts::wasm`. Wasmtime sandbox, fuel-bounded execution.
+- **Python.** Not supported in Praxis for latency reasons. CPEX has a PyO3 host; Praxis will not enable it.
+- **Sidecar / UDS gRPC.** Waits on `cpex-hosts::sidecar`. Reserved for async non-policy hooks where 50 to 500 microsecond IPC is acceptable.
+
+Each enters via an additive factory kind. None requires changes to the static-plugin authoring model.
+
+## 8. Configuration
+
+### 8.1 YAML surface
+
+`praxis.yaml` gains one top-level section, `plugins:`. The `routes:` section gains an optional `body_mode:` block (§4.3). All other sections are unchanged. A comprehensive example covering all hook families is in [Appendix B](#appendix-b-configuration-example).
+
+```yaml
+plugins:
+  - name: ext-authz
+    kind: builtin/ext-authz
+    hooks: [praxis.http.pre_upstream_select]
+    mode: sequential
+    priority: 10
+    on_error: fail
+    capabilities: [read_subject, read_headers]
+    config:
+      grpc_url: unix:///var/run/authz.sock
+      cache_ttl_ms: 5000
+
+  - name: mcp-tool-authz
+    kind: builtin/mcp-tool-authz
+    hooks: [praxis.mcp.tool_pre_invoke, praxis.mcp.tool_post_invoke]
+    mode: sequential
+    on_error: fail
+    capabilities: [read_subject, read_labels]
+    config:
+      policy_file: /etc/praxis/mcp-tool-policy.yaml
+
+routes:
+  - path_prefix: /mcp/
+    cluster: mcp-backend
+    body_mode:
+      request:
+        stream_buffer:
+          max_bytes: 65536
+      response:
+        stream_buffer:
+          max_bytes: 262144
+```
+
+### 8.2 Field semantics
 
 | Field | Required | Meaning |
 |---|---|---|
 | `name` | yes | Unique plugin identifier; used in logs and metrics. |
-| `kind` | yes | Scheme-prefixed location: `native://`, `wasm://`, `builtin:<name>`. Selects the host. |
+| `kind` | yes | Factory key; looked up in `PluginFactoryRegistry`. `builtin/<name>` for in-tree plugins, `dylib` for dynamic (when shipped). |
 | `version` | no | Advisory string, logged at startup. |
-| `subscribe[].hook` | yes | Hook name from the [catalog](#5-hook-catalog-lifecycle-hooks). |
-| `subscribe[].mode` | no | CPEX mode; default from the [catalog](#5-hook-catalog-lifecycle-hooks); validated against interaction class. |
-| `subscribe[].priority` | no | Ordering within a phase; default 100. |
-| `subscribe[].on_error` | no | Default per class (see [Failure modes and timeouts](#73-failure-modes-and-timeouts)). |
-| `subscribe[].timeout_ms` | no | Default per class (see [Failure modes and timeouts](#73-failure-modes-and-timeouts)). |
-| `config` | no | Opaque plugin-specific YAML; handed to `Plugin::initialize` as JSON. |
+| `hooks` | yes | One or more hook names from [§5](#5-hook-catalog-v1). |
+| `mode` | no | CPEX mode. Default from the catalog; validated against interaction class. |
+| `priority` | no | Ordering within a phase; default 100. |
+| `on_error` | no | Default per class (see [§6.8](#68-failure-modes-and-timeouts)). |
+| `timeout_ms` | no | Default per class. |
+| `capabilities` | no | Extension capabilities granted to this plugin. |
+| `config` | no | Opaque plugin-specific JSON; handed to `Plugin::initialize`. |
 
-### 9.3 Startup validation
+A plugin that needs different modes per hook registers twice with different `mode:` and the same `name`. CPEX accepts this.
+
+### 8.3 Startup validation
 
 Startup fails when:
 
 - Two plugins share a `name`.
-- A `subscribe[].hook` is not a registered Praxis hook.
-- A `subscribe[].mode` is not allowed for the hook's interaction class.
-- A synchronous hook (L1, L4) subscribes to a plugin whose `kind` is `sidecar://`.
-- WASM host is disabled at compile time and a plugin requests `wasm://`.
-- A plugin's `Plugin::initialize` returns `Err` with `on_error: fail`.
-- Any S1 plugin rejects the config.
+- A `hooks:` entry names a hook that does not exist in the [catalog](#5-hook-catalog-v1).
+- A `hooks:` entry names a reserved hook. The error names the hook and points at the staged-rollout section.
+- A `mode:` is not allowed for the hook's interaction class.
+- A plugin's `Plugin::initialize` returns `Err` and `on_error: fail`.
+- An S1 plugin rejects the config.
+- A dynamic plugin's ABI version does not match the host (when dynamic loading ships).
 
-Unknown fields under a plugin entry are rejected, consistent with Praxis' `deny_unknown_fields` convention elsewhere.
+Unknown fields under a plugin entry are rejected, consistent with Praxis's `deny_unknown_fields` convention.
 
-### 9.4 `insecure_options` interplay
+### 8.4 `insecure_options` interplay
 
-Plugins cannot flip `insecure_options`: they observe config, not mutate it. An S1 plugin can, however, reject startup when any `insecure_*` flag is set. Teams use this to enforce production-hardening policies.
+Plugins observe config, not mutate it. An S1 plugin can reject startup when any `insecure_*` flag is set. The example above uses this to enforce a production-hardening policy.
 
-### 9.5 Environment interpolation
+### 8.5 Environment interpolation
 
-Existing `${ENV_VAR}` resolution in `core/src/config/parse.rs` applies to `plugins[].config`. Secrets should flow through env vars, not YAML literals.
+Praxis does not yet support `${ENV_VAR}` interpolation in YAML config. The hook system requires this for `plugins[].config` secrets. Implementation adds a pre-parse substitution pass to `core/src/config/mod.rs` before `serde_yaml::from_str`, resolving `${VAR}` patterns against `std::env::var`. This ships as part of Phase 1 (foundation). Secrets flow through env vars, not YAML literals.
 
-## 10. Observability
+### 8.6 Observability
 
 Three metric series per plugin-hook pair:
 
 ```
-praxis_hook_invocations_total{plugin, hook, outcome}        continue | reject | error | timeout
-praxis_hook_duration_seconds{plugin, hook}                  histogram
+praxis_hook_invocations_total{plugin, hook, outcome}    continue | denied | error | timeout | soft_error
+praxis_hook_duration_seconds{plugin, hook}              histogram
 praxis_hook_last_error_timestamp_seconds{plugin, hook}
 ```
 
 Aggregate counters:
 
 ```
-praxis_hook_dispatch_cache_hits_total        AtomicBool fast path
-praxis_hook_dispatch_cache_misses_total
-praxis_plugins_loaded_total{host}
+praxis_hook_fast_path_hits_total
+praxis_hook_fast_path_misses_total
+praxis_plugins_loaded_total{kind}
 praxis_plugins_disabled_total{reason}
 ```
 
-Tracing integrates with Praxis' existing `tracing` output: each dispatch emits a `trace!` at invocation and a `debug!` at result, and the request span gains a `plugins.invoked` counter plus a `plugins.rejected_by` attribute populated on policy denial.
+Tracing integrates with Praxis's existing `tracing` output. Each dispatch emits a `trace!` at invocation and a `debug!` at result. The request span gains a `plugins.invoked` counter plus a `plugins.rejected_by` attribute populated on policy denial.
 
-Plugin-owned metrics flow through `PluginContext::metadata` and surface under `praxis_plugin_user_<plugin_name>_<metric_name>`.
+Plugin-owned metrics surface under `praxis_plugin_user_<plugin_name>_<metric_name>` via `PluginContext::metadata`.
 
-## 11. Security Invariants and Hook Mapping
+## 9. Security invariants and hook mapping
 
-### 11.1 Built-in boundary catalogue
+### 9.1 Built-in boundary catalogue
 
-Praxis enforces 18 load-bearing invariants today. The hook system lets plugins strengthen any without silently weakening any. Escape hatches listed; all default off.
+Praxis enforces the following invariants today. The hook system lets plugins strengthen any without silently weakening any. Escape hatches default off.
 
 | # | Boundary | Enforced at | Escape hatch |
 |---|---|---|---|
 | 1 | Refuse UID 0 | `server.rs::check_root_privilege` | `allow_root` |
 | 2 | TLS key perms ≤ 0600 (advisory) | `server.rs::warn_insecure_key_permissions` | (warn) |
-| 3 | Host header present, single-valued | `request_filter/validation.rs` (RFC 9112 §3.2) | — |
-| 4 | Max-Forwards TRACE redaction | same | — |
-| 5 | Request hop-by-hop strip | `handler/hop_by_hop.rs` | — |
-| 6 | Response hop-by-hop strip | same | — |
-| 7 | Via header injection | `handler/via.rs` | — |
-| 8 | Rewritten path validation | `handler/upstream_request.rs` | — |
+| 3 | Host header present, single-valued | `request_filter/validation.rs` (RFC 9112 §3.2) | none |
+| 4 | Max-Forwards TRACE redaction | same | none |
+| 5 | Request hop-by-hop strip | `handler/hop_by_hop.rs` | none |
+| 6 | Response hop-by-hop strip | same | none |
+| 7 | Via header injection | `handler/via.rs` | none |
+| 8 | Rewritten path validation | `handler/upstream_request.rs` | none |
 | 9 | Upstream SNI required for TLS | `handler/upstream_peer.rs::derive_sni` | `allow_tls_without_sni` |
-| 10 | Idempotent-only retries, max 3 | `handler/mod.rs::handle_connect_failure` | — |
+| 10 | Idempotent-only retries, max 3 | `handler/mod.rs::handle_connect_failure` | none |
 | 11 | Body size ceilings | `filter/src/pipeline/mod.rs::apply_body_limits` | `allow_unbounded_body` |
 | 12 | Pipeline ordering validation | `server/src/pipelines.rs::validate_pipeline` | `skip_pipeline_validation` |
 | 13 | Health probe allowlist | `config/validate/cluster/endpoints.rs` | `allow_private_health_checks` |
 | 14 | Admin not on 0.0.0.0 / :: | `config/validate/listener/address.rs` | `allow_public_admin` |
-| 15 | Duplicate SNI cert rejection | `tls/setup/sni.rs::build_sni_resolver` | — |
-| 16 | SNI parser rejects IP literals | `tls/sni.rs` (RFC 6066 §3) | — |
-| 17 | Cert reload fail-safe | `tls/reload.rs::reload` | — |
-| 18 | YAML ingest safety | `config/parse.rs::check_yaml_safety` | — |
+| 15 | Duplicate SNI cert rejection | `tls/setup/sni.rs::build_sni_resolver` | none |
+| 16 | SNI parser rejects IP literals | `tls/sni.rs` (RFC 6066 §3) | none |
+| 17 | Cert reload fail-safe | `tls/reload.rs::reload` | none |
+| 18 | YAML ingest safety | `config/parse.rs::check_yaml_safety` | none |
 
-### 11.2 Hook mapping
+### 9.2 Hook mapping
 
-| # | Boundary | Hook(s) | Direction |
-|---|---|---|---|
-| 1 | Refuse UID 0 | S1 | observe + startup veto |
-| 2 | TLS key perms | S1 | observe + startup veto |
-| 3 | Host validation | H2 | observe (non-bypassable) |
-| 4 | TRACE redaction | H3 | observe |
-| 5 | Request hop-by-hop strip | H10 (post-strip) | observe |
-| 6 | Response hop-by-hop strip | H11, H12 | observe |
-| 7 | Via injection | H10, H12 | observe |
-| 8 | Rewritten path | H10 | observe |
-| 9 | Upstream SNI required | H7 | tighten |
-| 10 | Idempotent-only retries | H9 | tighten (`RetryVote::NoRetry`) |
-| 11 | Body size ceilings | H6, H13 | observe |
-| 12 | Pipeline ordering | S2 | tighten |
-| 13 | Health probe allowlist | S1 | tighten |
-| 14 | Admin not public | S1 | tighten |
-| 15 | Duplicate SNI cert | S2, L2 | observe |
-| 16 | SNI IP literals | L1 | observe |
-| 17 | Cert reload fail-safe | L3 | observe + alert |
-| 18 | YAML ingest safety | S1 | observe |
+| # | Boundary | Hook | Status | Direction |
+|---|---|---|---|---|
+| 1 | Refuse UID 0 | S1 | v1 | observe + startup veto |
+| 2 | TLS key perms | S1 | v1 | observe + startup veto |
+| 3 | Host validation | H4 | v1 | observe (non-bypassable built-in; H4 can add policy) |
+| 4 | TRACE redaction | — | — | built-in only; no hook needed |
+| 5 | Request hop-by-hop strip | H10 (post-strip) | reserved | observe |
+| 6a | Response hop-by-hop strip | H11 | v1 | observe |
+| 6b | Response hop-by-hop strip | H12 | reserved | observe |
+| 7a | Via injection | H10 | reserved | observe |
+| 7b | Via injection | H12 | reserved | observe |
+| 8 | Rewritten path | H10 | reserved | observe |
+| 9 | Upstream SNI required | H7 | v1 | tighten |
+| 10 | Idempotent-only retries | H9 | v1 | tighten (deny suppresses retry) |
+| 11a | Body size ceilings | H6 | reserved | observe |
+| 11b | Body size ceilings | H13 | reserved | observe |
+| 12 | Pipeline ordering | S2 | reserved | tighten |
+| 13 | Health probe allowlist | S1 | v1 | tighten |
+| 14 | Admin not public | S1 | v1 | tighten |
+| 15a | Duplicate SNI cert | S2 | reserved | observe |
+| 15b | Duplicate SNI cert | L2 | reserved | observe |
+| 16 | SNI IP literals | L1 | reserved | observe |
+| 17 | Cert reload fail-safe | L3 | v1 | observe + alert |
+| 18 | YAML ingest safety | S1 | v1 | observe |
 
-Every "tighten" row maps to a specific monoid instance (see [Tighten-only composition](#74-tighten-only-composition)). No code path lets a plugin widen any boundary.
+Reducing the v1 hook surface does not weaken any invariant. Built-in enforcement remains. Observer hooks for the reserved invariants are deferred, not removed.
 
-## 12. Staged Rollout
+## 10. Staged rollout
 
-Each phase is independently shippable.
+Each phase is independently shippable. Phases are ordered by priority to the MCP gateway use case.
 
-**Phase 0, crate skeleton.** `praxis-hooks` crate, CPEX dependency pinned, CI-only. Publishes [Goals and Non-Goals](#2-goals-and-non-goals) types and [Hook Payloads](#6-hook-payloads) sketches.
+**Phase 1, foundation.** `praxis-hooks` crate with `cpex-core` pinned against a git commit. Hook type definitions for the 12 registered names plus the reserved set. `PluginManager` wired into `run_server`. Environment variable interpolation in `plugins:` config. S1 `praxis.startup.config_loaded` registered as the first fail-closed gate. Acceptance: S1 plugin rejects a bad config and aborts startup; `praxis_hook_*` metrics emit; CI green with the new crate.
 
-**Phase 1, startup and TLS observation (S1 through S4, L2, L3).** Wire the dispatcher into `run_server`. Ship `cert_rotation_alert` as the first `builtin:` plugin. Acceptance: rotation events visible end-to-end; startup-rejects-root example plugin passes.
+**Phase 2, MCP tool hooks.** Route-driven body mode (§4.3). MCP gateway filter at `filter/src/builtins/http/mcp/` (§4.4). M1 and M2 registered against `MessagePayload`. `mcp-tool-authz` as the reference plugin. Acceptance: an MCP `tools/call` plugin denial returns a JSON-RPC error to the client without contacting upstream; argument and response redaction work end-to-end; non-`tools/call` MCP methods (`ping`, `initialize`) do not allocate body buffers on the route.
 
-**Phase 2, HTTP observation (H1, H2, H3, H8, H14).** All observer-only, fail-open. Validates dispatcher fast path, metrics, and tracing at production rates. Acceptance: audit-log plugin at 50k RPS with <1% tail-latency impact.
+**Phase 3, lifecycle observers.** S4, L3, H14. `cert-rotation-alert` and `audit-log` as compiled-in plugins. Acceptance: rotation events visible end-to-end; audit-log plugin at 50k RPS with under 1% tail-latency impact.
 
-**Phase 3, TLS policy (L1, L4).** Sync dispatcher variant; fuel-bounded wasmtime for WASM plugins on this path. Ship `sni_allowlist` as reference. Acceptance: 1000-entry allowlist adds <10 µs p99 per handshake.
+**Phase 4, HTTP policy and identity.** H4, H7, H9, H11, I1, I2. Tighten-only `PluginViolation`. Identity hooks (I1, I2) route to CPEX `IdentityResolve` and `TokenDelegate` execution paths; `ext-authz` reference plugin. Acceptance: ext-authz denies within budget; identity resolution seals `SecurityExtension` before pipeline; delegation enforces scope narrowing; a plugin can deny to suppress retry on any request but cannot force a retry on a non-idempotent request (the built-in check applies independently); integration test verifies tighten-only behavior.
 
-**Phase 4, HTTP policy (H4, H5, H7, H9, H11).** Tighten-only monoid and `RetryVote` plumbing. Acceptance: ext-authz plugin denies within budget; integration test verifies a plugin can force `NoRetry` on a GET but not `Retry` on a POST.
+**Phase 5+, future work.** Each item below ships when a concrete consumer warrants it:
 
-**Phase 5, TCP hooks (T1 through T7).** Linear lifecycle, no sync context. Acceptance: T1 IP denylist adds <5 µs per accepted connection.
+- **Reserved hook promotions.** TCP family, body family (H6, H13), sync TLS (L1, L4), mutating HTTP (H10, H12). Each promotion is its own PR with a design note, a consumer plugin, and an integration test.
+- **Dynamic loading.** `dylib` factory backed by `libloading` and `register_raw`. Ships when cpex-core's `register_raw` story stabilizes and `cpex-hosts::native` lands. Static-plugin spec does not change.
+- **Protocol-native service.** `McpProxy` protocol-native service (§4.2). Triggered if Phase 2's filter-layer parsing becomes a bottleneck or abstraction inversion bites in practice. Hook names and plugin code do not change; the dispatch site moves from the gateway filter to the protocol-native service.
+- **Broader protocol-semantic hooks.** A2A task hooks and LLM input/output, gated on demand. Same `MessagePayload` shape, same registration pattern.
 
-**Phase 6, mutating HTTP (H6, H10, H12, H13).** Requires `HookPayloadPolicy` enforcement and body-mode participation in `BodyCapabilities`. Acceptance: DLP plugin at H13 redacts bodies correctly; H10 injects mTLS-derived headers; body ceiling regressions remain green.
+## 11. Open questions
 
-**Phase 7, protocol-native services (optional).** If and when `McpProxy`, `A2aProxy`, or LLM-aware services land, they expose `praxis.mcp.*`, `praxis.a2a.*`, `praxis.llm.*` hook types against the same dispatcher. Not scheduled; driven by demand.
+1. **CPEX version pinning.** cpex-core is unreleased. Pin against a git commit or dev tag until cpex-core ships a tagged release. Preference: pin tightly, refresh deliberately.
 
-**Phase 8, sidecar host (optional).** UDS gRPC to a local sidecar, limited to async non-policy hooks.
+2. **Per-plugin CPU accounting.** Tokio has no cheap per-task accounting. A `sequential` plugin within its timeout but burning CPU stays invisible. Options: process-level quota, push expensive plugins to `fire_and_forget`, require WASM for untrusted plugins when the host ships. Revisit after Phase 2.
 
-## 13. Open Questions
+3. **Body-chunk back-pressure.** When H6 and H13 are promoted, per-chunk deadlines plus a per-request cumulative budget are likely both needed. A slow plugin stalls HTTP/1.1 connections and HTTP/2 streams. Confirm in the H6 / H13 promotion design note.
 
-1. **CPEX version pinning.** CPEX PR #13 is Phase 1a and unreleased. Options: wait for CPEX 0.2 before starting Praxis Phase 0, or vendor the Rust core as a git submodule during Phase 0 and un-vendor on release. Preference: wait.
+4. **JSON-RPC batch requests.** Resolved: tool hooks fire per call within a batch; batch identity (array index, batch request ID) is carried in `PluginContext::local_state`. Per-call denial replaces only that call's response. See §4.4 step 5.
 
-2. **WASM on synchronous hooks.** [Failure modes and timeouts](#73-failure-modes-and-timeouts) allows fuel-bounded WASM on L1 and L4. Keeping handshake paths unambiguously in-process argues for native-only here. Decision deferred; leaning native-only for v1.
+5. **SSE response streaming for M2.** Tool responses may stream via SSE. v1 buffers the response or skips M2 on streaming responses, with the operator's `body_mode:` declaration as the explicit knob. Per-chunk M2 belongs in the protocol-native service.
 
-3. **Body-chunk back-pressure.** H6 and H13 default to 10 ms per chunk. A slow plugin stalls HTTP/1.1 connections and HTTP/2 streams. A per-request cumulative budget (e.g., 50 ms across all chunks) in addition to per-chunk deadlines is likely required. To be confirmed in Phase 6.
+6. **Route-mode interaction with body ceilings.** Route-declared `body_mode:` participates in `apply_body_limits`. Confirm in Phase 2 that an unbounded `StreamBuffer { max_bytes: None }` at the route level interacts cleanly with `allow_unbounded_body`.
 
-4. **Hook-filter ordering.** Filters run between H4 and H5 in the request path, so H5 plugins see post-filter state. H10 and H12 hooks run after filters in their respective directions. Worth a dedicated example in the developer guide.
+7. **ABI compatibility for dynamic loading.** Pin scheme to be decided: lockfile sharing, `=` version requirements, or `abi_stable`. Decision deferred until dynamic loading ships (Phase 5+).
 
-5. **Per-plugin CPU accounting.** Tokio has no cheap per-task accounting. A `sequential` plugin within its timeout but burning CPU stays invisible. Options: process-level quota, push expensive plugins to `fire_and_forget`, require WASM for untrusted plugins (fuel accounts for work). Revisit after Phase 4.
+8. **When does a reserved hook get promoted?** Suggested gate: a written design note, a concrete consumer plugin, and an integration test.
 
-6. **Cross-hook state.** A WAF-style plugin needs shared state between H4 (decision) and H14 (audit). CPEX's `PluginContext::local_state` is per-invocation. A `praxis-hooks::PerRequestState<T>` helper keyed by `request_id` and pruned at H14 likely fills the gap. Design in Phase 4.
+## Appendix A: Full hook catalog and payload sketches
 
-7. **Protocol-semantic hooks design work.** The MCP and A2A protocol-native services described in [How protocol-semantic hooks ship later](#43-how-protocol-semantic-hooks-ship-later) are speculative. A design doc for at least one (probably `McpProxy` first) is a prerequisite for Phase 7 and should be started in parallel with Phase 2, independent of the dispatcher work.
+The complete hook catalog including reserved hooks. The loader rejects subscription to reserved hooks until they are promoted (gate: design note, consumer plugin, integration test).
 
-## Appendix A: Payload type sketches
+### Startup
+
+| ID | Name | Interaction | Default mode | Status | Call site |
+|---|---|---|---|---|---|
+| S1 | `praxis.startup.config_loaded` | policy | sequential | v1 | `server.rs` after `Config::load` |
+| S2 | `praxis.startup.pipelines_built` | policy | sequential | reserved | after `resolve_pipelines` |
+| S3 | `praxis.startup.listeners_bound` | observe | audit | reserved | before `server.run_forever` |
+| S4 | `praxis.startup.shutdown` | observe | audit | v1 | on SIGTERM path |
+
+### TLS
+
+| ID | Name | Interaction | Default mode | Status | Call site |
+|---|---|---|---|---|---|
+| L1 | `praxis.tls.client_hello` | policy | sequential | reserved | `tls/src/setup/sni.rs` (sync) |
+| L2 | `praxis.tls.cert_resolved` | observe | audit | reserved | same, after successful match (sync) |
+| L3 | `praxis.tls.cert_reloaded` | observe | audit | v1 | `tls/src/reload.rs::reload` |
+| L4 | `praxis.tls.mtls_client_cert` | policy | sequential | reserved | rustls `ClientCertVerifier` (sync) |
+
+### TCP (all reserved)
+
+| ID | Name | Interaction | Default mode | Status | Call site |
+|---|---|---|---|---|---|
+| T1 | `praxis.tcp.accept` | policy | sequential | reserved | `protocol/src/tcp/` accept loop |
+| T2 | `praxis.tcp.sni_peeked` | policy | sequential | reserved | after SNI peek |
+| T3 | `praxis.tcp.pre_connect` | policy | sequential | reserved | before upstream connect |
+| T4 | `praxis.tcp.upstream_selected` | observe | audit | reserved | after `build_peer` |
+| T5 | `praxis.tcp.upstream_connected` | observe | audit | reserved | after upstream handshake |
+| T6 | `praxis.tcp.session_end` | observe | fire_and_forget | reserved | on session close |
+| T7 | `praxis.tcp.post_disconnect` | observe | fire_and_forget | reserved | after cleanup |
+
+### HTTP
+
+| ID | Name | Interaction | Default mode | Status | Call site |
+|---|---|---|---|---|---|
+| H4 | `praxis.http.pre_request_pipeline` | policy | sequential | v1 | `request_filter/mod.rs` before pipeline |
+| H5 | `praxis.http.post_request_pipeline` | policy | sequential | reserved | after `run_pipeline` |
+| H6 | `praxis.http.request_body_chunk` | mutating | transform | reserved | `request_body_filter.rs` |
+| H7 | `praxis.http.pre_upstream_select` | policy | sequential | v1 | before `upstream_peer::execute` |
+| H8 | `praxis.http.upstream_selected` | observe | audit | reserved | after `build_peer` |
+| H9 | `praxis.http.upstream_connect_failure` | policy | sequential | v1 | `handle_connect_failure` |
+| H10 | `praxis.http.pre_upstream_request_write` | mutating | transform | reserved | after strip + rewrite + Via |
+| H11 | `praxis.http.upstream_response_header` | policy | sequential | v1 | after hop-by-hop strip |
+| H12 | `praxis.http.post_response_pipeline` | mutating | transform | reserved | after response filters, before Via |
+| H13 | `praxis.http.response_body_chunk` | mutating | transform | reserved | `response_body_filter.rs` |
+| H14 | `praxis.http.session_logged` | observe | fire_and_forget | v1 | after `logging_cleanup` |
+
+### Identity
+
+| ID | Name | Interaction | Default mode | Status | Call site |
+|---|---|---|---|---|---|
+| I1 | `praxis.identity.resolve` | policy | sequential | v1 | `request_filter/mod.rs` at H4, before pipeline |
+| I2 | `praxis.identity.delegate` | mutating | transform | v1 | after route resolution, at H10 site |
+
+### Protocol-semantic
+
+| ID | Name | Interaction | Default mode | Status | Payload |
+|---|---|---|---|---|---|
+| M1 | `praxis.mcp.tool_pre_invoke` | policy | sequential | v1 | `MessagePayload` |
+| M2 | `praxis.mcp.tool_post_invoke` | mutating | transform | v1 | `MessagePayload` |
+
+Reserved protocol-semantic hooks (all use `MessagePayload`):
+
+```
+praxis.mcp.prompt_pre_fetch
+praxis.mcp.prompt_post_fetch
+praxis.mcp.resource_pre_fetch
+praxis.mcp.resource_post_fetch
+praxis.a2a.task_created
+praxis.a2a.task_updated
+praxis.a2a.task_completed
+praxis.llm.input
+praxis.llm.output
+```
+
+### Payload sketches
+
+Payload sketches below use `&'a` borrows to show logical data flow. Concrete implementations use owned types (`Arc<str>`, `Bytes`, cloned headers) to satisfy `PluginPayload: Clone + Send + Sync + 'static`. The borrow notation is for readability; the implementation clones at the call-site boundary.
 
 ```rust
-// Startup
+// --- v1 payloads ---
 
 pub struct ConfigLoadedPayload<'a> { pub config: &'a Config }
+
+pub struct ShutdownPayload { pub deadline: Instant }
+
+pub struct CertReloadedPayload<'a> {
+    pub cert_path: &'a str,
+    pub outcome: Result<CertFingerprint, &'a TlsError>,
+}
+
+pub struct HttpHookCtx<'a> {
+    pub client_addr: Option<IpAddr>,
+    pub client_http_version: http::Version,
+    pub listener: &'a str,
+    pub request_start: Instant,
+    pub request_id: Option<&'a str>,
+    pub cluster: Option<&'a str>,
+    pub upstream: Option<&'a Upstream>,
+    pub rewritten_path: Option<&'a str>,
+    pub retries: u32,
+}
+
+pub struct HttpRequestPipelinePayload<'a> {
+    pub ctx: HttpHookCtx<'a>,
+    pub request: &'a praxis_filter::Request,
+    pub pre_read_body: Option<&'a [Bytes]>,
+}
+
+pub struct UpstreamConnectFailurePayload<'a> {
+    pub ctx: HttpHookCtx<'a>,
+    pub err: &'a pingora_core::Error,
+    pub retry_count: u32,
+    pub is_idempotent: bool,
+}
+
+pub struct UpstreamResponseHeaderPayload<'a> {
+    pub ctx: HttpHookCtx<'a>,
+    pub upstream_response: &'a pingora_http::ResponseHeader,
+}
+
+pub struct SessionLoggedPayload<'a> {
+    pub ctx: HttpHookCtx<'a>,
+    pub status: http::StatusCode,
+    pub request_bytes: u64,
+    pub response_bytes: u64,
+    pub duration: Duration,
+    pub outcome: SessionOutcome,
+}
+
+// Identity hooks route to CPEX IdentityResolve / TokenDelegate framework execution paths.
+// Payloads are defined by cpex-core; Praxis passes them through.
+// IdentityResolve payload: raw credentials + request context → populates SecurityExtension slots.
+// TokenDelegate payload: sealed identity + audience + requested scopes → mints delegated token.
+
+// Tool hooks reuse cpex_core::cmf::MessagePayload directly.
+
+// --- Praxis-defined extensions ---
+
+/// MCP entity metadata for tool hook dispatch (Praxis-defined, not CPEX-defined).
+pub struct MCPExtension {
+    pub tool_server_id: Option<Arc<str>>,
+    pub registry_uri: Option<Arc<str>>,
+    pub protocol_version: Option<Arc<str>>,
+}
+
+// --- Reserved payloads ---
 
 pub struct PipelinesBuiltPayload<'a> {
     pub config: &'a Config,
@@ -596,10 +905,6 @@ pub struct PipelinesBuiltPayload<'a> {
 }
 
 pub struct ListenersBoundPayload<'a> { pub listeners: &'a [ListenerBinding] }
-
-pub struct ShutdownPayload { pub deadline: Instant }
-
-// TLS
 
 pub struct ClientHelloPayload<'a> {
     pub sni: Option<&'a str>,
@@ -611,13 +916,8 @@ pub struct ClientHelloPayload<'a> {
 
 pub struct CertResolvedPayload<'a> {
     pub sni: Option<&'a str>,
-    pub cert_fingerprint: CertFingerprint,    // sha256, 32 bytes
+    pub cert_fingerprint: CertFingerprint,
     pub listener: &'a str,
-}
-
-pub struct CertReloadedPayload<'a> {
-    pub cert_path: &'a str,
-    pub outcome: Result<CertFingerprint, &'a TlsError>,
 }
 
 pub struct MtlsClientCertPayload<'a> {
@@ -625,8 +925,6 @@ pub struct MtlsClientCertPayload<'a> {
     pub sni: Option<&'a str>,
     pub remote_addr: IpAddr,
 }
-
-// TCP
 
 pub struct TcpConnInfo<'a> {
     pub remote_addr: SocketAddr,
@@ -643,18 +941,6 @@ pub struct TcpSniPeekedPayload<'a> {
     pub peeked_bytes: &'a [u8],
 }
 
-pub struct TcpUpstreamCandidatePayload<'a> {
-    pub conn: TcpConnInfo<'a>,
-    pub sni: Option<&'a str>,
-    pub upstream_addr: Option<Cow<'a, str>>,
-}
-
-pub struct TcpUpstreamConnectedPayload<'a> {
-    pub conn: TcpConnInfo<'a>,
-    pub upstream_addr: &'a str,
-    pub upstream_peer: SocketAddr,
-}
-
 pub struct TcpSessionEndPayload<'a> {
     pub conn: TcpConnInfo<'a>,
     pub upstream_addr: Option<&'a str>,
@@ -664,132 +950,29 @@ pub struct TcpSessionEndPayload<'a> {
     pub close_reason: TcpCloseReason,
 }
 
-// HTTP
-
-pub struct HttpHookCtx<'a> {
-    pub client_addr: Option<IpAddr>,
-    pub client_http_version: http::Version,
-    pub listener: &'a str,
-    pub request_start: Instant,
-    pub request_id: Option<&'a str>,
-    pub cluster: Option<&'a str>,
-    pub upstream: Option<&'a Upstream>,
-    pub rewritten_path: Option<&'a str>,
-    pub retries: u32,
-}
-
-pub struct EarlyRequestPayload<'a> {
-    pub ctx: HttpHookCtx<'a>,
-    pub request_header: &'a pingora_http::RequestHeader,
-}
-
-pub struct HttpRequestPipelinePayload<'a> {
-    pub ctx: HttpHookCtx<'a>,
-    pub request: &'a praxis_filter::Request,
-    pub pre_read_body: Option<&'a [Bytes]>,
-}
-
-pub struct UpstreamSelectedPayload<'a> {
-    pub ctx: HttpHookCtx<'a>,
-    pub upstream: &'a Upstream,
-    pub peer: &'a pingora_load_balancing::prelude::HttpPeer,
-}
-
-pub struct UpstreamConnectFailurePayload<'a> {
-    pub ctx: HttpHookCtx<'a>,
-    pub err: &'a pingora_core::Error,
-    pub retry_count: u32,
-    pub is_idempotent: bool,
-}
-pub enum RetryVote { Retry, NoRetry, NoOpinion }
-
 pub struct PreUpstreamRequestWritePayload<'a> {
     pub ctx: HttpHookCtx<'a>,
-    pub upstream_request: &'a mut pingora_http::RequestHeader,
-}
-
-pub struct UpstreamResponseHeaderPayload<'a> {
-    pub ctx: HttpHookCtx<'a>,
-    pub upstream_response: &'a mut pingora_http::ResponseHeader,
-}
-
-pub struct PostResponsePipelinePayload<'a> {
-    pub ctx: HttpHookCtx<'a>,
-    pub response: &'a mut praxis_filter::Response,
+    pub upstream_request: &'a pingora_http::RequestHeader,
 }
 
 pub struct BodyChunkPayload<'a> {
     pub ctx: HttpHookCtx<'a>,
-    pub chunk: Option<&'a mut Bytes>,
+    pub chunk: Option<&'a Bytes>,
     pub end_of_stream: bool,
-}
-
-pub struct SessionLoggedPayload<'a> {
-    pub ctx: HttpHookCtx<'a>,
-    pub status: http::StatusCode,
-    pub request_bytes: u64,
-    pub response_bytes: u64,
-    pub duration: Duration,
-    pub outcome: SessionOutcome,
 }
 ```
 
-## Appendix B: Configuration examples
+## Appendix B: Configuration example
 
-A `plugins:` block covering multiple hook families:
+A `plugins:` block covering all 10 registered hook families, plus the matching `routes:` body-mode declaration:
 
 ```yaml
 plugins:
-  - name: ext-authz
-    kind: native:///opt/praxis/plugins/libextauthz.so
-    version: "1.0.2"
-    subscribe:
-      - hook: praxis.http.pre_upstream_select       # H7
-        mode: sequential
-        priority: 10
-        on_error: fail
-        timeout_ms: 50
-    config:
-      grpc_url: unix:///var/run/authz.sock
-      cache_ttl_ms: 5000
-
-  - name: audit-log
-    kind: wasm:///opt/praxis/plugins/audit.wasm
-    version: "0.3.0"
-    subscribe:
-      - hook: praxis.http.session_logged            # H14
-        mode: fire_and_forget
-        priority: 100
-        on_error: ignore
-        timeout_ms: 200
-      - hook: praxis.tcp.session_end                # T6
-        mode: fire_and_forget
-    config:
-      sink: https://audit.internal/v1/events
-
-  - name: cert-rotation-alert
-    kind: builtin:cert_rotation_alert               # ships in praxis
-    subscribe:
-      - hook: praxis.tls.cert_reloaded              # L3
-        mode: audit
-    config:
-      pagerduty_routing_key: ${PD_KEY}
-
-  - name: sni-allowlist
-    kind: native:///opt/praxis/plugins/libsniallow.so
-    subscribe:
-      - hook: praxis.tls.client_hello               # L1 synchronous
-        mode: sequential
-        on_error: fail
-        timeout_ms: 2
-    config:
-      allowlist_path: /etc/praxis/sni_allowed.txt
-
   - name: prod-hardening
-    kind: builtin:insecure_options_guard
-    subscribe:
-      - hook: praxis.startup.config_loaded          # S1
-        on_error: fail
+    kind: builtin/insecure-options-guard
+    hooks: [praxis.startup.config_loaded]
+    mode: sequential
+    on_error: fail
     config:
       forbid_flags:
         - allow_root
@@ -798,26 +981,85 @@ plugins:
         - skip_pipeline_validation
         - allow_tls_without_sni
         - allow_private_health_checks
+
+  - name: graceful-drain
+    kind: builtin/graceful-drain
+    hooks: [praxis.startup.shutdown]
+    mode: audit
+    on_error: ignore
+    config:
+      drain_timeout_ms: 5000
+
+  - name: cert-rotation-alert
+    kind: builtin/cert-rotation-alert
+    hooks: [praxis.tls.cert_reloaded]
+    mode: audit
+    on_error: ignore
+    config:
+      pagerduty_routing_key: ${PD_KEY}
+
+  - name: ext-authz
+    kind: builtin/ext-authz
+    hooks:
+      - praxis.http.pre_request_pipeline
+      - praxis.http.pre_upstream_select
+    mode: sequential
+    priority: 10
+    on_error: fail
+    capabilities: [read_subject, read_headers]
+    config:
+      grpc_url: unix:///var/run/authz.sock
+      cache_ttl_ms: 5000
+
+  - name: retry-policy
+    kind: builtin/retry-policy
+    hooks: [praxis.http.upstream_connect_failure]
+    mode: sequential
+    on_error: fail
+    config:
+      methods_no_retry: [POST, PUT, PATCH]
+
+  - name: response-policy
+    kind: builtin/response-policy
+    hooks: [praxis.http.upstream_response_header]
+    mode: sequential
+    priority: 50
+    on_error: fail
+    capabilities: [write_headers]
+    config:
+      strip_response_headers: [Server, X-Powered-By]
+
+  - name: audit-log
+    kind: builtin/audit-log
+    hooks: [praxis.http.session_logged]
+    mode: fire_and_forget
+    on_error: ignore
+    config:
+      sink: https://audit.internal/v1/events
+
+  - name: mcp-tool-authz
+    kind: builtin/mcp-tool-authz
+    hooks:
+      - praxis.mcp.tool_pre_invoke
+      - praxis.mcp.tool_post_invoke
+    mode: sequential
+    priority: 20
+    on_error: fail
+    capabilities: [read_subject, read_labels]
+    config:
+      policy_file: /etc/praxis/mcp-tool-policy.yaml
+
+routes:
+  - path_prefix: /mcp/
+    cluster: mcp-backend
+    body_mode:
+      request:
+        stream_buffer:
+          max_bytes: 65536
+      response:
+        stream_buffer:
+          max_bytes: 262144
+
+  - path_prefix: /api/
+    cluster: api-backend
 ```
-
-## Appendix C: Reserved protocol-semantic hook names
-
-These names are reserved but unregistered. They become live hook points when the corresponding protocol-native services (see [How how protocol-semantic hooks ship later](#43-how-protocol-semantic-hooks-ship-later)) land.
-
-```
-praxis.mcp.tool_pre_invoke
-praxis.mcp.tool_post_invoke
-praxis.mcp.prompt_pre_fetch
-praxis.mcp.prompt_post_fetch
-praxis.mcp.resource_pre_fetch
-praxis.mcp.resource_post_fetch
-
-praxis.a2a.task_created
-praxis.a2a.task_updated
-praxis.a2a.task_completed
-
-praxis.llm.input
-praxis.llm.output
-```
-
-Plugins must not `subscribe:` to these names in v1; the loader will reject any subscription to an unregistered hook. Authors designing MCP or A2A plugins today target the HTTP hooks (H4, H7, H10, H11) and re-target to protocol-semantic names once the corresponding service ships.


### PR DESCRIPTION
## Description

A proposal for a second extension surface in Praxis, complementing the existing HttpFilter / TcpFilter surface with typed, lifecycle-anchored hooks backed by the [CPEX](https://github.com/contextforge-org/contextforge-plugins-framework/tree/dev) runtime embedded in-process.

[Specification](https://github.com/araujof/praxis/blob/feat/hook_system/docs/plugins.md)          

Closes: praxis-proxy/ai#180                                                            
                                                                                                                                                                                                                                                                            
## What it adds                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                            
Hooks sit at well-defined points across the server lifecycle: startup, TLS handshake, TCP accept and session, and the HTTP request and response path. Each has a typed payload and a declared interaction class (observe, mutate, or policy), so plugin authors know what  they can touch and the dispatcher knows how to compose results.
                                                                                                                                                                                                                                                                              Plugins run as native shared libraries or WASM modules; Python is excluded because the latency budget does not accommodate it. A plugin call is an in-process function call, not an IPC hop, and a deployment with no plugins configured pays nothing beyond a single atomic check per call site.            
                                                                                                                                                                                                                                                                            
The central structural property is tighten-only composition. Policy hooks can strengthen any of Praxis' built-in security boundaries but never weaken them, and this is enforced by the dispatcher rather than left to plugin discipline.                                                                        

## What it defers                                                                                                                                                                                                                                                            
                                       
Protocol-semantic concerns, such as MCP resource and prompt invocations, A2A tasks, LLM inputs and outputs, are named and reserved but intentionally unregistered. Hot reload, Python, and sidecar hosts for synchronous paths are also out of scope for v1.

@shaneutt There is a design tradeoff discussed for protocol-semantic hooks.
                                                                                                                                                                                                                                                                            
## Operational surface                  
                                         
Configuration is YAML-driven, with per-hook timeouts, error policies, and priorities. Plugins that span multiple hooks, for example deciding at request-time and auditing at session-end, get a typed request-scoped state channel rather than having to smuggle state through headers. Body-handling hooks have cumulative budgets at the chunk, request, and plugin level, and a circuit breaker auto-disables plugins that repeatedly misbehave. Metrics and tracing cover invocations, rejections, short-circuits, and the time the plugin chain contributes to each request.                                                                                                                                                                                                                                        
                                       
## Rollout                                                                                                                                                                                                                                                                   
   
The work is staged so each phase is independently shippable. 

cc: @terylt @imolloy