### PR TITLE
feat: add Prometheus metrics foundation with /metrics admin endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1488,6 +1488,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "metrics"
+version = "0.24.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff56c2e7dce6bd462e3b8919986a617027481b1dcc703175b58cf9dd98a2f071"
+dependencies = [
+ "portable-atomic",
+ "rapidhash",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd7399781913e5393588a8d8c6a2867bf85fb38eaf2502fdce465aad2dc6f034"
+dependencies = [
+ "base64",
+ "indexmap 2.14.0",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8496cc523d1f94c1385dd8f0f0c2c480b2b8aeccb5b7e4485ad6365523ae376"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.15.5",
+ "metrics",
+ "quanta",
+ "rand 0.9.4",
+ "rand_xoshiro",
+ "sketches-ddsketch",
+]
+
+[[package]]
 name = "miette"
 version = "7.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2055,6 +2095,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2146,6 +2192,8 @@ dependencies = [
  "bytes",
  "futures",
  "http",
+ "metrics",
+ "metrics-exporter-prometheus",
  "pingora-core",
  "pingora-http",
  "pingora-proxy",
@@ -2483,6 +2531,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2560,6 +2623,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rapidhash"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -2954,6 +3044,12 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,8 @@ criterion = { version = "0.8.2", features = ["async_tokio"] }
 futures = "0.3.32"
 h2 = "0.4.14"
 http = "1.4.0"
+metrics = "0.24.2"
+metrics-exporter-prometheus = { version = "0.16.2", default-features = false }
 # Pinned to match Pingora's dependency.
 nix = "0.24.3"
 notify = "7.0.0"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -74,15 +74,22 @@ See [hot-reload.yaml] for an example.
 ## Admin
 
 `admin.address` binds a separate HTTP listener that serves
-`/ready` and `/healthy`. `/healthy` returns `200 OK` with
-`{"status":"ok"}` once the server is accepting
-connections (liveness). `/ready` returns per-cluster
-health status with healthy/unhealthy/total counts when
-active health checks are configured; it returns 503
-when any cluster has zero healthy endpoints. Without
-health checks, `/ready` returns `{"status":"ok"}`. Any
-other path returns 404. Useful for orchestrator health
-checks without exposing them on the main listeners.
+`/healthy`, `/ready`, and `/metrics`.
+
+- `/healthy` returns `200 OK` with `{"status":"ok"}`
+  once the server is accepting connections (liveness).
+- `/ready` returns per-cluster health status with
+  healthy/unhealthy/total counts when active health
+  checks are configured; it returns `503 SERVICE UNAVAILABLE` when any
+  cluster has zero healthy endpoints. Without health
+  checks, `/ready` returns `{"status":"ok"}`.
+- `/metrics` returns Prometheus text exposition format
+  with HTTP request metrics (`praxis_http_requests_total`,
+  `praxis_http_request_duration_seconds`).
+
+Any other path returns `404 NOT FOUND`. Useful for orchestrator
+health checks and monitoring without exposing them on
+the main listeners.
 
 ```yaml
 admin:

--- a/examples/configs/operations/admin-interface.yaml
+++ b/examples/configs/operations/admin-interface.yaml
@@ -1,19 +1,21 @@
 # Admin Interface
 #
-# Exposes an admin endpoint for operational health checks
-# and readiness probes. The admin listener is separate from
-# data-plane traffic and serves:
+# Exposes an admin endpoint for operational health checks,
+# readiness probes, and Prometheus metrics. The admin listener
+# is separate from data-plane traffic and serves:
 #
-#   GET /health   liveness probe (always 200)
+#   GET /healthy  liveness probe (always 200)
 #   GET /ready    readiness probe (checks upstream clusters)
+#   GET /metrics  Prometheus text exposition format
 #
 # With `verbose: true`, the /ready response includes
 # per-cluster health detail in the body.
 #
 # Usage:
 #   cargo run -p praxis -- -c examples/configs/operations/admin-interface.yaml
-#   curl http://localhost:9901/health     # liveness
+#   curl http://localhost:9901/healthy    # liveness
 #   curl http://localhost:9901/ready      # readiness (verbose)
+#   curl http://localhost:9901/metrics    # prometheus scrape
 
 admin:
   address: "127.0.0.1:9901"

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -22,6 +22,8 @@ async-trait = { workspace = true }
 bytes = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }
+metrics = { workspace = true }
+metrics-exporter-prometheus = { workspace = true }
 pingora-core = { workspace = true }
 pingora-http = { workspace = true }
 pingora-proxy = { workspace = true }

--- a/protocol/src/http/pingora/context.rs
+++ b/protocol/src/http/pingora/context.rs
@@ -60,6 +60,11 @@ pub struct PingoraRequestCtx {
     /// [`HttpFilterContext`]: praxis_filter::HttpFilterContext
     pub filter_metadata: std::collections::HashMap<String, String>,
 
+    /// Cluster name snapshot retained for metrics emission in the
+    /// `logging()` hook, after `cluster` has been consumed by filter
+    /// context construction.
+    pub metrics_cluster: Option<Arc<str>>,
+
     /// Pre-read body chunks (`StreamBuffer` mode). When `StreamBuffer` is
     /// active, the body is read during `request_filter` (before upstream
     /// selection) so that body-based routing can influence `upstream_peer`.
@@ -258,6 +263,7 @@ impl Default for PingoraRequestCtx {
             cluster: None,
             connection_upgraded: false,
             filter_metadata: std::collections::HashMap::new(),
+            metrics_cluster: None,
             pre_read_body: None,
             request_body_buffer: None,
             request_body_bytes: 0,

--- a/protocol/src/http/pingora/handler/mod.rs
+++ b/protocol/src/http/pingora/handler/mod.rs
@@ -12,7 +12,7 @@ use praxis_filter::{CompressionConfig, FilterPipeline};
 use tokio::sync::Semaphore;
 use tracing::{debug, warn};
 
-use super::context::PingoraRequestCtx;
+use super::{context::PingoraRequestCtx, metrics};
 
 /// Shared hop-by-hop header stripping logic.
 mod hop_by_hop;
@@ -211,6 +211,41 @@ async fn logging_cleanup(pipeline: &FilterPipeline, ctx: &mut PingoraRequestCtx)
     }
 }
 
+/// Emit Prometheus metrics for a completed HTTP request.
+///
+/// No-op when the Prometheus recorder has not been installed.
+fn emit_request_metrics(session: &Session, ctx: &PingoraRequestCtx) {
+    if !metrics::is_recorder_installed() {
+        return;
+    }
+
+    let status_code = session.response_written().map_or(0, |resp| resp.status.as_u16());
+    let status_class = metrics::status_class(status_code);
+
+    let request_method = session.req_header().method.as_str();
+    let raw_method = if request_method.is_empty() {
+        ctx.request_snapshot.as_ref().map_or("UNKNOWN", |r| r.method.as_str())
+    } else {
+        request_method
+    };
+    let method = metrics::method_label(raw_method);
+
+    let cluster = ctx.metrics_cluster.as_ref().map_or_else(
+        || ::metrics::SharedString::const_str("none"),
+        |cluster| ::metrics::SharedString::from(Arc::clone(cluster)),
+    );
+
+    let labels = metrics::RequestMetricLabels {
+        method,
+        status_class,
+        route: "unknown",
+        cluster,
+    };
+
+    let duration_secs = ctx.request_start.elapsed().as_secs_f64();
+    metrics::record_request_metrics(labels, duration_secs);
+}
+
 /// Record a passive health observation for the selected upstream endpoint.
 ///
 /// Called from the `logging` hook on every completed request. Determines
@@ -220,7 +255,8 @@ async fn logging_cleanup(pipeline: &FilterPipeline, ctx: &mut PingoraRequestCtx)
 /// No-op when no upstream was selected, no health registry is available,
 /// or passive checking is not configured for the cluster.
 fn record_passive_health(pipeline: &FilterPipeline, error: Option<&pingora_core::Error>, ctx: &PingoraRequestCtx) {
-    let Some(ref cluster_name) = ctx.cluster else {
+    let cluster_name = ctx.cluster.as_ref().or(ctx.metrics_cluster.as_ref());
+    let Some(cluster_name) = cluster_name else {
         return;
     };
     let Some(idx) = ctx.selected_endpoint_index else {
@@ -516,8 +552,26 @@ mod tests {
     fn passive_health_missing_cluster_is_noop() {
         let (pipeline, mut ctx) = make_passive_scenario(Some(1), Some(1));
         ctx.cluster = None;
+        ctx.metrics_cluster = None;
         let error = make_error();
         record_passive_health(&pipeline, Some(&error), &ctx);
+    }
+
+    #[test]
+    fn passive_health_falls_back_to_metrics_cluster() {
+        let (pipeline, mut ctx) = make_passive_scenario(Some(2), Some(1));
+        ctx.cluster = None;
+        ctx.metrics_cluster = Some(Arc::from("test-cluster"));
+        let error = make_error();
+        record_passive_health(&pipeline, Some(&error), &ctx);
+        record_passive_health(&pipeline, Some(&error), &ctx);
+
+        let registry = pipeline.health_registry().unwrap();
+        let entry = registry.get("test-cluster").unwrap();
+        assert!(
+            !entry.endpoints()[0].is_healthy(),
+            "fallback to metrics_cluster should still record passive health"
+        );
     }
 
     #[test]

--- a/protocol/src/http/pingora/handler/no_body.rs
+++ b/protocol/src/http/pingora/handler/no_body.rs
@@ -18,8 +18,8 @@ use tokio::sync::Semaphore;
 use tracing::{debug, warn};
 
 use super::{
-    adjust_compression, handle_connect_failure, logging_cleanup, record_passive_health, request_filter,
-    response_filter, upstream_peer, upstream_request, via,
+    adjust_compression, emit_request_metrics, handle_connect_failure, logging_cleanup, record_passive_health,
+    request_filter, response_filter, upstream_peer, upstream_request, via,
 };
 use crate::http::pingora::context::PingoraRequestCtx;
 
@@ -172,8 +172,9 @@ impl ProxyHttp for PingoraHttpHandlerNoBody {
         upstream_peer::execute(ctx)
     }
 
-    async fn logging(&self, _session: &mut Session, e: Option<&pingora_core::Error>, ctx: &mut Self::CTX) {
+    async fn logging(&self, session: &mut Session, e: Option<&pingora_core::Error>, ctx: &mut Self::CTX) {
         let pipeline = self.pipeline.load();
+        emit_request_metrics(session, ctx);
         record_passive_health(&pipeline, e, ctx);
         logging_cleanup(&pipeline, ctx).await;
     }

--- a/protocol/src/http/pingora/handler/request_filter/mod.rs
+++ b/protocol/src/http/pingora/handler/request_filter/mod.rs
@@ -161,6 +161,7 @@ async fn run_pipeline(
 
     ctx.request_snapshot = Some(request);
     ctx.filter_metadata = filter_metadata;
+    ctx.metrics_cluster = cluster.clone();
 
     match action {
         Ok(FilterAction::Continue | FilterAction::Release | FilterAction::BodyDone) => {

--- a/protocol/src/http/pingora/handler/with_body.rs
+++ b/protocol/src/http/pingora/handler/with_body.rs
@@ -19,8 +19,8 @@ use tokio::sync::Semaphore;
 use tracing::{debug, warn};
 
 use super::{
-    adjust_compression, handle_connect_failure, logging_cleanup, record_passive_health, request_body_filter,
-    request_filter, response_body_filter, response_filter, upstream_peer, upstream_request, via,
+    adjust_compression, emit_request_metrics, handle_connect_failure, logging_cleanup, record_passive_health,
+    request_body_filter, request_filter, response_body_filter, response_filter, upstream_peer, upstream_request, via,
 };
 use crate::http::pingora::context::PingoraRequestCtx;
 
@@ -217,8 +217,9 @@ impl ProxyHttp for PingoraHttpHandler {
         upstream_peer::execute(ctx)
     }
 
-    async fn logging(&self, _session: &mut Session, e: Option<&pingora_core::Error>, ctx: &mut Self::CTX) {
+    async fn logging(&self, session: &mut Session, e: Option<&pingora_core::Error>, ctx: &mut Self::CTX) {
         let pipeline = self.pipeline.load();
+        emit_request_metrics(session, ctx);
         record_passive_health(&pipeline, e, ctx);
         logging_cleanup(&pipeline, ctx).await;
     }

--- a/protocol/src/http/pingora/health/mod.rs
+++ b/protocol/src/http/pingora/health/mod.rs
@@ -11,4 +11,4 @@ pub mod runner;
 mod service;
 
 pub(in crate::http::pingora) use service::escape_json_string;
-pub use service::{PingoraHealthService, add_health_endpoint_to_pingora_server};
+pub use service::{PingoraHealthService, add_admin_endpoints_to_pingora_server, add_health_endpoint_to_pingora_server};

--- a/protocol/src/http/pingora/health/service.rs
+++ b/protocol/src/http/pingora/health/service.rs
@@ -11,7 +11,7 @@ use pingora_core::{
 use praxis_core::health::HealthRegistry;
 use tracing::info;
 
-use crate::http::pingora::json::json_response;
+use crate::http::pingora::{json::json_response, metrics};
 
 // -----------------------------------------------------------------------------
 // JSON Escaping
@@ -132,29 +132,62 @@ impl PingoraHealthService {
     }
 }
 
-/// Add the health check endpoints to a Pingora server.
+/// Build an HTTP response containing Prometheus text exposition format.
 ///
-/// Binds a [`PingoraHealthService`] to `admin_addr`, exposing `/ready` and `/healthy` endpoints.
+/// Returns 200 with `text/plain; version=0.0.4` content type when the
+/// recorder is installed, or 503 if it has not been initialised.
+#[allow(clippy::expect_used, reason = "valid static response")]
+fn prometheus_response() -> Response<Vec<u8>> {
+    match metrics::render_prometheus() {
+        Some(body) => Response::builder()
+            .status(200)
+            .header("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+            .body(body.into_bytes())
+            .expect("valid prometheus response"),
+        None => Response::builder()
+            .status(503)
+            .header("Content-Type", "text/plain")
+            .body(b"metrics recorder not installed\n".to_vec())
+            .expect("valid error response"),
+    }
+}
+
+/// Add the admin endpoints to a Pingora server.
+///
+/// Installs the global Prometheus metrics recorder and binds a
+/// [`PingoraHealthService`] to `admin_addr`, exposing `/ready`,
+/// `/healthy`, and `/metrics` endpoints.
 /// When `verbose` is `true`, `/ready` includes per-cluster detail.
 ///
 /// ```ignore
 /// use pingora_core::server::Server;
-/// use praxis_protocol::http::pingora::health::add_health_endpoint_to_pingora_server;
+/// use praxis_protocol::http::pingora::health::add_admin_endpoints_to_pingora_server;
 ///
 /// let mut server = Server::new(None).unwrap();
 /// server.bootstrap();
-/// add_health_endpoint_to_pingora_server(&mut server, "127.0.0.1:9090", None, false);
+/// add_admin_endpoints_to_pingora_server(&mut server, "127.0.0.1:9090", None, false);
 /// ```
+pub fn add_admin_endpoints_to_pingora_server(
+    server: &mut Server,
+    admin_addr: &str,
+    registry: Option<HealthRegistry>,
+    verbose: bool,
+) {
+    let _handle = metrics::install_prometheus_recorder();
+    let mut health_service = Service::new("health".to_owned(), PingoraHealthService::new(registry, verbose));
+    health_service.add_tcp(admin_addr);
+    info!(address = %admin_addr, verbose, "admin endpoints enabled (health + metrics)");
+    server.add_service(health_service);
+}
+
+/// Backward-compatible alias for [`add_admin_endpoints_to_pingora_server`].
 pub fn add_health_endpoint_to_pingora_server(
     server: &mut Server,
     admin_addr: &str,
     registry: Option<HealthRegistry>,
     verbose: bool,
 ) {
-    let mut health_service = Service::new("health".to_owned(), PingoraHealthService::new(registry, verbose));
-    health_service.add_tcp(admin_addr);
-    info!(address = %admin_addr, verbose, "health endpoints enabled");
-    server.add_service(health_service);
+    add_admin_endpoints_to_pingora_server(server, admin_addr, registry, verbose);
 }
 
 #[async_trait]
@@ -164,6 +197,7 @@ impl ServeHttp for PingoraHealthService {
 
         match path.as_str() {
             "/healthy" => json_response(200, br#"{"status":"ok"}"#),
+            "/metrics" => prometheus_response(),
             "/ready" => {
                 let (status, body) = self.ready_response();
                 json_response(status, body.as_bytes())
@@ -456,6 +490,25 @@ mod tests {
             escape_json_string("simple"),
             "simple",
             "plain string should pass through"
+        );
+    }
+
+    #[test]
+    fn prometheus_response_returns_200_with_valid_content_type() {
+        metrics::install_prometheus_recorder();
+        ::metrics::counter!("praxis_test_prometheus_response_total").increment(1);
+        let resp = prometheus_response();
+        assert_eq!(resp.status(), 200, "should be 200 when recorder is installed");
+        assert_eq!(
+            resp.headers()["Content-Type"],
+            "text/plain; version=0.0.4; charset=utf-8",
+            "content-type should be Prometheus text format"
+        );
+        let body = std::str::from_utf8(resp.body()).expect("prometheus body should be valid UTF-8");
+        assert!(!body.is_empty(), "prometheus body should not be empty");
+        assert!(
+            body.contains("praxis_test_prometheus_response_total"),
+            "prometheus body should contain recorded test metric: {body}"
         );
     }
 

--- a/protocol/src/http/pingora/metrics.rs
+++ b/protocol/src/http/pingora/metrics.rs
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Prometheus metrics: recorder installation, HTTP request metric recording, and scrape rendering.
+
+use std::sync::OnceLock;
+
+use metrics::{counter, histogram};
+use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
+
+// -----------------------------------------------------------------------------
+// Constants
+// -----------------------------------------------------------------------------
+
+/// Counter for completed HTTP requests.
+const HTTP_REQUESTS_TOTAL: &str = "praxis_http_requests_total";
+
+/// Histogram for HTTP request duration in seconds.
+const HTTP_REQUEST_DURATION_SECONDS: &str = "praxis_http_request_duration_seconds";
+
+// -----------------------------------------------------------------------------
+// Recorder Installation
+// -----------------------------------------------------------------------------
+
+/// Global handle to the Prometheus exporter.
+static PROMETHEUS_HANDLE: OnceLock<PrometheusHandle> = OnceLock::new();
+
+/// Install the global Prometheus metrics recorder.
+///
+/// Must be called exactly once during server startup. Subsequent
+/// calls are no-ops and return the existing handle.
+///
+/// # Panics
+///
+/// Panics if the global recorder cannot be installed (another
+/// recorder was already set by a different subsystem).
+pub fn install_prometheus_recorder() -> &'static PrometheusHandle {
+    #[allow(
+        clippy::expect_used,
+        reason = "recorder installation is a one-time startup operation"
+    )]
+    PROMETHEUS_HANDLE.get_or_init(|| {
+        let builder = PrometheusBuilder::new();
+        builder
+            .install_recorder()
+            .expect("failed to install Prometheus recorder")
+    })
+}
+
+/// Render all collected metrics in Prometheus text exposition format.
+///
+/// Returns `None` if the recorder has not been installed.
+pub fn render_prometheus() -> Option<String> {
+    PROMETHEUS_HANDLE.get().map(PrometheusHandle::render)
+}
+
+/// Returns `true` if the Prometheus recorder has been installed.
+pub(crate) fn is_recorder_installed() -> bool {
+    PROMETHEUS_HANDLE.get().is_some()
+}
+
+// -----------------------------------------------------------------------------
+// Status Class
+// -----------------------------------------------------------------------------
+
+/// Map an HTTP status code to its class label (`"1xx"`, `"2xx"`, etc.).
+///
+/// Returns `"unknown"` for zero (no response written) or codes
+/// outside the 100–599 range.
+///
+/// ```
+/// use praxis_protocol::http::pingora::metrics::status_class;
+///
+/// assert_eq!(status_class(200), "2xx");
+/// assert_eq!(status_class(404), "4xx");
+/// assert_eq!(status_class(0), "unknown");
+/// ```
+pub fn status_class(code: u16) -> &'static str {
+    match code {
+        100..=199 => "1xx",
+        200..=299 => "2xx",
+        300..=399 => "3xx",
+        400..=499 => "4xx",
+        500..=599 => "5xx",
+        _ => "unknown",
+    }
+}
+
+/// Map an HTTP method to a bounded label value.
+///
+/// Returns the method string for the nine standard methods
+/// defined in [RFC 9110]; all others collapse to `"OTHER"`.
+///
+/// ```
+/// use praxis_protocol::http::pingora::metrics::method_label;
+///
+/// assert_eq!(method_label("GET"), "GET");
+/// assert_eq!(method_label("PURGE"), "OTHER");
+/// ```
+///
+/// [RFC 9110]: https://datatracker.ietf.org/doc/html/rfc9110#section-9.1
+pub fn method_label(method: &str) -> &'static str {
+    match method {
+        "GET" => "GET",
+        "POST" => "POST",
+        "PUT" => "PUT",
+        "DELETE" => "DELETE",
+        "PATCH" => "PATCH",
+        "HEAD" => "HEAD",
+        "OPTIONS" => "OPTIONS",
+        "TRACE" => "TRACE",
+        "CONNECT" => "CONNECT",
+        _ => "OTHER",
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Metric Recording
+// -----------------------------------------------------------------------------
+
+/// Labels for a completed HTTP request.
+///
+/// Static labels (`method`, `status_class`, `route`) use `&'static str`
+/// so the metrics facade can intern them without per-request allocation.
+/// Only `cluster` is dynamic.
+pub(crate) struct RequestMetricLabels {
+    /// HTTP method (e.g. `"GET"`).
+    pub method: &'static str,
+    /// Status class (e.g. `"2xx"`).
+    pub status_class: &'static str,
+    /// Route name or `"unknown"`.
+    pub route: &'static str,
+    /// Cluster name or `"none"`.
+    pub cluster: ::metrics::SharedString,
+}
+
+/// Record HTTP request metrics for a completed request.
+pub(crate) fn record_request_metrics(labels: RequestMetricLabels, duration_secs: f64) {
+    let cluster = labels.cluster;
+    counter!(
+        HTTP_REQUESTS_TOTAL,
+        "method" => labels.method,
+        "status_class" => labels.status_class,
+        "route" => labels.route,
+        "cluster" => cluster.clone()
+    )
+    .increment(1);
+    histogram!(
+        HTTP_REQUEST_DURATION_SECONDS,
+        "method" => labels.method,
+        "status_class" => labels.status_class,
+        "route" => labels.route,
+        "cluster" => cluster
+    )
+    .record(duration_secs);
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing, reason = "tests")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn status_class_1xx() {
+        assert_eq!(status_class(100), "1xx", "100 should be 1xx");
+        assert_eq!(status_class(199), "1xx", "199 should be 1xx");
+    }
+
+    #[test]
+    fn status_class_2xx() {
+        assert_eq!(status_class(200), "2xx", "200 should be 2xx");
+        assert_eq!(status_class(204), "2xx", "204 should be 2xx");
+        assert_eq!(status_class(299), "2xx", "299 should be 2xx");
+    }
+
+    #[test]
+    fn status_class_3xx() {
+        assert_eq!(status_class(301), "3xx", "301 should be 3xx");
+        assert_eq!(status_class(399), "3xx", "399 should be 3xx");
+    }
+
+    #[test]
+    fn status_class_4xx() {
+        assert_eq!(status_class(400), "4xx", "400 should be 4xx");
+        assert_eq!(status_class(404), "4xx", "404 should be 4xx");
+        assert_eq!(status_class(499), "4xx", "499 should be 4xx");
+    }
+
+    #[test]
+    fn status_class_5xx() {
+        assert_eq!(status_class(500), "5xx", "500 should be 5xx");
+        assert_eq!(status_class(503), "5xx", "503 should be 5xx");
+        assert_eq!(status_class(599), "5xx", "599 should be 5xx");
+    }
+
+    #[test]
+    fn status_class_zero_is_unknown() {
+        assert_eq!(status_class(0), "unknown", "0 should be unknown");
+    }
+
+    #[test]
+    fn status_class_out_of_range_is_unknown() {
+        assert_eq!(status_class(600), "unknown", "600 should be unknown");
+        assert_eq!(status_class(99), "unknown", "99 should be unknown");
+    }
+
+    #[test]
+    fn method_label_standard_methods() {
+        for m in [
+            "GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS", "TRACE", "CONNECT",
+        ] {
+            assert_eq!(method_label(m), m, "{m} should pass through");
+        }
+    }
+
+    #[test]
+    fn method_label_custom_methods_collapse_to_other() {
+        assert_eq!(method_label("PURGE"), "OTHER", "PURGE should be OTHER");
+        assert_eq!(method_label("FOOBAR"), "OTHER", "FOOBAR should be OTHER");
+        assert_eq!(method_label(""), "OTHER", "empty should be OTHER");
+    }
+}

--- a/protocol/src/http/pingora/mod.rs
+++ b/protocol/src/http/pingora/mod.rs
@@ -24,6 +24,8 @@ pub(crate) mod json;
 pub mod kv;
 /// Listener configuration and TLS setup.
 pub mod listener;
+/// Prometheus metrics: recorder, HTTP request counters, and scrape endpoint.
+pub mod metrics;
 
 // -----------------------------------------------------------------------------
 // PingoraHttp
@@ -59,7 +61,7 @@ impl Protocol for PingoraHttp {
         }
 
         if let Some(admin_addr) = &config.admin.address {
-            health::add_health_endpoint_to_pingora_server(server.server_mut(), admin_addr, None, config.admin.verbose);
+            health::add_admin_endpoints_to_pingora_server(server.server_mut(), admin_addr, None, config.admin.verbose);
         }
 
         Ok(cert_watcher_shutdowns)

--- a/tests/integration/tests/suite/examples/admin_interface.rs
+++ b/tests/integration/tests/suite/examples/admin_interface.rs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Integration tests for the admin-interface example configuration.
+
+use std::collections::HashMap;
+
+use praxis_test_utils::{free_port, http_get, start_backend, start_proxy, wait_for_tcp};
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn admin_interface_config_parses() {
+    let backend_port = free_port();
+    let admin_port = free_port();
+    let config = super::load_example_config(
+        "operations/admin-interface.yaml",
+        free_port(),
+        HashMap::from([("127.0.0.1:3000", backend_port), ("127.0.0.1:9901", admin_port)]),
+    );
+
+    assert_eq!(config.listeners.len(), 1, "expected one listener");
+    assert!(config.admin.address.is_some(), "admin address should be set");
+    assert!(config.admin.verbose, "admin verbose should be true");
+}
+
+#[test]
+fn admin_interface_serves_health_and_metrics() {
+    let backend_port = start_backend("admin-test");
+    let proxy_port = free_port();
+    let admin_port = free_port();
+    let config = super::load_example_config(
+        "operations/admin-interface.yaml",
+        proxy_port,
+        HashMap::from([("127.0.0.1:3000", backend_port), ("127.0.0.1:9901", admin_port)]),
+    );
+
+    let _proxy = start_proxy(&config);
+
+    let admin_addr = format!("127.0.0.1:{admin_port}");
+    let proxy_addr = format!("127.0.0.1:{proxy_port}");
+    wait_for_tcp(&admin_addr);
+    wait_for_tcp(&proxy_addr);
+
+    let (healthy_status, _) = http_get(&admin_addr, "/healthy", None);
+    assert_eq!(healthy_status, 200, "/healthy should return 200");
+
+    let (ready_status, _) = http_get(&admin_addr, "/ready", None);
+    assert_eq!(ready_status, 200, "/ready should return 200");
+
+    let (proxy_status, proxy_body) = http_get(&proxy_addr, "/", None);
+    assert_eq!(proxy_status, 200, "proxy should return 200");
+    assert_eq!(proxy_body, "admin-test", "proxy should forward to backend");
+
+    let (metrics_status, metrics_body) = http_get(&admin_addr, "/metrics", None);
+    assert_eq!(metrics_status, 200, "/metrics should return 200");
+    assert!(
+        metrics_body.contains("praxis_http_requests_total"),
+        "/metrics should contain praxis_http_requests_total: {metrics_body}"
+    );
+    assert!(
+        metrics_body.contains("praxis_http_request_duration_seconds"),
+        "/metrics should contain praxis_http_request_duration_seconds: {metrics_body}"
+    );
+    assert!(
+        metrics_body.contains("method=\"GET\""),
+        "/metrics should contain method=GET label: {metrics_body}"
+    );
+    assert!(
+        metrics_body.contains("status_class=\"2xx\""),
+        "/metrics should contain status_class=2xx label: {metrics_body}"
+    );
+}

--- a/tests/integration/tests/suite/examples/mod.rs
+++ b/tests/integration/tests/suite/examples/mod.rs
@@ -8,6 +8,7 @@ mod test_utils;
 pub use test_utils::load_example_config;
 
 mod access_logging;
+mod admin_interface;
 mod api_key_filter;
 mod basic_reverse_proxy;
 mod canary_routing;

--- a/tests/schema/tests/suite/examples/operations/admin_interface.rs
+++ b/tests/schema/tests/suite/examples/operations/admin_interface.rs
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Admin interface example configuration tests.
+
+use praxis_core::config::Config;
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn admin_interface_parses() {
+    let path = praxis_test_utils::example_config_path("operations/admin-interface.yaml");
+    let config =
+        Config::from_file(std::path::Path::new(&path)).unwrap_or_else(|e| panic!("parse admin-interface: {e}"));
+    assert_eq!(config.listeners.len(), 1, "expected one listener");
+    assert_eq!(config.listeners[0].name, "default", "listener should be named default");
+    assert_eq!(
+        config.admin.address,
+        Some("127.0.0.1:9901".to_owned()),
+        "admin address should be 127.0.0.1:9901"
+    );
+    assert!(config.admin.verbose, "admin verbose should be true");
+    assert_eq!(config.filter_chains.len(), 1, "expected one filter chain");
+}

--- a/tests/schema/tests/suite/examples/operations/mod.rs
+++ b/tests/schema/tests/suite/examples/operations/mod.rs
@@ -3,5 +3,6 @@
 
 //! Operations example configuration tests.
 
+mod admin_interface;
 mod multi_listener;
 mod production_gateway;

--- a/tests/smoke/tests/suite/smoke.rs
+++ b/tests/smoke/tests/suite/smoke.rs
@@ -68,6 +68,21 @@ filter_chains:
 
     assert_eq!(healthy_status, 200, "/healthy must return 200");
     assert_eq!(ready_status, 200, "/ready must return 200");
+
+    let proxy_addr = format!("127.0.0.1:{proxy_port}");
+    wait_for_tcp(&proxy_addr);
+    drop(http_get(&proxy_addr, "/", None));
+
+    let (metrics_status, metrics_body) = http_get(&admin_addr, "/metrics", None);
+    assert_eq!(metrics_status, 200, "/metrics must return 200");
+    assert!(
+        metrics_body.contains("praxis_http_requests_total"),
+        "/metrics must contain praxis_http_requests_total: {metrics_body}"
+    );
+    assert!(
+        metrics_body.contains("praxis_http_request_duration_seconds"),
+        "/metrics must contain praxis_http_request_duration_seconds: {metrics_body}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Trying to keep this not obnoxiously large. Scoping to metrics foundation: `/metrics`, the Prom recorder, and low cardinality HTTP request metrics to make sure cardinality is a first class citizen here. With `/metrics` we can start thinking about token usage, quota, rate-limit, PoCs and how to scale them.

## Summary

  - Add /metrics scrape endpoint to the admin listener alongside /healthy and /ready
  - Install metrics + metrics-exporter-prometheus as workspace dependencies
  - Emit praxis_http_requests_total counter and praxis_http_request_duration_seconds histogram from both HTTP handler logging hooks
  - Labels: method, status_class (2xx/3xx/4xx/5xx), route (placeholder unknown), cluster (from router or none)

## Details

- The metrics module (protocol/src/http/pingora/metrics.rs) installs a global Prometheus recorder via OnceLock when the admin listener is configured. Both with_body and no_body handlers call emit_request_metrics() in their logging() hook, reading the response status from session.response_written() and the cluster name from a metrics_cluster snapshot on PingoraRequestCtx (since cluster is consumed by filter context construction before logging runs).
- Body-byte histograms (request_body_bytes, response_body_bytes) are intentionally excluded — the ctx byte counters are only populated when filter body hooks run, so the no-body handler path would emit misleading zeros. These will be reintroduced with independent transport-level byte counting.
- Added method_label() in metrics.rs that passes through the 9 RFC 9110 standard methods and collapses everything else to "OTHER". The caller in emit_request_metrics now runs the raw method through this function before labeling. Custom methods like PURGE or garbage strings can no longer create unbounded cardinality.

Deferred to follow-up PRs to try and keep this already too large PR reviewable 😬: active request gauge, TCP metrics, upstream metrics, error counters, configurable label sets, path grouping, route name schema changes.

## Cardinality

  I intentionally kept the initial label set conservative to give some time to think about scaling.

  - `status_class` is used instead of raw status codes to avoid creating one series per status.
  - `route` is currently emitted as `unknown` instead of using raw request paths. Raw paths are intentionally avoided because IDs, tenant names, model names, or arbitrary user-controlled path segments can create unbounded series.
  - `cluster` comes from the configured router cluster name, or `none` when no cluster was selected. This assumes clusters remain operator-controlled config values, not per-request dynamic values.
  - `method` is the only request-derived label. It is expected to remain low-cardinality; a follow-up can normalize unknown/custom methods to `OTHER` if needed.

Follow-up work for #8 should keep this rule: metrics labels must come from bounded config or normalized enums, not raw request data. Route naming/path grouping should be added before `route` is populated with anything more specific than `unknown`.

## Test plan

  - Unit tests for status_class() conversion (7 cases covering all classes + edge cases)
  - Unit test for prometheus_response() — verifies 200 status, correct content type, valid UTF-8 body
  - All 224 protocol crate tests pass
  - Clippy clean, cargo +nightly fmt clean
  - Manual: start proxy with admin config, curl localhost:9901/metrics returns Prometheus text format
  - Manual: send requests through proxy, verify praxis_http_requests_total and praxis_http_request_duration_seconds appear with correct labels

Manual validation/demo output: https://gist.github.com/nerdalert/e35609d4b38693fb27ae01e4b9644abd

Refs #8

Ty!