### PR TITLE
fix: replace the Copyright across the repo

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Shane Utt
+Copyright (c) 2026 Praxis Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/benchmarks/microbenchmarks/common.rs
+++ b/benchmarks/microbenchmarks/common.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Shared utility functions for Criterion benchmarks.
 

--- a/benchmarks/microbenchmarks/condition_eval.rs
+++ b/benchmarks/microbenchmarks/condition_eval.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Criterion benchmarks for condition evaluation.
 

--- a/benchmarks/microbenchmarks/config_parsing.rs
+++ b/benchmarks/microbenchmarks/config_parsing.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Criterion benchmarks for YAML config deserialization.
 

--- a/benchmarks/microbenchmarks/filter_pipeline.rs
+++ b/benchmarks/microbenchmarks/filter_pipeline.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Criterion benchmarks for filter pipeline construction and execution.
 

--- a/benchmarks/microbenchmarks/headers.rs
+++ b/benchmarks/microbenchmarks/headers.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Criterion benchmarks for header manipulation filter.
 

--- a/benchmarks/microbenchmarks/load_balancer.rs
+++ b/benchmarks/microbenchmarks/load_balancer.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Criterion benchmarks for load balancer endpoint selection.
 

--- a/benchmarks/microbenchmarks/router_lookup.rs
+++ b/benchmarks/microbenchmarks/router_lookup.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Criterion benchmarks for router path-prefix matching.
 

--- a/benchmarks/src/error.rs
+++ b/benchmarks/src/error.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Error types for benchmark operations.
 

--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 #![deny(unsafe_code)]
 #![deny(unreachable_pub)]

--- a/benchmarks/src/net.rs
+++ b/benchmarks/src/net.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Network utilities for benchmark orchestration.
 

--- a/benchmarks/src/proxy/envoy.rs
+++ b/benchmarks/src/proxy/envoy.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Built-in proxy configuration for Envoy.
 

--- a/benchmarks/src/proxy/haproxy.rs
+++ b/benchmarks/src/proxy/haproxy.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Built-in proxy configuration for `HAProxy`.
 

--- a/benchmarks/src/proxy/mod.rs
+++ b/benchmarks/src/proxy/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Proxy configuration trait and built-in implementations.
 

--- a/benchmarks/src/proxy/nginx.rs
+++ b/benchmarks/src/proxy/nginx.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Built-in proxy configuration for NGINX.
 

--- a/benchmarks/src/proxy/praxis.rs
+++ b/benchmarks/src/proxy/praxis.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Built-in proxy configuration for Praxis.
 

--- a/benchmarks/src/report.rs
+++ b/benchmarks/src/report.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Top-level benchmark report for serialization.
 //!

--- a/benchmarks/src/result.rs
+++ b/benchmarks/src/result.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Benchmark result types and comparison logic.
 

--- a/benchmarks/src/runner.rs
+++ b/benchmarks/src/runner.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Runner orchestration for benchmark execution.
 //!

--- a/benchmarks/src/scenario/mod.rs
+++ b/benchmarks/src/scenario/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Scenario definition and configuration.
 //!

--- a/benchmarks/src/scenario/settings.rs
+++ b/benchmarks/src/scenario/settings.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Serializable scenario settings for benchmark reports.
 

--- a/benchmarks/src/scenario/workload.rs
+++ b/benchmarks/src/scenario/workload.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Traffic pattern definitions for benchmark scenarios.
 

--- a/benchmarks/src/stats.rs
+++ b/benchmarks/src/stats.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Docker container resource metrics collection via `docker stats`.
 

--- a/benchmarks/src/tools/fortio.rs
+++ b/benchmarks/src/tools/fortio.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Fortio HTTP/TCP load generator wrapper.
 //!

--- a/benchmarks/src/tools/mod.rs
+++ b/benchmarks/src/tools/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! External load generator tool wrappers.
 

--- a/benchmarks/src/tools/vegeta.rs
+++ b/benchmarks/src/tools/vegeta.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Vegeta HTTP load generator wrapper.
 //!

--- a/core/src/config/admin.rs
+++ b/core/src/config/admin.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Admin endpoint configuration.
 

--- a/core/src/config/body_limits.rs
+++ b/core/src/config/body_limits.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Body size limit configuration.
 

--- a/core/src/config/bootstrap.rs
+++ b/core/src/config/bootstrap.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Configuration loading with fallback resolution.
 

--- a/core/src/config/branch_chain.rs
+++ b/core/src/config/branch_chain.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Branch chain configuration: conditional branching in filter pipelines.
 

--- a/core/src/config/chain_ref.rs
+++ b/core/src/config/chain_ref.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Chain reference: named or inline chain definition for branch chains.
 

--- a/core/src/config/cluster/endpoint.rs
+++ b/core/src/config/cluster/endpoint.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Upstream endpoint definition with optional weighting.
 

--- a/core/src/config/cluster/health_check.rs
+++ b/core/src/config/cluster/health_check.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Health check configuration for upstream clusters.
 

--- a/core/src/config/cluster/load_balancer_strategy.rs
+++ b/core/src/config/cluster/load_balancer_strategy.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Load-balancing strategy types for upstream clusters.
 

--- a/core/src/config/cluster/mod.rs
+++ b/core/src/config/cluster/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Upstream cluster definitions: endpoints, load-balancing strategies, and timeouts.
 

--- a/core/src/config/condition/mod.rs
+++ b/core/src/config/condition/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Condition predicates that gate filter execution.
 

--- a/core/src/config/condition/request.rs
+++ b/core/src/config/condition/request.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Request-phase condition predicates that gate filter execution.
 

--- a/core/src/config/condition/response.rs
+++ b/core/src/config/condition/response.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Response-phase condition predicates that gate filter execution.
 

--- a/core/src/config/filters.rs
+++ b/core/src/config/filters.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Filter configuration types: named chains and individual filter entries.
 //!

--- a/core/src/config/insecure_options.rs
+++ b/core/src/config/insecure_options.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Consolidated security override flags.
 //!

--- a/core/src/config/listener.rs
+++ b/core/src/config/listener.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Network listener configuration: bind address, protocol, TLS, and filter chains.
 

--- a/core/src/config/mod.rs
+++ b/core/src/config/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! YAML configuration parsing, defaults, and validation.
 

--- a/core/src/config/parse.rs
+++ b/core/src/config/parse.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! YAML input safety checks: size limits and alias expansion guards.
 

--- a/core/src/config/route.rs
+++ b/core/src/config/route.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Shorthand routing rules.
 

--- a/core/src/config/runtime.rs
+++ b/core/src/config/runtime.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Runtime tuning: worker thread count, work-stealing toggle, logging overrides, and upstream CA.
 

--- a/core/src/config/validate/branch_chain.rs
+++ b/core/src/config/validate/branch_chain.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Branch chain validation: name uniqueness, chain references, cycle detection, and nesting depth.
 

--- a/core/src/config/validate/cluster/endpoints.rs
+++ b/core/src/config/validate/cluster/endpoints.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Endpoint count and weight validation for clusters.
 

--- a/core/src/config/validate/cluster/health_check.rs
+++ b/core/src/config/validate/cluster/health_check.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Health check validation: constraints, thresholds, and SSRF prevention.
 

--- a/core/src/config/validate/cluster/mod.rs
+++ b/core/src/config/validate/cluster/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Cluster validation: endpoints, weights, SNI hostnames, timeouts, and health check addresses.
 

--- a/core/src/config/validate/cluster/timeouts.rs
+++ b/core/src/config/validate/cluster/timeouts.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Timeout bounds validation for clusters.
 

--- a/core/src/config/validate/cluster/tls.rs
+++ b/core/src/config/validate/cluster/tls.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! TLS settings and SNI hostname validation for clusters.
 

--- a/core/src/config/validate/filter_chain.rs
+++ b/core/src/config/validate/filter_chain.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Filter chain validation: cardinality, name uniqueness, and listener references.
 

--- a/core/src/config/validate/listener/address.rs
+++ b/core/src/config/validate/listener/address.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Address validation for listeners.
 

--- a/core/src/config/validate/listener/mod.rs
+++ b/core/src/config/validate/listener/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Listener validation rules.
 

--- a/core/src/config/validate/listener/rules.rs
+++ b/core/src/config/validate/listener/rules.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Listener validation: presence, count, protocol constraints, and name uniqueness.
 

--- a/core/src/config/validate/listener/timeouts.rs
+++ b/core/src/config/validate/listener/timeouts.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Timeout and TCP duration validation for listeners.
 

--- a/core/src/config/validate/mod.rs
+++ b/core/src/config/validate/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Configuration validation rules.
 

--- a/core/src/config/validate/rules.rs
+++ b/core/src/config/validate/rules.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Top-level configuration validation orchestration.
 

--- a/core/src/connectivity/connection_options.rs
+++ b/core/src/connectivity/connection_options.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Per-upstream connection tuning (timeouts).
 //!

--- a/core/src/connectivity/mod.rs
+++ b/core/src/connectivity/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Upstream connectivity types used by the filter pipeline and protocol layer.
 

--- a/core/src/connectivity/network.rs
+++ b/core/src/connectivity/network.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Network utilities: CIDR range matching and IP address normalization.
 

--- a/core/src/connectivity/upstream.rs
+++ b/core/src/connectivity/upstream.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Resolved upstream endpoint: address, TLS settings, and connection options.
 

--- a/core/src/errors.rs
+++ b/core/src/errors.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Shared error types for the Praxis workspace.
 //!

--- a/core/src/health.rs
+++ b/core/src/health.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Shared health state types for active health checking.
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 #![deny(unsafe_code)]
 #![deny(unreachable_pub)]

--- a/core/src/logging.rs
+++ b/core/src/logging.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Tracing subscriber setup shared by all Praxis binaries.
 

--- a/core/src/server/mod.rs
+++ b/core/src/server/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Server factory and lifecycle management.
 

--- a/core/src/server/pingora.rs
+++ b/core/src/server/pingora.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Pingora-specific server factory and lifecycle management.
 

--- a/core/src/server/runtime.rs
+++ b/core/src/server/runtime.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Runtime options passed from config into the server factory.
 

--- a/filter/src/actions.rs
+++ b/filter/src/actions.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Filter return types: continue processing or reject with a response.
 

--- a/filter/src/any_filter.rs
+++ b/filter/src/any_filter.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Protocol-tagged filter wrapper for storage in a mixed-protocol pipeline.
 

--- a/filter/src/body/access.rs
+++ b/filter/src/body/access.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Body access declarations for filter pipeline stages.
 

--- a/filter/src/body/buffer.rs
+++ b/filter/src/body/buffer.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Body chunk accumulation and overflow handling.
 

--- a/filter/src/body/builder.rs
+++ b/filter/src/body/builder.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Pre-computed body processing capabilities for filter pipelines.
 

--- a/filter/src/body/mod.rs
+++ b/filter/src/body/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Body access declarations, buffering, and capability computation.
 

--- a/filter/src/body/mode.rs
+++ b/filter/src/body/mode.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Body delivery mode declarations.
 

--- a/filter/src/builtins/http/ai/inference/mod.rs
+++ b/filter/src/builtins/http/ai/inference/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! AI inference proxy filters.
 

--- a/filter/src/builtins/http/ai/inference/model_to_header.rs
+++ b/filter/src/builtins/http/ai/inference/model_to_header.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Model-to-header filter: promotes the "model" JSON body field to a request header for routing.
 

--- a/filter/src/builtins/http/ai/mod.rs
+++ b/filter/src/builtins/http/ai/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! AI filters for HTTP workloads.
 

--- a/filter/src/builtins/http/mod.rs
+++ b/filter/src/builtins/http/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! HTTP protocol filters, organized by category.
 

--- a/filter/src/builtins/http/net.rs
+++ b/filter/src/builtins/http/net.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Shared IP address utilities for HTTP filters.
 

--- a/filter/src/builtins/http/observability/access_log.rs
+++ b/filter/src/builtins/http/observability/access_log.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Structured JSON access log filter with optional sampling.
 use std::{

--- a/filter/src/builtins/http/observability/mod.rs
+++ b/filter/src/builtins/http/observability/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! HTTP observability filters: structured access logs and request correlation IDs.
 

--- a/filter/src/builtins/http/observability/request_id.rs
+++ b/filter/src/builtins/http/observability/request_id.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Request correlation ID filter.
 

--- a/filter/src/builtins/http/payload_processing/compression.rs
+++ b/filter/src/builtins/http/payload_processing/compression.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Response compression filter: enables Pingora's built-in response compression when present in a filter chain.
 

--- a/filter/src/builtins/http/payload_processing/compression_config.rs
+++ b/filter/src/builtins/http/payload_processing/compression_config.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Compression configuration shared between the compression filter and the protocol handler.
 

--- a/filter/src/builtins/http/payload_processing/json_body_field/config.rs
+++ b/filter/src/builtins/http/payload_processing/json_body_field/config.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Deserialized YAML configuration types for the JSON body field filter.
 

--- a/filter/src/builtins/http/payload_processing/json_body_field/extract.rs
+++ b/filter/src/builtins/http/payload_processing/json_body_field/extract.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Field extraction logic and control character validation.
 

--- a/filter/src/builtins/http/payload_processing/json_body_field/mod.rs
+++ b/filter/src/builtins/http/payload_processing/json_body_field/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Extracts top-level JSON fields from the request body and promotes them to request headers.
 

--- a/filter/src/builtins/http/payload_processing/json_body_field/tests.rs
+++ b/filter/src/builtins/http/payload_processing/json_body_field/tests.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Tests for the JSON body field filter.
 

--- a/filter/src/builtins/http/payload_processing/mod.rs
+++ b/filter/src/builtins/http/payload_processing/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! HTTP payload processing filters: compression, JSON body field extraction, etc.
 

--- a/filter/src/builtins/http/security/cors/config.rs
+++ b/filter/src/builtins/http/security/cors/config.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Deserialized YAML configuration types for the CORS filter.
 

--- a/filter/src/builtins/http/security/cors/headers.rs
+++ b/filter/src/builtins/http/security/cors/headers.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Header injection, Vary handling, and Private Network Access (PNA) support.
 

--- a/filter/src/builtins/http/security/cors/mod.rs
+++ b/filter/src/builtins/http/security/cors/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Spec-compliant CORS filter with preflight handling, origin validation,
 //! and credential support per the Fetch Standard.

--- a/filter/src/builtins/http/security/cors/origin.rs
+++ b/filter/src/builtins/http/security/cors/origin.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Origin matching logic and wildcard subdomain support for the CORS filter.
 

--- a/filter/src/builtins/http/security/cors/tests.rs
+++ b/filter/src/builtins/http/security/cors/tests.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Tests for the CORS filter.
 

--- a/filter/src/builtins/http/security/forwarded_headers.rs
+++ b/filter/src/builtins/http/security/forwarded_headers.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! `X-Forwarded-For/Proto/Host` injection filter with trusted-proxy support.
 

--- a/filter/src/builtins/http/security/guardrails/config.rs
+++ b/filter/src/builtins/http/security/guardrails/config.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Deserialized YAML configuration types for the guardrails filter.
 

--- a/filter/src/builtins/http/security/guardrails/filter.rs
+++ b/filter/src/builtins/http/security/guardrails/filter.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! [`GuardrailsFilter`] implementation and `HttpFilter` trait impl.
 

--- a/filter/src/builtins/http/security/guardrails/mod.rs
+++ b/filter/src/builtins/http/security/guardrails/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Rejects requests matching string or regex guardrail rules.
 

--- a/filter/src/builtins/http/security/guardrails/rule.rs
+++ b/filter/src/builtins/http/security/guardrails/rule.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Compiled rule types and config-to-rule parsing.
 

--- a/filter/src/builtins/http/security/guardrails/tests.rs
+++ b/filter/src/builtins/http/security/guardrails/tests.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Tests for the guardrails filter.
 

--- a/filter/src/builtins/http/security/ip_acl.rs
+++ b/filter/src/builtins/http/security/ip_acl.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! IP-based access control filter (allow/deny by address or CIDR range).
 

--- a/filter/src/builtins/http/security/mod.rs
+++ b/filter/src/builtins/http/security/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! HTTP security filters: CORS, IP access control, forwarded-header injection and guardrails.
 

--- a/filter/src/builtins/http/traffic_management/load_balancer/entry.rs
+++ b/filter/src/builtins/http/traffic_management/load_balancer/entry.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Resolved cluster entry: strategy, connection options, and TLS config.
 

--- a/filter/src/builtins/http/traffic_management/load_balancer/mod.rs
+++ b/filter/src/builtins/http/traffic_management/load_balancer/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Load-balancer filter: select an upstream endpoint from the routed cluster.
 

--- a/filter/src/builtins/http/traffic_management/load_balancer/strategy.rs
+++ b/filter/src/builtins/http/traffic_management/load_balancer/strategy.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! HTTP-specific strategy wrapper that extracts the hash key from request context.
 

--- a/filter/src/builtins/http/traffic_management/load_balancer/tests.rs
+++ b/filter/src/builtins/http/traffic_management/load_balancer/tests.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Tests for the load balancer filter.
 

--- a/filter/src/builtins/http/traffic_management/mod.rs
+++ b/filter/src/builtins/http/traffic_management/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! HTTP traffic management filters: routing, load balancing, timeout enforcement, redirects and static responses.
 

--- a/filter/src/builtins/http/traffic_management/rate_limit/config.rs
+++ b/filter/src/builtins/http/traffic_management/rate_limit/config.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Deserialized YAML configuration types for the rate limit filter.
 

--- a/filter/src/builtins/http/traffic_management/rate_limit/limiter.rs
+++ b/filter/src/builtins/http/traffic_management/rate_limit/limiter.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Rate limiting logic: token acquisition, eviction, and header generation.
 

--- a/filter/src/builtins/http/traffic_management/rate_limit/mod.rs
+++ b/filter/src/builtins/http/traffic_management/rate_limit/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Token bucket rate limiter.
 

--- a/filter/src/builtins/http/traffic_management/rate_limit/tests.rs
+++ b/filter/src/builtins/http/traffic_management/rate_limit/tests.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Tests for the rate limit filter.
 

--- a/filter/src/builtins/http/traffic_management/redirect.rs
+++ b/filter/src/builtins/http/traffic_management/redirect.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Redirect filter: returns a 3xx redirect without contacting an upstream.
 

--- a/filter/src/builtins/http/traffic_management/router/config.rs
+++ b/filter/src/builtins/http/traffic_management/router/config.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Deserialized YAML configuration types for the router filter.
 

--- a/filter/src/builtins/http/traffic_management/router/matching.rs
+++ b/filter/src/builtins/http/traffic_management/router/matching.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Path, host, and header matching logic for the router filter.
 

--- a/filter/src/builtins/http/traffic_management/router/mod.rs
+++ b/filter/src/builtins/http/traffic_management/router/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Path-prefix and host-header routing filter.
 

--- a/filter/src/builtins/http/traffic_management/router/tests.rs
+++ b/filter/src/builtins/http/traffic_management/router/tests.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Tests for the router filter.
 

--- a/filter/src/builtins/http/traffic_management/static_response.rs
+++ b/filter/src/builtins/http/traffic_management/static_response.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Static response filter: returns a fixed status, headers, and body without contacting an upstream.
 

--- a/filter/src/builtins/http/traffic_management/timeout.rs
+++ b/filter/src/builtins/http/traffic_management/timeout.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Request timeout filter: returns 504 if the response takes too long.
 

--- a/filter/src/builtins/http/traffic_management/token_bucket.rs
+++ b/filter/src/builtins/http/traffic_management/token_bucket.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Lock-free token bucket for rate limiting.
 

--- a/filter/src/builtins/http/transformation/header/mod.rs
+++ b/filter/src/builtins/http/transformation/header/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Header manipulation filter: add request headers; add, set, or remove response headers.
 

--- a/filter/src/builtins/http/transformation/header/ops.rs
+++ b/filter/src/builtins/http/transformation/header/ops.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Header manipulation operations and config-time validation.
 

--- a/filter/src/builtins/http/transformation/header/tests.rs
+++ b/filter/src/builtins/http/transformation/header/tests.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Tests for the header manipulation filter.
 

--- a/filter/src/builtins/http/transformation/mod.rs
+++ b/filter/src/builtins/http/transformation/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! HTTP transformation filters: header manipulation, path rewriting, and URL rewriting.
 

--- a/filter/src/builtins/http/transformation/path_rewrite/config.rs
+++ b/filter/src/builtins/http/transformation/path_rewrite/config.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Deserialized YAML configuration types for the path rewrite filter.
 

--- a/filter/src/builtins/http/transformation/path_rewrite/mod.rs
+++ b/filter/src/builtins/http/transformation/path_rewrite/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Path rewriting filter: strip prefix, add prefix, or regex replace on request paths.
 

--- a/filter/src/builtins/http/transformation/path_rewrite/ops.rs
+++ b/filter/src/builtins/http/transformation/path_rewrite/ops.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Rewrite operations: `strip_prefix`, `add_prefix`, and regex replace.
 

--- a/filter/src/builtins/http/transformation/path_rewrite/tests.rs
+++ b/filter/src/builtins/http/transformation/path_rewrite/tests.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Tests for the path rewrite filter.
 

--- a/filter/src/builtins/http/transformation/path_sanitize.rs
+++ b/filter/src/builtins/http/transformation/path_sanitize.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Path sanitization utilities shared by rewrite filters.
 

--- a/filter/src/builtins/http/transformation/url_rewrite.rs
+++ b/filter/src/builtins/http/transformation/url_rewrite.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! URL rewrite filter: regex-based path transformation and query string manipulation.
 

--- a/filter/src/builtins/mod.rs
+++ b/filter/src/builtins/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Built-in filter implementations, organized by protocol and category.
 

--- a/filter/src/builtins/tcp/mod.rs
+++ b/filter/src/builtins/tcp/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! TCP protocol filters, organized by category.
 

--- a/filter/src/builtins/tcp/observability/mod.rs
+++ b/filter/src/builtins/tcp/observability/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! TCP observability filters: connection-level access logging.
 

--- a/filter/src/builtins/tcp/observability/tcp_access_log.rs
+++ b/filter/src/builtins/tcp/observability/tcp_access_log.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! TCP connection access log filter.
 

--- a/filter/src/builtins/tcp/traffic_management/mod.rs
+++ b/filter/src/builtins/tcp/traffic_management/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! TCP traffic management filters: SNI-based routing and load balancing.
 

--- a/filter/src/builtins/tcp/traffic_management/sni_router.rs
+++ b/filter/src/builtins/tcp/traffic_management/sni_router.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! SNI-based TCP routing filter.
 //!

--- a/filter/src/builtins/tcp/traffic_management/tcp_load_balancer.rs
+++ b/filter/src/builtins/tcp/traffic_management/tcp_load_balancer.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! TCP load-balancer filter: select an upstream endpoint from a cluster.
 

--- a/filter/src/condition/mod.rs
+++ b/filter/src/condition/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Condition evaluation for gating filter execution on request/response attributes.
 

--- a/filter/src/condition/request.rs
+++ b/filter/src/condition/request.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Request condition evaluation for gating filter execution.
 

--- a/filter/src/condition/response.rs
+++ b/filter/src/condition/response.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Response condition evaluation for gating filter execution.
 

--- a/filter/src/context.rs
+++ b/filter/src/context.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Transport-agnostic HTTP request/response metadata and per-request filter context.
 

--- a/filter/src/factory.rs
+++ b/filter/src/factory.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Filter factory types: closures that construct filters from YAML config.
 

--- a/filter/src/filter.rs
+++ b/filter/src/filter.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! The [`HttpFilter`] trait definition.
 //!

--- a/filter/src/lib.rs
+++ b/filter/src/lib.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 #![deny(unsafe_code)]
 #![deny(unreachable_pub)]

--- a/filter/src/load_balancing/consistent_hash.rs
+++ b/filter/src/load_balancing/consistent_hash.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Consistent-hash endpoint selection for session affinity.
 

--- a/filter/src/load_balancing/endpoint.rs
+++ b/filter/src/load_balancing/endpoint.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Weighted endpoint type and construction from cluster config.
 

--- a/filter/src/load_balancing/least_connections.rs
+++ b/filter/src/load_balancing/least_connections.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Least-connections endpoint selection with in-flight tracking.
 

--- a/filter/src/load_balancing/mod.rs
+++ b/filter/src/load_balancing/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Protocol-agnostic load-balancing strategies and endpoint types.
 

--- a/filter/src/load_balancing/round_robin.rs
+++ b/filter/src/load_balancing/round_robin.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Weighted round-robin endpoint selection via cumulative weight thresholds.
 

--- a/filter/src/load_balancing/strategy.rs
+++ b/filter/src/load_balancing/strategy.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Load-balancing strategy selection and dispatch.
 

--- a/filter/src/pipeline/body.rs
+++ b/filter/src/pipeline/body.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Body capabilities computation for filter pipelines.
 

--- a/filter/src/pipeline/branch.rs
+++ b/filter/src/pipeline/branch.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Branch chain runtime types for pipeline execution.
 

--- a/filter/src/pipeline/build.rs
+++ b/filter/src/pipeline/build.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Pipeline construction and ordering diagnostics.
 

--- a/filter/src/pipeline/build_branch.rs
+++ b/filter/src/pipeline/build_branch.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Branch chain resolution for filter pipeline construction.
 

--- a/filter/src/pipeline/checks.rs
+++ b/filter/src/pipeline/checks.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Ordering validation checks for filter pipelines.
 

--- a/filter/src/pipeline/clusters.rs
+++ b/filter/src/pipeline/clusters.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! YAML cluster name extraction from filter entries.
 

--- a/filter/src/pipeline/evaluate.rs
+++ b/filter/src/pipeline/evaluate.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Branch evaluation and execution for HTTP pipeline.
 

--- a/filter/src/pipeline/filter.rs
+++ b/filter/src/pipeline/filter.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Pipeline filter: a filter with its conditions and branch chains.
 

--- a/filter/src/pipeline/http.rs
+++ b/filter/src/pipeline/http.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! HTTP pipeline execution: request, response, and body filter phases.
 

--- a/filter/src/pipeline/http_utils.rs
+++ b/filter/src/pipeline/http_utils.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Utility functions for HTTP pipeline execution.
 

--- a/filter/src/pipeline/mod.rs
+++ b/filter/src/pipeline/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Filter pipeline: ordered chain of filters executed on each request.
 

--- a/filter/src/pipeline/tcp.rs
+++ b/filter/src/pipeline/tcp.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! TCP pipeline execution: connect and disconnect filter phases.
 

--- a/filter/src/pipeline/tests.rs
+++ b/filter/src/pipeline/tests.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Tests for pipeline construction, body capabilities, execution, and ordering warnings.
 

--- a/filter/src/registry.rs
+++ b/filter/src/registry.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Filter registry: maps filter type names to their factory functions.
 

--- a/filter/src/results.rs
+++ b/filter/src/results.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Filter result feedback for branch chain evaluation.
 

--- a/filter/src/tcp_filter.rs
+++ b/filter/src/tcp_filter.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! The [`TcpFilter`] trait and per-connection [`TcpFilterContext`].
 

--- a/protocol/src/http/mod.rs
+++ b/protocol/src/http/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! HTTP protocol implementation.
 

--- a/protocol/src/http/pingora/context.rs
+++ b/protocol/src/http/pingora/context.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Per-request context that carries filter pipeline results through Pingora's request/response lifecycle hooks.
 

--- a/protocol/src/http/pingora/convert.rs
+++ b/protocol/src/http/pingora/convert.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Conversions between Pingora types and Praxis transport-agnostic types.
 

--- a/protocol/src/http/pingora/handler/hop_by_hop.rs
+++ b/protocol/src/http/pingora/handler/hop_by_hop.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Shared hop-by-hop header stripping logic ([RFC 9110]).
 //!

--- a/protocol/src/http/pingora/handler/mod.rs
+++ b/protocol/src/http/pingora/handler/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Pingora `ProxyHttp` implementation: the main HTTP reverse-proxy handler.
 

--- a/protocol/src/http/pingora/handler/no_body.rs
+++ b/protocol/src/http/pingora/handler/no_body.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Pingora HTTP handler that skips body filter hooks for zero-overhead forwarding.
 

--- a/protocol/src/http/pingora/handler/normalize.rs
+++ b/protocol/src/http/pingora/handler/normalize.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Request header normalization per [RFC 9110] and [RFC 9112].
 //!

--- a/protocol/src/http/pingora/handler/request_body_filter.rs
+++ b/protocol/src/http/pingora/handler/request_body_filter.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Request body filter: buffers or streams body chunks through the pipeline, enforcing size limits.
 

--- a/protocol/src/http/pingora/handler/request_filter/mod.rs
+++ b/protocol/src/http/pingora/handler/request_filter/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Request-phase filter execution.
 

--- a/protocol/src/http/pingora/handler/request_filter/stream_buffer.rs
+++ b/protocol/src/http/pingora/handler/request_filter/stream_buffer.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! StreamBuffer pre-read logic and TRACE response construction.
 

--- a/protocol/src/http/pingora/handler/request_filter/validation.rs
+++ b/protocol/src/http/pingora/handler/request_filter/validation.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Host header validation and Max-Forwards handling per [RFC 9110]/[RFC 9112].
 //!

--- a/protocol/src/http/pingora/handler/response_body_filter.rs
+++ b/protocol/src/http/pingora/handler/response_body_filter.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Response body filter execution.
 

--- a/protocol/src/http/pingora/handler/response_filter.rs
+++ b/protocol/src/http/pingora/handler/response_filter.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Response-phase filter execution: runs the pipeline on upstream response headers and syncs modifications.
 

--- a/protocol/src/http/pingora/handler/upstream_peer.rs
+++ b/protocol/src/http/pingora/handler/upstream_peer.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Upstream peer selection: converts the filter pipeline's [`Upstream`] into a Pingora `HttpPeer`.
 //!

--- a/protocol/src/http/pingora/handler/upstream_request.rs
+++ b/protocol/src/http/pingora/handler/upstream_request.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Upstream request transformations: hop-by-hop header stripping
 //! and path rewriting ([RFC 9110]).

--- a/protocol/src/http/pingora/handler/upstream_response.rs
+++ b/protocol/src/http/pingora/handler/upstream_response.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Hop-by-hop header stripping on upstream responses ([RFC 9110]).
 //!

--- a/protocol/src/http/pingora/handler/via.rs
+++ b/protocol/src/http/pingora/handler/via.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Via header injection per [RFC 9110 Section 7.6.3].
 //!

--- a/protocol/src/http/pingora/handler/with_body.rs
+++ b/protocol/src/http/pingora/handler/with_body.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Pingora HTTP handler with body filter hooks enabled.
 

--- a/protocol/src/http/pingora/health/mod.rs
+++ b/protocol/src/http/pingora/health/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Health check infrastructure: admin endpoints, probes, and background runner.
 

--- a/protocol/src/http/pingora/health/probe.rs
+++ b/protocol/src/http/pingora/health/probe.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Health check probe functions for HTTP, HTTP/2, and TCP endpoints.
 

--- a/protocol/src/http/pingora/health/runner.rs
+++ b/protocol/src/http/pingora/health/runner.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Background health check runner that probes endpoints on a timer.
 

--- a/protocol/src/http/pingora/health/service.rs
+++ b/protocol/src/http/pingora/health/service.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Admin health-check HTTP service.
 

--- a/protocol/src/http/pingora/json.rs
+++ b/protocol/src/http/pingora/json.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Utility for building JSON HTTP responses.
 

--- a/protocol/src/http/pingora/listener.rs
+++ b/protocol/src/http/pingora/listener.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Adds TCP or TLS listeners to a Pingora HTTP proxy service.
 

--- a/protocol/src/http/pingora/mod.rs
+++ b/protocol/src/http/pingora/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Pingora HTTP integration: handler, listener setup, health endpoints.
 

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 #![deny(unsafe_code)]
 #![deny(unreachable_pub)]

--- a/protocol/src/pipelines.rs
+++ b/protocol/src/pipelines.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Maps listener names to their resolved [`FilterPipeline`].
 //!

--- a/protocol/src/tcp/mod.rs
+++ b/protocol/src/tcp/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Raw TCP/L4 bidirectional forwarding protocol.
 

--- a/protocol/src/tcp/proxy.rs
+++ b/protocol/src/tcp/proxy.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Pingora-backed bidirectional TCP proxy application.
 

--- a/protocol/src/tcp/tls_setup.rs
+++ b/protocol/src/tcp/tls_setup.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! TLS configuration and listener grouping utilities for TCP protocol.
 

--- a/protocol/src/tls_setup.rs
+++ b/protocol/src/tls_setup.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Shared TLS settings builder for HTTP and TCP listeners.
 

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 #![deny(unsafe_code)]
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 #![deny(unsafe_code)]
 

--- a/server/src/pipelines.rs
+++ b/server/src/pipelines.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Filter pipeline resolution for server listeners.
 

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Server bootstrap: protocol registration and startup.
 

--- a/tests/conformance/tests/suite/chunked.rs
+++ b/tests/conformance/tests/suite/chunked.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Chunked transfer encoding conformance tests.
 

--- a/tests/conformance/tests/suite/cors.rs
+++ b/tests/conformance/tests/suite/cors.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Fetch Standard CORS conformance tests.
 //!

--- a/tests/conformance/tests/suite/h2spec.rs
+++ b/tests/conformance/tests/suite/h2spec.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! HTTP/2 conformance tests via [h2spec]. Runs all h2spec tests in strict mode.
 //!

--- a/tests/conformance/tests/suite/http.rs
+++ b/tests/conformance/tests/suite/http.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! HTTP conformance tests.
 

--- a/tests/conformance/tests/suite/ipv6.rs
+++ b/tests/conformance/tests/suite/ipv6.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! IPv6 conformance tests.
 

--- a/tests/conformance/tests/suite/main.rs
+++ b/tests/conformance/tests/suite/main.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! HTTP conformance test suite for Praxis.
 

--- a/tests/conformance/tests/suite/rfcs/mod.rs
+++ b/tests/conformance/tests/suite/rfcs/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! RFC conformance tests.
 //!

--- a/tests/conformance/tests/suite/rfcs/rfc6265.rs
+++ b/tests/conformance/tests/suite/rfcs/rfc6265.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! [RFC 6265] HTTP State Management (Cookie) conformance tests.
 //!

--- a/tests/conformance/tests/suite/rfcs/rfc7239.rs
+++ b/tests/conformance/tests/suite/rfcs/rfc7239.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! [RFC 7239] Forwarded Header conformance tests.
 //!

--- a/tests/conformance/tests/suite/rfcs/rfc9110.rs
+++ b/tests/conformance/tests/suite/rfcs/rfc9110.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! [RFC 9110] HTTP Semantics conformance tests.
 //!

--- a/tests/conformance/tests/suite/rfcs/rfc9112.rs
+++ b/tests/conformance/tests/suite/rfcs/rfc9112.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! [RFC 9112] HTTP/1.1 conformance tests.
 //!

--- a/tests/conformance/tests/suite/rfcs/rfc9113.rs
+++ b/tests/conformance/tests/suite/rfcs/rfc9113.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! [RFC 9113] HTTP/2 conformance tests.
 //!

--- a/tests/conformance/tests/suite/rfcs/test_utils.rs
+++ b/tests/conformance/tests/suite/rfcs/test_utils.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Shared test utilities for RFC conformance tests.
 

--- a/tests/conformance/tests/suite/tls.rs
+++ b/tests/conformance/tests/suite/tls.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! TLS conformance tests.
 //!

--- a/tests/integration/tests/suite/adversarial/header_smuggling.rs
+++ b/tests/integration/tests/suite/adversarial/header_smuggling.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Adversarial tests for header-based smuggling and
 //! injection attack vectors.

--- a/tests/integration/tests/suite/adversarial/host_header.rs
+++ b/tests/integration/tests/suite/adversarial/host_header.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Adversarial tests for Host header attack vectors.
 

--- a/tests/integration/tests/suite/adversarial/ipv6_bypass.rs
+++ b/tests/integration/tests/suite/adversarial/ipv6_bypass.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Adversarial tests verifying IPv4-mapped IPv6 addresses
 //! cannot bypass IP ACL rules.

--- a/tests/integration/tests/suite/adversarial/mod.rs
+++ b/tests/integration/tests/suite/adversarial/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Adversarial security test scenarios.
 

--- a/tests/integration/tests/suite/adversarial/path_traversal.rs
+++ b/tests/integration/tests/suite/adversarial/path_traversal.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Adversarial tests for path traversal attack vectors.
 

--- a/tests/integration/tests/suite/adversarial/rate_limit_bypass.rs
+++ b/tests/integration/tests/suite/adversarial/rate_limit_bypass.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Adversarial tests verifying rate limit bypass attempts
 //! via spoofed headers.

--- a/tests/integration/tests/suite/body.rs
+++ b/tests/integration/tests/suite/body.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Tests for request and response body filtering.
 

--- a/tests/integration/tests/suite/body_pipeline.rs
+++ b/tests/integration/tests/suite/body_pipeline.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Integration tests for multi-filter body pipelines exercising Stream, Buffer, and StreamBuffer modes.
 

--- a/tests/integration/tests/suite/compression.rs
+++ b/tests/integration/tests/suite/compression.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Integration tests for the `compression` filter.
 

--- a/tests/integration/tests/suite/conditions.rs
+++ b/tests/integration/tests/suite/conditions.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 use praxis_core::config::Config;
 use praxis_test_utils::{

--- a/tests/integration/tests/suite/cors.rs
+++ b/tests/integration/tests/suite/cors.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Integration tests for the `cors` filter.
 

--- a/tests/integration/tests/suite/downstream_read_timeout.rs
+++ b/tests/integration/tests/suite/downstream_read_timeout.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Integration tests for per-listener downstream read timeout.
 

--- a/tests/integration/tests/suite/examples/access_logging.rs
+++ b/tests/integration/tests/suite/examples/access_logging.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Tests for the access logging example configuration.
 

--- a/tests/integration/tests/suite/examples/api_key_filter.rs
+++ b/tests/integration/tests/suite/examples/api_key_filter.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Tests for the API key filter example configuration.
 

--- a/tests/integration/tests/suite/examples/basic_reverse_proxy.rs
+++ b/tests/integration/tests/suite/examples/basic_reverse_proxy.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Tests for the basic reverse proxy example configuration.
 

--- a/tests/integration/tests/suite/examples/canary_routing.rs
+++ b/tests/integration/tests/suite/examples/canary_routing.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Tests for the canary routing example configuration.
 

--- a/tests/integration/tests/suite/examples/conditional_filters.rs
+++ b/tests/integration/tests/suite/examples/conditional_filters.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Tests for the conditional filters example configuration.
 

--- a/tests/integration/tests/suite/examples/default_config.rs
+++ b/tests/integration/tests/suite/examples/default_config.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Tests for the default example configuration.
 

--- a/tests/integration/tests/suite/examples/header_manipulation.rs
+++ b/tests/integration/tests/suite/examples/header_manipulation.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Tests for header manipulation behavior.
 

--- a/tests/integration/tests/suite/examples/health_checks.rs
+++ b/tests/integration/tests/suite/examples/health_checks.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Tests for health check behavior.
 

--- a/tests/integration/tests/suite/examples/least_connections.rs
+++ b/tests/integration/tests/suite/examples/least_connections.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Tests for least-connections load balancing behavior.
 

--- a/tests/integration/tests/suite/examples/logging.rs
+++ b/tests/integration/tests/suite/examples/logging.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Tests for logging behavior.
 

--- a/tests/integration/tests/suite/examples/max_body_guard.rs
+++ b/tests/integration/tests/suite/examples/max_body_guard.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Tests for max body guard filter behavior.
 

--- a/tests/integration/tests/suite/examples/max_connections.rs
+++ b/tests/integration/tests/suite/examples/max_connections.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Tests for max connections limiting behavior.
 

--- a/tests/integration/tests/suite/examples/mod.rs
+++ b/tests/integration/tests/suite/examples/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Integration tests for example configurations.
 

--- a/tests/integration/tests/suite/examples/model_to_header.rs
+++ b/tests/integration/tests/suite/examples/model_to_header.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Tests for model-to-header filter behavior.
 

--- a/tests/integration/tests/suite/examples/multi_listener.rs
+++ b/tests/integration/tests/suite/examples/multi_listener.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Tests for multi-listener behavior.
 

--- a/tests/integration/tests/suite/examples/path_based_routing.rs
+++ b/tests/integration/tests/suite/examples/path_based_routing.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Tests for path-based routing behavior.
 

--- a/tests/integration/tests/suite/examples/path_rewriting.rs
+++ b/tests/integration/tests/suite/examples/path_rewriting.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Tests for the path rewriting example configuration.
 

--- a/tests/integration/tests/suite/examples/payload_processing.rs
+++ b/tests/integration/tests/suite/examples/payload_processing.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Integration tests for payload-processing example configurations.
 

--- a/tests/integration/tests/suite/examples/protocols.rs
+++ b/tests/integration/tests/suite/examples/protocols.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Functional integration tests for TCP protocol example configurations.
 

--- a/tests/integration/tests/suite/examples/redirect.rs
+++ b/tests/integration/tests/suite/examples/redirect.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Tests for redirect filter behavior.
 

--- a/tests/integration/tests/suite/examples/round_robin.rs
+++ b/tests/integration/tests/suite/examples/round_robin.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Tests for round-robin load balancing behavior.
 

--- a/tests/integration/tests/suite/examples/session_affinity.rs
+++ b/tests/integration/tests/suite/examples/session_affinity.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Tests for session affinity behavior.
 

--- a/tests/integration/tests/suite/examples/static_response.rs
+++ b/tests/integration/tests/suite/examples/static_response.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Tests for static response filter behavior.
 

--- a/tests/integration/tests/suite/examples/stream_buffer.rs
+++ b/tests/integration/tests/suite/examples/stream_buffer.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Tests for stream buffer behavior.
 

--- a/tests/integration/tests/suite/examples/test_utils.rs
+++ b/tests/integration/tests/suite/examples/test_utils.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Re-export shared example config utilities.
 

--- a/tests/integration/tests/suite/examples/timeout.rs
+++ b/tests/integration/tests/suite/examples/timeout.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Tests for timeout filter behavior.
 

--- a/tests/integration/tests/suite/examples/virtual_hosts.rs
+++ b/tests/integration/tests/suite/examples/virtual_hosts.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Tests for virtual host behavior.
 

--- a/tests/integration/tests/suite/examples/websocket.rs
+++ b/tests/integration/tests/suite/examples/websocket.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Tests for the `WebSocket` proxy example configuration.
 

--- a/tests/integration/tests/suite/examples/weighted_load_balancing.rs
+++ b/tests/integration/tests/suite/examples/weighted_load_balancing.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Tests for weighted load balancing behavior.
 

--- a/tests/integration/tests/suite/filter_composition.rs
+++ b/tests/integration/tests/suite/filter_composition.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Integration tests for filter execution ordering and composition.
 

--- a/tests/integration/tests/suite/guardrails.rs
+++ b/tests/integration/tests/suite/guardrails.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Integration tests for the `guardrails` filter.
 

--- a/tests/integration/tests/suite/health_check.rs
+++ b/tests/integration/tests/suite/health_check.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Integration tests for active health checks.
 

--- a/tests/integration/tests/suite/ip_acl.rs
+++ b/tests/integration/tests/suite/ip_acl.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Integration tests for the `ip_acl` filter.
 

--- a/tests/integration/tests/suite/json_body_field.rs
+++ b/tests/integration/tests/suite/json_body_field.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Integration tests for the `json_body_field` filter.
 

--- a/tests/integration/tests/suite/main.rs
+++ b/tests/integration/tests/suite/main.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Integration test suite for Praxis.
 

--- a/tests/integration/tests/suite/path_rewrite.rs
+++ b/tests/integration/tests/suite/path_rewrite.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Integration tests for the path_rewrite filter.
 

--- a/tests/integration/tests/suite/payload_processing.rs
+++ b/tests/integration/tests/suite/payload_processing.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Integration tests for payload processing example configurations.
 

--- a/tests/integration/tests/suite/per_listener_pipeline.rs
+++ b/tests/integration/tests/suite/per_listener_pipeline.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Integration tests verifying that each HTTP listener uses its own filter pipeline.
 

--- a/tests/integration/tests/suite/rate_limit.rs
+++ b/tests/integration/tests/suite/rate_limit.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Integration tests for the `rate_limit` filter.
 

--- a/tests/integration/tests/suite/retry.rs
+++ b/tests/integration/tests/suite/retry.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Integration tests for retry behavior (or lack thereof).
 

--- a/tests/integration/tests/suite/routing/basic.rs
+++ b/tests/integration/tests/suite/routing/basic.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Basic proxy and dead backend tests.
 

--- a/tests/integration/tests/suite/routing/filters.rs
+++ b/tests/integration/tests/suite/routing/filters.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Response filter and access log tests.
 

--- a/tests/integration/tests/suite/routing/host_based.rs
+++ b/tests/integration/tests/suite/routing/host_based.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Host-based routing tests.
 

--- a/tests/integration/tests/suite/routing/infrastructure.rs
+++ b/tests/integration/tests/suite/routing/infrastructure.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Health endpoints, config parsing, and admin tests.
 

--- a/tests/integration/tests/suite/routing/listeners.rs
+++ b/tests/integration/tests/suite/routing/listeners.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Multiple listeners and per-listener pipeline tests.
 

--- a/tests/integration/tests/suite/routing/mod.rs
+++ b/tests/integration/tests/suite/routing/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Tests for routing and filter behavior.
 

--- a/tests/integration/tests/suite/routing/path_based.rs
+++ b/tests/integration/tests/suite/routing/path_based.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Path-based routing tests.
 

--- a/tests/integration/tests/suite/security.rs
+++ b/tests/integration/tests/suite/security.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Integration tests for secure HTTP behavior.
 

--- a/tests/integration/tests/suite/sni_router.rs
+++ b/tests/integration/tests/suite/sni_router.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Integration tests for the `sni_router` TCP filter.
 

--- a/tests/integration/tests/suite/tcp_access_log.rs
+++ b/tests/integration/tests/suite/tcp_access_log.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Integration tests for the `tcp_access_log` filter.
 

--- a/tests/integration/tests/suite/tcp_load_balancer.rs
+++ b/tests/integration/tests/suite/tcp_load_balancer.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Integration tests for TCP load balancing via the `tcp_load_balancer` filter.
 

--- a/tests/integration/tests/suite/tls.rs
+++ b/tests/integration/tests/suite/tls.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! TLS integration tests: listener termination, upstream origination,
 //! TCP TLS forwarding, mTLS, and SNI behavior.

--- a/tests/integration/tests/suite/url_rewrite.rs
+++ b/tests/integration/tests/suite/url_rewrite.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Integration tests for the url_rewrite filter.
 

--- a/tests/integration/tests/suite/websocket.rs
+++ b/tests/integration/tests/suite/websocket.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Integration tests for WebSocket upgrade proxying.
 

--- a/tests/integration/tests/suite/wildcard_routing.rs
+++ b/tests/integration/tests/suite/wildcard_routing.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Integration tests for wildcard subdomain routing.
 

--- a/tests/resilience/tests/suite/backend_failure.rs
+++ b/tests/resilience/tests/suite/backend_failure.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Tests for proxy behavior when backends are unreachable, slow, or drop connections mid-request.
 

--- a/tests/resilience/tests/suite/backend_recovery.rs
+++ b/tests/resilience/tests/suite/backend_recovery.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Tests for proxy behavior when backends go down and come
 //! back, verifying that traffic resumes correctly.

--- a/tests/resilience/tests/suite/concurrent_load.rs
+++ b/tests/resilience/tests/suite/concurrent_load.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Tests for proxy behavior under concurrent load.
 

--- a/tests/resilience/tests/suite/large_payload.rs
+++ b/tests/resilience/tests/suite/large_payload.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Tests for proxy behavior with large payloads and near body size limits.
 

--- a/tests/resilience/tests/suite/main.rs
+++ b/tests/resilience/tests/suite/main.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Resilience, fault-tolerance, and throughput test suite for Praxis.
 

--- a/tests/resilience/tests/suite/multi_listener_isolation.rs
+++ b/tests/resilience/tests/suite/multi_listener_isolation.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Tests verifying that multiple listeners have independent
 //! failure domains: a backend failure on one listener does

--- a/tests/resilience/tests/suite/rate_limit_burst.rs
+++ b/tests/resilience/tests/suite/rate_limit_burst.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Tests for rate limiter behavior under burst conditions.
 

--- a/tests/resilience/tests/suite/throughput_body.rs
+++ b/tests/resilience/tests/suite/throughput_body.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Body processing throughput benchmarks.
 

--- a/tests/resilience/tests/suite/throughput_filter_chain.rs
+++ b/tests/resilience/tests/suite/throughput_filter_chain.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Filter chain depth benchmarks.
 

--- a/tests/resilience/tests/suite/throughput_production.rs
+++ b/tests/resilience/tests/suite/throughput_production.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Production-simulation pipeline performance tests.
 

--- a/tests/resilience/tests/suite/throughput_simple.rs
+++ b/tests/resilience/tests/suite/throughput_simple.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Simple proxy throughput benchmarks.
 

--- a/tests/resilience/tests/suite/throughput_tcp.rs
+++ b/tests/resilience/tests/suite/throughput_tcp.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! TCP proxy throughput benchmarks.
 

--- a/tests/resilience/tests/suite/throughput_utils.rs
+++ b/tests/resilience/tests/suite/throughput_utils.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Shared benchmark harness for Praxis system benchmarks.
 

--- a/tests/schema/tests/suite/cluster.rs
+++ b/tests/schema/tests/suite/cluster.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Cluster validation tests.
 

--- a/tests/schema/tests/suite/cross_cutting.rs
+++ b/tests/schema/tests/suite/cross_cutting.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Cross-cutting validation tests.
 

--- a/tests/schema/tests/suite/edge_cases.rs
+++ b/tests/schema/tests/suite/edge_cases.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Edge case and meta-tests.
 

--- a/tests/schema/tests/suite/example_utils.rs
+++ b/tests/schema/tests/suite/example_utils.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Re-export shared example config utilities.
 

--- a/tests/schema/tests/suite/examples/ai/mod.rs
+++ b/tests/schema/tests/suite/examples/ai/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! AI example configuration tests.
 

--- a/tests/schema/tests/suite/examples/ai/model_to_header.rs
+++ b/tests/schema/tests/suite/examples/ai/model_to_header.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Model to header filter example tests.
 

--- a/tests/schema/tests/suite/examples/api_key_filter.rs
+++ b/tests/schema/tests/suite/examples/api_key_filter.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! API key filter example tests.
 

--- a/tests/schema/tests/suite/examples/branching/conditional_skip_to.rs
+++ b/tests/schema/tests/suite/examples/branching/conditional_skip_to.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Conditional skip-to branch example config tests.
 

--- a/tests/schema/tests/suite/examples/branching/conditional_terminal.rs
+++ b/tests/schema/tests/suite/examples/branching/conditional_terminal.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Conditional terminal branch example config tests.
 

--- a/tests/schema/tests/suite/examples/branching/cross_chain_flat.rs
+++ b/tests/schema/tests/suite/examples/branching/cross_chain_flat.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Cross-chain flat pipeline example config tests.
 

--- a/tests/schema/tests/suite/examples/branching/mod.rs
+++ b/tests/schema/tests/suite/examples/branching/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Branching example configuration tests.
 

--- a/tests/schema/tests/suite/examples/branching/multiple_branches.rs
+++ b/tests/schema/tests/suite/examples/branching/multiple_branches.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Multiple branches example config tests.
 

--- a/tests/schema/tests/suite/examples/branching/named_chain_ref.rs
+++ b/tests/schema/tests/suite/examples/branching/named_chain_ref.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Named chain reference example config tests.
 

--- a/tests/schema/tests/suite/examples/branching/nested_branches.rs
+++ b/tests/schema/tests/suite/examples/branching/nested_branches.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Nested branches example config tests.
 

--- a/tests/schema/tests/suite/examples/branching/reentrance.rs
+++ b/tests/schema/tests/suite/examples/branching/reentrance.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Re-entrant branch example config tests.
 

--- a/tests/schema/tests/suite/examples/branching/unconditional_branch.rs
+++ b/tests/schema/tests/suite/examples/branching/unconditional_branch.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Unconditional branch example config tests.
 

--- a/tests/schema/tests/suite/examples/max_body_guard.rs
+++ b/tests/schema/tests/suite/examples/max_body_guard.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Max body guard example tests.
 

--- a/tests/schema/tests/suite/examples/mod.rs
+++ b/tests/schema/tests/suite/examples/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Example configuration tests organized by category.
 //!

--- a/tests/schema/tests/suite/examples/observability/access_logging.rs
+++ b/tests/schema/tests/suite/examples/observability/access_logging.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Access logging example tests.
 

--- a/tests/schema/tests/suite/examples/observability/logging.rs
+++ b/tests/schema/tests/suite/examples/observability/logging.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Logging example tests.
 

--- a/tests/schema/tests/suite/examples/observability/mod.rs
+++ b/tests/schema/tests/suite/examples/observability/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Observability example configuration tests.
 

--- a/tests/schema/tests/suite/examples/operations/mod.rs
+++ b/tests/schema/tests/suite/examples/operations/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Operations example configuration tests.
 

--- a/tests/schema/tests/suite/examples/operations/multi_listener.rs
+++ b/tests/schema/tests/suite/examples/operations/multi_listener.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Multi-listener example tests.
 

--- a/tests/schema/tests/suite/examples/operations/production_gateway.rs
+++ b/tests/schema/tests/suite/examples/operations/production_gateway.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Production gateway example configuration tests.
 

--- a/tests/schema/tests/suite/examples/parse_configs.rs
+++ b/tests/schema/tests/suite/examples/parse_configs.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Tests that all example configs parse successfully.
 

--- a/tests/schema/tests/suite/examples/payload_processing/mod.rs
+++ b/tests/schema/tests/suite/examples/payload_processing/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Payload processing example configuration tests.
 

--- a/tests/schema/tests/suite/examples/payload_processing/stream_buffer.rs
+++ b/tests/schema/tests/suite/examples/payload_processing/stream_buffer.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Stream buffer example tests.
 

--- a/tests/schema/tests/suite/examples/pipeline/branch_chains.rs
+++ b/tests/schema/tests/suite/examples/pipeline/branch_chains.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Branch chains example config tests.
 

--- a/tests/schema/tests/suite/examples/pipeline/conditional_filters.rs
+++ b/tests/schema/tests/suite/examples/pipeline/conditional_filters.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Conditional filters example tests.
 

--- a/tests/schema/tests/suite/examples/pipeline/default_config.rs
+++ b/tests/schema/tests/suite/examples/pipeline/default_config.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Default pipeline config example tests.
 

--- a/tests/schema/tests/suite/examples/pipeline/mod.rs
+++ b/tests/schema/tests/suite/examples/pipeline/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Pipeline example configuration tests.
 

--- a/tests/schema/tests/suite/examples/protocols.rs
+++ b/tests/schema/tests/suite/examples/protocols.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Protocol and TLS example configuration tests.
 

--- a/tests/schema/tests/suite/examples/security/ip_acl.rs
+++ b/tests/schema/tests/suite/examples/security/ip_acl.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! IPv4 and IPv6 ip_acl configuration parsing tests.
 

--- a/tests/schema/tests/suite/examples/security/mod.rs
+++ b/tests/schema/tests/suite/examples/security/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Security example configuration tests.
 

--- a/tests/schema/tests/suite/examples/traffic_management/basic_reverse_proxy.rs
+++ b/tests/schema/tests/suite/examples/traffic_management/basic_reverse_proxy.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Basic reverse proxy example tests.
 

--- a/tests/schema/tests/suite/examples/traffic_management/canary_routing.rs
+++ b/tests/schema/tests/suite/examples/traffic_management/canary_routing.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Canary routing example tests.
 

--- a/tests/schema/tests/suite/examples/traffic_management/least_connections.rs
+++ b/tests/schema/tests/suite/examples/traffic_management/least_connections.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Least connections load balancing example tests.
 

--- a/tests/schema/tests/suite/examples/traffic_management/mod.rs
+++ b/tests/schema/tests/suite/examples/traffic_management/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Traffic management example configuration tests.
 

--- a/tests/schema/tests/suite/examples/traffic_management/path_based_routing.rs
+++ b/tests/schema/tests/suite/examples/traffic_management/path_based_routing.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Path-based routing example tests.
 

--- a/tests/schema/tests/suite/examples/traffic_management/round_robin.rs
+++ b/tests/schema/tests/suite/examples/traffic_management/round_robin.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Round-robin load balancing example tests.
 

--- a/tests/schema/tests/suite/examples/traffic_management/session_affinity.rs
+++ b/tests/schema/tests/suite/examples/traffic_management/session_affinity.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Session affinity example tests.
 

--- a/tests/schema/tests/suite/examples/traffic_management/static_response.rs
+++ b/tests/schema/tests/suite/examples/traffic_management/static_response.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Static response example tests.
 

--- a/tests/schema/tests/suite/examples/traffic_management/timeout.rs
+++ b/tests/schema/tests/suite/examples/traffic_management/timeout.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Timeout filter example tests.
 

--- a/tests/schema/tests/suite/examples/traffic_management/virtual_hosts.rs
+++ b/tests/schema/tests/suite/examples/traffic_management/virtual_hosts.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Virtual host example tests.
 

--- a/tests/schema/tests/suite/examples/traffic_management/weighted_load_balancing.rs
+++ b/tests/schema/tests/suite/examples/traffic_management/weighted_load_balancing.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Weighted load balancing example tests.
 

--- a/tests/schema/tests/suite/examples/transformation/header_manipulation.rs
+++ b/tests/schema/tests/suite/examples/transformation/header_manipulation.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Header manipulation transformation example tests.
 

--- a/tests/schema/tests/suite/examples/transformation/mod.rs
+++ b/tests/schema/tests/suite/examples/transformation/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Transformation example configuration tests.
 

--- a/tests/schema/tests/suite/filter_chain.rs
+++ b/tests/schema/tests/suite/filter_chain.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Filter chain validation tests.
 

--- a/tests/schema/tests/suite/guardrails.rs
+++ b/tests/schema/tests/suite/guardrails.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Guardrails filter configuration validation tests.
 

--- a/tests/schema/tests/suite/listener.rs
+++ b/tests/schema/tests/suite/listener.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Listener validation tests.
 

--- a/tests/schema/tests/suite/main.rs
+++ b/tests/schema/tests/suite/main.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Configuration test suite for Praxis.
 

--- a/tests/schema/tests/suite/route.rs
+++ b/tests/schema/tests/suite/route.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Route validation tests (routes within router filter configs).
 

--- a/tests/schema/tests/suite/test_utils.rs
+++ b/tests/schema/tests/suite/test_utils.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! YAML builder test utilities to reduce duplication across test modules.
 

--- a/tests/security/tests/suite/filter_leakage.rs
+++ b/tests/security/tests/suite/filter_leakage.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Filter header leakage security tests.
 

--- a/tests/security/tests/suite/forwarded_headers.rs
+++ b/tests/security/tests/suite/forwarded_headers.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Forwarded headers adversarial tests.
 

--- a/tests/security/tests/suite/header_injection.rs
+++ b/tests/security/tests/suite/header_injection.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Header injection adversarial tests.
 

--- a/tests/security/tests/suite/host_header.rs
+++ b/tests/security/tests/suite/host_header.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Host header adversarial tests.
 

--- a/tests/security/tests/suite/info_leakage.rs
+++ b/tests/security/tests/suite/info_leakage.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Information leakage adversarial tests.
 

--- a/tests/security/tests/suite/ip_acl.rs
+++ b/tests/security/tests/suite/ip_acl.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! IP ACL adversarial tests.
 

--- a/tests/security/tests/suite/main.rs
+++ b/tests/security/tests/suite/main.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Security test suite for Praxis.
 

--- a/tests/security/tests/suite/request_smuggling.rs
+++ b/tests/security/tests/suite/request_smuggling.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Request smuggling hardening tests.
 

--- a/tests/smoke/tests/suite/main.rs
+++ b/tests/smoke/tests/suite/main.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Smoke test suite for Praxis.
 

--- a/tests/smoke/tests/suite/smoke.rs
+++ b/tests/smoke/tests/suite/smoke.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Smoke tests.
 

--- a/tests/utils/src/example_config.rs
+++ b/tests/utils/src/example_config.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Test utilities for loading and patching example configuration files.
 

--- a/tests/utils/src/lib.rs
+++ b/tests/utils/src/lib.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 #![deny(unsafe_code)]
 #![allow(

--- a/tests/utils/src/net/backend/echo.rs
+++ b/tests/utils/src/net/backend/echo.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Echo backends that reflect request data back in
 //! the response.

--- a/tests/utils/src/net/backend/mod.rs
+++ b/tests/utils/src/net/backend/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! HTTP backends for integration testing.
 

--- a/tests/utils/src/net/backend/simple.rs
+++ b/tests/utils/src/net/backend/simple.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Simple fixed-response and routed backends.
 

--- a/tests/utils/src/net/backend/specialized.rs
+++ b/tests/utils/src/net/backend/specialized.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Specialized backends: hop-by-hop responses, slow backends,
 //! and shared TCP server utilities.

--- a/tests/utils/src/net/backend/websocket.rs
+++ b/tests/utils/src/net/backend/websocket.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! `WebSocket` echo backend for integration testing.
 

--- a/tests/utils/src/net/http_client.rs
+++ b/tests/utils/src/net/http_client.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Lightweight HTTP client for integration tests.
 

--- a/tests/utils/src/net/mod.rs
+++ b/tests/utils/src/net/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Networking test utilities: port allocation, readiness
 //! checks, mock backends, HTTP clients, and TLS utilities.

--- a/tests/utils/src/net/port.rs
+++ b/tests/utils/src/net/port.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Port allocation utilities for integration tests.
 

--- a/tests/utils/src/net/tls.rs
+++ b/tests/utils/src/net/tls.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! TLS certificate generation and client utilities for integration tests.
 

--- a/tests/utils/src/net/wait.rs
+++ b/tests/utils/src/net/wait.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Readiness check utilities for integration tests.
 

--- a/tests/utils/src/proxy.rs
+++ b/tests/utils/src/proxy.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Proxy startup and configuration test utilities for integration tests.
 

--- a/tls/src/cached.rs
+++ b/tls/src/cached.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Pre-parsed TLS certificate data for eager caching.
 //!

--- a/tls/src/client_auth.rs
+++ b/tls/src/client_auth.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Client certificate verifier construction for listener mTLS.
 

--- a/tls/src/config/certs.rs
+++ b/tls/src/config/certs.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Certificate/key pair and CA configuration types.
 

--- a/tls/src/config/cluster.rs
+++ b/tls/src/config/cluster.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Cluster (upstream) TLS configuration.
 

--- a/tls/src/config/listener.rs
+++ b/tls/src/config/listener.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Listener TLS configuration: `ListenerTls`, `ClientCertMode`, and `TlsVersion`.
 

--- a/tls/src/config/mod.rs
+++ b/tls/src/config/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! TLS configuration types: shared primitives and role-specific wrappers.
 

--- a/tls/src/error.rs
+++ b/tls/src/error.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! TLS error types.
 

--- a/tls/src/lib.rs
+++ b/tls/src/lib.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 #![deny(unsafe_code)]
 #![deny(unreachable_pub)]

--- a/tls/src/reload.rs
+++ b/tls/src/reload.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Hot-reloadable TLS certificate resolver.
 //!

--- a/tls/src/setup/loader.rs
+++ b/tls/src/setup/loader.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Certificate and key loading utilities.
 

--- a/tls/src/setup/mod.rs
+++ b/tls/src/setup/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Shared TLS listener setup: builds `rustls::ServerConfig` from [`ListenerTls`].
 //!

--- a/tls/src/setup/sni.rs
+++ b/tls/src/setup/sni.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! SNI-based certificate resolver for multi-cert listeners.
 

--- a/tls/src/sni.rs
+++ b/tls/src/sni.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Zero-copy `ClientHello` SNI parser for TLS 1.0-1.3.
 //!

--- a/tls/src/test_utils.rs
+++ b/tls/src/test_utils.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Shared test utilities for TLS certificate generation.
 

--- a/tls/src/watcher.rs
+++ b/tls/src/watcher.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Filesystem watcher for TLS certificate hot-reload.
 //!

--- a/xtask/src/benchmark/cli.rs
+++ b/xtask/src/benchmark/cli.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! CLI argument types and subcommand definitions for `cargo xtask benchmark`.
 

--- a/xtask/src/benchmark/compare.rs
+++ b/xtask/src/benchmark/compare.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Report comparison and regression detection for `cargo xtask benchmark compare`.
 

--- a/xtask/src/benchmark/flamegraph.rs
+++ b/xtask/src/benchmark/flamegraph.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! `cargo xtask benchmark flamegraph` — CPU profiling with flamegraphs.
 

--- a/xtask/src/benchmark/mod.rs
+++ b/xtask/src/benchmark/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! `cargo xtask benchmark` proxy benchmark runner.
 

--- a/xtask/src/benchmark/orchestrate.rs
+++ b/xtask/src/benchmark/orchestrate.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Benchmark orchestration: runs selected benchmarks across
 //! proxies and assembles the final report.

--- a/xtask/src/benchmark/proxy.rs
+++ b/xtask/src/benchmark/proxy.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Proxy configuration builders and Docker image management for benchmark runs.
 

--- a/xtask/src/benchmark/report.rs
+++ b/xtask/src/benchmark/report.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Benchmark report serialization and deserialization.
 

--- a/xtask/src/benchmark/resolve.rs
+++ b/xtask/src/benchmark/resolve.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Workload and proxy name resolution from CLI arguments.
 

--- a/xtask/src/benchmark/visualize.rs
+++ b/xtask/src/benchmark/visualize.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! `cargo xtask benchmark visualize` SVG chart generator.
 

--- a/xtask/src/debug.rs
+++ b/xtask/src/debug.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! `cargo xtask debug` — run praxis with dev settings.
 

--- a/xtask/src/echo.rs
+++ b/xtask/src/echo.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! `cargo xtask echo` — quick HTTP test server.
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Development tasks for the Praxis proxy.
 

--- a/xtask/src/port.rs
+++ b/xtask/src/port.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Port availability utilities for dev commands.
 


### PR DESCRIPTION
Replaces: Copyright (c) 2024 Shane Utt
With: Copyright (c) 2026 Praxis Contributors

Close if you'd rather incrementally replace, ty!