### PR TITLE
feat: reject failure_mode: open on security-critical filters

### DIFF
--- a/core/src/config/insecure_options.rs
+++ b/core/src/config/insecure_options.rs
@@ -23,12 +23,13 @@ use serde::Deserialize;
 /// use praxis_core::config::InsecureOptions;
 ///
 /// let opts = InsecureOptions::default();
-/// assert!(!opts.allow_root);
+/// assert!(!opts.allow_open_security_filters);
+/// assert!(!opts.allow_private_health_checks);
 /// assert!(!opts.allow_public_admin);
+/// assert!(!opts.allow_root);
+/// assert!(!opts.allow_tls_without_sni);
 /// assert!(!opts.allow_unbounded_body);
 /// assert!(!opts.skip_pipeline_validation);
-/// assert!(!opts.allow_tls_without_sni);
-/// assert!(!opts.allow_private_health_checks);
 /// ```
 ///
 /// ```
@@ -44,23 +45,27 @@ use serde::Deserialize;
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct InsecureOptions {
-    /// Allow running as root (UID 0).
-    pub allow_root: bool,
+    /// Allow security-critical filters to use `failure_mode: open`,
+    /// demoting the validation error to a warning.
+    pub allow_open_security_filters: bool,
+
+    /// Allow health checks to loopback/metadata addresses.
+    pub allow_private_health_checks: bool,
 
     /// Allow admin endpoint on `0.0.0.0` / `[::]`.
     pub allow_public_admin: bool,
+
+    /// Allow running as root (UID 0).
+    pub allow_root: bool,
+
+    /// Allow TLS without SNI hostname verification.
+    pub allow_tls_without_sni: bool,
 
     /// Allow stream-buffered body mode with no size limit.
     pub allow_unbounded_body: bool,
 
     /// Skip pipeline ordering validation.
     pub skip_pipeline_validation: bool,
-
-    /// Allow TLS without SNI hostname verification.
-    pub allow_tls_without_sni: bool,
-
-    /// Allow health checks to loopback/metadata addresses.
-    pub allow_private_health_checks: bool,
 }
 
 // -----------------------------------------------------------------------------
@@ -82,8 +87,20 @@ mod tests {
     #[test]
     fn all_flags_default_to_false() {
         let opts = InsecureOptions::default();
-        assert!(!opts.allow_root, "allow_root should default to false");
+        assert!(
+            !opts.allow_open_security_filters,
+            "allow_open_security_filters should default to false"
+        );
+        assert!(
+            !opts.allow_private_health_checks,
+            "allow_private_health_checks should default to false"
+        );
         assert!(!opts.allow_public_admin, "allow_public_admin should default to false");
+        assert!(!opts.allow_root, "allow_root should default to false");
+        assert!(
+            !opts.allow_tls_without_sni,
+            "allow_tls_without_sni should default to false"
+        );
         assert!(
             !opts.allow_unbounded_body,
             "allow_unbounded_body should default to false"
@@ -91,14 +108,6 @@ mod tests {
         assert!(
             !opts.skip_pipeline_validation,
             "skip_pipeline_validation should default to false"
-        );
-        assert!(
-            !opts.allow_tls_without_sni,
-            "allow_tls_without_sni should default to false"
-        );
-        assert!(
-            !opts.allow_private_health_checks,
-            "allow_private_health_checks should default to false"
         );
     }
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -102,22 +102,24 @@ All flags live under `insecure_options` in the YAML config and default to `false
 
 ```yaml
 insecure_options:
-  allow_root: false
+  allow_open_security_filters: false
+  allow_private_health_checks: false
   allow_public_admin: false
+  allow_root: false
+  allow_tls_without_sni: false
   allow_unbounded_body: false
   skip_pipeline_validation: false
-  allow_tls_without_sni: false
-  allow_private_health_checks: false
 ```
 
 | Flag | Effect |
 | ------ | -------- |
-| `allow_root` | Allow starting as root (UID 0). Praxis refuses to run as root by default. |
+| `allow_open_security_filters` | Allow security-critical filters (`ip_acl`, `forwarded_headers`) to use `failure_mode: open`. Without this flag, open security filters are rejected because a runtime error would bypass security enforcement. With this flag enabled, the error is demoted to a warning. |
+| `allow_private_health_checks` | Allow health check endpoints that resolve to loopback (`127.0.0.0/8`) or cloud metadata addresses. Blocked by default as SSRF protection. |
 | `allow_public_admin` | Allow the admin health endpoint to bind to a public interface (`0.0.0.0` / `[::]`). By default this is a validation error. |
+| `allow_root` | Allow starting as root (UID 0). Praxis refuses to run as root by default. |
+| `allow_tls_without_sni` | Allow upstream TLS connections without an explicit SNI hostname. Most TLS servers require SNI; without this flag, missing SNI is a validation error. |
 | `allow_unbounded_body` | Allow `StreamBuffer` body mode without a size limit (`max_bytes: None`). Without this flag, unbounded stream buffering is rejected. |
 | `skip_pipeline_validation` | Demote pipeline ordering errors (e.g. filter placement issues) to warnings instead of failing startup. |
-| `allow_tls_without_sni` | Allow upstream TLS connections without an explicit SNI hostname. Most TLS servers require SNI; without this flag, missing SNI is a validation error. |
-| `allow_private_health_checks` | Allow health check endpoints that resolve to loopback (`127.0.0.0/8`) or cloud metadata addresses. Blocked by default as SSRF protection. |
 
 Example overriding two flags for local development:
 

--- a/filter/src/pipeline/build.rs
+++ b/filter/src/pipeline/build.rs
@@ -100,7 +100,7 @@ impl FilterPipeline {
     ///     failure_mode: FailureMode::default(),
     /// }];
     /// let pipeline = FilterPipeline::build(&mut entries, &registry).unwrap();
-    /// let errors = pipeline.ordering_errors(&entries);
+    /// let errors = pipeline.ordering_errors(&entries, false);
     /// assert!(
     ///     errors
     ///         .iter()
@@ -109,7 +109,7 @@ impl FilterPipeline {
     /// ```
     ///
     /// [`build`]: FilterPipeline::build
-    pub fn ordering_errors(&self, entries: &[FilterEntry]) -> Vec<String> {
+    pub fn ordering_errors(&self, entries: &[FilterEntry], allow_open_security: bool) -> Vec<String> {
         let names: Vec<&str> = self.filters.iter().map(|pf| pf.filter.name()).collect();
 
         let mut errors = Vec::new();
@@ -117,6 +117,7 @@ impl FilterPipeline {
         super::checks::check_lb_without_router(&names, &mut errors);
         super::checks::check_unconditional_static_response(&names, &self.filters, &mut errors);
         super::checks::check_conditional_security(&names, &self.filters, &mut errors);
+        super::checks::check_open_security_filters(&names, &self.filters, allow_open_security, &mut errors);
         super::checks::check_duplicate_routers(&names, &mut errors);
         super::checks::check_duplicate_load_balancers(&names, &mut errors);
         super::checks::check_misaligned_clusters(entries, &mut errors);

--- a/filter/src/pipeline/checks.rs
+++ b/filter/src/pipeline/checks.rs
@@ -3,7 +3,7 @@
 
 //! Ordering validation checks for filter pipelines.
 
-use praxis_core::config::FilterEntry;
+use praxis_core::config::{FailureMode, FilterEntry};
 use tracing::warn;
 
 use super::filter::PipelineFilter;
@@ -72,6 +72,35 @@ pub(super) fn check_conditional_security(names: &[&str], filters: &[PipelineFilt
                      request conditions; it will be bypassed for \
                      non-matching requests"
                 ));
+            }
+        }
+    }
+}
+
+/// Security filters with `failure_mode: open` (bypass risk on error).
+///
+/// When `allow` is `true`, the error is demoted to a warning.
+#[allow(clippy::indexing_slicing, reason = "enumeration bounds")]
+pub(super) fn check_open_security_filters(
+    names: &[&str],
+    filters: &[PipelineFilter],
+    allow: bool,
+    errors: &mut Vec<String>,
+) {
+    for (i, name) in names.iter().enumerate() {
+        if SECURITY_FILTERS.contains(name) && filters[i].failure_mode == FailureMode::Open {
+            let msg = format!(
+                "security filter '{name}' at position {i} has \
+                 failure_mode: open; runtime errors will bypass \
+                 security enforcement"
+            );
+            if allow {
+                warn!(
+                    filter = %name,
+                    "{msg}; allowed by insecure_options.allow_open_security_filters"
+                );
+            } else {
+                errors.push(msg);
             }
         }
     }
@@ -323,6 +352,53 @@ mod tests {
         let mut errors = Vec::new();
         check_conditional_security(&names, &filters, &mut errors);
         assert!(errors.is_empty(), "unconditional security filter should not error");
+    }
+
+    #[test]
+    fn open_security_filter_errors() {
+        let names = vec!["ip_acl"];
+        let mut pf = make_pf(vec![]);
+        pf.failure_mode = FailureMode::Open;
+        let filters = vec![pf];
+        let mut errors = Vec::new();
+        check_open_security_filters(&names, &filters, false, &mut errors);
+        assert_eq!(errors.len(), 1, "should produce exactly one error");
+        assert!(
+            errors[0].contains("failure_mode: open"),
+            "error should mention failure_mode: {}",
+            errors[0]
+        );
+    }
+
+    #[test]
+    fn open_security_filter_allowed_demotes_to_warning() {
+        let names = vec!["ip_acl"];
+        let mut pf = make_pf(vec![]);
+        pf.failure_mode = FailureMode::Open;
+        let filters = vec![pf];
+        let mut errors = Vec::new();
+        check_open_security_filters(&names, &filters, true, &mut errors);
+        assert!(errors.is_empty(), "allow flag should demote error to warning");
+    }
+
+    #[test]
+    fn closed_security_filter_no_error() {
+        let names = vec!["ip_acl"];
+        let filters = vec![make_pf(vec![])];
+        let mut errors = Vec::new();
+        check_open_security_filters(&names, &filters, false, &mut errors);
+        assert!(errors.is_empty(), "closed security filter should not error");
+    }
+
+    #[test]
+    fn open_non_security_filter_no_error() {
+        let names = vec!["headers"];
+        let mut pf = make_pf(vec![]);
+        pf.failure_mode = FailureMode::Open;
+        let filters = vec![pf];
+        let mut errors = Vec::new();
+        check_open_security_filters(&names, &filters, false, &mut errors);
+        assert!(errors.is_empty(), "open non-security filter should not error");
     }
 
     #[test]

--- a/filter/src/pipeline/tests.rs
+++ b/filter/src/pipeline/tests.rs
@@ -763,7 +763,7 @@ fn errors_load_balancer_without_router() {
         failure_mode: FailureMode::default(),
     }];
     let pipeline = FilterPipeline::build(&mut entries, &registry).unwrap();
-    let errors = pipeline.ordering_errors(&entries);
+    let errors = pipeline.ordering_errors(&entries, false);
     assert!(
         errors
             .iter()
@@ -796,7 +796,7 @@ fn no_error_when_router_precedes_load_balancer() {
         },
     ];
     let pipeline = FilterPipeline::build(&mut entries, &registry).unwrap();
-    let errors = pipeline.ordering_errors(&entries);
+    let errors = pipeline.ordering_errors(&entries, false);
     assert!(
         errors.is_empty(),
         "router before load_balancer should produce no errors: {errors:?}"
@@ -827,7 +827,7 @@ fn errors_unconditional_static_response_followed_by_filters() {
         },
     ];
     let pipeline = FilterPipeline::build(&mut entries, &registry).unwrap();
-    let errors = pipeline.ordering_errors(&entries);
+    let errors = pipeline.ordering_errors(&entries, false);
     assert!(
         errors.iter().any(|e| e.contains("unreachable")),
         "should error on unreachable filters: {errors:?}"
@@ -867,7 +867,7 @@ fn no_error_for_conditional_static_response() {
         },
     ];
     let pipeline = FilterPipeline::build(&mut entries, &registry).unwrap();
-    let errors = pipeline.ordering_errors(&entries);
+    let errors = pipeline.ordering_errors(&entries, false);
     assert!(
         errors.is_empty(),
         "conditional static_response should not error: {errors:?}"
@@ -907,7 +907,7 @@ fn errors_duplicate_router() {
         },
     ];
     let pipeline = FilterPipeline::build(&mut entries, &registry).unwrap();
-    let errors = pipeline.ordering_errors(&entries);
+    let errors = pipeline.ordering_errors(&entries, false);
     assert!(
         errors.iter().any(|e| e.contains("multiple router")),
         "should error on duplicate router filters: {errors:?}"
@@ -947,7 +947,7 @@ fn errors_duplicate_load_balancer() {
         },
     ];
     let pipeline = FilterPipeline::build(&mut entries, &registry).unwrap();
-    let errors = pipeline.ordering_errors(&entries);
+    let errors = pipeline.ordering_errors(&entries, false);
     assert!(
         errors.iter().any(|e| e.contains("multiple load_balancer")),
         "should error on duplicate load_balancer filters: {errors:?}"
@@ -967,7 +967,7 @@ fn errors_conditional_security_filter() {
         failure_mode: FailureMode::default(),
     }];
     let pipeline = FilterPipeline::build(&mut entries, &registry).unwrap();
-    let errors = pipeline.ordering_errors(&entries);
+    let errors = pipeline.ordering_errors(&entries, false);
     assert!(
         errors
             .iter()
@@ -989,10 +989,52 @@ fn no_error_for_unconditional_security_filter() {
         failure_mode: FailureMode::default(),
     }];
     let pipeline = FilterPipeline::build(&mut entries, &registry).unwrap();
-    let errors = pipeline.ordering_errors(&entries);
+    let errors = pipeline.ordering_errors(&entries, false);
     assert!(
         !errors.iter().any(|e| e.contains("security filter")),
         "unconditional security filter should not error: {errors:?}"
+    );
+}
+
+#[test]
+fn errors_open_security_filter() {
+    let registry = FilterRegistry::with_builtins();
+    let mut entries = vec![FilterEntry {
+        branch_chains: None,
+        conditions: vec![],
+        filter_type: "ip_acl".into(),
+        config: serde_yaml::from_str("allow: [\"10.0.0.0/8\"]").unwrap(),
+        name: None,
+        response_conditions: vec![],
+        failure_mode: FailureMode::Open,
+    }];
+    let pipeline = FilterPipeline::build(&mut entries, &registry).unwrap();
+    let errors = pipeline.ordering_errors(&entries, false);
+    assert!(
+        errors
+            .iter()
+            .any(|e| e.contains("failure_mode: open") && e.contains("ip_acl")),
+        "should error on open security filter: {errors:?}"
+    );
+}
+
+#[test]
+fn allow_open_security_filter_with_insecure_flag() {
+    let registry = FilterRegistry::with_builtins();
+    let mut entries = vec![FilterEntry {
+        branch_chains: None,
+        conditions: vec![],
+        filter_type: "ip_acl".into(),
+        config: serde_yaml::from_str("allow: [\"10.0.0.0/8\"]").unwrap(),
+        name: None,
+        response_conditions: vec![],
+        failure_mode: FailureMode::Open,
+    }];
+    let pipeline = FilterPipeline::build(&mut entries, &registry).unwrap();
+    let errors = pipeline.ordering_errors(&entries, true);
+    assert!(
+        !errors.iter().any(|e| e.contains("failure_mode: open")),
+        "insecure flag should demote open security filter error to warning: {errors:?}"
     );
 }
 
@@ -1001,7 +1043,7 @@ fn empty_pipeline_no_errors() {
     let registry = FilterRegistry::with_builtins();
     let mut entries: Vec<FilterEntry> = vec![];
     let pipeline = FilterPipeline::build(&mut entries, &registry).unwrap();
-    let errors = pipeline.ordering_errors(&entries);
+    let errors = pipeline.ordering_errors(&entries, false);
     assert!(errors.is_empty(), "empty pipeline should produce no errors");
 }
 
@@ -1060,7 +1102,7 @@ fn errors_misaligned_clusters() {
         },
     ];
     let pipeline = FilterPipeline::build(&mut entries, &registry).unwrap();
-    let errors = pipeline.ordering_errors(&entries);
+    let errors = pipeline.ordering_errors(&entries, false);
     assert!(
         errors
             .iter()
@@ -1093,7 +1135,7 @@ fn no_error_for_aligned_clusters() {
         },
     ];
     let pipeline = FilterPipeline::build(&mut entries, &registry).unwrap();
-    let errors = pipeline.ordering_errors(&entries);
+    let errors = pipeline.ordering_errors(&entries, false);
     assert!(
         errors.is_empty(),
         "aligned clusters should produce no errors: {errors:?}"
@@ -1308,7 +1350,7 @@ fn errors_duplicate_path_rewrite_filters() {
         },
     ];
     let pipeline = FilterPipeline::build(&mut entries, &registry).unwrap();
-    let errors = pipeline.ordering_errors(&entries);
+    let errors = pipeline.ordering_errors(&entries, false);
     assert!(
         errors
             .iter()
@@ -1344,7 +1386,7 @@ fn errors_mixed_path_and_url_rewrite_filters() {
         },
     ];
     let pipeline = FilterPipeline::build(&mut entries, &registry).unwrap();
-    let errors = pipeline.ordering_errors(&entries);
+    let errors = pipeline.ordering_errors(&entries, false);
     assert!(
         errors
             .iter()
@@ -1366,7 +1408,7 @@ fn no_error_single_path_rewrite_filter() {
         failure_mode: FailureMode::default(),
     }];
     let pipeline = FilterPipeline::build(&mut entries, &registry).unwrap();
-    let errors = pipeline.ordering_errors(&entries);
+    let errors = pipeline.ordering_errors(&entries, false);
     assert!(
         !errors.iter().any(|e| e.contains("rewriting filters")),
         "single rewrite filter should not error: {errors:?}"
@@ -1400,7 +1442,7 @@ fn no_error_duplicate_rewrite_with_allow_override() {
         },
     ];
     let pipeline = FilterPipeline::build(&mut entries, &registry).unwrap();
-    let errors = pipeline.ordering_errors(&entries);
+    let errors = pipeline.ordering_errors(&entries, false);
     assert!(
         !errors.iter().any(|e| e.contains("rewriting filters")),
         "allow_rewrite_override should suppress error: {errors:?}"
@@ -1434,7 +1476,7 @@ fn error_when_allow_override_on_first_not_last() {
         },
     ];
     let pipeline = FilterPipeline::build(&mut entries, &registry).unwrap();
-    let errors = pipeline.ordering_errors(&entries);
+    let errors = pipeline.ordering_errors(&entries, false);
     assert!(
         errors.iter().any(|e| e.contains("rewriting filters")),
         "override on first filter should not suppress error: {errors:?}"

--- a/server/src/pipelines.rs
+++ b/server/src/pipelines.rs
@@ -50,7 +50,8 @@ pub(crate) fn resolve_pipelines(
         }
 
         let skip = config.insecure_options.skip_pipeline_validation;
-        validate_pipeline(&pipeline, &entries, &listener.name, skip)?;
+        let allow_open_security = config.insecure_options.allow_open_security_filters;
+        validate_pipeline(&pipeline, &entries, &listener.name, skip, allow_open_security)?;
 
         pipelines.insert(listener.name.clone(), Arc::new(pipeline));
     }
@@ -69,8 +70,9 @@ fn validate_pipeline(
     entries: &[praxis_core::config::FilterEntry],
     listener_name: &str,
     skip: bool,
+    allow_open_security: bool,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let errors = pipeline.ordering_errors(entries);
+    let errors = pipeline.ordering_errors(entries, allow_open_security);
 
     if skip {
         for msg in &errors {


### PR DESCRIPTION
Security filters (ip_acl, forwarded_headers) now fail pipeline validation when configured with failure_mode: open, since a runtime error would silently bypass security enforcement.

Override with insecure_options.allow_open_security_filters: true.

Closes #81

Developed with guided assistance from Claude Opus 4.6 for codebase exploration and implementation.