### PR TITLE
feat: expose JSON-RPC parser internally with filter metadata

### DIFF
--- a/benchmarks/microbenchmarks/common.rs
+++ b/benchmarks/microbenchmarks/common.rs
@@ -39,6 +39,7 @@ pub(crate) fn make_ctx(req: &Request) -> HttpFilterContext<'_> {
         cluster: None,
         executed_filter_indices: Vec::new(),
         extra_request_headers: Vec::new(),
+        filter_metadata: std::collections::HashMap::new(),
         filter_results: std::collections::HashMap::new(),
         health_registry: None,
         request: req,

--- a/filter/src/builtins/http/payload_processing/json_rpc/config.rs
+++ b/filter/src/builtins/http/payload_processing/json_rpc/config.rs
@@ -12,7 +12,7 @@ use crate::FilterError;
 // -----------------------------------------------------------------------------
 
 /// Default maximum request body size for `StreamBuffer` mode (1 MiB).
-pub(super) const DEFAULT_MAX_BODY_BYTES: usize = 1_048_576;
+pub(crate) const DEFAULT_MAX_BODY_BYTES: usize = 1_048_576;
 
 // -----------------------------------------------------------------------------
 // BatchPolicy
@@ -21,7 +21,7 @@ pub(super) const DEFAULT_MAX_BODY_BYTES: usize = 1_048_576;
 /// Batch handling policy for JSON-RPC arrays.
 #[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
-pub(super) enum BatchPolicy {
+pub(crate) enum BatchPolicy {
     /// Reject JSON-RPC batch arrays with HTTP 400.
     #[default]
     Reject,
@@ -36,7 +36,7 @@ pub(super) enum BatchPolicy {
 /// Invalid JSON or non-JSON-RPC input handling.
 #[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
-pub(super) enum InvalidJsonRpcBehavior {
+pub(crate) enum InvalidJsonRpcBehavior {
     /// Continue processing (default proxy behavior).
     #[default]
     Continue,
@@ -53,7 +53,7 @@ pub(super) enum InvalidJsonRpcBehavior {
 /// Header configuration for JSON-RPC metadata promotion.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub(super) struct JsonRpcHeaders {
+pub(crate) struct JsonRpcHeaders {
     /// Header name for JSON-RPC method (e.g., `X-Json-Rpc-Method`).
     pub method: Option<String>,
     /// Header name for JSON-RPC id (e.g., `X-Json-Rpc-Id`).
@@ -81,7 +81,7 @@ impl Default for JsonRpcHeaders {
 /// [`JsonRpcFilter`]: super::JsonRpcFilter
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub(super) struct JsonRpcConfig {
+pub(crate) struct JsonRpcConfig {
     /// Maximum body size in bytes for `StreamBuffer`.
     #[serde(default = "default_max_body_bytes")]
     pub max_body_bytes: usize,
@@ -109,7 +109,7 @@ fn default_max_body_bytes() -> usize {
 // -----------------------------------------------------------------------------
 
 /// Validate and build the final configuration.
-pub(super) fn build_config(cfg: JsonRpcConfig) -> Result<(usize, JsonRpcConfig), FilterError> {
+pub(crate) fn build_config(cfg: JsonRpcConfig) -> Result<(usize, JsonRpcConfig), FilterError> {
     if cfg.max_body_bytes == 0 {
         return Err("json_rpc: 'max_body_bytes' must be greater than 0".into());
     }

--- a/filter/src/builtins/http/payload_processing/json_rpc/envelope.rs
+++ b/filter/src/builtins/http/payload_processing/json_rpc/envelope.rs
@@ -13,7 +13,7 @@ use super::config::{BatchPolicy, InvalidJsonRpcBehavior, JsonRpcConfig};
 
 /// JSON-RPC message kind.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) enum JsonRpcKind {
+pub(crate) enum JsonRpcKind {
     /// Request with id (expects response).
     Request,
     /// Notification without id (no response expected).
@@ -26,7 +26,7 @@ pub(super) enum JsonRpcKind {
 
 impl JsonRpcKind {
     /// String representation for headers and filter results.
-    pub(super) fn as_str(&self) -> &'static str {
+    pub(crate) fn as_str(&self) -> &'static str {
         match self {
             Self::Request => "request",
             Self::Notification => "notification",
@@ -38,7 +38,7 @@ impl JsonRpcKind {
 
 /// JSON-RPC id type classification.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) enum JsonRpcIdKind {
+pub(crate) enum JsonRpcIdKind {
     /// String id.
     String,
     /// Integer id (i64/u64).
@@ -53,7 +53,7 @@ pub(super) enum JsonRpcIdKind {
 
 impl JsonRpcIdKind {
     /// String representation for filter results.
-    pub(super) fn as_str(&self) -> &'static str {
+    pub(crate) fn as_str(&self) -> &'static str {
         match self {
             Self::String => "string",
             Self::Integer => "integer",
@@ -66,7 +66,7 @@ impl JsonRpcIdKind {
 
 /// Parsed JSON-RPC envelope metadata.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) struct JsonRpcEnvelope {
+pub(crate) struct JsonRpcEnvelope {
     /// Message kind (request/notification/response/batch).
     pub kind: JsonRpcKind,
     /// Method name (for requests and notifications).
@@ -85,7 +85,7 @@ pub(super) struct JsonRpcEnvelope {
 
 /// JSON-RPC parsing error.
 #[derive(Debug, Clone)]
-pub(super) enum JsonRpcParseError {
+pub(crate) enum JsonRpcParseError {
     /// Invalid JSON.
     InvalidJson(String),
     /// Missing required `jsonrpc` field.
@@ -131,7 +131,7 @@ impl std::error::Error for JsonRpcParseError {}
 /// - `Ok(Some(envelope))` for valid JSON-RPC 2.0
 /// - `Ok(None)` for valid JSON but not JSON-RPC (when `on_invalid` allows continuing)
 /// - `Err(error)` for invalid JSON or JSON-RPC violations
-pub(super) fn parse_json_rpc_envelope(
+pub(crate) fn parse_json_rpc_envelope(
     input: &[u8],
     config: &JsonRpcConfig,
 ) -> Result<Option<JsonRpcEnvelope>, JsonRpcParseError> {

--- a/filter/src/builtins/http/payload_processing/json_rpc/mod.rs
+++ b/filter/src/builtins/http/payload_processing/json_rpc/mod.rs
@@ -3,8 +3,8 @@
 
 //! Extracts JSON-RPC 2.0 envelope metadata from request bodies for routing.
 
-mod config;
-mod envelope;
+pub(crate) mod config;
+pub(crate) mod envelope;
 
 #[cfg(test)]
 #[allow(
@@ -255,6 +255,6 @@ fn set_id_results(
 }
 
 /// Check whether a string contains control characters.
-fn contains_control_chars(s: &str) -> bool {
+pub(crate) fn contains_control_chars(s: &str) -> bool {
     s.bytes().any(|b| (b < 0x20 && b != 0x09) || b == 0x7F)
 }

--- a/filter/src/builtins/http/payload_processing/mod.rs
+++ b/filter/src/builtins/http/payload_processing/mod.rs
@@ -6,7 +6,7 @@
 mod compression;
 pub(crate) mod compression_config;
 mod json_body_field;
-mod json_rpc;
+pub(crate) mod json_rpc;
 
 pub use compression::CompressionFilter;
 pub use json_body_field::JsonBodyFieldFilter;

--- a/filter/src/context.rs
+++ b/filter/src/context.rs
@@ -144,8 +144,8 @@ impl HttpFilterContext<'_> {
     }
 
     /// Write a durable metadata value that persists across all phases.
-    pub fn set_metadata(&mut self, key: String, value: String) {
-        self.filter_metadata.insert(key, value);
+    pub fn set_metadata(&mut self, key: impl Into<String>, value: impl Into<String>) {
+        self.filter_metadata.insert(key.into(), value.into());
     }
 
     /// Upgrade the request body delivery mode for this request.
@@ -400,7 +400,7 @@ mod tests {
     fn set_metadata_then_get_returns_value() {
         let req = crate::test_utils::make_request(Method::GET, "/");
         let mut ctx = crate::test_utils::make_filter_context(&req);
-        ctx.set_metadata("mcp.method".to_owned(), "tools/call".to_owned());
+        ctx.set_metadata("mcp.method", "tools/call");
         assert_eq!(
             ctx.get_metadata("mcp.method"),
             Some("tools/call"),
@@ -412,8 +412,8 @@ mod tests {
     fn set_metadata_overwrites_existing() {
         let req = crate::test_utils::make_request(Method::GET, "/");
         let mut ctx = crate::test_utils::make_filter_context(&req);
-        ctx.set_metadata("a2a.method".to_owned(), "SendMessage".to_owned());
-        ctx.set_metadata("a2a.method".to_owned(), "GetTask".to_owned());
+        ctx.set_metadata("a2a.method", "SendMessage");
+        ctx.set_metadata("a2a.method", "GetTask");
         assert_eq!(
             ctx.get_metadata("a2a.method"),
             Some("GetTask"),
@@ -425,12 +425,26 @@ mod tests {
     fn metadata_independent_of_filter_results() {
         let req = crate::test_utils::make_request(Method::GET, "/");
         let mut ctx = crate::test_utils::make_filter_context(&req);
-        ctx.set_metadata("mcp.session_id".to_owned(), "gw-123".to_owned());
+        ctx.set_metadata("mcp.session_id", "gw-123");
         ctx.filter_results.clear();
         assert_eq!(
             ctx.get_metadata("mcp.session_id"),
             Some("gw-123"),
             "clearing filter_results should not affect metadata"
+        );
+    }
+
+    #[test]
+    fn set_metadata_accepts_owned_strings() {
+        let req = crate::test_utils::make_request(Method::GET, "/");
+        let mut ctx = crate::test_utils::make_filter_context(&req);
+        let key = "a2a.task_id".to_owned();
+        let value = "task-456".to_owned();
+        ctx.set_metadata(key, value);
+        assert_eq!(
+            ctx.get_metadata("a2a.task_id"),
+            Some("task-456"),
+            "set_metadata should accept owned Strings"
         );
     }
 }

--- a/filter/src/context.rs
+++ b/filter/src/context.rs
@@ -41,6 +41,15 @@ pub struct HttpFilterContext<'a> {
     /// Extra headers to inject into the upstream request.
     pub extra_request_headers: Vec<(Cow<'static, str>, String)>,
 
+    /// Durable per-request metadata that persists across all
+    /// Pingora lifecycle phases (request, request-body, response,
+    /// response-body, logging). Unlike [`filter_results`] which
+    /// are cleared after branch evaluation, metadata survives
+    /// for the entire request lifetime.
+    ///
+    /// [`filter_results`]: Self::filter_results
+    pub filter_metadata: HashMap<String, String>,
+
     /// Filter result map: `filter_name` -> result entries.
     ///
     /// Filters write string key-value pairs here during
@@ -124,9 +133,19 @@ impl HttpFilterContext<'_> {
         self.upstream.as_ref().map(|u| &*u.address)
     }
 
+    /// Read a durable metadata value by key.
+    pub fn get_metadata(&self, key: &str) -> Option<&str> {
+        self.filter_metadata.get(key).map(String::as_str)
+    }
+
     /// X-Request-ID header value, if present and valid UTF-8.
     pub fn request_id(&self) -> Option<&str> {
         self.request.headers.get("x-request-id").and_then(|v| v.to_str().ok())
+    }
+
+    /// Write a durable metadata value that persists across all phases.
+    pub fn set_metadata(&mut self, key: String, value: String) {
+        self.filter_metadata.insert(key, value);
     }
 
     /// Upgrade the request body delivery mode for this request.
@@ -364,6 +383,54 @@ mod tests {
             ctx.request_body_mode,
             BodyMode::StreamBuffer { max_bytes: Some(1024) },
             "smaller StreamBuffer limit should win when merging"
+        );
+    }
+
+    #[test]
+    fn get_metadata_returns_none_when_empty() {
+        let req = crate::test_utils::make_request(Method::GET, "/");
+        let ctx = crate::test_utils::make_filter_context(&req);
+        assert!(
+            ctx.get_metadata("mcp.method").is_none(),
+            "get_metadata should return None for absent key"
+        );
+    }
+
+    #[test]
+    fn set_metadata_then_get_returns_value() {
+        let req = crate::test_utils::make_request(Method::GET, "/");
+        let mut ctx = crate::test_utils::make_filter_context(&req);
+        ctx.set_metadata("mcp.method".to_owned(), "tools/call".to_owned());
+        assert_eq!(
+            ctx.get_metadata("mcp.method"),
+            Some("tools/call"),
+            "get_metadata should return the set value"
+        );
+    }
+
+    #[test]
+    fn set_metadata_overwrites_existing() {
+        let req = crate::test_utils::make_request(Method::GET, "/");
+        let mut ctx = crate::test_utils::make_filter_context(&req);
+        ctx.set_metadata("a2a.method".to_owned(), "SendMessage".to_owned());
+        ctx.set_metadata("a2a.method".to_owned(), "GetTask".to_owned());
+        assert_eq!(
+            ctx.get_metadata("a2a.method"),
+            Some("GetTask"),
+            "set_metadata should overwrite previous value"
+        );
+    }
+
+    #[test]
+    fn metadata_independent_of_filter_results() {
+        let req = crate::test_utils::make_request(Method::GET, "/");
+        let mut ctx = crate::test_utils::make_filter_context(&req);
+        ctx.set_metadata("mcp.session_id".to_owned(), "gw-123".to_owned());
+        ctx.filter_results.clear();
+        assert_eq!(
+            ctx.get_metadata("mcp.session_id"),
+            Some("gw-123"),
+            "clearing filter_results should not affect metadata"
         );
     }
 }

--- a/filter/src/lib.rs
+++ b/filter/src/lib.rs
@@ -232,6 +232,7 @@ pub(crate) mod test_utils {
             cluster: None,
             executed_filter_indices: Vec::new(),
             extra_request_headers: Vec::new(),
+            filter_metadata: std::collections::HashMap::new(),
             filter_results: std::collections::HashMap::new(),
             health_registry: None,
             request: req,

--- a/protocol/src/http/pingora/context.rs
+++ b/protocol/src/http/pingora/context.rs
@@ -53,6 +53,13 @@ pub struct PingoraRequestCtx {
     /// bytes are raw protocol frames (e.g. `WebSocket`), not HTTP bodies.
     pub connection_upgraded: bool,
 
+    /// Durable per-request metadata that persists across all lifecycle
+    /// phases. Swapped into each [`HttpFilterContext`] and written back
+    /// after filter execution.
+    ///
+    /// [`HttpFilterContext`]: praxis_filter::HttpFilterContext
+    pub filter_metadata: std::collections::HashMap<String, String>,
+
     /// Pre-read body chunks (`StreamBuffer` mode). When `StreamBuffer` is
     /// active, the body is read during `request_filter` (before upstream
     /// selection) so that body-based routing can influence `upstream_peer`.
@@ -154,6 +161,7 @@ macro_rules! filter_context {
             cluster: $ctx.cluster.take(),
             executed_filter_indices: Vec::new(),
             extra_request_headers: Vec::new(),
+            filter_metadata: std::mem::take(&mut $ctx.filter_metadata),
             filter_results: std::collections::HashMap::new(),
             health_registry: $pipeline.health_registry(),
             request: $request,
@@ -248,6 +256,7 @@ impl Default for PingoraRequestCtx {
             client_http_version: None,
             cluster: None,
             connection_upgraded: false,
+            filter_metadata: std::collections::HashMap::new(),
             pre_read_body: None,
             request_body_buffer: None,
             request_body_bytes: 0,

--- a/protocol/src/http/pingora/handler/mod.rs
+++ b/protocol/src/http/pingora/handler/mod.rs
@@ -207,6 +207,7 @@ async fn logging_cleanup(pipeline: &FilterPipeline, ctx: &mut PingoraRequestCtx)
         && let Some(mut filter_ctx) = ctx.filter_context_for(pipeline, None)
     {
         let _result = pipeline.execute_http_response(&mut filter_ctx).await;
+        ctx.filter_metadata = filter_ctx.filter_metadata;
     }
 }
 
@@ -381,6 +382,27 @@ mod tests {
         logging_cleanup(&pipeline, &mut ctx).await;
         assert!(ctx.cluster.is_none(), "cluster should be taken by logging_cleanup");
         assert!(ctx.upstream.is_none(), "upstream should be taken by logging_cleanup");
+    }
+
+    #[tokio::test]
+    async fn logging_cleanup_preserves_filter_metadata() {
+        let registry = praxis_filter::FilterRegistry::with_builtins();
+        let pipeline = FilterPipeline::build(&mut [], &registry).unwrap();
+        let mut ctx = PingoraRequestCtx::default();
+        ctx.response_phase_done = false;
+        ctx.filter_metadata
+            .insert("mcp.method".to_owned(), "tools/call".to_owned());
+        ctx.request_snapshot = Some(praxis_filter::Request {
+            method: http::Method::POST,
+            uri: "/mcp".parse().unwrap(),
+            headers: http::HeaderMap::new(),
+        });
+        logging_cleanup(&pipeline, &mut ctx).await;
+        assert_eq!(
+            ctx.filter_metadata.get("mcp.method").map(String::as_str),
+            Some("tools/call"),
+            "filter_metadata should survive logging_cleanup"
+        );
     }
 
     #[test]

--- a/protocol/src/http/pingora/handler/request_body_filter.rs
+++ b/protocol/src/http/pingora/handler/request_body_filter.rs
@@ -95,7 +95,7 @@ pub(super) async fn execute(
         BodyMode::StreamBuffer { .. } | BodyMode::Stream | _ => {},
     }
 
-    let (result, body_bytes, cluster, upstream) = {
+    let (result, body_bytes, cluster, upstream, filter_metadata) = {
         let mut fctx = ctx.filter_context_for(pipeline, None).ok_or_else(|| {
             pingora_core::Error::explain(
                 pingora_core::ErrorType::InternalError,
@@ -103,11 +103,18 @@ pub(super) async fn execute(
             )
         })?;
         let r = pipeline.execute_http_request_body(&mut fctx, body, end_of_stream).await;
-        (r, fctx.request_body_bytes, fctx.cluster, fctx.upstream)
+        (
+            r,
+            fctx.request_body_bytes,
+            fctx.cluster,
+            fctx.upstream,
+            fctx.filter_metadata,
+        )
     };
     ctx.request_body_bytes = body_bytes;
     ctx.cluster = cluster;
     ctx.upstream = upstream;
+    ctx.filter_metadata = filter_metadata;
 
     match result {
         Ok(FilterAction::Continue | FilterAction::BodyDone) => {

--- a/protocol/src/http/pingora/handler/request_filter/mod.rs
+++ b/protocol/src/http/pingora/handler/request_filter/mod.rs
@@ -128,12 +128,22 @@ pub(in crate::http) async fn execute(
 /// Run the request-phase filter pipeline and snapshot the request for later phases.
 ///
 /// Returns the final action and any extra headers promoted by filters.
+#[allow(clippy::too_many_lines, reason = "writeback destructuring")]
 async fn run_pipeline(
     pipeline: &FilterPipeline,
     request: Request,
     ctx: &mut PingoraRequestCtx,
 ) -> std::result::Result<(FilterAction, Vec<(Cow<'static, str>, String)>), FilterError> {
-    let (action, extra_headers, cluster, upstream, rewritten_path, request_body_mode, selected_endpoint_index) = {
+    let (
+        action,
+        extra_headers,
+        cluster,
+        upstream,
+        rewritten_path,
+        request_body_mode,
+        selected_endpoint_index,
+        filter_metadata,
+    ) = {
         let mut filter_ctx = ctx.build_filter_context(pipeline, &request, None);
 
         let action = pipeline.execute_http_request(&mut filter_ctx).await;
@@ -145,10 +155,12 @@ async fn run_pipeline(
             filter_ctx.rewritten_path,
             filter_ctx.request_body_mode,
             filter_ctx.selected_endpoint_index,
+            filter_ctx.filter_metadata,
         )
     };
 
     ctx.request_snapshot = Some(request);
+    ctx.filter_metadata = filter_metadata;
 
     match action {
         Ok(FilterAction::Continue | FilterAction::Release | FilterAction::BodyDone) => {

--- a/protocol/src/http/pingora/handler/request_filter/stream_buffer.rs
+++ b/protocol/src/http/pingora/handler/request_filter/stream_buffer.rs
@@ -144,6 +144,7 @@ pub(super) async fn pre_read_body(
         ctx.request_body_bytes = filter_ctx.request_body_bytes;
         ctx.cluster = filter_ctx.cluster;
         ctx.upstream = filter_ctx.upstream;
+        ctx.filter_metadata = filter_ctx.filter_metadata;
         all_extra_headers.extend(filter_ctx.extra_request_headers);
 
         match action {

--- a/protocol/src/http/pingora/handler/response_body_filter.rs
+++ b/protocol/src/http/pingora/handler/response_body_filter.rs
@@ -83,7 +83,7 @@ pub(super) fn execute(
         BodyMode::StreamBuffer { .. } | BodyMode::Stream | _ => {},
     }
 
-    let (result, body_bytes, cluster, upstream) = {
+    let (result, body_bytes, cluster, upstream, filter_metadata) = {
         let mut fctx = ctx.filter_context_for(pipeline, None).ok_or_else(|| {
             pingora_core::Error::explain(
                 pingora_core::ErrorType::InternalError,
@@ -91,11 +91,18 @@ pub(super) fn execute(
             )
         })?;
         let r = pipeline.execute_http_response_body(&mut fctx, body, end_of_stream);
-        (r, fctx.response_body_bytes, fctx.cluster, fctx.upstream)
+        (
+            r,
+            fctx.response_body_bytes,
+            fctx.cluster,
+            fctx.upstream,
+            fctx.filter_metadata,
+        )
     };
     ctx.response_body_bytes = body_bytes;
     ctx.cluster = cluster;
     ctx.upstream = upstream;
+    ctx.filter_metadata = filter_metadata;
     match result {
         Ok(FilterAction::Continue | FilterAction::BodyDone) => {
             if is_stream_buffer && !ctx.response_body_released && !end_of_stream {

--- a/protocol/src/http/pingora/handler/response_filter.rs
+++ b/protocol/src/http/pingora/handler/response_filter.rs
@@ -45,7 +45,7 @@ async fn run_response_pipeline(
     ctx: &mut PingoraRequestCtx,
     resp: &mut praxis_filter::Response,
 ) -> Result<(std::result::Result<FilterAction, praxis_filter::FilterError>, bool)> {
-    let (r, headers_modified, response_body_mode) = {
+    let (r, headers_modified, response_body_mode, filter_metadata) = {
         let mut fctx = ctx.filter_context_for(pipeline, Some(resp)).ok_or_else(|| {
             pingora_core::Error::explain(
                 pingora_core::ErrorType::InternalError,
@@ -53,9 +53,15 @@ async fn run_response_pipeline(
             )
         })?;
         let r = pipeline.execute_http_response(&mut fctx).await;
-        (r, fctx.response_headers_modified, fctx.response_body_mode)
+        (
+            r,
+            fctx.response_headers_modified,
+            fctx.response_body_mode,
+            fctx.filter_metadata,
+        )
     };
     ctx.response_body_mode = response_body_mode;
+    ctx.filter_metadata = filter_metadata;
     Ok((r, headers_modified))
 }
 

--- a/tests/fuzz/fuzz_targets/fuzz_filter_pipeline.rs
+++ b/tests/fuzz/fuzz_targets/fuzz_filter_pipeline.rs
@@ -54,6 +54,7 @@ fuzz_target!(|data: &str| {
             cluster: None,
             executed_filter_indices: Vec::new(),
             extra_request_headers: Vec::new(),
+            filter_metadata: std::collections::HashMap::new(),
             filter_results: std::collections::HashMap::new(),
             health_registry: None,
             request: &request,


### PR DESCRIPTION
  Expose the existing JSON-RPC parser/config types internally so MCP, A2A, and future JSON-RPC-based filters can reuse one shared parser instead of duplicating envelope parsing logic.

  Add durable per-request filter metadata to carry protocol-derived facts across Pingora request, body, response, response-body, and logging phases. This gives future protocol filters a stable place to store values such as MCP method/session IDs or A2A method/task IDs for routing, policy, logging, and state updates.

Where this fits in the broader epic can be seen here praxis-proxy/ai#148. This changes the existing JSON-RPC code from a private implementation detail of the `json_rpc` filter into shared crate-internal. Added some higher level design info to get a feel for what this underpins.

## Summary

  This adds the first MCP/A2A protocol foundation pieces:

  - Make the existing JSON-RPC 2.0 parser/config types reusable inside the filter crate.
  - Add durable per-request `filter_metadata` to `HttpFilterContext`.
  - Carry that metadata through Pingora request, request-body, response, response-body, and logging lifecycle paths.
  - Keep `filter_metadata` separate from `filter_results`, which remains branch-evaluation state and is cleared by the pipeline.

  This is intended as groundwork for MCP and A2A filters, which both need shared JSON-RPC parsing and request-scoped protocol facts that survive beyond a single filter phase.

  ## How This Used

  MCP and A2A both sit on top of JSON-RPC, but they need more than one request-phase parse.

  The proxy needs to extract protocol facts from the request body, then reuse those facts later for routing, upstream mutation, response handling, logging, and eventually
  session/task state updates.

  Examples of durable metadata that future MCP/A2A filters can set:

  - `mcp.method`
  - `mcp.name`
  - `mcp.session_id`
  - `a2a.method`
  - `a2a.task_id`

  `filter_results` is not enough for this because it is used for branch evaluation and is cleared as the pipeline progresses. MCP/A2A need request-lifetime protocol context.

  ## Changes

  ### JSON-RPC Parser Reuse

  Changed selected JSON-RPC internals from `pub(super)` to `pub(crate)` so future MCP/A2A filters can reuse the existing parser instead of duplicating JSON-RPC parsing logic.

  Updated:

  - `filter/src/builtins/http/payload_processing/json_rpc/config.rs`
  - `filter/src/builtins/http/payload_processing/json_rpc/envelope.rs`
  - `filter/src/builtins/http/payload_processing/json_rpc/mod.rs`

  This keeps the API internal to the crate. It does not expose a new public API.

  ### Durable Filter Metadata

  Added:

  - `filter_metadata: HashMap<String, String>` to `HttpFilterContext`
  - `get_metadata()` and `set_metadata()` helpers
  - `filter_metadata` storage on `PingoraRequestCtx`

  The Pingora adapter now moves metadata into each `HttpFilterContext` and writes it back after filter execution.

  Writeback paths covered:

  - request filter
  - StreamBuffer pre-read body path
  - request body filter
  - response filter
  - response body filter
  - logging cleanup path

  This lets metadata survive across the full Pingora lifecycle for a request.

  ### Constructors And Test Utilities

  Updated constructors/defaults in:

  - filter test utilities
  - protocol request context default
  - benchmarks
  - fuzz target

  ## Request Flow

  High-level flow after this change:

  1. A body-aware filter parses JSON-RPC request content.
  2. The filter stores protocol facts in `HttpFilterContext::filter_metadata`.
  3. The Pingora handler writes metadata back into `PingoraRequestCtx`.
  4. Later phases rebuild `HttpFilterContext` from `PingoraRequestCtx`.
  5. Future filters can read the same metadata during response handling, logging, routing decisions, or state updates.

  Example future MCP flow:

  ```text
  request body filter
    parses JSON-RPC initialize/tools.call
    sets mcp.method and mcp.session_id

  request routing/filtering
    reads mcp.method
    routes to the correct tool/server pool

  response filter/body filter
    reads mcp.session_id
    updates session state or logs protocol-specific fields

  logging
    emits MCP-aware request metadata
  ```

  ## Non-Goals

This PR does not implement MCP protocol support, A2A protocol support, PR does not add session storage, task tracking, routing policy, or protocol-specific behavior.
This PR does not change StreamBuffer buffering or replay semantics.

See praxis-proxy/ai#148 for a mapping of features to PRs.

  ## Risk

Adding this because I am always wary about touching something shared.

This does not change existing routing, buffering, or filter behavior; it only carries an empty metadata map by default and moves it between existing per-request contexts, so existing proxy features continue to run the same path with negligible overhead. If empty, it is effectively a no-op aside from allocating/owning an empty HashMap in the request context and moving it between contexts. It is not serialized, added to headers, forwarded upstream, returned downstream, or logged unless a future filter explicitly reads it and chooses to do something with it.

  ## Test Plan

  Reported verification:

  - 49 filter tests pass
  - 6 protocol tests pass
  - 356 integration tests pass
  - make lint clean

  Additional targeted verification:

```
  cargo test -p praxis-proxy-filter metadata --lib
  cargo test -p praxis-proxy-protocol logging_cleanup --lib
  git diff --check
```

Related or tracking issues:

  Refs praxis-proxy/ai#149
  Refs praxis-proxy/praxis#26
  Refs praxis-proxy/ai#151
  Refs praxis-proxy/praxis#43
  Refs praxis-proxy/ai#146

