### PR TITLE
feat: add Prometheus metrics foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -715,6 +715,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "evmap"
+version = "11.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8874945f036109c72242964c1174cf99434e30cfa45bf45fedc983f50046f8"
+dependencies = [
+ "hashbag",
+ "left-right",
+ "smallvec",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -888,6 +899,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link",
+ "windows-result",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -962,6 +988,12 @@ dependencies = [
  "crunchy",
  "zerocopy",
 ]
+
+[[package]]
+name = "hashbag"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7040a10f52cba493ddb09926e15d10a9d8a28043708a405931fe4c6f19fac064"
 
 [[package]]
 name = "hashbrown"
@@ -1209,6 +1241,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "left-right"
+version = "0.11.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f0c21e4c8ff95f487fb34e6f9182875f42c84cef966d29216bf115d9bba835a"
+dependencies = [
+ "crossbeam-utils",
+ "loom",
+ "slab",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1258,6 +1301,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "lru"
 version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1288,6 +1344,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "metrics"
+version = "0.24.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff56c2e7dce6bd462e3b8919986a617027481b1dcc703175b58cf9dd98a2f071"
+dependencies = [
+ "portable-atomic",
+ "rapidhash",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1db0d8f1fc9e62caebd0319e11eaec5822b0186c171568f0480b46a0137f9108"
+dependencies = [
+ "base64",
+ "evmap",
+ "indexmap 2.14.0",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e56997f084e57b045edf17c3ed8ba7f9f779c670df8206dfd1c736f4c02dc4a"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.16.1",
+ "metrics",
+ "quanta",
+ "rand 0.9.4",
+ "rand_xoshiro",
+ "rapidhash",
+ "sketches-ddsketch",
 ]
 
 [[package]]
@@ -1793,6 +1891,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1865,6 +1969,8 @@ dependencies = [
  "bytes",
  "futures",
  "http",
+ "metrics",
+ "metrics-exporter-prometheus",
  "pingora-core",
  "pingora-http",
  "pingora-proxy",
@@ -2043,6 +2149,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2120,6 +2241,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rapidhash"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -2356,6 +2504,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2504,6 +2658,12 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,8 @@ criterion = { version = "0.8.2", features = ["async_tokio"] }
 futures = "0.3.32"
 h2 = "0.4.13"
 http = "1.4.0"
+metrics = "0.24.5"
+metrics-exporter-prometheus = { version = "0.18.3", default-features = false }
 # Pinned to match Pingora's dependency.
 nix = "0.24.3"
 notify = "7.0.0"

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -22,6 +22,8 @@ async-trait = { workspace = true }
 bytes = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }
+metrics = { workspace = true }
+metrics-exporter-prometheus = { workspace = true }
 pingora-core = { workspace = true }
 pingora-http = { workspace = true }
 pingora-proxy = { workspace = true }

--- a/protocol/src/http/pingora/metrics.rs
+++ b/protocol/src/http/pingora/metrics.rs
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Prometheus metrics: recorder installation, HTTP request metric recording, and scrape rendering.
+
+use std::sync::OnceLock;
+
+use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
+
+// -----------------------------------------------------------------------------
+// Recorder Installation
+// -----------------------------------------------------------------------------
+
+/// Global handle to the Prometheus exporter.
+static PROMETHEUS_HANDLE: OnceLock<PrometheusHandle> = OnceLock::new();
+
+/// Install the global Prometheus metrics recorder.
+///
+/// Must be called exactly once during server startup. Subsequent
+/// calls are no-ops and return the existing handle.
+///
+/// # Panics
+///
+/// Panics if the global recorder cannot be installed (another
+/// recorder was already set by a different subsystem).
+pub fn install_prometheus_recorder() -> &'static PrometheusHandle {
+    #[allow(
+        clippy::expect_used,
+        reason = "recorder installation is a one-time startup operation"
+    )]
+    PROMETHEUS_HANDLE.get_or_init(|| {
+        let builder = PrometheusBuilder::new();
+        builder
+            .install_recorder()
+            .expect("failed to install Prometheus recorder")
+    })
+}
+
+/// Render all collected metrics in Prometheus text exposition format.
+///
+/// Returns `None` if the recorder has not been installed.
+pub fn render_prometheus() -> Option<String> {
+    PROMETHEUS_HANDLE.get().map(PrometheusHandle::render)
+}
+
+// -----------------------------------------------------------------------------
+// Status Class
+// -----------------------------------------------------------------------------
+
+/// Map an HTTP status code to its class label (`"1xx"`, `"2xx"`, etc.).
+///
+/// Returns `"unknown"` for zero (no response written) or codes
+/// outside the 100–599 range.
+///
+/// ```
+/// use praxis_protocol::http::pingora::metrics::status_class;
+///
+/// assert_eq!(status_class(200), "2xx");
+/// assert_eq!(status_class(404), "4xx");
+/// assert_eq!(status_class(0), "unknown");
+/// ```
+pub fn status_class(code: u16) -> &'static str {
+    match code {
+        100..=199 => "1xx",
+        200..=299 => "2xx",
+        300..=399 => "3xx",
+        400..=499 => "4xx",
+        500..=599 => "5xx",
+        _ => "unknown",
+    }
+}
+
+/// Map an HTTP method to a bounded label value.
+///
+/// Returns the method string for the nine standard methods
+/// defined in [RFC 9110]; all others collapse to `"OTHER"`.
+///
+/// ```
+/// use praxis_protocol::http::pingora::metrics::method_label;
+///
+/// assert_eq!(method_label("GET"), "GET");
+/// assert_eq!(method_label("PURGE"), "OTHER");
+/// ```
+///
+/// [RFC 9110]: https://datatracker.ietf.org/doc/html/rfc9110#section-9.1
+pub fn method_label(method: &str) -> &'static str {
+    match method {
+        "GET" => "GET",
+        "POST" => "POST",
+        "PUT" => "PUT",
+        "DELETE" => "DELETE",
+        "PATCH" => "PATCH",
+        "HEAD" => "HEAD",
+        "OPTIONS" => "OPTIONS",
+        "TRACE" => "TRACE",
+        "CONNECT" => "CONNECT",
+        _ => "OTHER",
+    }
+}

--- a/protocol/src/http/pingora/mod.rs
+++ b/protocol/src/http/pingora/mod.rs
@@ -22,6 +22,8 @@ pub mod health;
 pub(crate) mod json;
 /// Listener configuration and TLS setup.
 pub mod listener;
+/// Prometheus metrics: recorder, HTTP request counters, and scrape endpoint.
+pub mod metrics;
 
 // -----------------------------------------------------------------------------
 // PingoraHttp


### PR DESCRIPTION
This is the first of 3 PRs that breaks up #80 (that has a preliminary pass at review and fixes) into smaller commits to get past praxis-bot 400 loc cap that the bot closed. See #167 for a summary of the 3 PRs. The 3 PRs will be the same as 80, just split up.

- protocol/src/http/pingora/metrics.rs — new file with:
- install_prometheus_recorder() / render_prometheus() via OnceLock<PrometheusHandle>
- status_class() — maps status codes to "1xx".."5xx" / "unknown"
- method_label() — bounds HTTP methods to RFC 9110 set or "OTHER"
- No request recording API, no tests, no counter!/histogram! imports
- protocol/src/http/pingora/mod.rs — added pub mod metrics; export line

Ty!