### PR TITLE
feat: add --validate / -t CLI flag for config checking

### DIFF
--- a/core/src/logging.rs
+++ b/core/src/logging.rs
@@ -38,6 +38,21 @@ pub fn init_tracing(config: &Config) -> Result<(), ProxyError> {
     Ok(())
 }
 
+/// Validate log overrides from config without initializing the global subscriber.
+///
+/// Useful for configuration validation that needs to check log override
+/// syntax without affecting the global tracing state.
+///
+/// # Errors
+///
+/// Returns [`ProxyError::Config`] if any `log_overrides` entry is invalid.
+///
+/// [`ProxyError::Config`]: crate::errors::ProxyError::Config
+pub fn validate_log_overrides(config: &Config) -> Result<(), ProxyError> {
+    build_env_filter(config)?;
+    Ok(())
+}
+
 // -----------------------------------------------------------------------------
 // EnvFilter Factory
 // -----------------------------------------------------------------------------

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,6 +17,23 @@ shutdown_timeout_secs: # Optional. Graceful drain time (default: 30).
 insecure_options:      # Optional. Dev/test overrides. See development.md.
 ```
 
+## Validating Configuration
+
+Use `--validate` (or `-t`) to check configuration
+without starting the server. The flag loads the config
+through the same parsing and validation path used
+during startup, including filter pipeline construction
+and ordering checks.
+
+```sh
+praxis --validate --config praxis.yaml
+praxis -t -c praxis.yaml
+```
+
+Exits `0` on success (no output). Exits non-zero and
+prints an error to stderr on failure. Does not bind
+listener ports or enter the server runtime.
+
 ## Dynamic Configuration Reload
 
 Praxis watches the config file for changes and

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -9,6 +9,6 @@ pub(crate) mod pipelines;
 pub(crate) mod reload;
 mod server;
 pub(crate) mod watcher;
-
+pub use pipelines::resolve_pipelines;
 pub use praxis_core::{config::load_config, logging::init_tracing};
 pub use server::{check_root_privilege, fatal, resolve_config_path, run_server, run_server_with_registry};

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -31,6 +31,10 @@ struct Cli {
     /// Path to the YAML configuration file.
     #[arg(short = 'c', long = "config")]
     config: Option<String>,
+
+    /// Validate configuration and exit.
+    #[arg(short = 't', long = "validate")]
+    validate: bool,
 }
 
 // -----------------------------------------------------------------------------
@@ -42,9 +46,110 @@ struct Cli {
 fn main() {
     let cli = Cli::parse();
     let explicit = cli.config.or_else(|| std::env::var("PRAXIS_CONFIG").ok());
+
+    if cli.validate {
+        if let Err(e) = run_validate(explicit.as_deref()) {
+            eprintln!("invalid configuration: {e}");
+            std::process::exit(1);
+        }
+        return;
+    }
+
     let config_path = praxis::resolve_config_path(explicit.as_deref());
     let config = praxis::load_config(explicit.as_deref()).unwrap_or_else(|e| praxis::fatal(&e));
     praxis::init_tracing(&config).unwrap_or_else(|e| praxis::fatal(&e));
     info!("starting server");
     praxis::run_server(config, config_path)
+}
+
+/// Load and fully validate configuration without starting the server.
+#[allow(clippy::print_stderr, reason = "validation error output")]
+fn run_validate(explicit: Option<&str>) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let config = praxis::load_config(explicit)?;
+    validate_config(&config)?;
+    Ok(())
+}
+
+/// Validate a parsed configuration by building filter pipelines.
+///
+/// Runs the same validation checks used during server startup:
+/// log override validation (validates `runtime.log_overrides`),
+/// filter factory instantiation, chain expansion, ordering checks,
+/// and body-limit application.
+fn validate_config(config: &praxis_core::config::Config) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    // Validate log overrides (same validation as startup)
+    praxis_core::logging::validate_log_overrides(config)?;
+    let registry = praxis_filter::FilterRegistry::with_builtins();
+    let health_registry = praxis_core::health::build_health_registry(&config.clusters);
+    praxis::resolve_pipelines(config, &registry, &health_registry)?;
+    Ok(())
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing, reason = "tests")]
+mod tests {
+    use clap::Parser;
+
+    use super::{Cli, validate_config};
+
+    #[test]
+    fn cli_validate_short_flag() {
+        let cli = Cli::parse_from(["praxis", "-t"]);
+        assert!(cli.validate, "-t should set validate to true");
+        assert!(cli.config.is_none(), "config should be None");
+    }
+
+    #[test]
+    fn cli_validate_long_flag() {
+        let cli = Cli::parse_from(["praxis", "--validate"]);
+        assert!(cli.validate, "--validate should set validate to true");
+    }
+
+    #[test]
+    fn cli_validate_with_config() {
+        let cli = Cli::parse_from(["praxis", "-t", "-c", "custom.yaml"]);
+        assert!(cli.validate, "-t should set validate to true");
+        assert_eq!(cli.config.as_deref(), Some("custom.yaml"), "-c should set config path");
+    }
+
+    #[test]
+    fn cli_default_no_validate() {
+        let cli = Cli::parse_from(["praxis"]);
+        assert!(!cli.validate, "validate should default to false");
+    }
+
+    #[test]
+    fn validate_config_catches_invalid_log_overrides() {
+        let config = praxis_core::config::Config::from_yaml(
+            r#"
+runtime:
+  log_overrides:
+    "invalid module": "info"
+    "praxis_core": "invalid_level"
+listeners:
+  - name: web
+    address: "127.0.0.1:8080"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters: []
+"#,
+        )
+        .unwrap();
+        let result = validate_config(&config);
+        assert!(result.is_err(), "invalid log overrides should fail validation");
+        let err = result.err().unwrap().to_string();
+        assert!(
+            err.contains("invalid module path 'invalid module'"),
+            "error should mention invalid module path: {err}"
+        );
+        assert!(
+            err.contains("invalid level 'invalid_level'"),
+            "error should mention invalid level: {err}"
+        );
+    }
 }

--- a/server/src/pipelines.rs
+++ b/server/src/pipelines.rs
@@ -15,8 +15,14 @@ use praxis_protocol::ListenerPipelines;
 
 /// Build a [`FilterPipeline`] for each listener by resolving named chains.
 ///
+/// # Errors
+///
+/// Returns an error when pipeline construction fails (unknown filter chain
+/// referenced by listener, filter instantiation failure, branch chain
+/// resolution error, body limit conflict, or pipeline ordering violation).
+///
 /// [`FilterPipeline`]: praxis_filter::FilterPipeline
-pub(crate) fn resolve_pipelines(
+pub fn resolve_pipelines(
     config: &Config,
     registry: &FilterRegistry,
     health_registry: &praxis_core::health::HealthRegistry,


### PR DESCRIPTION
## Summary

This is half of #131 - the Validate configuration files without starting the proxy part. Keeping it smol and under the LOC cap. Will follow up with the second half of the issue, dump mode, once merged.

- Add `--validate` / `-t` flag that loads and fully validates configuration then exits without starting the proxy
- Validation runs the same pipeline resolution as server startup (filter instantiation, chain expansion, ordering checks, body limits)
- Normal server startup unchanged when flag is absent

## Test plan

  - [x] `cargo test -p praxis` — 43 tests pass (4 new CLI parsing + 4 new validation + existing)
  - [x] `cargo clippy -p praxis -- -D warnings` — clean
  - [x] `cargo +nightly fmt -p praxis -- --check` — clean
  - [x] `praxis -t` exits 0 with default config
  - [x] `praxis --validate -c examples/configs/traffic-management/basic-reverse-proxy.yaml` exits 0
  - [x] `praxis -t -c /nonexistent` exits 1 with actionable error to stderr
  - [x] Validate does not bind listener ports or enter the Pingora runtime

## Validation Output

See validation output here: https://gist.github.com/nerdalert/9b222eb03755ffc7fbede26472b5ab11