### PR TITLE
feat: add --dump / -T CLI flag for effective config output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2125,6 +2125,8 @@ dependencies = [
  "praxis-proxy-core",
  "praxis-proxy-filter",
  "praxis-proxy-protocol",
+ "serde",
+ "serde_yaml",
  "tempfile",
  "tikv-jemallocator",
  "tokio",

--- a/core/src/config/admin.rs
+++ b/core/src/config/admin.rs
@@ -24,7 +24,7 @@ use serde::Deserialize;
 /// assert_eq!(admin.address.as_deref(), Some("127.0.0.1:9901"));
 /// assert!(admin.verbose);
 /// ```
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize, serde::Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct AdminConfig {
     /// Admin endpoint bind address.

--- a/core/src/config/body_limits.rs
+++ b/core/src/config/body_limits.rs
@@ -24,7 +24,7 @@ use serde::Deserialize;
 /// assert_eq!(limits.max_request_bytes, Some(10_485_760));
 /// assert_eq!(limits.max_response_bytes, Some(5_242_880));
 /// ```
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize, serde::Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct BodyLimitsConfig {
     /// Maximum request body size in bytes.

--- a/core/src/config/branch_chain.rs
+++ b/core/src/config/branch_chain.rs
@@ -37,7 +37,7 @@ use super::chain_ref::ChainRef;
 /// assert!(branch.on_result.is_some());
 /// assert_eq!(branch.rejoin, "terminal");
 /// ```
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, serde::Serialize)]
 pub struct BranchChainConfig {
     /// Globally unique name for this branch.
     pub name: String,
@@ -97,7 +97,7 @@ fn default_rejoin() -> String {
 /// assert_eq!(cond.key, "status");
 /// assert_eq!(cond.value, "hit");
 /// ```
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, serde::Serialize)]
 pub struct BranchCondition {
     /// Name of the filter whose results to inspect.
     pub filter: String,

--- a/core/src/config/chain_ref.rs
+++ b/core/src/config/chain_ref.rs
@@ -33,7 +33,7 @@ use super::filters::FilterEntry;
 /// .unwrap();
 /// assert!(matches!(inline, ChainRef::Inline { ref name, .. } if name == "inline_chain"));
 /// ```
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, serde::Serialize)]
 #[serde(untagged)]
 pub enum ChainRef {
     /// Inline chain definition.

--- a/core/src/config/condition/mod.rs
+++ b/core/src/config/condition/mod.rs
@@ -59,3 +59,26 @@ macro_rules! impl_condition_deserialize {
 }
 
 pub(crate) use impl_condition_deserialize;
+
+/// Generates a `Serialize` impl for a when/unless condition enum.
+///
+/// Produces a one-entry map (`when: <match>` or `unless: <match>`)
+/// that round-trips through the custom [`impl_condition_deserialize`]
+/// deserializer.
+macro_rules! impl_condition_serialize {
+    ($cond:ident, $match_:ty) => {
+        impl serde::Serialize for $cond {
+            fn serialize<S: serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+                use serde::ser::SerializeMap as _;
+                let mut map = serializer.serialize_map(Some(1))?;
+                match self {
+                    $cond::When(m) => map.serialize_entry("when", m)?,
+                    $cond::Unless(m) => map.serialize_entry("unless", m)?,
+                }
+                map.end()
+            }
+        }
+    };
+}
+
+pub(crate) use impl_condition_serialize;

--- a/core/src/config/condition/request.rs
+++ b/core/src/config/condition/request.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 
 use serde::Deserialize;
 
-use super::impl_condition_deserialize;
+use super::{impl_condition_deserialize, impl_condition_serialize};
 
 // -----------------------------------------------------------------------------
 // Condition
@@ -39,6 +39,7 @@ pub enum Condition {
 }
 
 impl_condition_deserialize!(Condition, ConditionMatch, "condition");
+impl_condition_serialize!(Condition, ConditionMatch);
 
 // -----------------------------------------------------------------------------
 // ConditionMatch
@@ -59,7 +60,7 @@ impl_condition_deserialize!(Condition, ConditionMatch, "condition");
 /// assert_eq!(m.path_prefix.as_deref(), Some("/api"));
 /// assert_eq!(m.methods.as_ref().unwrap().len(), 2);
 /// ```
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, serde::Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ConditionMatch {
     /// Request URI must match this exact path.

--- a/core/src/config/condition/response.rs
+++ b/core/src/config/condition/response.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 
 use serde::Deserialize;
 
-use super::impl_condition_deserialize;
+use super::{impl_condition_deserialize, impl_condition_serialize};
 
 // -----------------------------------------------------------------------------
 // ResponseCondition
@@ -40,6 +40,7 @@ pub enum ResponseCondition {
 }
 
 impl_condition_deserialize!(ResponseCondition, ResponseConditionMatch, "response condition");
+impl_condition_serialize!(ResponseCondition, ResponseConditionMatch);
 
 // -----------------------------------------------------------------------------
 // ResponseConditionMatch
@@ -60,7 +61,7 @@ impl_condition_deserialize!(ResponseCondition, ResponseConditionMatch, "response
 /// .unwrap();
 /// assert_eq!(m.status.as_ref().unwrap(), &[200, 201]);
 /// ```
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, serde::Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ResponseConditionMatch {
     /// Response status code must be one of these.

--- a/core/src/config/filters.rs
+++ b/core/src/config/filters.rs
@@ -16,7 +16,7 @@ use super::{Condition, ResponseCondition};
 /// Per-filter failure behaviour.
 ///
 /// Controls what happens when a filter returns an error during execution.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize, serde::Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum FailureMode {
     /// The request is aborted on filter error (default, current behaviour).
@@ -48,7 +48,7 @@ pub enum FailureMode {
 /// assert_eq!(chain.name, "observability");
 /// assert_eq!(chain.filters.len(), 2);
 /// ```
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, serde::Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct FilterChainConfig {
     /// Unique name for this filter chain.
@@ -81,7 +81,7 @@ pub struct FilterChainConfig {
 /// assert!(entry.conditions.is_empty());
 /// assert!(entry.name.is_none());
 /// ```
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, serde::Serialize)]
 pub struct FilterEntry {
     /// Filter type name (e.g. `"router"`, `"load_balancer"`, or a custom name).
     #[serde(rename = "filter")]

--- a/core/src/config/insecure_options.rs
+++ b/core/src/config/insecure_options.rs
@@ -43,7 +43,7 @@ use serde::Deserialize;
 /// assert!(!opts.allow_unbounded_body);
 /// ```
 #[allow(clippy::struct_excessive_bools, reason = "security override flags")]
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize, serde::Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct InsecureOptions {
     /// Allow security-critical filters to use `failure_mode: open`,

--- a/core/src/config/mod.rs
+++ b/core/src/config/mod.rs
@@ -66,7 +66,7 @@ pub use validate::{MAX_BRANCH_DEPTH, MAX_ITERATIONS_CEILING};
 /// .unwrap();
 /// assert_eq!(config.listeners[0].address, "127.0.0.1:8080");
 /// ```
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, serde::Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Config {
     /// Admin endpoint settings (address and verbosity).

--- a/core/src/config/runtime.rs
+++ b/core/src/config/runtime.rs
@@ -28,7 +28,7 @@ use serde::Deserialize;
 /// assert_eq!(cfg.threads, 4);
 /// assert!(cfg.work_stealing);
 /// ```
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, serde::Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RuntimeConfig {
     /// Number of worker threads per service.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,6 +34,24 @@ Exits `0` on success (no output). Exits non-zero and
 prints an error to stderr on failure. Does not bind
 listener ports or enter the server runtime.
 
+## Dumping Effective Configuration
+
+Use `--dump` (or `-T`) to validate and dump the
+effective parsed configuration as YAML to stdout. The
+output includes the effective parsed config (with
+defaults applied) plus resolved top-level listener
+chains.
+
+```sh
+praxis --dump --config praxis.yaml
+praxis -T -c praxis.yaml
+```
+
+Exits `0` on valid config, writing YAML to stdout.
+Exits non-zero and writes errors to stderr on failure.
+Does not start the proxy or bind listeners. `--dump`
+and `--validate` are mutually exclusive.
+
 ## Dynamic Configuration Reload
 
 Praxis watches the config file for changes and

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -27,6 +27,8 @@ notify = { workspace = true }
 praxis-core = { workspace = true }
 praxis-filter = { workspace = true }
 praxis-protocol = { workspace = true }
+serde = { workspace = true }
+serde_yaml = { workspace = true }
 tokio = { workspace = true, features = ["rt", "sync", "time", "fs"] }
 tokio-util = { workspace = true }
 tracing = { workspace = true }

--- a/server/src/commands.rs
+++ b/server/src/commands.rs
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Check-mode command helpers shared by `--validate` and `--dump`.
+
+use praxis_core::config::Config;
+
+use crate::dump;
+
+// -----------------------------------------------------------------------------
+// Shared Validation
+// -----------------------------------------------------------------------------
+
+/// Load and fully validate configuration without starting the server.
+///
+/// Shared by `--validate` and `--dump`. Runs the same validation
+/// checks used during server startup: log override validation,
+/// filter factory instantiation, chain expansion, ordering checks,
+/// and body-limit application.
+///
+/// # Errors
+///
+/// Returns an error if loading or validation fails.
+pub(crate) fn load_and_validate_for_cli(
+    explicit: Option<&str>,
+) -> Result<Config, Box<dyn std::error::Error + Send + Sync>> {
+    let config = praxis::load_config(explicit)?;
+    validate_config_for_startup(&config)?;
+    Ok(config)
+}
+
+/// Validate a parsed configuration by building filter pipelines.
+pub(crate) fn validate_config_for_startup(config: &Config) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    praxis_core::logging::validate_log_overrides(config)?;
+    let registry = praxis_filter::FilterRegistry::with_builtins();
+    let health_registry = praxis_core::health::build_health_registry(&config.clusters);
+    let kv_stores = praxis_core::kv::KvStoreRegistry::new();
+    praxis::resolve_pipelines(config, &registry, &health_registry, &kv_stores)?;
+    Ok(())
+}
+
+// -----------------------------------------------------------------------------
+// Dump
+// -----------------------------------------------------------------------------
+
+/// Load, validate, and dump effective configuration to stdout.
+///
+/// # Errors
+///
+/// Returns an error if loading, validation, or serialization fails.
+pub(crate) fn run_dump(explicit: Option<&str>) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let config = load_and_validate_for_cli(explicit)?;
+    let source = match explicit {
+        Some(path) => path.to_owned(),
+        None => default_config_source(),
+    };
+    let dump_model = dump::build_dump(&config, &source)?;
+    dump::write_dump(&dump_model)
+}
+
+/// Determine the human-readable label for implicit config sources.
+fn default_config_source() -> String {
+    if std::path::Path::new("praxis.yaml").exists() {
+        return "praxis.yaml".to_owned();
+    }
+    "<built-in default>".to_owned()
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing, reason = "tests")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_catches_invalid_log_overrides() {
+        let config = Config::from_yaml(
+            r#"
+runtime:
+  log_overrides:
+    "invalid module": "info"
+    "praxis_core": "invalid_level"
+listeners:
+  - name: web
+    address: "127.0.0.1:8080"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters: []
+"#,
+        )
+        .unwrap();
+        let result = validate_config_for_startup(&config);
+        assert!(result.is_err(), "invalid log overrides should fail validation");
+        let err = result.err().unwrap().to_string();
+        assert!(
+            err.contains("invalid module path 'invalid module'"),
+            "error should mention invalid module path: {err}"
+        );
+        assert!(
+            err.contains("invalid level 'invalid_level'"),
+            "error should mention invalid level: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_unknown_filter_type() {
+        let config = Config::from_yaml(
+            r#"
+listeners:
+  - name: web
+    address: "127.0.0.1:8080"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: nonexistent_filter_type
+"#,
+        )
+        .unwrap();
+        let result = validate_config_for_startup(&config);
+        assert!(result.is_err(), "unknown filter type should fail validation");
+    }
+}

--- a/server/src/dump.rs
+++ b/server/src/dump.rs
@@ -1,0 +1,371 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! `--dump` output: serializable effective configuration with resolved top-level listener chains.
+
+use std::{collections::HashMap, io::Write as _};
+
+use praxis_core::config::{Config, FailureMode};
+use serde::Serialize;
+
+// -----------------------------------------------------------------------------
+// Dump Model
+// -----------------------------------------------------------------------------
+
+/// Top-level dump output written to stdout as YAML.
+#[derive(Serialize)]
+pub(crate) struct EffectiveConfigDump<'a> {
+    /// Where the configuration was loaded from.
+    pub config_source: String,
+
+    /// The fully parsed configuration (with defaults applied).
+    pub configuration: &'a Config,
+
+    /// Resolved top-level listener chains, preserving config order.
+    pub resolved_listeners: Vec<ResolvedListenerDump>,
+}
+
+/// A single listener with its resolved chain and filter information.
+#[derive(Serialize)]
+pub(crate) struct ResolvedListenerDump {
+    /// Listener name from configuration.
+    pub name: String,
+
+    /// Named chains referenced by this listener, in config order.
+    pub chains: Vec<String>,
+
+    /// Flattened filters across all chains, in execution order.
+    pub filters: Vec<ResolvedFilterDump>,
+}
+
+/// A single resolved filter entry with its position metadata.
+#[derive(Serialize)]
+pub(crate) struct ResolvedFilterDump {
+    /// Name of the chain this filter belongs to.
+    pub chain: String,
+
+    /// Zero-based index of this filter within its chain.
+    pub chain_index: usize,
+
+    /// Zero-based index of this filter in the overall pipeline.
+    pub pipeline_index: usize,
+
+    /// Filter type name (e.g. `"router"`, `"load_balancer"`).
+    pub filter: String,
+
+    /// Optional user-assigned name for this filter entry.
+    pub name: Option<String>,
+
+    /// Per-filter failure behaviour.
+    pub failure_mode: FailureMode,
+}
+
+// -----------------------------------------------------------------------------
+// Build + Write
+// -----------------------------------------------------------------------------
+
+/// Build the dump model from a validated configuration.
+///
+/// # Errors
+///
+/// Returns an error if a listener references a chain not present in the config
+/// (should not happen after validation).
+pub(crate) fn build_dump<'a>(
+    config: &'a Config,
+    config_source: &str,
+) -> Result<EffectiveConfigDump<'a>, Box<dyn std::error::Error + Send + Sync>> {
+    let chains: HashMap<&str, &[_]> = config
+        .filter_chains
+        .iter()
+        .map(|c| (c.name.as_str(), c.filters.as_slice()))
+        .collect();
+
+    Ok(EffectiveConfigDump {
+        config_source: config_source.to_owned(),
+        configuration: config,
+        resolved_listeners: build_resolved_listeners(config, &chains)?,
+    })
+}
+
+/// Resolve all listeners into their dump representations.
+fn build_resolved_listeners(
+    config: &Config,
+    chains: &HashMap<&str, &[praxis_core::config::FilterEntry]>,
+) -> Result<Vec<ResolvedListenerDump>, Box<dyn std::error::Error + Send + Sync>> {
+    config
+        .listeners
+        .iter()
+        .map(|listener| build_resolved_listener(listener, chains))
+        .collect()
+}
+
+/// Resolve a single listener's chains into a flat filter list.
+fn build_resolved_listener(
+    listener: &praxis_core::config::Listener,
+    chains: &HashMap<&str, &[praxis_core::config::FilterEntry]>,
+) -> Result<ResolvedListenerDump, Box<dyn std::error::Error + Send + Sync>> {
+    Ok(ResolvedListenerDump {
+        name: listener.name.clone(),
+        chains: listener.filter_chains.clone(),
+        filters: build_resolved_filters(&listener.filter_chains, chains)?,
+    })
+}
+
+/// Flatten chain references into an ordered list of resolved filters.
+fn build_resolved_filters(
+    chain_names: &[String],
+    chains: &HashMap<&str, &[praxis_core::config::FilterEntry]>,
+) -> Result<Vec<ResolvedFilterDump>, Box<dyn std::error::Error + Send + Sync>> {
+    let mut filters = Vec::new();
+    let mut pipeline_index = 0;
+
+    for chain_name in chain_names {
+        let chain_filters = chains
+            .get(chain_name.as_str())
+            .ok_or_else(|| format!("unknown chain '{chain_name}' in validated config"))?;
+        for (chain_index, entry) in chain_filters.iter().enumerate() {
+            filters.push(ResolvedFilterDump {
+                chain: chain_name.clone(),
+                chain_index,
+                pipeline_index,
+                filter: entry.filter_type.clone(),
+                name: entry.name.clone(),
+                failure_mode: entry.failure_mode,
+            });
+            pipeline_index += 1;
+        }
+    }
+
+    Ok(filters)
+}
+
+/// Serialize the dump to YAML and write it to stdout.
+///
+/// # Errors
+///
+/// Returns an error if YAML serialization or stdout write fails.
+pub(crate) fn write_dump(dump: &EffectiveConfigDump<'_>) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let yaml = serde_yaml::to_string(dump)?;
+    std::io::stdout().lock().write_all(yaml.as_bytes())?;
+    Ok(())
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing, reason = "tests")]
+mod tests {
+    use praxis_core::config::{Config, FailureMode};
+
+    use super::*;
+
+    const ORDERED_CHAINS_YAML: &str = r#"
+listeners:
+  - name: web
+    address: "127.0.0.1:8080"
+    filter_chains: [first, second]
+filter_chains:
+  - name: first
+    filters:
+      - filter: request_id
+  - name: second
+    filters:
+      - filter: access_log
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: backend
+"#;
+
+    const REPRESENTATIVE_CONFIG_YAML: &str = r#"
+listeners:
+  - name: web
+    address: "127.0.0.1:8080"
+    filter_chains: [main]
+filter_chains:
+  - name: branch_target
+    filters:
+      - filter: request_id
+  - name: main
+    filters:
+      - filter: request_id
+        name: mark
+        conditions:
+          - when:
+              path_prefix: /api
+              methods: [GET, POST]
+        branch_chains:
+          - name: audit_branch
+            on_result:
+              filter: mark
+              result: hit
+            chains:
+              - branch_target
+              - name: inline_audit
+                filters:
+                  - filter: access_log
+            rejoin: next
+      - filter: access_log
+        response_conditions:
+          - unless:
+              status: [500]
+      - filter: static_response
+        status: 204
+"#;
+
+    #[test]
+    fn dump_defaults_appear_under_configuration() {
+        let config = Config::from_yaml(
+            r#"
+listeners:
+  - name: web
+    address: "127.0.0.1:8080"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters: []
+"#,
+        )
+        .unwrap();
+
+        let dump = build_dump(&config, "test.yaml").unwrap();
+        let yaml = serde_yaml::to_string(&dump).unwrap();
+        assert!(
+            yaml.contains("shutdown_timeout_secs: 30"),
+            "defaults should appear: {yaml}"
+        );
+        assert!(
+            yaml.contains("config_source: test.yaml"),
+            "config_source should appear: {yaml}"
+        );
+    }
+
+    #[test]
+    fn resolved_filters_preserve_chain_order() {
+        let config = Config::from_yaml(ORDERED_CHAINS_YAML).unwrap();
+
+        let dump = build_dump(&config, "test.yaml").unwrap();
+        let filters = &dump.resolved_listeners[0].filters;
+        assert_eq!(filters.len(), 3);
+        assert_filter(&filters[0], "first", 0, 0, "request_id");
+        assert_filter(&filters[1], "second", 0, 1, "access_log");
+        assert_filter(&filters[2], "second", 1, 2, "router");
+    }
+
+    /// Assert a resolved filter's chain, indices, and type name.
+    fn assert_filter(f: &ResolvedFilterDump, chain: &str, chain_idx: usize, pipeline_idx: usize, filter: &str) {
+        assert_eq!(f.chain, chain, "chain mismatch for filter {filter}");
+        assert_eq!(f.chain_index, chain_idx, "chain_index mismatch for filter {filter}");
+        assert_eq!(
+            f.pipeline_index, pipeline_idx,
+            "pipeline_index mismatch for filter {filter}"
+        );
+        assert_eq!(f.filter, filter, "filter type mismatch");
+    }
+
+    #[test]
+    fn representative_config_roundtrips_through_yaml_serialization() {
+        let config = Config::from_yaml(REPRESENTATIVE_CONFIG_YAML).unwrap();
+        let serialized = serde_yaml::to_string(&config).unwrap();
+
+        assert!(
+            serialized.contains("when:"),
+            "request conditions should serialize as maps"
+        );
+        assert!(
+            serialized.contains("unless:"),
+            "response conditions should serialize as maps"
+        );
+        assert!(
+            !serialized.contains("!when"),
+            "request conditions should not serialize as tags"
+        );
+        assert!(
+            !serialized.contains("!unless"),
+            "response conditions should not serialize as tags"
+        );
+
+        let reparsed = Config::from_yaml(&serialized).unwrap();
+        assert_eq!(reparsed.listeners.len(), config.listeners.len());
+        assert_eq!(reparsed.filter_chains.len(), config.filter_chains.len());
+    }
+
+    #[test]
+    fn empty_listener_chains_produce_empty_filter_list() {
+        let config = Config::from_yaml(
+            r#"
+listeners:
+  - name: web
+    address: "127.0.0.1:8080"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters: []
+"#,
+        )
+        .unwrap();
+
+        let dump = build_dump(&config, "test.yaml").unwrap();
+        let listener = &dump.resolved_listeners[0];
+        assert!(listener.filters.is_empty(), "empty chain should produce no filters");
+        assert_eq!(listener.chains, vec!["main"]);
+    }
+
+    #[test]
+    fn failure_mode_serializes_lowercase() {
+        let config = Config::from_yaml(
+            r#"
+listeners:
+  - name: web
+    address: "127.0.0.1:8080"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: access_log
+        failure_mode: open
+      - filter: router
+        routes: []
+"#,
+        )
+        .unwrap();
+
+        let dump = build_dump(&config, "test.yaml").unwrap();
+        assert_eq!(dump.resolved_listeners[0].filters[0].failure_mode, FailureMode::Open);
+        assert_eq!(dump.resolved_listeners[0].filters[1].failure_mode, FailureMode::Closed);
+
+        let yaml = serde_yaml::to_string(&dump).unwrap();
+        assert!(
+            yaml.contains("failure_mode: open"),
+            "open should serialize lowercase: {yaml}"
+        );
+        assert!(
+            yaml.contains("failure_mode: closed"),
+            "closed should serialize lowercase: {yaml}"
+        );
+    }
+
+    #[test]
+    fn filter_name_included_when_set() {
+        let config = Config::from_yaml(
+            r#"
+listeners:
+  - name: web
+    address: "127.0.0.1:8080"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: router
+        name: routing
+        routes: []
+"#,
+        )
+        .unwrap();
+
+        let dump = build_dump(&config, "test.yaml").unwrap();
+        assert_eq!(dump.resolved_listeners[0].filters[0].name.as_deref(), Some("routing"));
+    }
+}

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -17,6 +17,9 @@
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
+mod commands;
+mod dump;
+
 use clap::Parser;
 use tracing::info;
 
@@ -31,6 +34,10 @@ struct Cli {
     /// Path to the YAML configuration file.
     #[arg(short = 'c', long = "config")]
     config: Option<String>,
+
+    /// Dump effective configuration as YAML and exit.
+    #[arg(short = 'T', long = "dump", conflicts_with = "validate")]
+    dump: bool,
 
     /// Validate configuration and exit.
     #[arg(short = 't', long = "validate")]
@@ -48,8 +55,16 @@ fn main() {
     let explicit = cli.config.or_else(|| std::env::var("PRAXIS_CONFIG").ok());
 
     if cli.validate {
-        if let Err(e) = run_validate(explicit.as_deref()) {
+        if let Err(e) = commands::load_and_validate_for_cli(explicit.as_deref()) {
             eprintln!("invalid configuration: {e}");
+            std::process::exit(1);
+        }
+        return;
+    }
+
+    if cli.dump {
+        if let Err(e) = commands::run_dump(explicit.as_deref()) {
+            eprintln!("dump failed: {e}");
             std::process::exit(1);
         }
         return;
@@ -62,28 +77,6 @@ fn main() {
     praxis::run_server(config, config_path)
 }
 
-/// Load and fully validate configuration without starting the server.
-fn run_validate(explicit: Option<&str>) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let config = praxis::load_config(explicit)?;
-    validate_config(&config)?;
-    Ok(())
-}
-
-/// Validate a parsed configuration by building filter pipelines.
-///
-/// Runs the same validation checks used during server startup:
-/// log override validation (validates `runtime.log_overrides`),
-/// filter factory instantiation, chain expansion, ordering checks,
-/// and body-limit application.
-fn validate_config(config: &praxis_core::config::Config) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    praxis_core::logging::validate_log_overrides(config)?;
-    let registry = praxis_filter::FilterRegistry::with_builtins();
-    let health_registry = praxis_core::health::build_health_registry(&config.clusters);
-    let kv_stores = praxis_core::kv::KvStoreRegistry::new();
-    praxis::resolve_pipelines(config, &registry, &health_registry, &kv_stores)?;
-    Ok(())
-}
-
 // -----------------------------------------------------------------------------
 // Tests
 // -----------------------------------------------------------------------------
@@ -93,7 +86,11 @@ fn validate_config(config: &praxis_core::config::Config) -> Result<(), Box<dyn s
 mod tests {
     use clap::Parser;
 
-    use super::{Cli, validate_config};
+    use super::Cli;
+
+    // -------------------------------------------------------------------------
+    // --validate CLI parsing
+    // -------------------------------------------------------------------------
 
     #[test]
     fn cli_validate_short_flag() {
@@ -119,36 +116,42 @@ mod tests {
     fn cli_default_no_validate() {
         let cli = Cli::parse_from(["praxis"]);
         assert!(!cli.validate, "validate should default to false");
+        assert!(!cli.dump, "dump should default to false");
+    }
+
+    // -------------------------------------------------------------------------
+    // --dump CLI parsing
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn cli_dump_short_flag() {
+        let cli = Cli::parse_from(["praxis", "-T"]);
+        assert!(cli.dump, "-T should set dump to true");
+        assert!(!cli.validate, "validate should remain false");
     }
 
     #[test]
-    fn validate_config_catches_invalid_log_overrides() {
-        let config = praxis_core::config::Config::from_yaml(
-            r#"
-runtime:
-  log_overrides:
-    "invalid module": "info"
-    "praxis_core": "invalid_level"
-listeners:
-  - name: web
-    address: "127.0.0.1:8080"
-    filter_chains: [main]
-filter_chains:
-  - name: main
-    filters: []
-"#,
-        )
-        .unwrap();
-        let result = validate_config(&config);
-        assert!(result.is_err(), "invalid log overrides should fail validation");
-        let err = result.err().unwrap().to_string();
-        assert!(
-            err.contains("invalid module path 'invalid module'"),
-            "error should mention invalid module path: {err}"
-        );
-        assert!(
-            err.contains("invalid level 'invalid_level'"),
-            "error should mention invalid level: {err}"
-        );
+    fn cli_dump_long_flag() {
+        let cli = Cli::parse_from(["praxis", "--dump"]);
+        assert!(cli.dump, "--dump should set dump to true");
+    }
+
+    #[test]
+    fn cli_dump_with_config() {
+        let cli = Cli::parse_from(["praxis", "-T", "-c", "custom.yaml"]);
+        assert!(cli.dump, "-T should set dump to true");
+        assert_eq!(cli.config.as_deref(), Some("custom.yaml"), "-c should set config path");
+    }
+
+    #[test]
+    fn cli_dump_conflicts_with_validate() {
+        let result = Cli::try_parse_from(["praxis", "--dump", "--validate"]);
+        assert!(result.is_err(), "--dump and --validate should conflict");
+    }
+
+    #[test]
+    fn cli_dump_short_conflicts_with_validate_short() {
+        let result = Cli::try_parse_from(["praxis", "-T", "-t"]);
+        assert!(result.is_err(), "-T and -t should conflict");
     }
 }


### PR DESCRIPTION
## Summary

2nd half of #131. This is the `--dump` functionality. It grew a bit more than I planned as it moves some `--validate` functions out of main.rs to avoid growing the binary.

- Moved load_and_validate_for_cli, validate_config_for_startup, run_dump, and resolve_config_source from main.rs into commands.rs so main.rs stays a thin CLI dispatcher and the check-mode behavior is testable without growing the binary entry point.
- Add `praxis --dump` / `-T` as a non-serving CLI mode.
- Emit YAML with the config source, effective parsed configuration with defaults, and resolved top-level listener chains.
- Add serialization support for config types needed by the effective config dump.
- `--dump` and `--validate` are mutually exclusive; both exit 0 on success, non-zero with errors to stderr on failure; neither starts the server

  ## Testing

  - `cargo check -p praxis`
  - `cargo test -p praxis`
  - `cargo clippy -p praxis --all-targets -- -D warnings`

Example output can be found here: https://gist.github.com/nerdalert/0a2028d9581bd17ea8b5463f56e85870