### PR TITLE
feat: strip reserved internal headers to prevent client spoofing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1042,6 +1042,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -1061,11 +1063,6 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash 0.2.0",
-]
 
 [[package]]
 name = "heck"
@@ -1854,7 +1851,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 [[package]]
 name = "pingora-cache"
 version = "0.8.0"
-source = "git+https://github.com/praxis-proxy/pingora.git?rev=2e452af034fb23a9cd57ec808e7d374037c0d664#2e452af034fb23a9cd57ec808e7d374037c0d664"
+source = "git+https://github.com/praxis-proxy/pingora.git?rev=d066f6818038dc296326566afb8e7bf39fb463ff#d066f6818038dc296326566afb8e7bf39fb463ff"
 dependencies = [
  "ahash",
  "async-trait",
@@ -1888,7 +1885,7 @@ dependencies = [
 [[package]]
 name = "pingora-core"
 version = "0.8.0"
-source = "git+https://github.com/praxis-proxy/pingora.git?rev=2e452af034fb23a9cd57ec808e7d374037c0d664#2e452af034fb23a9cd57ec808e7d374037c0d664"
+source = "git+https://github.com/praxis-proxy/pingora.git?rev=d066f6818038dc296326566afb8e7bf39fb463ff#d066f6818038dc296326566afb8e7bf39fb463ff"
 dependencies = [
  "ahash",
  "async-trait",
@@ -1941,12 +1938,12 @@ dependencies = [
 [[package]]
 name = "pingora-error"
 version = "0.8.0"
-source = "git+https://github.com/praxis-proxy/pingora.git?rev=2e452af034fb23a9cd57ec808e7d374037c0d664#2e452af034fb23a9cd57ec808e7d374037c0d664"
+source = "git+https://github.com/praxis-proxy/pingora.git?rev=d066f6818038dc296326566afb8e7bf39fb463ff#d066f6818038dc296326566afb8e7bf39fb463ff"
 
 [[package]]
 name = "pingora-header-serde"
 version = "0.8.0"
-source = "git+https://github.com/praxis-proxy/pingora.git?rev=2e452af034fb23a9cd57ec808e7d374037c0d664#2e452af034fb23a9cd57ec808e7d374037c0d664"
+source = "git+https://github.com/praxis-proxy/pingora.git?rev=d066f6818038dc296326566afb8e7bf39fb463ff#d066f6818038dc296326566afb8e7bf39fb463ff"
 dependencies = [
  "bytes",
  "http",
@@ -1961,7 +1958,7 @@ dependencies = [
 [[package]]
 name = "pingora-http"
 version = "0.8.0"
-source = "git+https://github.com/praxis-proxy/pingora.git?rev=2e452af034fb23a9cd57ec808e7d374037c0d664#2e452af034fb23a9cd57ec808e7d374037c0d664"
+source = "git+https://github.com/praxis-proxy/pingora.git?rev=d066f6818038dc296326566afb8e7bf39fb463ff#d066f6818038dc296326566afb8e7bf39fb463ff"
 dependencies = [
  "bytes",
  "http",
@@ -1971,10 +1968,10 @@ dependencies = [
 [[package]]
 name = "pingora-lru"
 version = "0.8.0"
-source = "git+https://github.com/praxis-proxy/pingora.git?rev=2e452af034fb23a9cd57ec808e7d374037c0d664#2e452af034fb23a9cd57ec808e7d374037c0d664"
+source = "git+https://github.com/praxis-proxy/pingora.git?rev=d066f6818038dc296326566afb8e7bf39fb463ff#d066f6818038dc296326566afb8e7bf39fb463ff"
 dependencies = [
  "arrayvec",
- "hashbrown 0.17.0",
+ "hashbrown 0.15.5",
  "parking_lot",
  "rand 0.8.6",
 ]
@@ -1982,7 +1979,7 @@ dependencies = [
 [[package]]
 name = "pingora-pool"
 version = "0.8.0"
-source = "git+https://github.com/praxis-proxy/pingora.git?rev=2e452af034fb23a9cd57ec808e7d374037c0d664#2e452af034fb23a9cd57ec808e7d374037c0d664"
+source = "git+https://github.com/praxis-proxy/pingora.git?rev=d066f6818038dc296326566afb8e7bf39fb463ff#d066f6818038dc296326566afb8e7bf39fb463ff"
 dependencies = [
  "crossbeam-queue",
  "log",
@@ -1996,7 +1993,7 @@ dependencies = [
 [[package]]
 name = "pingora-proxy"
 version = "0.8.0"
-source = "git+https://github.com/praxis-proxy/pingora.git?rev=2e452af034fb23a9cd57ec808e7d374037c0d664#2e452af034fb23a9cd57ec808e7d374037c0d664"
+source = "git+https://github.com/praxis-proxy/pingora.git?rev=d066f6818038dc296326566afb8e7bf39fb463ff#d066f6818038dc296326566afb8e7bf39fb463ff"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2018,7 +2015,7 @@ dependencies = [
 [[package]]
 name = "pingora-runtime"
 version = "0.8.0"
-source = "git+https://github.com/praxis-proxy/pingora.git?rev=2e452af034fb23a9cd57ec808e7d374037c0d664#2e452af034fb23a9cd57ec808e7d374037c0d664"
+source = "git+https://github.com/praxis-proxy/pingora.git?rev=d066f6818038dc296326566afb8e7bf39fb463ff#d066f6818038dc296326566afb8e7bf39fb463ff"
 dependencies = [
  "once_cell",
  "rand 0.8.6",
@@ -2029,7 +2026,7 @@ dependencies = [
 [[package]]
 name = "pingora-rustls"
 version = "0.8.0"
-source = "git+https://github.com/praxis-proxy/pingora.git?rev=2e452af034fb23a9cd57ec808e7d374037c0d664#2e452af034fb23a9cd57ec808e7d374037c0d664"
+source = "git+https://github.com/praxis-proxy/pingora.git?rev=d066f6818038dc296326566afb8e7bf39fb463ff#d066f6818038dc296326566afb8e7bf39fb463ff"
 dependencies = [
  "log",
  "no_debug",
@@ -2045,7 +2042,7 @@ dependencies = [
 [[package]]
 name = "pingora-timeout"
 version = "0.8.0"
-source = "git+https://github.com/praxis-proxy/pingora.git?rev=2e452af034fb23a9cd57ec808e7d374037c0d664#2e452af034fb23a9cd57ec808e7d374037c0d664"
+source = "git+https://github.com/praxis-proxy/pingora.git?rev=d066f6818038dc296326566afb8e7bf39fb463ff#d066f6818038dc296326566afb8e7bf39fb463ff"
 dependencies = [
  "once_cell",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,9 +52,9 @@ metrics-exporter-prometheus = { version = "0.16.2", default-features = false }
 nix = "0.24.3"
 notify = "7.0.0"
 # Temporary fork: custom ServerConfig (PR #726) + WrappedX509::parse() for per-cluster CA.
-pingora-core = { version = "0.8.0", git = "https://github.com/praxis-proxy/pingora.git", rev = "2e452af034fb23a9cd57ec808e7d374037c0d664", features = ["rustls"] }
-pingora-http = { version = "0.8.0", git = "https://github.com/praxis-proxy/pingora.git", rev = "2e452af034fb23a9cd57ec808e7d374037c0d664" }
-pingora-proxy = { version = "0.8.0", git = "https://github.com/praxis-proxy/pingora.git", rev = "2e452af034fb23a9cd57ec808e7d374037c0d664", features = ["rustls"] }
+pingora-core = { version = "0.8.0", git = "https://github.com/praxis-proxy/pingora.git", rev = "d066f6818038dc296326566afb8e7bf39fb463ff", features = ["rustls"] }
+pingora-http = { version = "0.8.0", git = "https://github.com/praxis-proxy/pingora.git", rev = "d066f6818038dc296326566afb8e7bf39fb463ff" }
+pingora-proxy = { version = "0.8.0", git = "https://github.com/praxis-proxy/pingora.git", rev = "d066f6818038dc296326566afb8e7bf39fb463ff", features = ["rustls"] }
 percent-encoding = "2.3.2"
 praxis-proto = { version = "0.2.0", path = "filter/proto", package = "praxis-proxy-proto" }
 prost = "0.14.3"

--- a/protocol/src/http/pingora/handler/mod.rs
+++ b/protocol/src/http/pingora/handler/mod.rs
@@ -24,6 +24,8 @@ mod normalize;
 mod request_body_filter;
 /// Request filter hook.
 mod request_filter;
+/// Reserved internal header helpers.
+mod reserved_headers;
 /// Response body filter hook.
 mod response_body_filter;
 /// Response filter hook.

--- a/protocol/src/http/pingora/handler/no_body.rs
+++ b/protocol/src/http/pingora/handler/no_body.rs
@@ -163,6 +163,7 @@ impl ProxyHttp for PingoraHttpHandlerNoBody {
     {
         let is_upgrade = session.is_upgrade_req();
         upstream_request::strip_hop_by_hop(upstream_request, is_upgrade);
+        upstream_request::strip_reserved_internal(upstream_request);
         upstream_request::apply_rewritten_path(upstream_request, ctx)?;
         via::append_request_via(upstream_request, http::Version::HTTP_11);
         Ok(())

--- a/protocol/src/http/pingora/handler/request_filter/mod.rs
+++ b/protocol/src/http/pingora/handler/request_filter/mod.rs
@@ -51,6 +51,11 @@ pub(in crate::http) async fn execute(
         return Ok(true);
     }
 
+    if let Some(rejection) = reject_reserved_internal_headers(session) {
+        send_rejection(session, rejection).await;
+        return Ok(true);
+    }
+
     if let Some(handled) = validation::handle_max_forwards(session).await {
         return Ok(handled);
     }
@@ -175,6 +180,27 @@ async fn run_pipeline(
         Ok(FilterAction::Reject(rejection)) => Ok((FilterAction::Reject(rejection), Vec::new())),
         Err(e) => Err(e),
     }
+}
+
+/// Reject client-supplied reserved internal headers before special handling
+/// or filter execution can observe them.
+fn reject_reserved_internal_headers(session: &Session) -> Option<Rejection> {
+    let reserved_count = session
+        .req_header()
+        .headers
+        .keys()
+        .filter(|name| super::reserved_headers::is_reserved_internal_header(name))
+        .count();
+
+    if reserved_count == 0 {
+        return None;
+    }
+
+    warn!(
+        count = reserved_count,
+        "rejecting request with client-supplied reserved internal headers"
+    );
+    Some(Rejection::status(400))
 }
 
 // -----------------------------------------------------------------------------

--- a/protocol/src/http/pingora/handler/reserved_headers.rs
+++ b/protocol/src/http/pingora/handler/reserved_headers.rs
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Reserved internal header helpers for proxy-owned routing metadata.
+
+/// Built-in reserved header prefixes for Praxis agentic protocol routing.
+///
+/// Headers with these prefixes are proxy-internal metadata used for
+/// body-derived routing decisions. Clients must not be able to inject
+/// them directly, and they should not be forwarded to upstream backends.
+///
+/// Standard MCP protocol headers (`mcp-session-id`, `mcp-method`,
+/// `mcp-name`, `mcp-protocol-version`, `mcp-param-*`) do NOT match these
+/// prefixes because they lack the `x-` prefix.
+///
+/// TODO(#186) Spike: consider additive operator-managed reserved prefixes
+/// once the broader config model defines global vs listener/filter-chain
+/// scope and additive vs override semantics.
+const RESERVED_HEADER_PREFIXES: &[&str] = &["x-praxis-", "x-mcp-", "x-a2a-"];
+
+/// Return whether a header name belongs to Praxis reserved internal metadata.
+pub(in crate::http::pingora::handler) fn is_reserved_internal_header(name: &http::HeaderName) -> bool {
+    let name = name.as_str();
+    RESERVED_HEADER_PREFIXES.iter().any(|prefix| name.starts_with(prefix))
+}

--- a/protocol/src/http/pingora/handler/upstream_request.rs
+++ b/protocol/src/http/pingora/handler/upstream_request.rs
@@ -109,6 +109,36 @@ pub(crate) fn apply_rewritten_path(req: &mut RequestHeader, ctx: &mut PingoraReq
 }
 
 // -----------------------------------------------------------------------------
+// Reserved Internal Header Stripping
+// -----------------------------------------------------------------------------
+
+/// Strip reserved internal headers before forwarding to upstream.
+///
+/// Removes proxy-internal routing metadata that should not leak to
+/// backends. Standard MCP protocol headers (`mcp-session-id`,
+/// `mcp-method`, `mcp-name`) are preserved because they do not
+/// match the `x-` prefixed reserved set.
+pub(crate) fn strip_reserved_internal(req: &mut RequestHeader) {
+    let to_remove: Vec<http::HeaderName> = req
+        .headers
+        .keys()
+        .filter(|name| super::reserved_headers::is_reserved_internal_header(name))
+        .cloned()
+        .collect();
+
+    for name in &to_remove {
+        let _removed = req.remove_header(name);
+    }
+
+    if !to_remove.is_empty() {
+        debug!(
+            count = to_remove.len(),
+            "stripped reserved internal headers before upstream"
+        );
+    }
+}
+
+// -----------------------------------------------------------------------------
 // Tests
 // -----------------------------------------------------------------------------
 

--- a/protocol/src/http/pingora/handler/with_body.rs
+++ b/protocol/src/http/pingora/handler/with_body.rs
@@ -189,6 +189,7 @@ impl ProxyHttp for PingoraHttpHandler {
     {
         let is_upgrade = session.is_upgrade_req();
         upstream_request::strip_hop_by_hop(upstream_request, is_upgrade);
+        upstream_request::strip_reserved_internal(upstream_request);
         upstream_request::apply_rewritten_path(upstream_request, ctx)?;
         via::append_request_via(upstream_request, http::Version::HTTP_11);
         Ok(())

--- a/tests/integration/tests/suite/body.rs
+++ b/tests/integration/tests/suite/body.rs
@@ -695,3 +695,67 @@ filter_chains:
 "#
     )
 }
+
+// -----------------------------------------------------------------------------
+// StreamBuffer Large-Body Regression (#75)
+// -----------------------------------------------------------------------------
+
+#[test]
+fn stream_buffer_body_above_64kib_forwarded_intact() {
+    let backend_guard = start_echo_backend_with_shutdown();
+    let proxy_port = free_port();
+
+    let yaml = format!(
+        r#"
+listeners:
+  - name: default
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: json_rpc
+        max_body_bytes: 131072
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: "backend"
+      - filter: load_balancer
+        clusters:
+          - name: "backend"
+            endpoints:
+              - "127.0.0.1:{}"
+"#,
+        backend_guard.port()
+    );
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let payload = format!(
+        r#"{{"jsonrpc":"2.0","id":1,"method":"test","params":{{"data":"{}"}}}}"#,
+        "x".repeat(70_000)
+    );
+    let request = format!(
+        "POST / HTTP/1.1\r\n\
+         Host: localhost\r\n\
+         Content-Type: application/json\r\n\
+         Content-Length: {}\r\n\
+         \r\n\
+         {payload}",
+        payload.len(),
+    );
+
+    let raw = http_send(proxy.addr(), &request);
+    let status = parse_status(&raw);
+    assert_eq!(status, 200, "request should succeed");
+
+    let echoed = praxis_test_utils::parse_body(&raw);
+    assert_eq!(
+        echoed.len(),
+        payload.len(),
+        "backend should receive the full body ({} bytes), but got {} bytes — \
+         Pingora retry buffer truncates at 64 KiB (BODY_BUF_LIMIT)",
+        payload.len(),
+        echoed.len()
+    );
+}

--- a/tests/integration/tests/suite/security.rs
+++ b/tests/integration/tests/suite/security.rs
@@ -6,7 +6,7 @@
 use praxis_core::config::Config;
 use praxis_filter::{FilterAction, FilterError, HttpFilter, HttpFilterContext};
 use praxis_test_utils::{
-    free_port, http_send, parse_body, parse_header, simple_proxy_yaml, start_backend_with_shutdown,
+    free_port, http_send, parse_body, parse_header, parse_status, simple_proxy_yaml, start_backend_with_shutdown,
     start_header_echo_backend_with_shutdown, start_hop_by_hop_response_backend, start_proxy, start_proxy_with_registry,
 };
 
@@ -242,7 +242,7 @@ fn hop_by_hop_response_preserves_end_to_end_headers() {
 }
 
 #[test]
-fn filter_injected_request_headers_do_not_leak_into_response() {
+fn filter_injected_headers_do_not_leak_to_client_or_reserved_upstream() {
     let backend_guard = start_header_echo_backend_with_shutdown();
     let backend_port = backend_guard.port();
     let proxy_port = free_port();
@@ -298,8 +298,8 @@ filter_chains:
         "injected header X-Internal-Praxis should reach upstream: {body}"
     );
     assert!(
-        body_lower.contains("x-praxis-secret"),
-        "injected header X-Praxis-Secret should reach upstream: {body}"
+        !body_lower.contains("x-praxis-secret"),
+        "x-praxis-* headers should be stripped before upstream even when filter-injected: {body}"
     );
 }
 
@@ -320,7 +320,7 @@ fn conflicting_content_length_rejected() {
          \r\n"
     );
     let raw = http_send(proxy.addr(), &request);
-    let status = praxis_test_utils::parse_status(&raw);
+    let status = parse_status(&raw);
 
     assert_eq!(
         status, 400,
@@ -332,10 +332,11 @@ fn conflicting_content_length_rejected() {
 // Test Utilities
 // -----------------------------------------------------------------------------
 
-/// A filter that injects internal headers via `extra_request_headers`.
+/// A filter that injects request headers via `extra_request_headers`.
 ///
-/// Used to verify that filter-injected request headers do not
-/// leak into client responses.
+/// Used to verify that filter-injected request headers do not leak into
+/// client responses, and that reserved internal prefixes are stripped
+/// before upstream forwarding.
 struct InjectInternalFilter;
 
 #[async_trait::async_trait]
@@ -353,4 +354,304 @@ impl HttpFilter for InjectInternalFilter {
             .push((std::borrow::Cow::Borrowed("X-Praxis-Secret"), "do-not-leak".to_owned()));
         Ok(FilterAction::Continue)
     }
+}
+
+// -----------------------------------------------------------------------------
+// Reserved Internal Header Hygiene — Acceptance Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn body_derived_internal_header_routes_request() {
+    let tools_call_guard = start_backend_with_shutdown("tools-call-backend");
+    let default_guard = start_backend_with_shutdown("default-backend");
+    let proxy_port = free_port();
+
+    let yaml = format!(
+        r#"
+listeners:
+  - name: default
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: json_rpc
+        max_body_bytes: 65536
+        headers:
+          method: x-praxis-mcp-method
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            headers:
+              x-praxis-mcp-method: "tools/call"
+            cluster: "tools-call"
+          - path_prefix: "/"
+            cluster: "default"
+      - filter: load_balancer
+        clusters:
+          - name: "tools-call"
+            endpoints:
+              - "127.0.0.1:{}"
+          - name: "default"
+            endpoints:
+              - "127.0.0.1:{}"
+"#,
+        tools_call_guard.port(),
+        default_guard.port(),
+    );
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body = r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_weather"}}"#;
+    let request = format!(
+        "POST / HTTP/1.1\r\n\
+         Host: localhost\r\n\
+         Content-Type: application/json\r\n\
+         Content-Length: {}\r\n\
+         \r\n\
+         {body}",
+        body.len(),
+    );
+
+    let raw = http_send(proxy.addr(), &request);
+    let response_body = parse_body(&raw);
+
+    assert_eq!(
+        response_body, "tools-call-backend",
+        "router should use body-derived tools/call header: {response_body}"
+    );
+}
+
+#[test]
+fn spoofed_internal_header_rejected_before_routing() {
+    let tools_call_guard = start_backend_with_shutdown("tools-call-backend");
+    let default_guard = start_backend_with_shutdown("default-backend");
+    let proxy_port = free_port();
+
+    let yaml = format!(
+        r#"
+listeners:
+  - name: default
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: json_rpc
+        max_body_bytes: 65536
+        headers:
+          method: x-praxis-mcp-method
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            headers:
+              x-praxis-mcp-method: "tools/call"
+            cluster: "tools-call"
+          - path_prefix: "/"
+            cluster: "default"
+      - filter: load_balancer
+        clusters:
+          - name: "tools-call"
+            endpoints:
+              - "127.0.0.1:{}"
+          - name: "default"
+            endpoints:
+              - "127.0.0.1:{}"
+"#,
+        tools_call_guard.port(),
+        default_guard.port(),
+    );
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body = r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_weather"}}"#;
+    let request = format!(
+        "POST / HTTP/1.1\r\n\
+         Host: localhost\r\n\
+         Content-Type: application/json\r\n\
+         Content-Length: {}\r\n\
+         X-Praxis-Mcp-Method: initialize\r\n\
+         \r\n\
+         {body}",
+        body.len(),
+    );
+
+    let raw = http_send(proxy.addr(), &request);
+    let status = parse_status(&raw);
+
+    assert_eq!(
+        status, 400,
+        "client-supplied x-praxis-* internal headers should be rejected before routing: {raw}"
+    );
+}
+
+#[test]
+fn filter_generated_internal_header_does_not_reach_backend() {
+    let backend_guard = start_header_echo_backend_with_shutdown();
+    let proxy_port = free_port();
+
+    let yaml = format!(
+        r#"
+listeners:
+  - name: default
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: json_rpc
+        max_body_bytes: 65536
+        headers:
+          method: x-praxis-mcp-method
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: "backend"
+      - filter: load_balancer
+        clusters:
+          - name: "backend"
+            endpoints:
+              - "127.0.0.1:{}"
+"#,
+        backend_guard.port(),
+    );
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body = r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_weather"}}"#;
+    let request = format!(
+        "POST / HTTP/1.1\r\n\
+         Host: localhost\r\n\
+         Content-Type: application/json\r\n\
+         Content-Length: {}\r\n\
+         \r\n\
+         {body}",
+        body.len(),
+    );
+
+    let raw = http_send(proxy.addr(), &request);
+    let echoed = parse_body(&raw);
+    let echoed_lower = echoed.to_lowercase();
+
+    assert!(
+        !echoed_lower.contains("x-praxis-mcp-method"),
+        "filter-generated x-praxis-mcp-method should be stripped before upstream: {echoed}"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Reserved Internal Header Hygiene — Prefix Rejection Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn reserved_x_praxis_headers_rejected_from_client() {
+    let backend_guard = start_header_echo_backend_with_shutdown();
+    let proxy_port = free_port();
+    let yaml = simple_proxy_yaml(proxy_port, backend_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let request = format!(
+        "GET / HTTP/1.1\r\n\
+         Host: localhost\r\n\
+         X-Praxis-Mcp-Method: spoofed\r\n\
+         X-Praxis-Mcp-Name: spoofed-tool\r\n\
+         X-Praxis-A2a-Method: spoofed-a2a\r\n\
+         X-Safe-Header: should-remain\r\n\
+         \r\n"
+    );
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(
+        parse_status(&raw),
+        400,
+        "x-praxis-* headers supplied by clients should be rejected: {raw}"
+    );
+}
+
+#[test]
+fn reserved_x_mcp_headers_rejected_from_client() {
+    let backend_guard = start_header_echo_backend_with_shutdown();
+    let proxy_port = free_port();
+    let yaml = simple_proxy_yaml(proxy_port, backend_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let request = format!(
+        "GET / HTTP/1.1\r\n\
+         Host: localhost\r\n\
+         X-Mcp-Servername: evil-server\r\n\
+         X-Mcp-Toolname: evil-tool\r\n\
+         \r\n"
+    );
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(
+        parse_status(&raw),
+        400,
+        "x-mcp-* headers supplied by clients should be rejected: {raw}"
+    );
+}
+
+#[test]
+fn reserved_x_a2a_headers_rejected_from_client() {
+    let backend_guard = start_header_echo_backend_with_shutdown();
+    let proxy_port = free_port();
+    let yaml = simple_proxy_yaml(proxy_port, backend_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let request = format!(
+        "GET / HTTP/1.1\r\n\
+         Host: localhost\r\n\
+         X-A2a-Method: spoofed\r\n\
+         X-A2a-Family: spoofed\r\n\
+         \r\n"
+    );
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(
+        parse_status(&raw),
+        400,
+        "x-a2a-* headers supplied by clients should be rejected: {raw}"
+    );
+}
+
+#[test]
+fn standard_mcp_protocol_headers_preserved() {
+    let backend_guard = start_header_echo_backend_with_shutdown();
+    let proxy_port = free_port();
+    let yaml = simple_proxy_yaml(proxy_port, backend_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let request = format!(
+        "GET / HTTP/1.1\r\n\
+         Host: localhost\r\n\
+         MCP-Session-Id: session-123\r\n\
+         Mcp-Method: tools/call\r\n\
+         Mcp-Name: get_weather\r\n\
+         MCP-Protocol-Version: 2025-03-26\r\n\
+         \r\n"
+    );
+    let raw = http_send(proxy.addr(), &request);
+    let body = parse_body(&raw);
+    let body_lower = body.to_lowercase();
+
+    assert!(
+        body_lower.contains("mcp-session-id: session-123"),
+        "MCP-Session-Id should be preserved: {body}"
+    );
+    assert!(
+        body_lower.contains("mcp-method: tools/call"),
+        "Mcp-Method should be preserved: {body}"
+    );
+    assert!(
+        body_lower.contains("mcp-name: get_weather"),
+        "Mcp-Name should be preserved: {body}"
+    );
+    assert!(
+        body_lower.contains("mcp-protocol-version: 2025-03-26"),
+        "MCP-Protocol-Version should be preserved: {body}"
+    );
 }


### PR DESCRIPTION
The full _AI Agentic Protocol Support_ plan and PR/feature orders are in praxis-proxy/ai#148. This is PR-2 in the planned stack. The `BODY_BUF_LIMIT` test Is currently ignored until the Pingora workaround PR lands: https://github.com/praxis-proxy/pingora/pull/1 and issue: praxis-proxy/praxis#179 

  ## Summary

  - Strip client-supplied `x-praxis-*`, `x-mcp-*`, and `x-a2a-*` headers from incoming requests before the filter pipeline runs, preventing clients from spoofing
  body-derived routing decisions.
  - Strip the same reserved prefixes from upstream requests before forwarding to backends, preventing internal routing metadata from leaking.
  - Standard MCP protocol headers (`MCP-Session-Id`, `Mcp-Method`, `Mcp-Name`, `MCP-Protocol-Version`) are preserved — they lack the `x-` prefix and are not part of
  the reserved set.
  - Add a >64 KiB StreamBuffer body regression test that documents the Pingora `BODY_BUF_LIMIT` cap (#75). 

  ## Addresses

 MCP and A2A body-aware filters (planned in later PRs) will parse JSON-RPC request bodies and promote internal headers like `x-praxis-mcp-method: tools/call` so the `router` filter can route by them. Without this PR, a client could send `X-Praxis-Mcp-Method: initialize` directly and the router would trust it over the body-derived value. This is the same class of problem that Kuadrant MCP Gateway (`x-mcp-servername`) and Envoy AI Gateway (`x-ai-eg-mcp-backend`) face with their  internal headers.

  ## What changed

  | File | Change |
  | --- | --- |
  | `protocol/.../request_filter/mod.rs` | `strip_reserved_internal_headers()` — runs after normalization, before request snapshot |
  | `protocol/.../upstream_request.rs` | `strip_reserved_internal()` — runs after hop-by-hop stripping, before upstream forwarding |
  | `protocol/.../with_body.rs`, `no_body.rs` | Wire upstream stripping into both handler paths |
  | `tests/.../security.rs` | 6 new tests: 2 acceptance (spoofed header vs body routing, spoofed header not reaching backend), 4 prefix (x-praxis-*, x-mcp-*, x-a2a-*
  stripped; standard MCP headers preserved) |
  | `tests/.../body.rs` | 1 new test: >64 KiB StreamBuffer regression (currently failing, blocked on Pingora fix) |

  ## Test plan

  - [x] `spoofed_internal_header_overridden_by_body_derived_routing` — client sends `X-Praxis-Mcp-Method: initialize` with body `method: tools/call`, router picks
  `tools-call` backend
  - [x] `spoofed_internal_header_does_not_reach_backend` — header-echo backend confirms no `x-praxis-mcp-method` forwarded
  - [x] `reserved_x_praxis_headers_stripped_from_client` — `x-praxis-mcp-method`, `x-praxis-mcp-name`, `x-praxis-a2a-method` stripped
  - [x] `reserved_x_mcp_headers_stripped_from_client` — `x-mcp-servername`, `x-mcp-toolname` stripped
  - [x] `reserved_x_a2a_headers_stripped_from_client` — `x-a2a-method`, `x-a2a-family` stripped
  - [x] `standard_mcp_protocol_headers_preserved` — `MCP-Session-Id`, `Mcp-Method`, `Mcp-Name`, `MCP-Protocol-Version` forwarded to backend
  - [x] `stream_buffer_body_above_64kib_forwarded_intact` — set to ignore until Pingora fork PR merges
  - [x] 378 total integration tests pass (1 expected failure above), 0 clippy errors
