### PR TITLE
feat(filter): ext_proc filter skeleton with config parsing

### DIFF
--- a/filter/src/builtins/http/mod.rs
+++ b/filter/src/builtins/http/mod.rs
@@ -4,6 +4,8 @@
 //! HTTP protocol filters, organized by category.
 
 mod ai;
+#[cfg(feature = "ext-proc")]
+pub(crate) mod net;
 mod observability;
 pub(crate) mod payload_processing;
 mod security;
@@ -11,6 +13,8 @@ mod traffic_management;
 mod transformation;
 
 pub use ai::ModelToHeaderFilter;
+#[cfg(feature = "ext-proc")]
+pub use net::ExtProcFilter;
 pub use observability::{AccessLogFilter, RequestIdFilter};
 pub use payload_processing::{CompressionFilter, JsonBodyFieldFilter, JsonRpcFilter};
 pub use security::{

--- a/filter/src/builtins/http/net/ext_proc/mod.rs
+++ b/filter/src/builtins/http/net/ext_proc/mod.rs
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Envoy-compatible external processing (`ext_proc`) filter.
+//!
+//! Sends request and response data to an external gRPC server for
+//! inspection or mutation via the Envoy [`ext_proc`] protocol.
+//!
+//! [`ext_proc`]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/ext_proc/v3/external_processor.proto
+
+#[cfg(test)]
+mod tests;
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use praxis_core::config::FailureMode;
+use serde::Deserialize;
+use tonic::transport::{Channel, Endpoint};
+
+use crate::{
+    FilterAction, FilterError,
+    factory::parse_filter_config,
+    filter::{HttpFilter, HttpFilterContext},
+};
+
+// -----------------------------------------------------------------------------
+// Constants
+// -----------------------------------------------------------------------------
+
+/// Default per-message timeout in milliseconds.
+const DEFAULT_MESSAGE_TIMEOUT_MS: u64 = 200;
+
+// -----------------------------------------------------------------------------
+// ExtProcConfig
+// -----------------------------------------------------------------------------
+
+/// YAML configuration for the `ext_proc` filter.
+///
+/// ```yaml
+/// filter: ext_proc
+/// target: "http://127.0.0.1:50051"
+/// failure_mode: open        # optional, default: closed
+/// message_timeout_ms: 200   # optional, default: 200
+/// ```
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ExtProcConfig {
+    /// gRPC endpoint URI of the external processing server.
+    target: String,
+
+    /// Behaviour when the external processor is unreachable or returns an error.
+    #[serde(default)]
+    failure_mode: FailureMode,
+
+    /// Per-message timeout in milliseconds.
+    #[serde(default = "default_message_timeout_ms")]
+    message_timeout_ms: u64,
+}
+
+/// Returns the default message timeout in milliseconds.
+fn default_message_timeout_ms() -> u64 {
+    DEFAULT_MESSAGE_TIMEOUT_MS
+}
+
+// -----------------------------------------------------------------------------
+// ExtProcFilter
+// -----------------------------------------------------------------------------
+
+/// External processing filter using the Envoy `ext_proc` gRPC protocol.
+///
+/// Establishes a gRPC channel to an external server at construction time.
+/// The channel connects lazily on first use, but a malformed endpoint URI
+/// is rejected immediately.
+///
+/// For each request, the filter opens a new bidirectional `Process` stream
+/// and sends the request headers as the first message. The server responds
+/// with header mutations or an immediate response. The same pattern repeats
+/// during the response phase.
+///
+/// # YAML configuration
+///
+/// ```yaml
+/// filter: ext_proc
+/// target: "http://127.0.0.1:50051"
+/// failure_mode: open        # optional, default: closed
+/// message_timeout_ms: 200   # optional, default: 200
+/// ```
+pub struct ExtProcFilter {
+    /// Lazily-connecting gRPC channel to the external processor.
+    #[allow(dead_code, reason = "used by gRPC callout in subsequent commits")]
+    channel: Channel,
+
+    /// Behaviour when the external processor is unreachable or errors.
+    #[allow(dead_code, reason = "used by gRPC callout in subsequent commits")]
+    failure_mode: FailureMode,
+
+    /// Per-message timeout for gRPC calls.
+    #[allow(dead_code, reason = "used by gRPC callout in subsequent commits")]
+    message_timeout: Duration,
+
+    /// gRPC endpoint URI (retained for diagnostics).
+    target: String,
+}
+
+impl ExtProcFilter {
+    /// Create from parsed YAML config.
+    ///
+    /// Validates the target URI and builds a lazily-connecting gRPC channel.
+    /// A malformed URI is rejected at construction time (fail-fast).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FilterError`] if the YAML config is malformed or the
+    /// target URI is invalid.
+    pub fn from_config(config: &serde_yaml::Value) -> Result<Box<dyn HttpFilter>, FilterError> {
+        let cfg: ExtProcConfig = parse_filter_config("ext_proc", config)?;
+
+        let endpoint: Endpoint = cfg
+            .target
+            .parse()
+            .map_err(|e: tonic::transport::Error| -> FilterError {
+                format!("ext_proc: invalid target URI '{}': {e}", cfg.target).into()
+            })?;
+
+        let channel = endpoint.connect_lazy();
+
+        Ok(Box::new(Self {
+            channel,
+            failure_mode: cfg.failure_mode,
+            message_timeout: Duration::from_millis(cfg.message_timeout_ms),
+            target: cfg.target,
+        }))
+    }
+}
+
+#[async_trait]
+impl HttpFilter for ExtProcFilter {
+    fn name(&self) -> &'static str {
+        "ext_proc"
+    }
+
+    async fn on_request(&self, _ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
+        tracing::trace!(
+            target = %self.target,
+            "ext_proc on_request (skeleton)"
+        );
+        Ok(FilterAction::Continue)
+    }
+}

--- a/filter/src/builtins/http/net/ext_proc/tests.rs
+++ b/filter/src/builtins/http/net/ext_proc/tests.rs
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    reason = "tests"
+)]
+
+use super::*;
+use crate::factory::parse_filter_config;
+
+// -----------------------------------------------------------------------------
+// Config Parsing
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn parse_valid_config() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+target: "http://127.0.0.1:50051"
+failure_mode: open
+message_timeout_ms: 500
+"#,
+    )
+    .unwrap();
+
+    let filter = ExtProcFilter::from_config(&yaml).unwrap();
+    assert_eq!(filter.name(), "ext_proc");
+}
+
+#[tokio::test]
+async fn parse_minimal_config() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(r#"target: "http://127.0.0.1:50051""#).unwrap();
+    let filter = ExtProcFilter::from_config(&yaml).unwrap();
+    assert_eq!(filter.name(), "ext_proc");
+}
+
+#[test]
+fn parse_defaults() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(r#"target: "http://127.0.0.1:50051""#).unwrap();
+    let cfg: ExtProcConfig = parse_filter_config("ext_proc", &yaml).unwrap();
+
+    assert_eq!(
+        cfg.failure_mode,
+        FailureMode::Closed,
+        "default failure_mode should be Closed"
+    );
+    assert_eq!(
+        cfg.message_timeout_ms, DEFAULT_MESSAGE_TIMEOUT_MS,
+        "default message_timeout_ms should be {DEFAULT_MESSAGE_TIMEOUT_MS}"
+    );
+}
+
+#[test]
+fn missing_target_errors() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str("failure_mode: open").unwrap();
+    let err = ExtProcFilter::from_config(&yaml).err().expect("should error");
+    assert!(
+        err.to_string().contains("target"),
+        "error should mention missing target field: {err}"
+    );
+}
+
+#[test]
+fn invalid_failure_mode_errors() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+target: "http://127.0.0.1:50051"
+failure_mode: invalid
+"#,
+    )
+    .unwrap();
+
+    let err = ExtProcFilter::from_config(&yaml).err().expect("should error");
+    assert!(
+        err.to_string().contains("unknown variant"),
+        "error should mention unknown variant: {err}"
+    );
+}
+
+#[test]
+fn unknown_field_errors() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+target: "http://127.0.0.1:50051"
+bogus_field: true
+"#,
+    )
+    .unwrap();
+
+    let err = ExtProcFilter::from_config(&yaml).err().expect("should error");
+    assert!(
+        err.to_string().contains("unknown field"),
+        "error should mention unknown field: {err}"
+    );
+}

--- a/filter/src/builtins/http/net/mod.rs
+++ b/filter/src/builtins/http/net/mod.rs
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Network callout filters: external processing, remote auth, etc.
+
+#[cfg(feature = "ext-proc")]
+pub(crate) mod ext_proc;
+
+#[cfg(feature = "ext-proc")]
+pub use ext_proc::ExtProcFilter;

--- a/filter/src/builtins/mod.rs
+++ b/filter/src/builtins/mod.rs
@@ -6,6 +6,8 @@
 pub(crate) mod http;
 mod tcp;
 
+#[cfg(feature = "ext-proc")]
+pub use http::ExtProcFilter;
 pub use http::{
     AccessLogFilter, CircuitBreakerFilter, CompressionFilter, CorsFilter, CredentialInjectionFilter, CsrfFilter,
     ForwardedHeadersFilter, GuardrailsAction, GuardrailsFilter, HeaderFilter, IpAclFilter, JsonBodyFieldFilter,

--- a/filter/src/registry.rs
+++ b/filter/src/registry.rs
@@ -139,6 +139,12 @@ fn register_http_builtins(factories: &mut HashMap<String, FilterFactory>) {
     register_http(factories, "url_rewrite", UrlRewriteFilter::from_config);
     register_http(factories, "json_body_field", JsonBodyFieldFilter::from_config);
     register_http(factories, "json_rpc", JsonRpcFilter::from_config);
+    #[cfg(feature = "ext-proc")]
+    register_http(
+        factories,
+        "ext_proc",
+        crate::builtins::ExtProcFilter::from_config,
+    );
     #[cfg(feature = "ai-inference")]
     register_http(
         factories,
@@ -248,6 +254,8 @@ mod tests {
             "json_body_field should be registered"
         );
         assert!(names.contains(&"json_rpc"), "json_rpc should be registered");
+        #[cfg(feature = "ext-proc")]
+        assert!(names.contains(&"ext_proc"), "ext_proc should be registered");
         #[cfg(feature = "ai-inference")]
         assert!(
             names.contains(&"model_to_header"),


### PR DESCRIPTION
## Summary

- Introduce the `ext_proc` filter module under `builtins/http/net/` with YAML configuration (`target`, `failure_mode`, `message_timeout_ms`)
- Lazy gRPC channel setup via the `praxis-proto` crate's Envoy ext_proc protocol definitions
- No-op `HttpFilter` implementation (skeleton for subsequent callout PRs)
- Wired into the filter registry behind the `ext-proc` feature gate
- 6 unit tests covering config parsing, defaults, and validation errors

## Context

This is the first in a series of PRs for issue #17 (External Processing). The proto crate (#94) landed the Envoy ext_proc protocol definitions; this PR adds the filter skeleton that validates config and registers in the pipeline. Subsequent PRs will add proto conversion, gRPC callout, header mutations, and integration tests.

## Test plan

- [x] `cargo test -p praxis-proxy-filter --features ext-proc -- ext_proc` (6 tests)
- [x] `cargo clippy -p praxis-proxy-filter --features ext-proc`
- [x] Default features still compile (`cargo check -p praxis-proxy-filter`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>