### PR TITLE
fix: resolve config watcher failure with bare filename paths

### DIFF
--- a/server/src/watcher.rs
+++ b/server/src/watcher.rs
@@ -425,11 +425,14 @@ mod tests {
             shutdown: shutdown.clone(),
         });
 
-        std::thread::sleep(Duration::from_millis(100));
-        assert!(
-            !handle.is_finished(),
-            "watcher should be running, not early-exited due to empty watch dir"
-        );
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        while std::time::Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(10));
+            assert!(
+                !handle.is_finished(),
+                "watcher exited early: bare filename caused empty-path notify error"
+            );
+        }
         shutdown.cancel();
         handle.join().unwrap();
     }
@@ -455,7 +458,7 @@ mod tests {
 
     impl Drop for CwdGuard {
         fn drop(&mut self) {
-            drop(std::env::set_current_dir(&self.0));
+            std::env::set_current_dir(&self.0).expect("failed to restore working directory");
         }
     }
 

--- a/server/src/watcher.rs
+++ b/server/src/watcher.rs
@@ -88,12 +88,7 @@ pub(crate) fn spawn_config_watcher(params: WatcherParams) -> std::thread::JoinHa
 async fn watch_loop(params: WatcherParams) {
     let (tx, mut rx) = mpsc::channel::<()>(16);
 
-    let watch_dir = params
-        .config_path
-        .parent()
-        .filter(|p| !p.as_os_str().is_empty())
-        .unwrap_or_else(|| std::path::Path::new("."))
-        .to_path_buf();
+    let watch_dir = watch_dir_for_path(&params.config_path);
 
     let _watcher = match setup_watcher(tx, &watch_dir) {
         Ok(w) => w,
@@ -215,6 +210,18 @@ async fn drain_and_debounce(rx: &mut mpsc::Receiver<()>) {
 /// Whether a notify event kind is relevant for config reload.
 fn is_relevant_event(kind: EventKind) -> bool {
     matches!(kind, EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_))
+}
+
+/// Resolve the directory to watch for a given config path.
+///
+/// Falls back to `.` when the path has no non-empty parent, covering
+/// bare filenames like `praxis.yaml` where [`Path::parent`] returns
+/// `Some("")` rather than `None`.
+fn watch_dir_for_path(path: &std::path::Path) -> PathBuf {
+    path.parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .unwrap_or_else(|| std::path::Path::new("."))
+        .to_path_buf()
 }
 
 // -----------------------------------------------------------------------------
@@ -371,6 +378,62 @@ mod tests {
         assert_ne!(old_ptr, new_ptr, "pipeline should recover after valid config");
 
         shutdown.cancel();
+    }
+
+    #[test]
+    fn watch_dir_for_path_bare_filename() {
+        assert_eq!(
+            watch_dir_for_path(std::path::Path::new("praxis.yaml")),
+            PathBuf::from("."),
+            "bare filename should resolve to current directory"
+        );
+    }
+
+    #[test]
+    fn watch_dir_for_path_with_directory() {
+        assert_eq!(
+            watch_dir_for_path(std::path::Path::new("/etc/praxis/praxis.yaml")),
+            PathBuf::from("/etc/praxis"),
+            "absolute path should use its parent directory"
+        );
+    }
+
+    #[test]
+    fn watcher_starts_with_bare_filename() {
+        let dir = tempfile::tempdir().unwrap();
+        let original_dir = std::env::current_dir().unwrap();
+        std::env::set_current_dir(dir.path()).unwrap();
+
+        std::fs::write("praxis.yaml", VALID_YAML).unwrap();
+
+        let config = Config::from_yaml(VALID_YAML).unwrap();
+        let registry = Arc::new(FilterRegistry::with_builtins());
+        let health_registry = Arc::new(std::collections::HashMap::new());
+        let kv_stores = praxis_core::kv::KvStoreRegistry::new();
+        let pipelines =
+            Arc::new(crate::pipelines::resolve_pipelines(&config, &registry, &health_registry, &kv_stores).unwrap());
+        let health_shutdown = Arc::new(Mutex::new(CancellationToken::new()));
+        let shutdown = CancellationToken::new();
+
+        let handle = spawn_config_watcher(WatcherParams {
+            config_path: PathBuf::from("praxis.yaml"),
+            health_shutdown,
+            initial_config: config,
+            kv_stores: praxis_core::kv::KvStoreRegistry::new(),
+            pipelines,
+            registry,
+            shutdown: shutdown.clone(),
+        });
+
+        std::thread::sleep(Duration::from_millis(100));
+        assert!(
+            !handle.is_finished(),
+            "watcher should be running, not early-exited due to empty watch dir"
+        );
+        shutdown.cancel();
+        handle.join().unwrap();
+
+        std::env::set_current_dir(original_dir).unwrap();
     }
 
     // -------------------------------------------------------------------------

--- a/server/src/watcher.rs
+++ b/server/src/watcher.rs
@@ -400,9 +400,9 @@ mod tests {
 
     #[test]
     fn watcher_starts_with_bare_filename() {
+        let _lock = CWD_MUTEX.get_or_init(Mutex::default).lock().unwrap();
         let dir = tempfile::tempdir().unwrap();
-        let original_dir = std::env::current_dir().unwrap();
-        std::env::set_current_dir(dir.path()).unwrap();
+        let _cwd = CwdGuard::new(dir.path());
 
         std::fs::write("praxis.yaml", VALID_YAML).unwrap();
 
@@ -419,7 +419,7 @@ mod tests {
             config_path: PathBuf::from("praxis.yaml"),
             health_shutdown,
             initial_config: config,
-            kv_stores: praxis_core::kv::KvStoreRegistry::new(),
+            kv_stores,
             pipelines,
             registry,
             shutdown: shutdown.clone(),
@@ -432,13 +432,32 @@ mod tests {
         );
         shutdown.cancel();
         handle.join().unwrap();
-
-        std::env::set_current_dir(original_dir).unwrap();
     }
 
     // -------------------------------------------------------------------------
     // Test Utilities
     // -------------------------------------------------------------------------
+
+    /// Serializes tests that mutate the process working directory.
+    static CWD_MUTEX: std::sync::OnceLock<Mutex<()>> = std::sync::OnceLock::new();
+
+    /// RAII guard that restores the process working directory on drop.
+    struct CwdGuard(PathBuf);
+
+    impl CwdGuard {
+        /// Change to `path` and capture the original directory for restore.
+        fn new(path: &std::path::Path) -> Self {
+            let original = std::env::current_dir().unwrap();
+            std::env::set_current_dir(path).unwrap();
+            Self(original)
+        }
+    }
+
+    impl Drop for CwdGuard {
+        fn drop(&mut self) {
+            drop(std::env::set_current_dir(&self.0));
+        }
+    }
 
     /// Valid YAML config for watcher tests.
     const VALID_YAML: &str = r#"

--- a/server/src/watcher.rs
+++ b/server/src/watcher.rs
@@ -215,7 +215,7 @@ fn is_relevant_event(kind: EventKind) -> bool {
 /// Resolve the directory to watch for a given config path.
 ///
 /// Falls back to `.` when the path has no non-empty parent, covering
-/// bare filenames like `praxis.yaml` where [`Path::parent`] returns
+/// bare filenames like `praxis.yaml` where [`std::path::Path::parent`] returns
 /// `Some("")` rather than `None`.
 fn watch_dir_for_path(path: &std::path::Path) -> PathBuf {
     path.parent()

--- a/server/src/watcher.rs
+++ b/server/src/watcher.rs
@@ -91,6 +91,7 @@ async fn watch_loop(params: WatcherParams) {
     let watch_dir = params
         .config_path
         .parent()
+        .filter(|p| !p.as_os_str().is_empty())
         .unwrap_or_else(|| std::path::Path::new("."))
         .to_path_buf();
 

--- a/tls/src/watcher.rs
+++ b/tls/src/watcher.rs
@@ -188,7 +188,8 @@ fn is_relevant_event(kind: EventKind) -> bool {
     matches!(kind, EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_))
 }
 
-/// Extract the parent directory of a path, defaulting to `.`.
+/// Extract the parent directory of a path, defaulting to `.` when the
+/// parent is missing or empty.
 fn parent_dir(path: &str) -> PathBuf {
     Path::new(path)
         .parent()

--- a/tls/src/watcher.rs
+++ b/tls/src/watcher.rs
@@ -190,7 +190,11 @@ fn is_relevant_event(kind: EventKind) -> bool {
 
 /// Extract the parent directory of a path, defaulting to `.`.
 fn parent_dir(path: &str) -> PathBuf {
-    Path::new(path).parent().unwrap_or_else(|| Path::new(".")).to_path_buf()
+    Path::new(path)
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."))
+        .to_path_buf()
 }
 
 // -----------------------------------------------------------------------------
@@ -219,6 +223,12 @@ mod tests {
     fn parent_dir_root_file() {
         let dir = parent_dir("/cert.pem");
         assert_eq!(dir, PathBuf::from("/"), "root file parent should be /");
+    }
+
+    #[test]
+    fn parent_dir_bare_filename() {
+        let dir = parent_dir("cert.pem");
+        assert_eq!(dir, PathBuf::from("."), "bare filename should fall back to .");
     }
 
     #[test]


### PR DESCRIPTION
**Summary:**

- `PathBuf::parent()` returns `Some("")` for bare filenames like `praxis.yaml`, not `None`,  the `unwrap_or_else` fallback to "." never triggered
- Added `.filter(|p| !p.as_os_str().is_empty())` in both the config watcher and the TLS cert watcher to treat empty parent paths the same as no parent
- Added a `parent_dir_bare_filename` unit test to the TLS watcher to cover this case

/fix #183