### PR TITLE
feat: add model alias config types and router validation

### DIFF
--- a/filter/src/builtins/http/traffic_management/router/config.rs
+++ b/filter/src/builtins/http/traffic_management/router/config.rs
@@ -7,6 +7,19 @@ use praxis_core::config::Route;
 use serde::Deserialize;
 
 // -----------------------------------------------------------------------------
+// Constants
+// -----------------------------------------------------------------------------
+
+/// Default header name for the resolved JSON alias value.
+pub(super) const DEFAULT_JSON_ALIAS_HEADER: &str = "X-Json-Alias";
+
+/// Default maximum body bytes to buffer for JSON alias resolution.
+pub(super) const DEFAULT_JSON_ALIAS_MAX_BODY_BYTES: usize = 10_485_760; // 10 MiB
+
+/// Hard upper bound for `json_alias_max_body_bytes`.
+pub(super) const MAX_JSON_ALIAS_BODY_BYTES: usize = 67_108_864; // 64 MiB
+
+// -----------------------------------------------------------------------------
 // RouterConfig
 // -----------------------------------------------------------------------------
 
@@ -14,7 +27,64 @@ use serde::Deserialize;
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(super) struct RouterConfig {
+    /// Header name for the promoted JSON field value during alias
+    /// resolution.
+    #[serde(default = "default_json_alias_header")]
+    pub json_alias_header: String,
+
+    /// Maximum body bytes to buffer when resolving JSON aliases.
+    #[serde(default = "default_json_alias_max_body_bytes")]
+    pub json_alias_max_body_bytes: usize,
+
     /// Route table entries.
     #[serde(default)]
-    pub routes: Vec<Route>,
+    pub routes: Vec<RouterRouteConfig>,
+}
+
+/// Router-owned route config so JSON body aliasing stays out of
+/// [`praxis_core::config::Route`].
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct RouterRouteConfig {
+    /// Generic path, host, header, and cluster routing fields.
+    #[serde(flatten)]
+    pub route: Route,
+
+    /// Optional JSON field aliases evaluated for this route.
+    #[serde(default)]
+    pub json_aliases: Option<Vec<JsonAlias>>,
+}
+
+impl From<Route> for RouterRouteConfig {
+    fn from(route: Route) -> Self {
+        Self {
+            route,
+            json_aliases: None,
+        }
+    }
+}
+
+/// JSON field alias rule scoped to a router route.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct JsonAlias {
+    /// Request JSON field whose string value is compared with `pattern`.
+    pub field: String,
+
+    /// Exact or single-wildcard pattern for the configured field value.
+    #[serde(rename = "match")]
+    pub pattern: String,
+
+    /// Replacement value; omitted aliases preserve the original value.
+    #[serde(default)]
+    pub target: Option<String>,
+}
+
+/// Serde default for [`RouterConfig::json_alias_header`].
+fn default_json_alias_header() -> String {
+    DEFAULT_JSON_ALIAS_HEADER.to_owned()
+}
+
+/// Serde default for [`RouterConfig::json_alias_max_body_bytes`].
+fn default_json_alias_max_body_bytes() -> usize {
+    DEFAULT_JSON_ALIAS_MAX_BODY_BYTES
 }

--- a/filter/src/builtins/http/traffic_management/router/json_alias.rs
+++ b/filter/src/builtins/http/traffic_management/router/json_alias.rs
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024 Shane Utt
+
+//! JSON alias pattern matching and resolution helpers.
+
+#![allow(dead_code, reason = "alias helpers are validated before body aliasing is wired")]
+
+use super::{ResolvedRoute, config::JsonAlias};
+
+/// Alias patterns intentionally support a single `*` so matching stays
+/// predictable and validation can reject ambiguous patterns.
+pub(super) fn pattern_matches(pattern: &str, value: &str) -> bool {
+    if let Some(pos) = pattern.find('*') {
+        let (prefix, rest) = pattern.split_at(pos);
+        let suffix = &rest[1..];
+        value.starts_with(prefix) && value.ends_with(suffix) && value.len() >= prefix.len() + suffix.len()
+    } else {
+        pattern == value
+    }
+}
+
+/// Exact patterns get `u32::MAX` so they always beat wildcards.
+/// Wildcard patterns score by literal character count.
+pub(super) fn pattern_specificity(pattern: &str) -> u32 {
+    if pattern.contains('*') {
+        let literal_len = pattern.len().saturating_sub(1);
+        u32::try_from(literal_len).unwrap_or(u32::MAX - 1)
+    } else {
+        u32::MAX
+    }
+}
+
+/// Carries the matched route so alias resolution can select the target cluster
+/// without re-running route resolution.
+#[derive(Debug, Clone)]
+pub(super) struct AliasMatch<'a> {
+    /// The matching alias rule.
+    pub alias: &'a JsonAlias,
+    /// The route that owns the matching alias.
+    #[allow(dead_code, reason = "cluster selection is validated before body aliasing is wired")]
+    pub route: &'a ResolvedRoute,
+    /// Alias specificity within the owning route.
+    pub specificity: u32,
+}
+
+/// Route order wins before alias specificity because the router has
+/// already sorted routes by path specificity.
+pub(super) fn resolve_json_alias<'a>(
+    field: &str,
+    value: &str,
+    routes: impl Iterator<Item = &'a ResolvedRoute>,
+) -> Option<AliasMatch<'a>> {
+    for route in routes {
+        let Some(aliases) = &route.json_aliases else {
+            continue;
+        };
+        let best = best_alias_in_route(field, value, aliases, route);
+        if best.is_some() {
+            return best;
+        }
+    }
+    None
+}
+
+/// Alias specificity only decides among aliases on the same route;
+/// route order has already been handled by `resolve_json_alias`.
+fn best_alias_in_route<'a>(
+    field: &str,
+    value: &str,
+    aliases: &'a [JsonAlias],
+    route: &'a ResolvedRoute,
+) -> Option<AliasMatch<'a>> {
+    let mut best: Option<AliasMatch<'a>> = None;
+    for alias in aliases {
+        if alias.field != field || !pattern_matches(&alias.pattern, value) {
+            continue;
+        }
+        let specificity = pattern_specificity(&alias.pattern);
+        let dominated = best.as_ref().is_some_and(|b| specificity <= b.specificity);
+        if !dominated {
+            best = Some(AliasMatch {
+                alias,
+                route,
+                specificity,
+            });
+        }
+    }
+    best
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    reason = "tests"
+)]
+mod tests {
+    use std::sync::Arc;
+
+    use praxis_core::config::{PathMatch, Route};
+
+    use super::*;
+
+    #[test]
+    fn pattern_matches_exact() {
+        assert!(pattern_matches("fast", "fast"));
+        assert!(pattern_matches("claude-3", "claude-3"));
+        assert!(!pattern_matches("fast", "slow"));
+        assert!(!pattern_matches("claude-3", "claude-2"));
+    }
+
+    #[test]
+    fn pattern_matches_wildcard_prefix() {
+        assert!(pattern_matches("claude-*", "claude-3"));
+        assert!(pattern_matches("claude-*", "claude-3-sonnet"));
+        assert!(pattern_matches("gpt-*", "gpt-4"));
+        assert!(!pattern_matches("claude-*", "gpt-4"));
+        assert!(!pattern_matches("claude-*", "claude"));
+    }
+
+    #[test]
+    fn pattern_matches_wildcard_suffix() {
+        assert!(pattern_matches("*-turbo", "gpt-4-turbo"));
+        assert!(pattern_matches("*-turbo", "claude-3-turbo"));
+        assert!(!pattern_matches("*-turbo", "gpt-4"));
+        assert!(!pattern_matches("*-turbo", "turbo"));
+    }
+
+    #[test]
+    fn pattern_matches_wildcard_middle() {
+        assert!(pattern_matches("gpt-*-turbo", "gpt-4-turbo"));
+        assert!(pattern_matches("gpt-*-turbo", "gpt-3.5-turbo"));
+        assert!(!pattern_matches("gpt-*-turbo", "gpt-4"));
+        assert!(!pattern_matches("gpt-*-turbo", "claude-3-turbo"));
+    }
+
+    #[test]
+    fn pattern_specificity_exact_beats_wildcard() {
+        assert!(pattern_specificity("exact") > pattern_specificity("wild-*"));
+        assert!(pattern_specificity("claude-3") > pattern_specificity("claude-*"));
+    }
+
+    #[test]
+    fn pattern_specificity_more_literals_beat_fewer() {
+        assert!(pattern_specificity("claude-3-*") > pattern_specificity("claude-*"));
+        assert!(pattern_specificity("gpt-*-turbo") > pattern_specificity("gpt-*"));
+        assert!(pattern_specificity("*-turbo") > pattern_specificity("*"));
+    }
+
+    #[test]
+    fn resolve_json_alias_exact_match() {
+        let routes = [test_route_with_alias("fast", Some("gpt-4o-mini"))];
+        let matched = resolve_json_alias("model", "fast", routes.iter()).unwrap();
+        assert_eq!(matched.alias.pattern, "fast");
+        assert_eq!(matched.alias.target.as_deref(), Some("gpt-4o-mini"));
+    }
+
+    #[test]
+    fn resolve_json_alias_wildcard_match() {
+        let routes = [test_route_with_alias("claude-*", None)];
+        let matched = resolve_json_alias("model", "claude-3", routes.iter()).unwrap();
+        assert_eq!(matched.alias.pattern, "claude-*");
+        assert!(matched.alias.target.is_none());
+    }
+
+    #[test]
+    fn resolve_json_alias_no_match() {
+        let routes = [test_route_with_alias("claude-*", None)];
+        let matched = resolve_json_alias("model", "gpt-4", routes.iter());
+        assert!(matched.is_none());
+    }
+
+    #[test]
+    fn resolve_json_alias_field_must_match() {
+        let routes = [test_route_with_field_alias("tenant_id", "acme", Some("tenant-acme"))];
+        let matched = resolve_json_alias("model", "acme", routes.iter());
+        assert!(matched.is_none());
+
+        let matched = resolve_json_alias("tenant_id", "acme", routes.iter()).unwrap();
+        assert_eq!(matched.alias.target.as_deref(), Some("tenant-acme"));
+    }
+
+    #[test]
+    fn resolve_json_alias_exact_beats_wildcard_same_route() {
+        let routes = [test_route_with_aliases(vec![
+            ("claude-*", Some("claude-generic")),
+            ("claude-3", Some("claude-3-exact")),
+        ])];
+
+        let matched = resolve_json_alias("model", "claude-3", routes.iter()).unwrap();
+        assert_eq!(
+            matched.alias.pattern, "claude-3",
+            "exact should beat wildcard within route"
+        );
+        assert_eq!(matched.alias.target.as_deref(), Some("claude-3-exact"));
+    }
+
+    #[test]
+    fn resolve_json_alias_more_literals_beat_fewer_same_route() {
+        let routes = [test_route_with_aliases(vec![
+            ("claude-*", Some("generic")),
+            ("claude-3-*", Some("specific")),
+        ])];
+
+        let matched = resolve_json_alias("model", "claude-3-sonnet", routes.iter()).unwrap();
+        assert_eq!(
+            matched.alias.pattern, "claude-3-*",
+            "more literal chars should beat fewer within route"
+        );
+        assert_eq!(matched.alias.target.as_deref(), Some("specific"));
+    }
+
+    #[test]
+    fn resolve_json_alias_route_order_wins_over_alias_specificity() {
+        let routes = [
+            test_route_with_alias("claude-*", Some("first-route")),
+            test_route_with_alias("claude-3", Some("second-route")),
+        ];
+
+        let matched = resolve_json_alias("model", "claude-3", routes.iter()).unwrap();
+        assert_eq!(
+            matched.alias.target.as_deref(),
+            Some("first-route"),
+            "first route should win even though second route has a more specific alias"
+        );
+    }
+
+    #[test]
+    fn resolve_json_alias_skips_non_matching_route() {
+        let routes = [
+            test_route_with_alias("gpt-*", Some("first-route")),
+            test_route_with_alias("claude-*", Some("second-route")),
+        ];
+
+        let matched = resolve_json_alias("model", "claude-3", routes.iter()).unwrap();
+        assert_eq!(
+            matched.alias.target.as_deref(),
+            Some("second-route"),
+            "should skip first route whose alias doesn't match"
+        );
+    }
+
+    #[test]
+    fn resolve_json_alias_route_order_preserved_on_ties() {
+        let routes = [
+            test_route_with_alias("*", Some("first")),
+            test_route_with_alias("*", Some("second")),
+        ];
+
+        let matched = resolve_json_alias("model", "anything", routes.iter()).unwrap();
+        assert_eq!(
+            matched.alias.target.as_deref(),
+            Some("first"),
+            "first route should win on equal specificity"
+        );
+    }
+
+    fn test_route_with_alias(pattern: &str, target: Option<&str>) -> ResolvedRoute {
+        test_route_with_aliases(vec![(pattern, target)])
+    }
+
+    fn test_route_with_field_alias(field: &str, pattern: &str, target: Option<&str>) -> ResolvedRoute {
+        test_route_with_json_aliases(vec![(field, pattern, target)])
+    }
+
+    fn test_route_with_aliases(aliases: Vec<(&str, Option<&str>)>) -> ResolvedRoute {
+        test_route_with_json_aliases(
+            aliases
+                .into_iter()
+                .map(|(pattern, target)| ("model", pattern, target))
+                .collect(),
+        )
+    }
+
+    fn test_route_with_json_aliases(aliases: Vec<(&str, &str, Option<&str>)>) -> ResolvedRoute {
+        ResolvedRoute {
+            route: Route {
+                path_match: PathMatch::Prefix {
+                    path_prefix: "/".to_owned(),
+                },
+                host: None,
+                headers: None,
+                cluster: Arc::from("test"),
+            },
+            json_aliases: Some(
+                aliases
+                    .into_iter()
+                    .map(|(field, pattern, target)| JsonAlias {
+                        field: field.to_owned(),
+                        pattern: pattern.to_owned(),
+                        target: target.map(str::to_owned),
+                    })
+                    .collect(),
+            ),
+            wildcard_suffix: None,
+        }
+    }
+}

--- a/filter/src/builtins/http/traffic_management/router/mod.rs
+++ b/filter/src/builtins/http/traffic_management/router/mod.rs
@@ -4,6 +4,7 @@
 //! Path-prefix and host-header routing filter.
 
 mod config;
+mod json_alias;
 mod matching;
 
 #[cfg(test)]
@@ -21,12 +22,15 @@ mod tests;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use http::HeaderMap;
+use http::{HeaderMap, header::HeaderName};
 use praxis_core::config::{PathMatch, Route};
 use tracing::{debug, trace};
 
 use self::{
-    config::RouterConfig,
+    config::{
+        DEFAULT_JSON_ALIAS_HEADER, DEFAULT_JSON_ALIAS_MAX_BODY_BYTES, JsonAlias, MAX_JSON_ALIAS_BODY_BYTES,
+        RouterConfig, RouterRouteConfig,
+    },
     matching::{route_matches_request, should_stop_early, update_best_match},
 };
 use crate::{
@@ -74,6 +78,18 @@ use crate::{
 /// [`rewritten_path`]: crate::HttpFilterContext::rewritten_path
 #[derive(Debug)]
 pub struct RouterFilter {
+    /// Whether any route has JSON aliases configured.
+    #[allow(dead_code, reason = "alias config is validated before body access is wired")]
+    has_json_alias_routes: bool,
+
+    /// Maximum body bytes to buffer for JSON alias resolution.
+    #[allow(dead_code, reason = "alias config is validated before body buffering is wired")]
+    json_alias_max_body_bytes: usize,
+
+    /// Header name for the promoted JSON alias value.
+    #[allow(dead_code, reason = "alias config is validated before header promotion is wired")]
+    json_alias_header: HeaderName,
+
     /// Ordered route table with pre-computed wildcard suffixes.
     routes: Vec<ResolvedRoute>,
 }
@@ -84,6 +100,10 @@ struct ResolvedRoute {
     /// The original route configuration.
     route: Route,
 
+    /// Optional JSON aliases configured on this route.
+    #[allow(dead_code, reason = "route aliases are validated before body aliasing is wired")]
+    json_aliases: Option<Vec<JsonAlias>>,
+
     /// For wildcard hosts (e.g. `*.example.com`), the pre-lowercased
     /// suffix with leading dot: `.example.com`. `None` for exact hosts
     /// or routes without a host constraint.
@@ -91,7 +111,7 @@ struct ResolvedRoute {
 }
 
 impl RouterFilter {
-    /// Create a router from a list of routes.
+    /// Create a router from a list of routes with default alias options.
     ///
     /// Returns an error if any `path_prefix` (other than `"/"`)
     /// does not end with `'/'`.
@@ -142,21 +162,44 @@ impl RouterFilter {
     ///
     /// [`FilterError`]: crate::FilterError
     pub fn new(routes: Vec<Route>) -> Result<Self, FilterError> {
+        Self::with_alias_options(
+            routes.into_iter().map(RouterRouteConfig::from).collect(),
+            DEFAULT_JSON_ALIAS_HEADER,
+            DEFAULT_JSON_ALIAS_MAX_BODY_BYTES,
+        )
+    }
+
+    /// Create a router with explicit alias options.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FilterError`] if route or alias configuration is invalid.
+    fn with_alias_options(
+        routes: Vec<RouterRouteConfig>,
+        json_alias_header: &str,
+        json_alias_max_body_bytes: usize,
+    ) -> Result<Self, FilterError> {
         let mut routes = routes;
         sort_routes(&mut routes);
         validate_prefixes(&routes)?;
-        let resolved: Vec<ResolvedRoute> = routes
-            .into_iter()
-            .map(|route| {
-                let wildcard_suffix = route.host.as_ref().and_then(|h| h.strip_prefix("*.")).map(|suffix| {
-                    let lower = suffix.to_ascii_lowercase();
-                    format!(".{lower}")
-                });
-                ResolvedRoute { route, wildcard_suffix }
-            })
-            .collect();
-        debug!(routes = resolved.len(), "router initialized");
-        Ok(Self { routes: resolved })
+        validate_json_aliases(&routes)?;
+        let json_alias_header = parse_json_alias_header(json_alias_header)?;
+        validate_alias_options(&routes, json_alias_max_body_bytes)?;
+
+        let has_json_alias_routes = routes.iter().any(|r| r.json_aliases.is_some());
+
+        let resolved = resolve_routes(routes);
+        debug!(
+            routes = resolved.len(),
+            has_aliases = has_json_alias_routes,
+            "router initialized"
+        );
+        Ok(Self {
+            has_json_alias_routes,
+            json_alias_max_body_bytes,
+            json_alias_header,
+            routes: resolved,
+        })
     }
 
     /// Create a router from parsed YAML config.
@@ -168,7 +211,11 @@ impl RouterFilter {
     /// [`FilterError`]: crate::FilterError
     pub fn from_config(config: &serde_yaml::Value) -> Result<Box<dyn HttpFilter>, FilterError> {
         let cfg: RouterConfig = crate::parse_filter_config("router", config)?;
-        Ok(Box::new(Self::new(cfg.routes)?))
+        Ok(Box::new(Self::with_alias_options(
+            cfg.routes,
+            &cfg.json_alias_header,
+            cfg.json_alias_max_body_bytes,
+        )?))
     }
 
     /// Find the best matching route for the given path, host, and headers.
@@ -194,19 +241,20 @@ impl RouterFilter {
 }
 
 /// Sorts routes by specificity: exact paths first, then longest prefix.
-fn sort_routes(routes: &mut [Route]) {
+fn sort_routes(routes: &mut [RouterRouteConfig]) {
     routes.sort_by(|a, b| {
-        b.path_match.len().cmp(&a.path_match.len()).then_with(|| {
-            let a_exact = u8::from(a.path_match.is_exact());
-            let b_exact = u8::from(b.path_match.is_exact());
+        b.route.path_match.len().cmp(&a.route.path_match.len()).then_with(|| {
+            let a_exact = u8::from(a.route.path_match.is_exact());
+            let b_exact = u8::from(b.route.path_match.is_exact());
             b_exact.cmp(&a_exact)
         })
     });
 }
 
 /// Validates that prefix-only routes have segment-bounded prefixes.
-fn validate_prefixes(routes: &[Route]) -> Result<(), FilterError> {
-    for route in routes {
+fn validate_prefixes(routes: &[RouterRouteConfig]) -> Result<(), FilterError> {
+    for route_config in routes {
+        let route = &route_config.route;
         if let PathMatch::Prefix { path_prefix } = &route.path_match
             && path_prefix != "/"
             && !path_prefix.ends_with('/')
@@ -220,6 +268,98 @@ fn validate_prefixes(routes: &[Route]) -> Result<(), FilterError> {
         }
     }
     Ok(())
+}
+
+/// Validates JSON alias configuration on all routes.
+fn validate_json_aliases(routes: &[RouterRouteConfig]) -> Result<(), FilterError> {
+    for route_config in routes {
+        let route = &route_config.route;
+        let Some(aliases) = &route_config.json_aliases else {
+            continue;
+        };
+        if aliases.is_empty() {
+            return Err(format!(
+                "router: json_aliases for cluster '{}' must not be empty (omit the key instead)",
+                route.cluster,
+            )
+            .into());
+        }
+        for alias in aliases {
+            validate_single_alias(alias, &route.cluster)?;
+        }
+    }
+    Ok(())
+}
+
+/// Validates a single JSON alias field, pattern, and target.
+fn validate_single_alias(alias: &JsonAlias, cluster: &str) -> Result<(), FilterError> {
+    if alias.field.is_empty() {
+        return Err(format!("router: json alias field for cluster '{cluster}' must not be empty").into());
+    }
+    if alias.pattern.is_empty() {
+        return Err(format!("router: json alias match pattern for cluster '{cluster}' must not be empty").into());
+    }
+    if alias.pattern.chars().filter(|&c| c == '*').count() > 1 {
+        return Err(format!(
+            "router: json alias pattern '{}' for cluster '{cluster}' must contain at most one '*'",
+            alias.pattern,
+        )
+        .into());
+    }
+    if alias.target.as_ref().is_some_and(String::is_empty) {
+        return Err(format!(
+            "router: json alias target for pattern '{}' in cluster '{cluster}' \
+             must not be empty (omit the key to preserve the original value)",
+            alias.pattern,
+        )
+        .into());
+    }
+    Ok(())
+}
+
+/// Parsed unconditionally so an invalid name fails at construction, not at
+/// request time when alias validation may have been skipped (no alias routes).
+fn parse_json_alias_header(json_alias_header: &str) -> Result<HeaderName, FilterError> {
+    HeaderName::from_bytes(json_alias_header.as_bytes()).map_err(|e| {
+        format!("router: json_alias_header '{json_alias_header}' is not a valid HTTP header name: {e}").into()
+    })
+}
+
+/// Validates global alias options when alias routes exist.
+fn validate_alias_options(routes: &[RouterRouteConfig], max_bytes: usize) -> Result<(), FilterError> {
+    let has_aliases = routes.iter().any(|r| r.json_aliases.is_some());
+    if !has_aliases {
+        return Ok(());
+    }
+    if max_bytes == 0 {
+        return Err("router: json_alias_max_body_bytes must be greater than 0".into());
+    }
+    if max_bytes > MAX_JSON_ALIAS_BODY_BYTES {
+        return Err(format!(
+            "router: json_alias_max_body_bytes must be <= {MAX_JSON_ALIAS_BODY_BYTES} bytes (got {max_bytes})",
+        )
+        .into());
+    }
+    Ok(())
+}
+
+/// Converts raw routes into resolved routes with pre-computed wildcard suffixes.
+fn resolve_routes(routes: Vec<RouterRouteConfig>) -> Vec<ResolvedRoute> {
+    routes
+        .into_iter()
+        .map(|route_config| {
+            let route = route_config.route;
+            let wildcard_suffix = route.host.as_ref().and_then(|h| h.strip_prefix("*.")).map(|suffix| {
+                let lower = suffix.to_ascii_lowercase();
+                format!(".{lower}")
+            });
+            ResolvedRoute {
+                route,
+                json_aliases: route_config.json_aliases,
+                wildcard_suffix,
+            }
+        })
+        .collect()
 }
 
 #[async_trait]

--- a/filter/src/builtins/http/traffic_management/router/tests.rs
+++ b/filter/src/builtins/http/traffic_management/router/tests.rs
@@ -10,6 +10,7 @@ use praxis_core::config::{PathMatch, Route};
 
 use super::{
     ResolvedRoute, RouterFilter,
+    config::{JsonAlias, RouterConfig, RouterRouteConfig},
     matching::{route_matches_request, should_stop_early, update_best_match},
 };
 use crate::{FilterAction, filter::HttpFilter};
@@ -476,6 +477,7 @@ fn route_matches_request_path_only_hit() {
     let route = prefix_route("/api/", "api");
     let resolved = ResolvedRoute {
         route,
+        json_aliases: None,
         wildcard_suffix: None,
     };
     assert!(
@@ -489,6 +491,7 @@ fn route_matches_request_path_miss() {
     let route = prefix_route("/api/", "api");
     let resolved = ResolvedRoute {
         route,
+        json_aliases: None,
         wildcard_suffix: None,
     };
     assert!(
@@ -509,6 +512,7 @@ fn route_matches_request_host_hit() {
     };
     let resolved = ResolvedRoute {
         route,
+        json_aliases: None,
         wildcard_suffix: None,
     };
     assert!(
@@ -529,6 +533,7 @@ fn route_matches_request_host_miss() {
     };
     let resolved = ResolvedRoute {
         route,
+        json_aliases: None,
         wildcard_suffix: None,
     };
     assert!(
@@ -549,6 +554,7 @@ fn route_matches_request_host_miss_when_no_host() {
     };
     let resolved = ResolvedRoute {
         route,
+        json_aliases: None,
         wildcard_suffix: None,
     };
     assert!(
@@ -569,6 +575,7 @@ fn route_matches_request_header_hit() {
     };
     let resolved = ResolvedRoute {
         route,
+        json_aliases: None,
         wildcard_suffix: None,
     };
     let mut hdrs = HeaderMap::new();
@@ -591,6 +598,7 @@ fn route_matches_request_header_miss() {
     };
     let resolved = ResolvedRoute {
         route,
+        json_aliases: None,
         wildcard_suffix: None,
     };
     let mut hdrs = HeaderMap::new();
@@ -613,6 +621,7 @@ fn route_matches_request_compound() {
     };
     let resolved = ResolvedRoute {
         route,
+        json_aliases: None,
         wildcard_suffix: None,
     };
     let mut hdrs = HeaderMap::new();
@@ -1184,6 +1193,320 @@ fn mixed_exact_and_prefix_ordering() {
 }
 
 // -----------------------------------------------------------------------------
+// JSON Alias Validation Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn json_alias_validation_empty_aliases_rejected() {
+    let err = RouterFilter::with_alias_options(
+        vec![router_route("/", "test", Some(vec![]))],
+        super::config::DEFAULT_JSON_ALIAS_HEADER,
+        super::config::DEFAULT_JSON_ALIAS_MAX_BODY_BYTES,
+    )
+    .unwrap_err();
+    assert!(
+        err.to_string().contains("must not be empty"),
+        "empty json_aliases should be rejected: {err}"
+    );
+}
+
+#[test]
+fn json_alias_validation_empty_field_rejected() {
+    let err = RouterFilter::with_alias_options(
+        vec![router_route(
+            "/",
+            "test",
+            Some(vec![JsonAlias {
+                field: String::new(),
+                pattern: "fast".to_owned(),
+                target: None,
+            }]),
+        )],
+        super::config::DEFAULT_JSON_ALIAS_HEADER,
+        super::config::DEFAULT_JSON_ALIAS_MAX_BODY_BYTES,
+    )
+    .unwrap_err();
+    assert!(
+        err.to_string().contains("field"),
+        "empty field should be rejected: {err}"
+    );
+}
+
+#[test]
+fn json_alias_validation_empty_pattern_rejected() {
+    let err = RouterFilter::with_alias_options(
+        vec![router_route(
+            "/",
+            "test",
+            Some(vec![JsonAlias {
+                field: "model".to_owned(),
+                pattern: String::new(),
+                target: None,
+            }]),
+        )],
+        super::config::DEFAULT_JSON_ALIAS_HEADER,
+        super::config::DEFAULT_JSON_ALIAS_MAX_BODY_BYTES,
+    )
+    .unwrap_err();
+    assert!(
+        err.to_string().contains("must not be empty"),
+        "empty match pattern should be rejected: {err}"
+    );
+}
+
+#[test]
+fn json_alias_validation_multiple_wildcards_rejected() {
+    let err = RouterFilter::with_alias_options(
+        vec![router_route(
+            "/",
+            "test",
+            Some(vec![JsonAlias {
+                field: "model".to_owned(),
+                pattern: "a-*-b-*".to_owned(),
+                target: None,
+            }]),
+        )],
+        super::config::DEFAULT_JSON_ALIAS_HEADER,
+        super::config::DEFAULT_JSON_ALIAS_MAX_BODY_BYTES,
+    )
+    .unwrap_err();
+    assert!(
+        err.to_string().contains("at most one"),
+        "multiple wildcards should be rejected: {err}"
+    );
+}
+
+#[test]
+fn json_alias_validation_empty_target_rejected() {
+    let err = RouterFilter::with_alias_options(
+        vec![router_route(
+            "/",
+            "test",
+            Some(vec![JsonAlias {
+                field: "model".to_owned(),
+                pattern: "fast".to_owned(),
+                target: Some(String::new()),
+            }]),
+        )],
+        super::config::DEFAULT_JSON_ALIAS_HEADER,
+        super::config::DEFAULT_JSON_ALIAS_MAX_BODY_BYTES,
+    )
+    .unwrap_err();
+    assert!(
+        err.to_string().contains("must not be empty"),
+        "empty target should be rejected: {err}"
+    );
+}
+
+#[test]
+fn json_alias_config_stores_header_and_max_bytes() {
+    let filter = RouterFilter::with_alias_options(
+        vec![json_alias_route(
+            "/",
+            "test",
+            vec![("tenant_id", "acme", Some("tenant-acme"))],
+        )],
+        "X-Tenant",
+        4096,
+    )
+    .unwrap();
+
+    assert_eq!(
+        filter.json_alias_header.as_str(),
+        "x-tenant",
+        "custom json_alias_header"
+    );
+    assert_eq!(filter.json_alias_max_body_bytes, 4096, "custom max body bytes");
+}
+
+#[test]
+fn json_alias_config_preserves_route_count() {
+    let filter = make_alias_config_filter();
+    assert_eq!(filter.routes.len(), 3, "should have 3 routes");
+}
+
+#[test]
+fn json_alias_config_preserves_anthropic_alias() {
+    let filter = make_alias_config_filter();
+    let anthropic = find_resolved_route(&filter, "anthropic");
+    let aliases = anthropic.json_aliases.as_ref().unwrap();
+
+    assert_eq!(aliases.len(), 1, "anthropic should have 1 alias");
+    assert_eq!(aliases[0].field, "model", "anthropic alias field");
+    assert_eq!(aliases[0].pattern, "claude-*", "wildcard alias pattern");
+    assert!(aliases[0].target.is_none(), "wildcard alias should have no target");
+}
+
+#[test]
+fn json_alias_config_preserves_openai_aliases() {
+    let filter = make_alias_config_filter();
+    let openai = find_resolved_route(&filter, "openai");
+    let aliases = openai.json_aliases.as_ref().unwrap();
+
+    assert_eq!(aliases.len(), 2, "openai should have 2 aliases");
+    assert_eq!(aliases[0].field, "model", "first alias field");
+    assert_eq!(aliases[0].pattern, "fast", "first alias pattern");
+    assert_eq!(aliases[0].target.as_deref(), Some("gpt-4o-mini"), "first alias target");
+    assert_eq!(aliases[1].field, "tenant_id", "second alias field");
+    assert_eq!(aliases[1].pattern, "cheap", "second alias pattern");
+}
+
+#[test]
+fn json_alias_config_preserves_fallback_without_aliases() {
+    let filter = make_alias_config_filter();
+    let fallback = find_resolved_route(&filter, "fallback");
+
+    assert!(fallback.json_aliases.is_none(), "fallback should have no aliases");
+}
+
+#[test]
+fn json_alias_from_config_parses_global_options() {
+    let cfg = parse_json_alias_config();
+
+    assert_eq!(cfg.json_alias_header, "X-AI-Model", "custom json alias header");
+    assert_eq!(cfg.json_alias_max_body_bytes, 4096, "custom max body bytes");
+    assert_eq!(cfg.routes.len(), 3, "should parse 3 routes");
+}
+
+#[test]
+fn json_alias_from_config_parses_first_route_alias() {
+    let cfg = parse_json_alias_config();
+    let first = &cfg.routes[0];
+
+    assert_eq!(&*first.route.cluster, "openai", "first route cluster");
+    let aliases = first.json_aliases.as_ref().unwrap();
+    assert_eq!(aliases.len(), 1, "first route should have one alias");
+    assert_eq!(aliases[0].field, "model", "first alias field");
+    assert_eq!(aliases[0].pattern, "fast", "first alias pattern");
+    assert_eq!(aliases[0].target.as_deref(), Some("gpt-4o-mini"), "first alias target");
+}
+
+#[test]
+fn json_alias_from_config_parses_second_route_alias() {
+    let cfg = parse_json_alias_config();
+    let second = &cfg.routes[1];
+
+    assert_eq!(&*second.route.cluster, "tenant", "second route cluster");
+    let aliases = second.json_aliases.as_ref().unwrap();
+    assert_eq!(aliases.len(), 1, "second route should have one alias");
+    assert_eq!(aliases[0].field, "tenant_id", "second alias field");
+    assert_eq!(aliases[0].pattern, "fast", "second alias pattern");
+    assert_eq!(aliases[0].target.as_deref(), Some("tenant-fast"), "second alias target");
+}
+
+#[test]
+fn json_alias_from_config_parses_fallback_without_aliases() {
+    let cfg = parse_json_alias_config();
+    let third = &cfg.routes[2];
+
+    assert_eq!(&*third.route.cluster, "fallback", "third route cluster");
+    assert!(third.json_aliases.is_none(), "fallback should have no aliases");
+}
+
+#[test]
+fn json_alias_from_config_builds_filter() {
+    let yaml = serde_yaml::from_str::<serde_yaml::Value>(json_alias_config_yaml()).unwrap();
+    let filter = RouterFilter::from_config(&yaml).unwrap();
+
+    assert_eq!(filter.name(), "router", "from_config should produce a valid router");
+}
+
+#[test]
+fn json_alias_from_config_uses_defaults() {
+    let cfg: RouterConfig = serde_yaml::from_str(
+        r#"
+routes:
+  - path_prefix: "/"
+    cluster: "default"
+    json_aliases:
+      - field: model
+        match: fast
+        target: gpt-4o-mini
+"#,
+    )
+    .unwrap();
+
+    assert_eq!(
+        cfg.json_alias_header,
+        super::config::DEFAULT_JSON_ALIAS_HEADER,
+        "should use default json_alias_header"
+    );
+    assert_eq!(
+        cfg.json_alias_max_body_bytes,
+        super::config::DEFAULT_JSON_ALIAS_MAX_BODY_BYTES,
+        "should use default max body bytes"
+    );
+}
+
+#[test]
+fn json_alias_validate_invalid_header_name_rejected() {
+    let err = RouterFilter::with_alias_options(
+        vec![json_alias_route(
+            "/",
+            "test",
+            vec![("model", "fast", Some("gpt-4o-mini"))],
+        )],
+        "bad header",
+        super::config::DEFAULT_JSON_ALIAS_MAX_BODY_BYTES,
+    )
+    .unwrap_err();
+    assert!(
+        err.to_string().contains("not a valid HTTP header name"),
+        "invalid header name should be rejected: {err}"
+    );
+}
+
+#[test]
+fn json_alias_validate_zero_max_bytes_rejected() {
+    let err = RouterFilter::with_alias_options(
+        vec![json_alias_route(
+            "/",
+            "test",
+            vec![("model", "fast", Some("gpt-4o-mini"))],
+        )],
+        super::config::DEFAULT_JSON_ALIAS_HEADER,
+        0,
+    )
+    .unwrap_err();
+    assert!(
+        err.to_string().contains("must be greater than 0"),
+        "zero max bytes should be rejected: {err}"
+    );
+}
+
+#[test]
+fn json_alias_validate_max_bytes_above_upper_bound_rejected() {
+    let err = RouterFilter::with_alias_options(
+        vec![json_alias_route(
+            "/",
+            "test",
+            vec![("model", "fast", Some("gpt-4o-mini"))],
+        )],
+        super::config::DEFAULT_JSON_ALIAS_HEADER,
+        super::config::MAX_JSON_ALIAS_BODY_BYTES + 1,
+    )
+    .unwrap_err();
+    assert!(
+        err.to_string().contains("must be <="),
+        "above upper bound should be rejected: {err}"
+    );
+}
+
+#[test]
+fn json_alias_validate_max_bytes_at_upper_bound_accepted() {
+    let result = RouterFilter::with_alias_options(
+        vec![json_alias_route(
+            "/",
+            "test",
+            vec![("model", "fast", Some("gpt-4o-mini"))],
+        )],
+        super::config::DEFAULT_JSON_ALIAS_HEADER,
+        super::config::MAX_JSON_ALIAS_BODY_BYTES,
+    );
+    assert!(result.is_ok(), "exactly at upper bound should be accepted");
+}
+
+// -----------------------------------------------------------------------------
 // Test Utilities
 // -----------------------------------------------------------------------------
 
@@ -1191,7 +1514,32 @@ fn make_router(routes: Vec<Route>) -> RouterFilter {
     RouterFilter::new(routes).expect("test routes should be valid")
 }
 
-/// Build a simple prefix route with no host or header constraints.
+fn json_alias_config_yaml() -> &'static str {
+    r#"
+json_alias_header: X-AI-Model
+json_alias_max_body_bytes: 4096
+routes:
+  - path_prefix: "/v1/chat/"
+    cluster: "openai"
+    json_aliases:
+      - field: model
+        match: fast
+        target: gpt-4o-mini
+  - path_prefix: "/tenant/"
+    cluster: "tenant"
+    json_aliases:
+      - field: tenant_id
+        match: fast
+        target: tenant-fast
+  - path_prefix: "/"
+    cluster: "fallback"
+"#
+}
+
+fn parse_json_alias_config() -> RouterConfig {
+    serde_yaml::from_str(json_alias_config_yaml()).unwrap()
+}
+
 fn prefix_route(prefix: &str, cluster: &str) -> Route {
     Route {
         path_match: PathMatch::Prefix {
@@ -1203,7 +1551,6 @@ fn prefix_route(prefix: &str, cluster: &str) -> Route {
     }
 }
 
-/// Build a simple exact-path route with no host or header constraints.
 fn exact_route(path: &str, cluster: &str) -> Route {
     Route {
         path_match: PathMatch::Exact { path: path.to_owned() },
@@ -1211,4 +1558,58 @@ fn exact_route(path: &str, cluster: &str) -> Route {
         headers: None,
         cluster: cluster.into(),
     }
+}
+
+fn router_route(prefix: &str, cluster: &str, json_aliases: Option<Vec<JsonAlias>>) -> RouterRouteConfig {
+    RouterRouteConfig {
+        route: prefix_route(prefix, cluster),
+        json_aliases,
+    }
+}
+
+fn json_alias_route(prefix: &str, cluster: &str, aliases: Vec<(&str, &str, Option<&str>)>) -> RouterRouteConfig {
+    router_route(
+        prefix,
+        cluster,
+        Some(
+            aliases
+                .into_iter()
+                .map(|(field, pattern, target)| JsonAlias {
+                    field: field.to_owned(),
+                    pattern: pattern.to_owned(),
+                    target: target.map(str::to_owned),
+                })
+                .collect(),
+        ),
+    )
+}
+
+/// Build the standard three-route alias config used by multiple tests.
+fn make_alias_config_filter() -> RouterFilter {
+    RouterFilter::with_alias_options(
+        vec![
+            json_alias_route(
+                "/v1/chat/",
+                "openai",
+                vec![
+                    ("model", "fast", Some("gpt-4o-mini")),
+                    ("tenant_id", "cheap", Some("tenant-cheap")),
+                ],
+            ),
+            json_alias_route("/v1/messages/", "anthropic", vec![("model", "claude-*", None)]),
+            router_route("/", "fallback", None),
+        ],
+        "X-AI-Model",
+        4096,
+    )
+    .unwrap()
+}
+
+/// Find a route by cluster name (panics if not found).
+fn find_resolved_route<'a>(filter: &'a RouterFilter, cluster: &str) -> &'a ResolvedRoute {
+    filter
+        .routes
+        .iter()
+        .find(|r| &*r.route.cluster == cluster)
+        .unwrap_or_else(|| panic!("no route with cluster '{cluster}'"))
 }


### PR DESCRIPTION

## Summary

  Add model alias config types and router validation as the foundation for model aliasing (#139). This is PR 1 of 2. Its about as thin as I can get it to have PRs that build.

  - `ModelAlias` config struct with `match` (pattern) and optional `target`
  - `model_aliases: Option<Vec<ModelAlias>>` on `Route`
  - `RouterConfig` gains `model_header` and `model_alias_max_body_bytes`
  - Validation: empty aliases, empty pattern, multiple wildcards, empty
    target, invalid header name all rejected
  - Pattern matching and specificity helpers in `model_alias.rs`
  - Example config and all test literal fixups

  No runtime behavior change. Aliases parse and validate but the router ignores them at runtime.

  ## PR breakdown

  | | PR 1 (this PR) | PR 2 |
  |---|---|---|
  | **Scope** | Config types, validation, test infrastructure | Body processing, routing, Content-Length fix |
  | **Files** | 8 | 14 |
  | **Lines** | +784 | ~+600 |
  | **Runtime change** | None | Full feature activation |
  | **Core** | `ModelAlias` struct, `Route.model_aliases` field, export | — |
  | **Router config** | `model_header`, `model_alias_max_body_bytes`, defaults | — |
  | **Router construction** | `with_alias_options()`, alias validation, `resolve_routes()` | — |
  | **Alias matching** | `model_alias.rs`: pattern matching, specificity, resolution helpers | — |
  | **Body processing** | — | `on_request_body`: JSON parse, alias resolve, body rewrite |
  | **Route selection** | — | `on_request` rewrite: metadata check, alias-route gating, fallback pass |
  | **Content-Length** | — | `content_length_override` on `PingoraRequestCtx`, applied in upstream filter |
  | **Tests** | 7 (5 validation + 1 config parse + 1 pattern matching) | 14 unit + 3 schema + 5 integration |
  | **Docs** | Example config, `README.md` | `configuration.md`, `features.md`, `filters.md` |

  ## Test plan

  - [ ] `cargo test -p praxis-proxy-core route`
  - [ ] `cargo test -p praxis-proxy-filter router --features ai-inference` — 116 tests
  - [ ] `cargo clippy -p praxis-proxy-filter --features ai-inference` — clean
  - [ ] All existing router and pipeline tests pass unchanged
  - [ ] `all_example_configs_parse` validates the new example config