### PR TITLE
feat: add MCP classifier filter for body-aware routing

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -382,6 +382,7 @@ supports TCP-level filters too.
 | `ip_acl` | Security | HTTP |
 | `credential_injection` | Security | HTTP |
 | `json_body_field` | Payload Processing | HTTP |
+| `mcp` | Payload Processing | HTTP |
 | `compression` | Payload Processing | HTTP |
 | `cors` | Security | HTTP |
 | `csrf` | Security | HTTP |

--- a/docs/filters.md
+++ b/docs/filters.md
@@ -487,6 +487,7 @@ A filter can have both `conditions` (request phase) and
 | `credential_injection` | Security | HTTP | Per-cluster API key injection with client credential stripping. Literal `value` fields are redacted in `--dump` output. |
 | `json_body_field` | Payload Processing | HTTP | Extract a JSON body field and promote to header |
 | `json_rpc` | Payload Processing | HTTP | Parse JSON-RPC 2.0 envelopes and extract method/id/kind for routing |
+| `mcp` | Payload Processing | HTTP | MCP protocol classifier: extract method, tool/resource/prompt name, and session metadata for routing |
 | `compression` | Payload Processing | HTTP | Gzip, brotli, and zstd response compression |
 | `cors` | Security | HTTP | CORS preflight handling, origin validation, credential support |
 | `csrf` | Security | HTTP | Origin-based CSRF protection with gradual rollout and Sec-Fetch-Site support |

--- a/examples/README.md
+++ b/examples/README.md
@@ -44,6 +44,7 @@ page.
 | ------ | ------------- |
 | [ai-inference-body-based-routing.yaml](configs/payload-processing/ai-inference-body-based-routing.yaml) | Route LLM requests by model field in JSON body |
 | [json-rpc-routing.yaml](configs/payload-processing/json-rpc-routing.yaml) | Route JSON-RPC 2.0 requests by method for MCP and A2A protocols |
+| [mcp-classifier-routing.yaml](configs/payload-processing/mcp-classifier-routing.yaml) | Route MCP requests by body-derived method and tool name |
 | [stream-buffer.yaml](configs/payload-processing/stream-buffer.yaml) | Stream-buffered body inspection before forwarding |
 | [compression.yaml](configs/payload-processing/compression.yaml) | Gzip, brotli, and zstd response compression |
 | [multi-field-extraction.yaml](configs/payload-processing/multi-field-extraction.yaml) | Extract multiple JSON fields into headers in one pass |

--- a/examples/configs/payload-processing/mcp-classifier-routing.yaml
+++ b/examples/configs/payload-processing/mcp-classifier-routing.yaml
@@ -1,0 +1,59 @@
+# MCP Classifier Routing
+#
+# Routes MCP requests by body-derived method and tool name.
+# The `mcp` filter parses JSON-RPC bodies and promotes internal
+# routing headers (x-praxis-mcp-*) for router matching. These
+# internal headers are stripped before upstream by header hygiene.
+#
+# This example uses `missing: synthesize` so it works with real
+# MCP clients that do not send Mcp-Method / Mcp-Name headers.
+# Standard MCP headers are synthesized from body-derived values
+# and forwarded to backends. Mismatched headers are still rejected.
+#
+# For non-MCP traffic (e.g. old SSE transport), set on_invalid:
+# continue and header_validation.missing: ignore.
+
+listeners:
+  - name: mcp
+    address: "127.0.0.1:8080"
+    filter_chains: [mcp-routing]
+
+filter_chains:
+  - name: mcp-routing
+    filters:
+      - filter: mcp
+        max_body_bytes: 65536
+        on_invalid: reject
+        header_validation:
+          mismatch: reject
+          missing: synthesize
+        headers:
+          method: x-praxis-mcp-method
+          name: x-praxis-mcp-name
+          kind: x-praxis-mcp-kind
+          session_present: x-praxis-mcp-session-present
+
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            headers:
+              x-praxis-mcp-name: "get_weather"
+            cluster: "weather-tools"
+          - path_prefix: "/"
+            headers:
+              x-praxis-mcp-name: "get_calendar"
+            cluster: "calendar-tools"
+          - path_prefix: "/"
+            cluster: "default-mcp"
+
+      - filter: load_balancer
+        clusters:
+          - name: "weather-tools"
+            endpoints:
+              - "127.0.0.1:9001"
+          - name: "calendar-tools"
+            endpoints:
+              - "127.0.0.1:9002"
+          - name: "default-mcp"
+            endpoints:
+              - "127.0.0.1:9003"

--- a/filter/src/builtins/http/mod.rs
+++ b/filter/src/builtins/http/mod.rs
@@ -12,7 +12,7 @@ mod transformation;
 
 pub use ai::ModelToHeaderFilter;
 pub use observability::{AccessLogFilter, RequestIdFilter};
-pub use payload_processing::{CompressionFilter, JsonBodyFieldFilter, JsonRpcFilter};
+pub use payload_processing::{CompressionFilter, JsonBodyFieldFilter, JsonRpcFilter, McpFilter};
 pub use security::{
     CorsFilter, CredentialInjectionFilter, CsrfFilter, DisallowedOriginMode, ForwardedHeadersFilter, GuardrailsAction,
     GuardrailsFilter, IpAclFilter, RuleTargetKind,

--- a/filter/src/builtins/http/payload_processing/json_rpc/envelope.rs
+++ b/filter/src/builtins/http/payload_processing/json_rpc/envelope.rs
@@ -136,10 +136,20 @@ pub(crate) fn parse_json_rpc_envelope(
     config: &JsonRpcConfig,
 ) -> Result<Option<JsonRpcEnvelope>, JsonRpcParseError> {
     let value: Value = serde_json::from_slice(input).map_err(|e| JsonRpcParseError::InvalidJson(e.to_string()))?;
+    parse_json_rpc_value(&value, config)
+}
 
+/// Parse a JSON-RPC 2.0 envelope from a pre-parsed [`Value`].
+///
+/// Same semantics as [`parse_json_rpc_envelope`] but avoids re-parsing
+/// the raw bytes when the caller already has a [`Value`].
+pub(crate) fn parse_json_rpc_value(
+    value: &Value,
+    config: &JsonRpcConfig,
+) -> Result<Option<JsonRpcEnvelope>, JsonRpcParseError> {
     match value {
-        Value::Array(ref items) => parse_batch(items, config),
-        Value::Object(_) => match parse_single_message(&value) {
+        Value::Array(items) => parse_batch(items, config),
+        Value::Object(_) => match parse_single_message(value) {
             Ok(envelope) => Ok(Some(envelope)),
             Err(JsonRpcParseError::MissingVersion) => handle_non_json_rpc(config),
             Err(e) => Err(e),

--- a/filter/src/builtins/http/payload_processing/mcp/config.rs
+++ b/filter/src/builtins/http/payload_processing/mcp/config.rs
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Configuration types for the MCP filter.
+
+use serde::Deserialize;
+
+use crate::FilterError;
+
+// -----------------------------------------------------------------------------
+// Constants
+// -----------------------------------------------------------------------------
+
+/// Default maximum request body size for `StreamBuffer` mode (64 `KiB`).
+pub(crate) const DEFAULT_MAX_BODY_BYTES: usize = 65_536;
+
+// -----------------------------------------------------------------------------
+// Behavior Enums
+// -----------------------------------------------------------------------------
+
+/// Header validation mismatch behavior.
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum MismatchBehavior {
+    /// Reject the request with a JSON-RPC error response.
+    #[default]
+    Reject,
+    /// Ignore the mismatch and continue processing.
+    Ignore,
+}
+
+/// Header validation missing behavior.
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum MissingHeaderBehavior {
+    /// Ignore the missing headers and continue processing.
+    #[default]
+    Ignore,
+    /// Synthesize the missing headers from body-derived values.
+    Synthesize,
+    /// Reject the request when expected MCP headers are absent.
+    Reject,
+}
+
+/// Invalid MCP message handling.
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum InvalidMcpBehavior {
+    /// Reject non-MCP input with HTTP 400.
+    #[default]
+    Reject,
+    /// Continue processing without MCP metadata.
+    Continue,
+}
+
+// -----------------------------------------------------------------------------
+// HeaderValidation
+// -----------------------------------------------------------------------------
+
+/// Header validation config controlling how header/body mismatches are handled.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct HeaderValidation {
+    /// Behavior when header value conflicts with body-derived value.
+    #[serde(default)]
+    pub mismatch: MismatchBehavior,
+    /// Behavior when expected MCP headers are absent.
+    #[serde(default)]
+    pub missing: MissingHeaderBehavior,
+}
+
+// -----------------------------------------------------------------------------
+// McpHeaders
+// -----------------------------------------------------------------------------
+
+/// Promoted header names for MCP metadata.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct McpHeaders {
+    /// Header name for the MCP method (e.g. `x-praxis-mcp-method`).
+    #[serde(default = "default_method_header")]
+    pub method: Option<String>,
+    /// Header name for the tool/resource/prompt name (e.g. `x-praxis-mcp-name`).
+    #[serde(default = "default_name_header")]
+    pub name: Option<String>,
+    /// Header name for the JSON-RPC kind (e.g. `x-praxis-mcp-kind`).
+    #[serde(default = "default_kind_header")]
+    pub kind: Option<String>,
+    /// Header name for MCP session presence (e.g. `x-praxis-mcp-session-present`).
+    #[serde(default = "default_session_present_header")]
+    pub session_present: Option<String>,
+}
+
+impl Default for McpHeaders {
+    fn default() -> Self {
+        Self {
+            method: default_method_header(),
+            name: default_name_header(),
+            kind: default_kind_header(),
+            session_present: default_session_present_header(),
+        }
+    }
+}
+
+/// Default method header name.
+#[allow(
+    clippy::unnecessary_wraps,
+    reason = "serde default functions require Option return type"
+)]
+fn default_method_header() -> Option<String> {
+    Some("x-praxis-mcp-method".to_owned())
+}
+
+/// Default name header name.
+#[allow(
+    clippy::unnecessary_wraps,
+    reason = "serde default functions require Option return type"
+)]
+fn default_name_header() -> Option<String> {
+    Some("x-praxis-mcp-name".to_owned())
+}
+
+/// Default kind header name.
+#[allow(
+    clippy::unnecessary_wraps,
+    reason = "serde default functions require Option return type"
+)]
+fn default_kind_header() -> Option<String> {
+    Some("x-praxis-mcp-kind".to_owned())
+}
+
+/// Default session-present header name.
+#[allow(
+    clippy::unnecessary_wraps,
+    reason = "serde default functions require Option return type"
+)]
+fn default_session_present_header() -> Option<String> {
+    Some("x-praxis-mcp-session-present".to_owned())
+}
+
+// -----------------------------------------------------------------------------
+// McpConfig
+// -----------------------------------------------------------------------------
+
+/// YAML configuration for the MCP filter.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct McpConfig {
+    /// Maximum body size in bytes for `StreamBuffer`.
+    #[serde(default = "default_max_body_bytes")]
+    pub max_body_bytes: usize,
+
+    /// Invalid input handling behavior.
+    #[serde(default)]
+    pub on_invalid: InvalidMcpBehavior,
+
+    /// Header validation settings.
+    #[serde(default)]
+    pub header_validation: HeaderValidation,
+
+    /// Header names for MCP metadata promotion.
+    #[serde(default)]
+    pub headers: McpHeaders,
+}
+
+/// Default max body bytes.
+fn default_max_body_bytes() -> usize {
+    DEFAULT_MAX_BODY_BYTES
+}
+
+// -----------------------------------------------------------------------------
+// Config Validation
+// -----------------------------------------------------------------------------
+
+/// Validate and build the final configuration.
+pub(crate) fn build_config(cfg: McpConfig) -> Result<McpConfig, FilterError> {
+    if cfg.max_body_bytes == 0 {
+        return Err("mcp: 'max_body_bytes' must be greater than 0".into());
+    }
+    validate_header_name("method", cfg.headers.method.as_deref())?;
+    validate_header_name("name", cfg.headers.name.as_deref())?;
+    validate_header_name("kind", cfg.headers.kind.as_deref())?;
+    validate_header_name("session_present", cfg.headers.session_present.as_deref())?;
+    Ok(cfg)
+}
+
+/// Validate configured header names using the HTTP header-name parser.
+fn validate_header_name(field: &str, header_name: Option<&str>) -> Result<(), FilterError> {
+    let Some(header_name) = header_name else {
+        return Ok(());
+    };
+    if header_name.is_empty() {
+        return Err(format!("mcp: {field} header name must not be empty").into());
+    }
+    if http::HeaderName::from_bytes(header_name.as_bytes()).is_err() {
+        return Err(format!("mcp: {field} header name is not a valid HTTP header name").into());
+    }
+    Ok(())
+}

--- a/filter/src/builtins/http/payload_processing/mcp/envelope.rs
+++ b/filter/src/builtins/http/payload_processing/mcp/envelope.rs
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! MCP-specific extraction from parsed JSON-RPC values and MCP request headers.
+
+use serde_json::Value;
+
+// -----------------------------------------------------------------------------
+// McpMethod
+// -----------------------------------------------------------------------------
+
+/// MCP method classification.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum McpMethod {
+    /// `initialize` handshake request.
+    Initialize,
+    /// `notifications/initialized` post-handshake notification.
+    NotificationsInitialized,
+    /// `tools/list` discovery request.
+    ToolsList,
+    /// `tools/call` invocation request.
+    ToolsCall,
+    /// `resources/read` resource access request.
+    ResourcesRead,
+    /// `resources/list` resource discovery request.
+    ResourcesList,
+    /// `prompts/get` prompt retrieval request.
+    PromptsGet,
+    /// `prompts/list` prompt discovery request.
+    PromptsList,
+    /// `ping` keep-alive request.
+    Ping,
+    /// `logging/setLevel` log configuration request.
+    LoggingSetLevel,
+    /// `completion/complete` completion request.
+    CompletionComplete,
+    /// `notifications/tools/list_changed` tool change notification.
+    NotificationsToolsListChanged,
+    /// `notifications/resources/list_changed` resource change notification.
+    NotificationsResourcesListChanged,
+    /// `notifications/prompts/list_changed` prompt change notification.
+    NotificationsPromptsListChanged,
+    /// Any other method string not in the known set.
+    Other(String),
+}
+
+impl McpMethod {
+    /// Parse an MCP method from the JSON-RPC method string.
+    pub(crate) fn from_method_str(s: &str) -> Self {
+        match s {
+            "initialize" => Self::Initialize,
+            "notifications/initialized" => Self::NotificationsInitialized,
+            "tools/list" => Self::ToolsList,
+            "tools/call" => Self::ToolsCall,
+            "resources/read" => Self::ResourcesRead,
+            "resources/list" => Self::ResourcesList,
+            "prompts/get" => Self::PromptsGet,
+            "prompts/list" => Self::PromptsList,
+            "ping" => Self::Ping,
+            "logging/setLevel" => Self::LoggingSetLevel,
+            "completion/complete" => Self::CompletionComplete,
+            "notifications/tools/list_changed" => Self::NotificationsToolsListChanged,
+            "notifications/resources/list_changed" => Self::NotificationsResourcesListChanged,
+            "notifications/prompts/list_changed" => Self::NotificationsPromptsListChanged,
+            other => Self::Other(other.to_owned()),
+        }
+    }
+
+    /// String representation for headers and metadata.
+    pub(crate) fn as_str(&self) -> &str {
+        match self {
+            Self::Initialize => "initialize",
+            Self::NotificationsInitialized => "notifications/initialized",
+            Self::ToolsList => "tools/list",
+            Self::ToolsCall => "tools/call",
+            Self::ResourcesRead => "resources/read",
+            Self::ResourcesList => "resources/list",
+            Self::PromptsGet => "prompts/get",
+            Self::PromptsList => "prompts/list",
+            Self::Ping => "ping",
+            Self::LoggingSetLevel => "logging/setLevel",
+            Self::CompletionComplete => "completion/complete",
+            Self::NotificationsToolsListChanged => "notifications/tools/list_changed",
+            Self::NotificationsResourcesListChanged => "notifications/resources/list_changed",
+            Self::NotificationsPromptsListChanged => "notifications/prompts/list_changed",
+            Self::Other(s) => s,
+        }
+    }
+
+    /// Whether extraction of `params.name` is attempted for this method.
+    pub(crate) fn requires_name(&self) -> bool {
+        matches!(self, Self::ToolsCall | Self::PromptsGet)
+    }
+
+    /// Whether extraction of `params.uri` is attempted for this method.
+    pub(crate) fn requires_uri(&self) -> bool {
+        matches!(self, Self::ResourcesRead)
+    }
+}
+
+// -----------------------------------------------------------------------------
+// McpEnvelope
+// -----------------------------------------------------------------------------
+
+/// Extracted MCP envelope metadata.
+#[derive(Debug, Clone)]
+pub(crate) struct McpEnvelope {
+    /// Classified MCP method.
+    pub method: McpMethod,
+    /// Tool/resource/prompt name extracted from params.
+    pub name: Option<String>,
+    /// `Mcp-Session-Id` value from the request header.
+    pub session_id: Option<String>,
+    /// Protocol version from initialize params or `Mcp-Protocol-Version` header.
+    pub protocol_version: Option<String>,
+}
+
+// -----------------------------------------------------------------------------
+// Extraction
+// -----------------------------------------------------------------------------
+
+/// Extract MCP-specific metadata from a pre-parsed JSON value and request headers.
+pub(crate) fn extract_mcp_envelope(value: &Value, method_str: &str, request_headers: &http::HeaderMap) -> McpEnvelope {
+    let method = McpMethod::from_method_str(method_str);
+    let name = extract_name(value, &method);
+    let session_id = request_headers
+        .get("mcp-session-id")
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_owned);
+    let protocol_version = extract_protocol_version(value, &method, request_headers);
+
+    McpEnvelope {
+        method,
+        name,
+        session_id,
+        protocol_version,
+    }
+}
+
+/// Extract the name (tool name, resource URI, or prompt name) from params.
+fn extract_name(value: &Value, method: &McpMethod) -> Option<String> {
+    if !method.requires_name() && !method.requires_uri() {
+        return None;
+    }
+
+    let params = value.get("params")?;
+
+    if method.requires_uri() {
+        params.get("uri").and_then(|v| v.as_str()).map(str::to_owned)
+    } else {
+        params.get("name").and_then(|v| v.as_str()).map(str::to_owned)
+    }
+}
+
+/// Extract protocol version from initialize body params or `Mcp-Protocol-Version` header.
+///
+/// For `initialize`, `params.protocolVersion` from the handshake body takes
+/// precedence. For all other methods, the `Mcp-Protocol-Version` request
+/// header is used if present.
+fn extract_protocol_version(value: &Value, method: &McpMethod, headers: &http::HeaderMap) -> Option<String> {
+    if let McpMethod::Initialize = method
+        && let Some(version) = value
+            .get("params")
+            .and_then(|p| p.get("protocolVersion"))
+            .and_then(|v| v.as_str())
+    {
+        return Some(version.to_owned());
+    }
+
+    headers
+        .get("mcp-protocol-version")
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_owned)
+}

--- a/filter/src/builtins/http/payload_processing/mcp/mod.rs
+++ b/filter/src/builtins/http/payload_processing/mcp/mod.rs
@@ -1,0 +1,400 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! MCP protocol classifier filter for body-aware routing.
+
+pub(crate) mod config;
+pub(crate) mod envelope;
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::err_expect,
+    clippy::indexing_slicing,
+    clippy::panic,
+    clippy::needless_raw_strings,
+    clippy::needless_raw_string_hashes,
+    reason = "tests"
+)]
+mod tests;
+
+use std::borrow::Cow;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use tracing::{trace, warn};
+
+use self::{
+    config::{InvalidMcpBehavior, McpConfig, MismatchBehavior, MissingHeaderBehavior, build_config},
+    envelope::{McpEnvelope, extract_mcp_envelope},
+};
+use crate::{
+    FilterAction, FilterError, Rejection,
+    body::{BodyAccess, BodyMode},
+    builtins::http::payload_processing::json_rpc::{
+        config::JsonRpcConfig, contains_control_chars, envelope::parse_json_rpc_value,
+    },
+    factory::parse_filter_config,
+    filter::{HttpFilter, HttpFilterContext},
+};
+
+// -----------------------------------------------------------------------------
+// McpFilter
+// -----------------------------------------------------------------------------
+
+/// Extracts MCP protocol metadata from JSON-RPC request bodies and promotes
+/// method, tool/resource/prompt name, session ID, and protocol version to
+/// request headers, filter results, and durable metadata for routing.
+///
+/// # YAML
+///
+/// ```yaml
+/// filter: mcp
+/// ```
+///
+/// # Full YAML
+///
+/// ```yaml
+/// filter: mcp
+/// max_body_bytes: 65536
+/// on_invalid: reject
+/// header_validation:
+///   mismatch: reject
+///   missing: ignore
+/// headers:
+///   method: x-praxis-mcp-method
+///   name: x-praxis-mcp-name
+///   kind: x-praxis-mcp-kind
+///   session_present: x-praxis-mcp-session-present
+/// ```
+pub struct McpFilter {
+    /// Parsed filter configuration.
+    config: McpConfig,
+    /// Shared JSON-RPC parser configuration.
+    json_rpc_config: JsonRpcConfig,
+    /// Maximum body bytes for `StreamBuffer`.
+    max_body_bytes: usize,
+}
+
+impl McpFilter {
+    /// Create a filter from parsed YAML config.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FilterError`] if the YAML config is invalid.
+    ///
+    /// [`FilterError`]: crate::FilterError
+    pub fn from_config(config: &serde_yaml::Value) -> Result<Box<dyn HttpFilter>, FilterError> {
+        let cfg: McpConfig = parse_filter_config("mcp", config)?;
+        let validated_config = build_config(cfg)?;
+        let json_rpc_config = build_json_rpc_config(validated_config.max_body_bytes);
+
+        Ok(Box::new(Self {
+            max_body_bytes: validated_config.max_body_bytes,
+            config: validated_config,
+            json_rpc_config,
+        }))
+    }
+}
+
+#[async_trait]
+impl HttpFilter for McpFilter {
+    fn name(&self) -> &'static str {
+        "mcp"
+    }
+
+    fn request_body_access(&self) -> BodyAccess {
+        BodyAccess::ReadOnly
+    }
+
+    fn request_body_mode(&self) -> BodyMode {
+        BodyMode::StreamBuffer {
+            max_bytes: Some(self.max_body_bytes),
+        }
+    }
+
+    async fn on_request(&self, _ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
+        Ok(FilterAction::Continue)
+    }
+
+    #[allow(
+        clippy::too_many_lines,
+        reason = "sequential parse-extract-validate-promote pipeline"
+    )]
+    async fn on_request_body(
+        &self,
+        ctx: &mut HttpFilterContext<'_>,
+        body: &mut Option<Bytes>,
+        end_of_stream: bool,
+    ) -> Result<FilterAction, FilterError> {
+        let Some(chunk) = body.as_ref() else {
+            return Ok(FilterAction::Continue);
+        };
+
+        if !end_of_stream {
+            return Ok(FilterAction::Continue);
+        }
+
+        let value: serde_json::Value = match serde_json::from_slice(chunk) {
+            Ok(v) => v,
+            Err(_) => return handle_non_mcp(&self.config),
+        };
+
+        let envelope = match parse_json_rpc_value(&value, &self.json_rpc_config) {
+            Ok(Some(envelope)) => envelope,
+            Ok(None) => return handle_non_mcp(&self.config),
+            Err(ref e) => return handle_parse_error(e, &self.config),
+        };
+
+        let Some(method_str) = &envelope.method else {
+            return handle_non_mcp(&self.config);
+        };
+
+        let mcp_envelope = extract_mcp_envelope(&value, method_str, &ctx.request.headers);
+
+        if let Err(action) = validate_mcp_headers(ctx, &mcp_envelope, &envelope, &self.config) {
+            return Ok(action);
+        }
+
+        write_metadata(ctx, &envelope, &mcp_envelope);
+        promote_mcp_headers(&mcp_envelope, &envelope, &self.config, &mut ctx.extra_request_headers);
+        promote_filter_results(ctx, &envelope, &mcp_envelope)?;
+
+        trace!(
+            mcp_method = mcp_envelope.method.as_str(),
+            mcp_name = ?mcp_envelope.name,
+            session_present = mcp_envelope.session_id.is_some(),
+            "extracted MCP envelope metadata"
+        );
+
+        Ok(FilterAction::Release)
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------------
+
+/// Build a `JsonRpcConfig` for the shared parser with MCP-appropriate defaults.
+fn build_json_rpc_config(max_body_bytes: usize) -> JsonRpcConfig {
+    use crate::builtins::http::payload_processing::json_rpc::config::{
+        BatchPolicy, InvalidJsonRpcBehavior, JsonRpcHeaders,
+    };
+
+    JsonRpcConfig {
+        max_body_bytes,
+        batch_policy: BatchPolicy::Reject,
+        on_invalid: InvalidJsonRpcBehavior::Continue,
+        headers: JsonRpcHeaders {
+            method: None,
+            id: None,
+            kind: None,
+        },
+    }
+}
+
+/// Handle JSON-RPC parse errors, separating batch rejection from general errors.
+fn handle_parse_error(
+    e: &crate::builtins::http::payload_processing::json_rpc::envelope::JsonRpcParseError,
+    config: &McpConfig,
+) -> Result<FilterAction, FilterError> {
+    use crate::builtins::http::payload_processing::json_rpc::envelope::JsonRpcParseError;
+
+    match e {
+        JsonRpcParseError::UnsupportedBatch | JsonRpcParseError::EmptyBatch => {
+            Ok(FilterAction::Reject(Rejection::status(400)))
+        },
+        _ => handle_non_mcp(config),
+    }
+}
+
+/// Handle non-MCP input based on config.
+#[allow(
+    clippy::unnecessary_wraps,
+    reason = "caller returns Result<FilterAction, FilterError> from trait method"
+)]
+fn handle_non_mcp(config: &McpConfig) -> Result<FilterAction, FilterError> {
+    match config.on_invalid {
+        InvalidMcpBehavior::Continue => Ok(FilterAction::Continue),
+        InvalidMcpBehavior::Reject => Ok(FilterAction::Reject(Rejection::status(400))),
+    }
+}
+
+/// Validate `Mcp-Method` and `Mcp-Name` headers against body-derived values.
+///
+/// When `missing: synthesize` is configured and a standard MCP header is
+/// absent, the body-derived value is injected as an upstream request header.
+fn validate_mcp_headers(
+    ctx: &mut HttpFilterContext<'_>,
+    mcp: &McpEnvelope,
+    envelope: &crate::builtins::http::payload_processing::json_rpc::envelope::JsonRpcEnvelope,
+    config: &McpConfig,
+) -> Result<(), FilterAction> {
+    validate_single_header(ctx, "mcp-method", mcp.method.as_str(), envelope, config)?;
+
+    if let Some(name) = &mcp.name {
+        validate_single_header(ctx, "mcp-name", name, envelope, config)?;
+    }
+
+    Ok(())
+}
+
+/// Validate a single MCP header value against its body-derived counterpart.
+#[allow(clippy::too_many_lines, reason = "present/missing/invalid UTF-8 branches")]
+fn validate_single_header(
+    ctx: &mut HttpFilterContext<'_>,
+    header_name: &str,
+    body_value: &str,
+    envelope: &crate::builtins::http::payload_processing::json_rpc::envelope::JsonRpcEnvelope,
+    config: &McpConfig,
+) -> Result<(), FilterAction> {
+    match ctx.request.headers.get(header_name) {
+        Some(raw_value) => {
+            let Ok(header_value) = raw_value.to_str() else {
+                match config.header_validation.mismatch {
+                    MismatchBehavior::Reject => {
+                        warn!(header_name = header_name, "MCP header contains invalid UTF-8");
+                        return Err(mcp_header_mismatch_rejection(envelope));
+                    },
+                    MismatchBehavior::Ignore => return Ok(()),
+                }
+            };
+            if header_value != body_value {
+                match config.header_validation.mismatch {
+                    MismatchBehavior::Reject => {
+                        warn!(
+                            header_name = header_name,
+                            header_value = header_value,
+                            body_value = body_value,
+                            "MCP header/body mismatch"
+                        );
+                        return Err(mcp_header_mismatch_rejection(envelope));
+                    },
+                    MismatchBehavior::Ignore => {},
+                }
+            }
+        },
+        None => match config.header_validation.missing {
+            MissingHeaderBehavior::Reject => {
+                return Err(FilterAction::Reject(Rejection::status(400)));
+            },
+            MissingHeaderBehavior::Synthesize => {
+                if !contains_control_chars(body_value) {
+                    ctx.extra_request_headers
+                        .push((Cow::Owned(header_name.to_owned()), body_value.to_owned()));
+                }
+            },
+            MissingHeaderBehavior::Ignore => {},
+        },
+    }
+
+    Ok(())
+}
+
+/// Build the JSON-RPC error -32001 (`HeaderMismatch`) rejection.
+fn mcp_header_mismatch_rejection(
+    envelope: &crate::builtins::http::payload_processing::json_rpc::envelope::JsonRpcEnvelope,
+) -> FilterAction {
+    use crate::builtins::http::payload_processing::json_rpc::envelope::JsonRpcIdKind;
+
+    let id_json = match (&envelope.id, &envelope.id_kind) {
+        (Some(id), JsonRpcIdKind::Integer | JsonRpcIdKind::Number) => id.clone(),
+        (Some(id), JsonRpcIdKind::String) => serde_json::to_string(id).unwrap_or_else(|_| "null".to_owned()),
+        _ => "null".to_owned(),
+    };
+    let body = Bytes::from(format!(
+        r#"{{"jsonrpc":"2.0","error":{{"code":-32001,"message":"HeaderMismatch"}},"id":{id_json}}}"#,
+    ));
+    FilterAction::Reject(
+        Rejection::status(400)
+            .with_header("content-type", "application/json")
+            .with_body(body),
+    )
+}
+
+/// Write durable metadata that persists across all Pingora lifecycle phases.
+fn write_metadata(
+    ctx: &mut HttpFilterContext<'_>,
+    envelope: &crate::builtins::http::payload_processing::json_rpc::envelope::JsonRpcEnvelope,
+    mcp: &McpEnvelope,
+) {
+    let method_str = mcp.method.as_str();
+    if !contains_control_chars(method_str) {
+        ctx.set_metadata("json_rpc.method", method_str);
+        ctx.set_metadata("mcp.method", method_str);
+    }
+    ctx.set_metadata("json_rpc.kind", envelope.kind.as_str());
+
+    if let Some(name) = &mcp.name
+        && !contains_control_chars(name)
+    {
+        ctx.set_metadata("mcp.name", name.clone());
+    }
+    if let Some(sid) = &mcp.session_id
+        && !contains_control_chars(sid)
+    {
+        ctx.set_metadata("mcp.session_id", sid.clone());
+    }
+    if let Some(pv) = &mcp.protocol_version
+        && !contains_control_chars(pv)
+    {
+        ctx.set_metadata("mcp.protocol_version", pv.clone());
+    }
+}
+
+/// Promote MCP metadata to internal request headers.
+fn promote_mcp_headers(
+    mcp: &McpEnvelope,
+    envelope: &crate::builtins::http::payload_processing::json_rpc::envelope::JsonRpcEnvelope,
+    config: &McpConfig,
+    headers: &mut Vec<(Cow<'static, str>, String)>,
+) {
+    if let Some(header_name) = &config.headers.method {
+        let method_str = mcp.method.as_str();
+        if !contains_control_chars(method_str) {
+            headers.push((Cow::Owned(header_name.clone()), method_str.to_owned()));
+        }
+    }
+
+    if let Some(header_name) = &config.headers.name
+        && let Some(name) = &mcp.name
+        && !contains_control_chars(name)
+    {
+        headers.push((Cow::Owned(header_name.clone()), name.clone()));
+    }
+
+    if let Some(header_name) = &config.headers.kind {
+        headers.push((Cow::Owned(header_name.clone()), envelope.kind.as_str().to_owned()));
+    }
+
+    if let Some(header_name) = &config.headers.session_present {
+        let present = if mcp.session_id.is_some() { "true" } else { "false" };
+        headers.push((Cow::Owned(header_name.clone()), present.to_owned()));
+    }
+}
+
+/// Promote MCP metadata to filter results for router branch conditions.
+fn promote_filter_results(
+    ctx: &mut HttpFilterContext<'_>,
+    envelope: &crate::builtins::http::payload_processing::json_rpc::envelope::JsonRpcEnvelope,
+    mcp: &McpEnvelope,
+) -> Result<(), FilterError> {
+    let results = ctx.filter_results.entry("mcp").or_default();
+    let method_str = mcp.method.as_str();
+    if !contains_control_chars(method_str) {
+        results.set("method", method_str.to_owned())?;
+    }
+
+    if let Some(name) = &mcp.name
+        && !contains_control_chars(name)
+    {
+        results.set("name", name.clone())?;
+    }
+
+    let session_present = if mcp.session_id.is_some() { "true" } else { "false" };
+    results.set("session_present", session_present)?;
+    results.set("kind", envelope.kind.as_str())?;
+
+    Ok(())
+}

--- a/filter/src/builtins/http/payload_processing/mcp/tests.rs
+++ b/filter/src/builtins/http/payload_processing/mcp/tests.rs
@@ -1,0 +1,639 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Unit tests for the MCP filter.
+
+use bytes::Bytes;
+
+use super::{
+    McpFilter,
+    config::{McpConfig, build_config},
+};
+use crate::{FilterAction, filter::HttpFilter};
+
+// -----------------------------------------------------------------------------
+// Config Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn parse_minimal_config() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str("{}").unwrap();
+    let filter = McpFilter::from_config(&yaml).unwrap();
+    assert_eq!(filter.name(), "mcp");
+}
+
+#[test]
+fn parse_full_config() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+        max_body_bytes: 131072
+        on_invalid: continue
+        header_validation:
+          mismatch: ignore
+          missing: synthesize
+        headers:
+          method: x-mcp-method
+          name: x-mcp-name
+          kind: x-mcp-kind
+          session_present: x-mcp-session
+        "#,
+    )
+    .unwrap();
+    let filter = McpFilter::from_config(&yaml).unwrap();
+    assert_eq!(filter.name(), "mcp");
+}
+
+#[test]
+fn reject_zero_max_body_bytes() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str("max_body_bytes: 0").unwrap();
+    let err = McpFilter::from_config(&yaml).err().expect("should fail");
+    assert!(err.to_string().contains("must be greater than 0"));
+}
+
+#[test]
+fn reject_empty_header_names() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+        headers:
+          method: ""
+        "#,
+    )
+    .unwrap();
+    let err = McpFilter::from_config(&yaml).err().expect("should fail");
+    assert!(err.to_string().contains("must not be empty"));
+}
+
+#[test]
+fn reject_invalid_header_names() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+        headers:
+          method: "bad header"
+        "#,
+    )
+    .unwrap();
+    let err = McpFilter::from_config(&yaml).err().expect("should fail");
+    assert!(err.to_string().contains("not a valid HTTP header name"));
+}
+
+// -----------------------------------------------------------------------------
+// Filter Behavior Tests
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn tools_call_extracts_method_and_name() {
+    let filter = make_default_filter();
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_weather"}}"#;
+    let req = make_mcp_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    assert!(matches!(action, FilterAction::Release));
+    assert_eq!(ctx.get_metadata("mcp.method"), Some("tools/call"));
+    assert_eq!(ctx.get_metadata("mcp.name"), Some("get_weather"));
+}
+
+#[tokio::test]
+async fn initialize_extracts_protocol_version() {
+    let filter = make_default_filter();
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26"}}"#;
+    let req = make_mcp_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    assert!(matches!(action, FilterAction::Release));
+    assert_eq!(ctx.get_metadata("mcp.method"), Some("initialize"));
+    assert_eq!(ctx.get_metadata("mcp.protocol_version"), Some("2025-03-26"));
+}
+
+#[tokio::test]
+async fn session_id_detected() {
+    let filter = make_default_filter();
+    let body_str = r#"{"jsonrpc":"2.0","id":2,"method":"tools/list"}"#;
+    let mut req = make_mcp_request(&[]);
+    req.headers.insert("mcp-session-id", "gw-123".parse().unwrap());
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    assert!(matches!(action, FilterAction::Release));
+    assert_eq!(ctx.get_metadata("mcp.session_id"), Some("gw-123"));
+}
+
+#[tokio::test]
+async fn resources_read_extracts_uri() {
+    let filter = make_default_filter();
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"resources/read","params":{"uri":"file:///data.csv"}}"#;
+    let req = make_mcp_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    assert!(matches!(action, FilterAction::Release));
+    assert_eq!(ctx.get_metadata("mcp.method"), Some("resources/read"));
+    assert_eq!(ctx.get_metadata("mcp.name"), Some("file:///data.csv"));
+}
+
+#[tokio::test]
+async fn non_json_rpc_continues_when_configured() {
+    let filter = make_filter(r#"{"on_invalid": "continue"}"#);
+    let body_str = r#"{"message":"hello"}"#;
+    let req = make_mcp_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    assert!(matches!(action, FilterAction::Continue));
+}
+
+#[tokio::test]
+async fn non_json_rpc_rejected_by_default() {
+    let filter = make_default_filter();
+    let body_str = r#"{"message":"hello"}"#;
+    let req = make_mcp_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    assert!(matches!(action, FilterAction::Reject(_)));
+}
+
+#[tokio::test]
+async fn on_request_is_noop() {
+    let filter = make_default_filter();
+    let req = make_mcp_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let action = filter.on_request(&mut ctx).await.unwrap();
+
+    assert!(matches!(action, FilterAction::Continue));
+}
+
+#[tokio::test]
+async fn returns_continue_on_none_body() {
+    let filter = make_default_filter();
+    let req = make_mcp_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body: Option<Bytes> = None;
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    assert!(matches!(action, FilterAction::Continue));
+}
+
+#[test]
+fn body_access_is_read_only() {
+    let filter = make_default_filter();
+    assert_eq!(filter.request_body_access(), crate::body::BodyAccess::ReadOnly);
+}
+
+#[test]
+fn body_mode_is_stream_buffer() {
+    let filter = make_default_filter();
+    assert_eq!(
+        filter.request_body_mode(),
+        crate::body::BodyMode::StreamBuffer {
+            max_bytes: Some(super::config::DEFAULT_MAX_BODY_BYTES)
+        }
+    );
+}
+
+#[tokio::test]
+async fn promotes_filter_results() {
+    let filter = make_default_filter();
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_weather"}}"#;
+    let req = make_mcp_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    assert!(matches!(action, FilterAction::Release));
+
+    let results = ctx.filter_results.get("mcp").unwrap();
+    assert_eq!(results.get("method"), Some("tools/call"));
+    assert_eq!(results.get("name"), Some("get_weather"));
+    assert_eq!(results.get("kind"), Some("request"));
+    assert_eq!(results.get("session_present"), Some("false"));
+}
+
+#[tokio::test]
+async fn promotes_internal_headers() {
+    let filter = make_default_filter();
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_weather"}}"#;
+    let req = make_mcp_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    assert!(matches!(action, FilterAction::Release));
+
+    let headers: std::collections::HashMap<_, _> = ctx
+        .extra_request_headers
+        .iter()
+        .map(|(k, v)| (k.as_ref(), v.as_str()))
+        .collect();
+
+    assert_eq!(headers.get("x-praxis-mcp-method"), Some(&"tools/call"));
+    assert_eq!(headers.get("x-praxis-mcp-name"), Some(&"get_weather"));
+    assert_eq!(headers.get("x-praxis-mcp-kind"), Some(&"request"));
+    assert_eq!(headers.get("x-praxis-mcp-session-present"), Some(&"false"));
+}
+
+#[tokio::test]
+async fn session_present_true_in_results() {
+    let filter = make_default_filter();
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"ping"}"#;
+    let mut req = make_mcp_request(&[]);
+    req.headers.insert("mcp-session-id", "sess-456".parse().unwrap());
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    assert!(matches!(action, FilterAction::Release));
+
+    let results = ctx.filter_results.get("mcp").unwrap();
+    assert_eq!(results.get("session_present"), Some("true"));
+}
+
+#[tokio::test]
+async fn notification_sets_kind() {
+    let filter = make_default_filter();
+    let body_str = r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#;
+    let req = make_mcp_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    assert!(matches!(action, FilterAction::Release));
+    assert_eq!(ctx.get_metadata("json_rpc.kind"), Some("notification"));
+    assert_eq!(ctx.get_metadata("mcp.method"), Some("notifications/initialized"));
+}
+
+// -----------------------------------------------------------------------------
+// Envelope Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn mcp_method_round_trips() {
+    use super::envelope::McpMethod;
+
+    let cases = [
+        McpMethod::Initialize,
+        McpMethod::NotificationsInitialized,
+        McpMethod::ToolsList,
+        McpMethod::ToolsCall,
+        McpMethod::ResourcesRead,
+        McpMethod::ResourcesList,
+        McpMethod::PromptsGet,
+        McpMethod::PromptsList,
+        McpMethod::Ping,
+        McpMethod::LoggingSetLevel,
+        McpMethod::CompletionComplete,
+        McpMethod::NotificationsToolsListChanged,
+        McpMethod::NotificationsResourcesListChanged,
+        McpMethod::NotificationsPromptsListChanged,
+        McpMethod::Other("custom/method".to_owned()),
+    ];
+
+    for method in &cases {
+        assert_eq!(
+            McpMethod::from_method_str(method.as_str()),
+            *method,
+            "round-trip failed for {}",
+            method.as_str()
+        );
+    }
+}
+
+#[test]
+fn tools_call_requires_name() {
+    use super::envelope::McpMethod;
+    assert!(McpMethod::ToolsCall.requires_name());
+    assert!(!McpMethod::ToolsCall.requires_uri());
+}
+
+#[test]
+fn resources_read_requires_uri() {
+    use super::envelope::McpMethod;
+    assert!(McpMethod::ResourcesRead.requires_uri());
+    assert!(!McpMethod::ResourcesRead.requires_name());
+}
+
+#[test]
+fn prompts_get_requires_name() {
+    use super::envelope::McpMethod;
+    assert!(McpMethod::PromptsGet.requires_name());
+}
+
+// -----------------------------------------------------------------------------
+// StreamBuffer / EOS Tests
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn complete_json_before_eos_still_continues() {
+    let filter = make_default_filter();
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#;
+    let req = make_mcp_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, false).await.unwrap();
+
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "complete JSON-RPC before EOS should continue, not release"
+    );
+}
+
+#[tokio::test]
+async fn complete_json_at_eos_releases() {
+    let filter = make_default_filter();
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#;
+    let req = make_mcp_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    assert!(matches!(action, FilterAction::Release));
+}
+
+// -----------------------------------------------------------------------------
+// Control Character Safety Tests
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn control_char_method_skips_all_promotions() {
+    let filter = make_default_filter();
+    let body_str = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"custom\\nmethod\"}";
+    let req = make_mcp_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    assert!(matches!(action, FilterAction::Release));
+
+    let headers: std::collections::HashMap<_, _> = ctx
+        .extra_request_headers
+        .iter()
+        .map(|(k, v)| (k.as_ref(), v.as_str()))
+        .collect();
+    assert!(
+        !headers.contains_key("x-praxis-mcp-method"),
+        "method with control chars should not be promoted to header"
+    );
+
+    let results = ctx.filter_results.get("mcp").unwrap();
+    assert_eq!(
+        results.get("method"),
+        None,
+        "method with control chars should not be set in filter results"
+    );
+
+    assert_eq!(
+        ctx.get_metadata("mcp.method"),
+        None,
+        "method with control chars should not be set in durable metadata"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Header Validation Tests
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn matching_headers_succeed() {
+    let filter = make_default_filter();
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_weather"}}"#;
+    let req = make_mcp_request(&[("mcp-method", "tools/call"), ("mcp-name", "get_weather")]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    assert!(matches!(action, FilterAction::Release));
+    assert_eq!(ctx.get_metadata("mcp.method"), Some("tools/call"));
+    assert_eq!(ctx.get_metadata("mcp.name"), Some("get_weather"));
+}
+
+#[tokio::test]
+async fn header_body_mismatch_rejected() {
+    let filter = make_default_filter();
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_weather"}}"#;
+    let req = make_mcp_request(&[("mcp-method", "tools/list"), ("mcp-name", "get_weather")]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    assert!(matches!(action, FilterAction::Reject(_)));
+}
+
+#[tokio::test]
+async fn missing_headers_ignored_by_default() {
+    let filter = make_filter("{}");
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"test"}}"#;
+    let req = make_mcp_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    assert!(matches!(action, FilterAction::Release));
+    assert_eq!(ctx.get_metadata("mcp.method"), Some("tools/call"));
+}
+
+#[tokio::test]
+async fn missing_headers_rejected_when_configured() {
+    let filter = make_filter(r#"{"header_validation": {"missing": "reject"}}"#);
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"test"}}"#;
+    let req = make_mcp_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    assert!(matches!(action, FilterAction::Reject(_)));
+}
+
+#[tokio::test]
+async fn invalid_utf8_header_treated_as_mismatch() {
+    let filter = make_default_filter();
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#;
+    let mut req = make_mcp_request(&[]);
+    req.headers.insert(
+        http::HeaderName::from_static("mcp-method"),
+        http::HeaderValue::from_bytes(&[0x80, 0x81]).unwrap(),
+    );
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    assert!(
+        matches!(action, FilterAction::Reject(_)),
+        "invalid UTF-8 header should be treated as mismatch"
+    );
+}
+
+#[tokio::test]
+async fn invalid_utf8_header_ignored_when_mismatch_ignore() {
+    let filter = make_filter(r#"{"header_validation": {"mismatch": "ignore"}}"#);
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#;
+    let mut req = make_mcp_request(&[]);
+    req.headers.insert(
+        http::HeaderName::from_static("mcp-method"),
+        http::HeaderValue::from_bytes(&[0x80, 0x81]).unwrap(),
+    );
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    assert!(matches!(action, FilterAction::Release));
+}
+
+// -----------------------------------------------------------------------------
+// Batch Rejection Tests
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn batch_rejected_even_with_on_invalid_continue() {
+    let filter = make_filter(r#"{"on_invalid": "continue"}"#);
+    let body_str = r#"[{"jsonrpc":"2.0","id":1,"method":"tools/list"}]"#;
+    let req = make_mcp_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    assert!(
+        matches!(action, FilterAction::Reject(_)),
+        "batch should be rejected regardless of on_invalid"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// HeaderMismatch ID Tests
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn header_mismatch_preserves_numeric_id() {
+    let filter = make_default_filter();
+    let body_str = r#"{"jsonrpc":"2.0","id":42,"method":"tools/call","params":{"name":"get_weather"}}"#;
+    let req = make_mcp_request(&[("mcp-method", "tools/list"), ("mcp-name", "get_weather")]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    match action {
+        FilterAction::Reject(rejection) => {
+            let body_bytes = rejection.body.expect("rejection should have body");
+            let body_str = std::str::from_utf8(&body_bytes).unwrap();
+            assert!(
+                body_str.contains(r#""id":42}"#),
+                "rejection should include numeric id without quotes: {body_str}"
+            );
+        },
+        other => panic!("expected Reject, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn header_mismatch_preserves_string_id() {
+    let filter = make_default_filter();
+    let body_str = r#"{"jsonrpc":"2.0","id":"req-1","method":"tools/call","params":{"name":"test"}}"#;
+    let req = make_mcp_request(&[("mcp-method", "tools/list"), ("mcp-name", "test")]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    match action {
+        FilterAction::Reject(rejection) => {
+            let body_bytes = rejection.body.expect("rejection should have body");
+            let parsed: serde_json::Value = serde_json::from_slice(&body_bytes).expect("response must be valid JSON");
+            assert_eq!(parsed["id"].as_str(), Some("req-1"));
+        },
+        other => panic!("expected Reject, got {other:?}"),
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Synthesize Tests
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn synthesize_injects_standard_mcp_headers() {
+    let filter = make_filter(r#"{"header_validation": {"missing": "synthesize"}}"#);
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_weather"}}"#;
+    let req = make_mcp_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    assert!(matches!(action, FilterAction::Release));
+
+    let headers: std::collections::HashMap<_, _> = ctx
+        .extra_request_headers
+        .iter()
+        .map(|(k, v)| (k.as_ref(), v.as_str()))
+        .collect();
+
+    assert_eq!(
+        headers.get("mcp-method"),
+        Some(&"tools/call"),
+        "synthesize should inject standard mcp-method header"
+    );
+    assert_eq!(
+        headers.get("mcp-name"),
+        Some(&"get_weather"),
+        "synthesize should inject standard mcp-name header"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Test Utilities
+// -----------------------------------------------------------------------------
+
+fn make_default_filter() -> McpFilter {
+    make_filter("{}")
+}
+
+fn make_filter(yaml: &str) -> McpFilter {
+    let cfg: McpConfig = serde_yaml::from_str(yaml).unwrap();
+    let validated_config = build_config(cfg).unwrap();
+    let json_rpc_config = super::build_json_rpc_config(validated_config.max_body_bytes);
+    McpFilter {
+        max_body_bytes: validated_config.max_body_bytes,
+        config: validated_config,
+        json_rpc_config,
+    }
+}
+
+fn make_mcp_request(extra_headers: &[(&str, &str)]) -> crate::context::Request {
+    let mut req = crate::test_utils::make_request(http::Method::POST, "/mcp");
+    req.headers.insert("content-type", "application/json".parse().unwrap());
+    for (name, value) in extra_headers {
+        req.headers.insert(
+            http::HeaderName::from_bytes(name.as_bytes()).unwrap(),
+            value.parse().unwrap(),
+        );
+    }
+    req
+}

--- a/filter/src/builtins/http/payload_processing/mod.rs
+++ b/filter/src/builtins/http/payload_processing/mod.rs
@@ -7,7 +7,9 @@ mod compression;
 pub(crate) mod compression_config;
 mod json_body_field;
 pub(crate) mod json_rpc;
+mod mcp;
 
 pub use compression::CompressionFilter;
 pub use json_body_field::JsonBodyFieldFilter;
 pub use json_rpc::JsonRpcFilter;
+pub use mcp::McpFilter;

--- a/filter/src/builtins/mod.rs
+++ b/filter/src/builtins/mod.rs
@@ -9,8 +9,8 @@ mod tcp;
 pub use http::{
     AccessLogFilter, CircuitBreakerFilter, CompressionFilter, CorsFilter, CredentialInjectionFilter, CsrfFilter,
     DisallowedOriginMode, ForwardedHeadersFilter, GuardrailsAction, GuardrailsFilter, HeaderFilter, IpAclFilter,
-    JsonBodyFieldFilter, JsonRpcFilter, LoadBalancerFilter, ModelToHeaderFilter, PathRewriteFilter, RateLimitFilter,
-    RateLimitMode, RedirectFilter, RedirectStatus, RequestIdFilter, RouterFilter, RuleTargetKind, StaticResponseFilter,
-    TimeoutFilter, UrlRewriteFilter, normalize_rewritten_path,
+    JsonBodyFieldFilter, JsonRpcFilter, LoadBalancerFilter, McpFilter, ModelToHeaderFilter, PathRewriteFilter,
+    RateLimitFilter, RateLimitMode, RedirectFilter, RedirectStatus, RequestIdFilter, RouterFilter, RuleTargetKind,
+    StaticResponseFilter, TimeoutFilter, UrlRewriteFilter, normalize_rewritten_path,
 };
 pub use tcp::{SniRouterFilter, TcpAccessLogFilter, TcpLoadBalancerFilter};

--- a/filter/src/registry.rs
+++ b/filter/src/registry.rs
@@ -110,8 +110,9 @@ impl FilterRegistry {
 fn register_http_builtins(factories: &mut HashMap<String, FilterFactory>) {
     use crate::builtins::{
         AccessLogFilter, CircuitBreakerFilter, CompressionFilter, CorsFilter, CredentialInjectionFilter, CsrfFilter,
-        ForwardedHeadersFilter, HeaderFilter, IpAclFilter, JsonBodyFieldFilter, JsonRpcFilter, PathRewriteFilter,
-        RateLimitFilter, RedirectFilter, RequestIdFilter, StaticResponseFilter, TimeoutFilter, UrlRewriteFilter,
+        ForwardedHeadersFilter, HeaderFilter, IpAclFilter, JsonBodyFieldFilter, JsonRpcFilter, McpFilter,
+        PathRewriteFilter, RateLimitFilter, RedirectFilter, RequestIdFilter, StaticResponseFilter, TimeoutFilter,
+        UrlRewriteFilter,
     };
 
     register_http(factories, "access_log", AccessLogFilter::from_config);
@@ -139,6 +140,7 @@ fn register_http_builtins(factories: &mut HashMap<String, FilterFactory>) {
     register_http(factories, "url_rewrite", UrlRewriteFilter::from_config);
     register_http(factories, "json_body_field", JsonBodyFieldFilter::from_config);
     register_http(factories, "json_rpc", JsonRpcFilter::from_config);
+    register_http(factories, "mcp", McpFilter::from_config);
     #[cfg(feature = "ai-inference")]
     register_http(
         factories,
@@ -250,6 +252,7 @@ mod tests {
             "json_body_field should be registered"
         );
         assert!(names.contains(&"json_rpc"), "json_rpc should be registered");
+        assert!(names.contains(&"mcp"), "mcp should be registered");
         #[cfg(feature = "ai-inference")]
         assert!(
             names.contains(&"model_to_header"),

--- a/tests/integration/tests/suite/examples/payload_processing.rs
+++ b/tests/integration/tests/suite/examples/payload_processing.rs
@@ -559,3 +559,131 @@ fn json_rpc_routing_falls_through_to_default() {
         "unknown method should route to default cluster"
     );
 }
+
+#[test]
+fn mcp_classifier_routing_routes_by_tool_name() {
+    let weather_guard = start_backend_with_shutdown("weather-response");
+    let weather_port = weather_guard.port();
+    let calendar_guard = start_backend_with_shutdown("calendar-response");
+    let calendar_port = calendar_guard.port();
+    let default_guard = start_backend_with_shutdown("default-response");
+    let default_port = default_guard.port();
+    let proxy_port = free_port();
+
+    let config = load_example_config(
+        "payload-processing/mcp-classifier-routing.yaml",
+        proxy_port,
+        HashMap::from([
+            ("127.0.0.1:9001", weather_port),
+            ("127.0.0.1:9002", calendar_port),
+            ("127.0.0.1:9003", default_port),
+        ]),
+    );
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        &mcp_json_post(
+            "/",
+            r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_weather"}}"#,
+            &[("Mcp-Method", "tools/call"), ("Mcp-Name", "get_weather")],
+        ),
+    );
+    assert_eq!(parse_status(&raw), 200, "tools/call get_weather should return 200");
+    assert_eq!(
+        parse_body(&raw),
+        "weather-response",
+        "tools/call with name=get_weather should route to weather-tools cluster"
+    );
+}
+
+#[test]
+fn mcp_classifier_routing_default_fallback() {
+    let weather_guard = start_backend_with_shutdown("weather-response");
+    let weather_port = weather_guard.port();
+    let calendar_guard = start_backend_with_shutdown("calendar-response");
+    let calendar_port = calendar_guard.port();
+    let default_guard = start_backend_with_shutdown("default-response");
+    let default_port = default_guard.port();
+    let proxy_port = free_port();
+
+    let config = load_example_config(
+        "payload-processing/mcp-classifier-routing.yaml",
+        proxy_port,
+        HashMap::from([
+            ("127.0.0.1:9001", weather_port),
+            ("127.0.0.1:9002", calendar_port),
+            ("127.0.0.1:9003", default_port),
+        ]),
+    );
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        &mcp_json_post(
+            "/",
+            r#"{"jsonrpc":"2.0","id":2,"method":"tools/list"}"#,
+            &[("Mcp-Method", "tools/list")],
+        ),
+    );
+    assert_eq!(parse_status(&raw), 200, "tools/list should return 200");
+    assert_eq!(
+        parse_body(&raw),
+        "default-response",
+        "tools/list should route to default-mcp cluster"
+    );
+}
+
+#[test]
+fn mcp_classifier_routing_routes_calendar_without_client_mcp_headers() {
+    let weather_guard = start_backend_with_shutdown("weather-response");
+    let weather_port = weather_guard.port();
+    let calendar_guard = start_backend_with_shutdown("calendar-response");
+    let calendar_port = calendar_guard.port();
+    let default_guard = start_backend_with_shutdown("default-response");
+    let default_port = default_guard.port();
+    let proxy_port = free_port();
+
+    let config = load_example_config(
+        "payload-processing/mcp-classifier-routing.yaml",
+        proxy_port,
+        HashMap::from([
+            ("127.0.0.1:9001", weather_port),
+            ("127.0.0.1:9002", calendar_port),
+            ("127.0.0.1:9003", default_port),
+        ]),
+    );
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        &mcp_json_post(
+            "/",
+            r#"{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"get_calendar"}}"#,
+            &[],
+        ),
+    );
+    assert_eq!(parse_status(&raw), 200, "tools/call get_calendar should return 200");
+    assert_eq!(
+        parse_body(&raw),
+        "calendar-response",
+        "tools/call with name=get_calendar should route to calendar-tools cluster without client Mcp-* headers"
+    );
+}
+
+fn mcp_json_post(path: &str, body: &str, headers: &[(&str, &str)]) -> String {
+    let mut extra = String::new();
+    for (name, value) in headers {
+        extra.push_str(&format!("{name}: {value}\r\n"));
+    }
+    format!(
+        "POST {path} HTTP/1.1\r\n\
+         Host: localhost\r\n\
+         Content-Type: application/json\r\n\
+         Content-Length: {}\r\n\
+         {extra}\
+         \r\n\
+         {body}",
+        body.len(),
+    )
+}

--- a/tests/integration/tests/suite/main.rs
+++ b/tests/integration/tests/suite/main.rs
@@ -51,6 +51,7 @@ mod hot_reload;
 mod ip_acl;
 mod json_body_field;
 mod json_rpc;
+mod mcp;
 mod path_rewrite;
 mod payload_processing;
 mod per_listener_pipeline;

--- a/tests/integration/tests/suite/mcp.rs
+++ b/tests/integration/tests/suite/mcp.rs
@@ -1,0 +1,498 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Integration tests for MCP classifier filter.
+
+use std::{io::Write, net::TcpStream};
+
+use praxis_core::config::Config;
+use praxis_test_utils::{
+    free_port, http_send, parse_body, parse_status, start_backend_with_shutdown,
+    start_header_echo_backend_with_shutdown, start_proxy,
+};
+
+// -----------------------------------------------------------------------------
+// Routing Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn mcp_tools_call_routes_by_name() {
+    let weather_guard = start_backend_with_shutdown("weather-backend");
+    let default_guard = start_backend_with_shutdown("default-backend");
+    let proxy_port = free_port();
+
+    let yaml = mcp_routing_yaml(proxy_port, weather_guard.port(), default_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body = r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_weather"}}"#;
+    let request = json_post_with_mcp_headers("/mcp/", body, &[]);
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(parse_status(&raw), 200);
+    assert_eq!(
+        parse_body(&raw),
+        "weather-backend",
+        "tools/call with name=get_weather should route to weather cluster"
+    );
+}
+
+#[test]
+fn mcp_tools_list_routes_to_default() {
+    let weather_guard = start_backend_with_shutdown("weather-backend");
+    let default_guard = start_backend_with_shutdown("default-backend");
+    let proxy_port = free_port();
+
+    let yaml = mcp_routing_yaml(proxy_port, weather_guard.port(), default_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body = r#"{"jsonrpc":"2.0","id":2,"method":"tools/list"}"#;
+    let request = json_post_with_mcp_headers("/mcp/", body, &[]);
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(parse_status(&raw), 200);
+    assert_eq!(
+        parse_body(&raw),
+        "default-backend",
+        "tools/list should route to default cluster"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Header Validation Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn mcp_header_body_mismatch_rejected_with_id() {
+    let backend_guard = start_backend_with_shutdown("backend");
+    let proxy_port = free_port();
+
+    let yaml = mcp_default_yaml(proxy_port, backend_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body = r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_weather"}}"#;
+    let request = json_post_with_mcp_headers(
+        "/mcp/",
+        body,
+        &[("Mcp-Method", "tools/list"), ("Mcp-Name", "get_weather")],
+    );
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(parse_status(&raw), 400);
+    let response_body = parse_body(&raw);
+    let parsed: serde_json::Value = serde_json::from_str(&response_body).unwrap();
+    assert_eq!(parsed["error"]["code"], -32001);
+    assert_eq!(parsed["error"]["message"], "HeaderMismatch");
+    assert_eq!(parsed["id"], 1);
+}
+
+#[test]
+fn mcp_mismatch_ignore_routes_by_body() {
+    let weather_guard = start_backend_with_shutdown("weather-backend");
+    let default_guard = start_backend_with_shutdown("default-backend");
+    let proxy_port = free_port();
+
+    let yaml = mcp_mismatch_ignore_yaml(proxy_port, weather_guard.port(), default_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body = r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_weather"}}"#;
+    let request = json_post_with_mcp_headers("/mcp/", body, &[("Mcp-Method", "tools/list")]);
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(parse_status(&raw), 200);
+    assert_eq!(
+        parse_body(&raw),
+        "weather-backend",
+        "mismatch: ignore should route by body-derived values"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Batch Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn mcp_batch_rejected_even_with_on_invalid_continue() {
+    let backend_guard = start_backend_with_shutdown("backend");
+    let proxy_port = free_port();
+
+    let yaml = mcp_passthrough_yaml(proxy_port, backend_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body = r#"[{"jsonrpc":"2.0","id":1,"method":"tools/list"}]"#;
+    let request = json_post_with_mcp_headers("/mcp/", body, &[]);
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(
+        parse_status(&raw),
+        400,
+        "batch should be rejected even with on_invalid: continue"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Compatibility Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn mcp_on_invalid_continue_passes_non_json() {
+    let backend_guard = start_backend_with_shutdown("backend");
+    let proxy_port = free_port();
+
+    let yaml = mcp_passthrough_yaml(proxy_port, backend_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let request = format!(
+        "GET /sse HTTP/1.1\r\n\
+         Host: localhost\r\n\
+         Accept: text/event-stream\r\n\
+         \r\n"
+    );
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(parse_status(&raw), 200);
+}
+
+// -----------------------------------------------------------------------------
+// Synthesize Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn mcp_synthesize_injects_standard_headers_when_missing() {
+    let backend_guard = start_header_echo_backend_with_shutdown();
+    let proxy_port = free_port();
+
+    let yaml = mcp_synthesize_yaml(proxy_port, backend_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body = r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_weather"}}"#;
+    let request = json_post_with_mcp_headers("/mcp/", body, &[]);
+    let raw = http_send(proxy.addr(), &request);
+    let echoed = parse_body(&raw);
+    let echoed_lower = echoed.to_lowercase();
+
+    assert_eq!(parse_status(&raw), 200);
+    assert!(
+        echoed_lower.contains("mcp-method: tools/call"),
+        "synthesize should inject mcp-method to backend: {echoed}"
+    );
+    assert!(
+        echoed_lower.contains("mcp-name: get_weather"),
+        "synthesize should inject mcp-name to backend: {echoed}"
+    );
+    assert!(
+        !echoed_lower.contains("x-praxis-mcp-method"),
+        "internal x-praxis-mcp-method should NOT reach backend: {echoed}"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Header Leak Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn mcp_standard_headers_preserved_internal_stripped() {
+    let backend_guard = start_header_echo_backend_with_shutdown();
+    let proxy_port = free_port();
+
+    let yaml = mcp_passthrough_yaml(proxy_port, backend_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body = r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"test"}}"#;
+    let request = json_post_with_mcp_headers("/mcp", body, &[("MCP-Session-Id", "sess-123")]);
+    let raw = http_send(proxy.addr(), &request);
+    let echoed = parse_body(&raw);
+    let echoed_lower = echoed.to_lowercase();
+
+    assert!(
+        echoed_lower.contains("mcp-session-id: sess-123"),
+        "standard MCP-Session-Id should reach backend: {echoed}"
+    );
+    assert!(
+        !echoed_lower.contains("x-praxis-mcp-method"),
+        "internal x-praxis-mcp-method should NOT reach backend: {echoed}"
+    );
+    assert!(
+        !echoed_lower.contains("x-praxis-mcp-name"),
+        "internal x-praxis-mcp-name should NOT reach backend: {echoed}"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Fragmented / Oversized Body Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn mcp_fragmented_body_routes_correctly() {
+    let weather_guard = start_backend_with_shutdown("weather-backend");
+    let default_guard = start_backend_with_shutdown("default-backend");
+    let proxy_port = free_port();
+
+    let yaml = mcp_routing_yaml(proxy_port, weather_guard.port(), default_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let _proxy = start_proxy(&config);
+
+    let body = r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_weather"}}"#;
+    let headers = format!(
+        "POST /mcp/ HTTP/1.1\r\n\
+         Host: localhost\r\n\
+         Content-Type: application/json\r\n\
+         Content-Length: {}\r\n\
+         Connection: close\r\n\
+         \r\n",
+        body.len(),
+    );
+    let body_half = body.len() / 2;
+
+    let mut stream = TcpStream::connect(format!("127.0.0.1:{proxy_port}")).unwrap();
+    stream
+        .set_read_timeout(Some(std::time::Duration::from_secs(5)))
+        .unwrap();
+    stream.write_all(headers.as_bytes()).unwrap();
+    stream.write_all(&body.as_bytes()[..body_half]).unwrap();
+    stream.flush().unwrap();
+    std::thread::sleep(std::time::Duration::from_millis(10));
+    stream.write_all(&body.as_bytes()[body_half..]).unwrap();
+    stream.flush().unwrap();
+
+    let mut response = Vec::new();
+    std::io::Read::read_to_end(&mut stream, &mut response).unwrap();
+    let raw = String::from_utf8_lossy(&response);
+
+    assert_eq!(parse_status(&raw), 200);
+    assert_eq!(
+        parse_body(&raw),
+        "weather-backend",
+        "fragmented body should still route correctly"
+    );
+}
+
+#[test]
+fn mcp_oversized_body_rejected() {
+    let backend_guard = start_backend_with_shutdown("backend");
+    let proxy_port = free_port();
+
+    let yaml = mcp_small_body_yaml(proxy_port, backend_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let payload = format!(
+        r#"{{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{{"name":"test","data":"{}"}}}}"#,
+        "x".repeat(2000)
+    );
+    let request = json_post_with_mcp_headers("/mcp/", &payload, &[]);
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(
+        parse_status(&raw),
+        413,
+        "body exceeding max_body_bytes should return 413"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Test Utilities
+// -----------------------------------------------------------------------------
+
+fn json_post_with_mcp_headers(path: &str, body: &str, headers: &[(&str, &str)]) -> String {
+    let mut extra = String::new();
+    for (name, value) in headers {
+        extra.push_str(&format!("{name}: {value}\r\n"));
+    }
+    format!(
+        "POST {path} HTTP/1.1\r\n\
+         Host: localhost\r\n\
+         Content-Type: application/json\r\n\
+         Content-Length: {}\r\n\
+         {extra}\
+         \r\n\
+         {body}",
+        body.len(),
+    )
+}
+
+fn mcp_routing_yaml(proxy_port: u16, weather_port: u16, default_port: u16) -> String {
+    format!(
+        r#"
+listeners:
+  - name: default
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: mcp
+        max_body_bytes: 65536
+        on_invalid: continue
+        headers:
+          method: x-praxis-mcp-method
+          name: x-praxis-mcp-name
+      - filter: router
+        routes:
+          - path_prefix: "/mcp/"
+            headers:
+              x-praxis-mcp-name: "get_weather"
+            cluster: "weather"
+          - path_prefix: "/mcp/"
+            cluster: "default"
+      - filter: load_balancer
+        clusters:
+          - name: "weather"
+            endpoints:
+              - "127.0.0.1:{weather_port}"
+          - name: "default"
+            endpoints:
+              - "127.0.0.1:{default_port}"
+"#,
+    )
+}
+
+fn mcp_default_yaml(proxy_port: u16, backend_port: u16) -> String {
+    format!(
+        r#"
+listeners:
+  - name: default
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: mcp
+        max_body_bytes: 65536
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: "backend"
+      - filter: load_balancer
+        clusters:
+          - name: "backend"
+            endpoints:
+              - "127.0.0.1:{backend_port}"
+"#,
+    )
+}
+
+fn mcp_mismatch_ignore_yaml(proxy_port: u16, weather_port: u16, default_port: u16) -> String {
+    format!(
+        r#"
+listeners:
+  - name: default
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: mcp
+        max_body_bytes: 65536
+        header_validation:
+          mismatch: ignore
+        headers:
+          method: x-praxis-mcp-method
+          name: x-praxis-mcp-name
+      - filter: router
+        routes:
+          - path_prefix: "/mcp/"
+            headers:
+              x-praxis-mcp-name: "get_weather"
+            cluster: "weather"
+          - path_prefix: "/mcp/"
+            cluster: "default"
+      - filter: load_balancer
+        clusters:
+          - name: "weather"
+            endpoints:
+              - "127.0.0.1:{weather_port}"
+          - name: "default"
+            endpoints:
+              - "127.0.0.1:{default_port}"
+"#,
+    )
+}
+
+fn mcp_synthesize_yaml(proxy_port: u16, backend_port: u16) -> String {
+    format!(
+        r#"
+listeners:
+  - name: default
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: mcp
+        max_body_bytes: 65536
+        header_validation:
+          missing: synthesize
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: "backend"
+      - filter: load_balancer
+        clusters:
+          - name: "backend"
+            endpoints:
+              - "127.0.0.1:{backend_port}"
+"#,
+    )
+}
+
+fn mcp_passthrough_yaml(proxy_port: u16, backend_port: u16) -> String {
+    format!(
+        r#"
+listeners:
+  - name: default
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: mcp
+        max_body_bytes: 65536
+        on_invalid: continue
+        header_validation:
+          mismatch: ignore
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: "backend"
+      - filter: load_balancer
+        clusters:
+          - name: "backend"
+            endpoints:
+              - "127.0.0.1:{backend_port}"
+"#,
+    )
+}
+
+fn mcp_small_body_yaml(proxy_port: u16, backend_port: u16) -> String {
+    format!(
+        r#"
+listeners:
+  - name: default
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: mcp
+        max_body_bytes: 256
+        on_invalid: continue
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: "backend"
+      - filter: load_balancer
+        clusters:
+          - name: "backend"
+            endpoints:
+              - "127.0.0.1:{backend_port}"
+"#,
+    )
+}


### PR DESCRIPTION
  ## Summary

  Adds an `mcp` filter that parses JSON-RPC request bodies to extract MCP protocol metadata for routing. This is MCP classification and static routing only, not full MCP gateway support. See the entire e2e PoC for agentic and how the PRs will be chunked here https://github.com/praxis-proxy/ai/issues/148#issuecomment-4368239729. Also a section on what was added for the broader end to end needs: 

  - Classifies 14 known MCP methods (`initialize`, `tools/call`, `tools/list`, `resources/read`, `prompts/get`, `ping`, etc.) with `Other` for unknown methods
  - Extracts `params.name` (tools/call, prompts/get), `params.uri` (resources/read), session ID from `MCP-Session-Id`, protocol version from initialize body or
  `MCP-Protocol-Version` header
  - Promotes durable metadata (`mcp.method`, `mcp.name`, `mcp.session_id`, `mcp.protocol_version`) and filter results under `"mcp"` key
  - Promotes internal routing headers (`x-praxis-mcp-method`, `x-praxis-mcp-name`, `x-praxis-mcp-kind`, `x-praxis-mcp-session-present`) for router matching —
  stripped before upstream by PR 2 header hygiene
  - Validates `Mcp-Method`/`Mcp-Name` headers against body-derived values; mismatches rejected with JSON-RPC error `-32001 HeaderMismatch`
  - Rejects JSON-RPC batches regardless of `on_invalid` config
  - Enforces required `params.name`/`params.uri` for methods that need them
  - Handles partial StreamBuffer chunks correctly (continues before EOS, processes at EOS)
  - Reuses the shared `json_rpc` parser — no duplicate envelope parsing

  ### Config

  ```yaml
  filter: mcp
  max_body_bytes: 65536
  on_invalid: reject        # or continue (pass-through for old SSE transport, I validated both with FastMCP which you can see in the epic issue)
  header_validation:
    mismatch: reject        # or ignore
    missing: reject         # reject, synthesize, or ignore
```

 ### Follow-up: header validation hardening

  A second PR will add on top of this one. I genuinely worked hard to try and get this smoll but at 1500 LOC apparently failed 😿 The tests ballooned it a lot even with trying to split hardening/testing out:
  - `missing: synthesize` actually injecting standard `mcp-method` / `mcp-name` headers
  - Required `params.name` / `params.uri` enforcement for:
    - `tools/call`
    - `prompts/get`
    - `resources/read`
  - Batch request rejection regardless of `on_invalid`
  - Safer partial chunk handling for StreamBuffer parse failures before EOS
  - Spurious `Mcp-Name` rejection for nameless methods such as `tools/list`
  - HeaderMismatch responses preserving the original JSON-RPC id
  - Additional unit and integration tests for the above hardening cases

### Expanded scope from the issue

  The original issue focused on MCP-aware routing, but this PR also lays down several reusable pieces needed by the broader MCP/A2A plan:

  - Uses the shared JSON-RPC parser instead of introducing MCP-specific parsing logic.
  - Writes durable per-request metadata so later filters, response handling, and logging can access MCP context beyond the body phase.
  - Extracts MCP session presence and protocol version, even though full MCP session management is deferred to later gateway/session PRs.
  - Promotes bounded internal routing headers for compatibility with the existing `router` filter, allowing useful static MCP routing before full `mcp_gateway` behavior exists.
  - Adds strict header/body validation around `Mcp-Method` and `Mcp-Name` to prevent clients from spoofing routing decisions with headers.
  - Includes compatibility behavior for legacy/old-SSE deployments through `on_invalid: continue` and configurable missing-header handling.
  - Adds docs, examples, and integration coverage so the classifier can be exercised independently before catalog aggregation, backend session mapping, and tool-prefix rewriting land later.
 ### Test plan

  - 34 unit tests: config parsing, method classification, name/URI extraction, protocol version, session detection, metadata promotion, header promotion, filter
   results, mismatch rejection, missing-header rejection, required-name enforcement, batch rejection, partial-chunk handling, compatibility mode
  - 12 integration tests: routing by tool name, default fallback, header/body mismatch 400, missing-name 400, batch rejection, non-JSON pass-through, standard
  MCP headers preserved upstream, internal headers stripped, example config routing
  - Full suite: 407 pass, 0 regressions, 0 clippy errors

  Refs praxis-proxy/ai#149
  