### PR TITLE
feat: add MCP header validation hardening

### DIFF
--- a/filter/src/builtins/http/payload_processing/mcp/mod.rs
+++ b/filter/src/builtins/http/payload_processing/mcp/mod.rs
@@ -153,6 +153,10 @@ impl HttpFilter for McpFilter {
 
         let mcp_envelope = extract_mcp_envelope(&value, method_str, &ctx.request.headers);
 
+        if let Some(action) = reject_missing_required_selector(&mcp_envelope, &envelope, &self.config) {
+            return Ok(action);
+        }
+
         if let Err(action) = validate_mcp_headers(ctx, &mcp_envelope, &envelope, &self.config) {
             return Ok(action);
         }
@@ -221,6 +225,23 @@ fn handle_non_mcp(config: &McpConfig) -> Result<FilterAction, FilterError> {
     }
 }
 
+/// Selector-bearing methods cannot be trusted when the selector is absent or malformed.
+fn reject_missing_required_selector(
+    mcp: &McpEnvelope,
+    envelope: &crate::builtins::http::payload_processing::json_rpc::envelope::JsonRpcEnvelope,
+    config: &McpConfig,
+) -> Option<FilterAction> {
+    let requires = mcp.method.requires_name() || mcp.method.requires_uri();
+    if requires && mcp.name.is_none() {
+        match config.on_invalid {
+            InvalidMcpBehavior::Reject => Some(mcp_invalid_params_rejection(envelope)),
+            InvalidMcpBehavior::Continue => Some(FilterAction::Continue),
+        }
+    } else {
+        None
+    }
+}
+
 /// Validate `Mcp-Method` and `Mcp-Name` headers against body-derived values.
 ///
 /// When `missing: synthesize` is configured and a standard MCP header is
@@ -235,6 +256,14 @@ fn validate_mcp_headers(
 
     if let Some(name) = &mcp.name {
         validate_single_header(ctx, "mcp-name", name, envelope, config)?;
+    } else if ctx.request.headers.get("mcp-name").is_some() {
+        match config.header_validation.mismatch {
+            MismatchBehavior::Reject => {
+                warn!("client sent Mcp-Name header but body method has no name");
+                return Err(mcp_header_mismatch_rejection(envelope));
+            },
+            MismatchBehavior::Ignore => {},
+        }
     }
 
     Ok(())
@@ -292,9 +321,25 @@ fn validate_single_header(
     Ok(())
 }
 
+/// Build the JSON-RPC error -32602 (`InvalidParams`) rejection.
+fn mcp_invalid_params_rejection(
+    envelope: &crate::builtins::http::payload_processing::json_rpc::envelope::JsonRpcEnvelope,
+) -> FilterAction {
+    mcp_json_rpc_error_rejection(envelope, -32602, "InvalidParams")
+}
+
 /// Build the JSON-RPC error -32001 (`HeaderMismatch`) rejection.
 fn mcp_header_mismatch_rejection(
     envelope: &crate::builtins::http::payload_processing::json_rpc::envelope::JsonRpcEnvelope,
+) -> FilterAction {
+    mcp_json_rpc_error_rejection(envelope, -32001, "HeaderMismatch")
+}
+
+/// MCP rejections preserve JSON-RPC IDs so clients can correlate errors.
+fn mcp_json_rpc_error_rejection(
+    envelope: &crate::builtins::http::payload_processing::json_rpc::envelope::JsonRpcEnvelope,
+    code: i32,
+    message: &str,
 ) -> FilterAction {
     use crate::builtins::http::payload_processing::json_rpc::envelope::JsonRpcIdKind;
 
@@ -304,7 +349,7 @@ fn mcp_header_mismatch_rejection(
         _ => "null".to_owned(),
     };
     let body = Bytes::from(format!(
-        r#"{{"jsonrpc":"2.0","error":{{"code":-32001,"message":"HeaderMismatch"}},"id":{id_json}}}"#,
+        r#"{{"jsonrpc":"2.0","error":{{"code":{code},"message":"{message}"}},"id":{id_json}}}"#,
     ));
     FilterAction::Reject(
         Rejection::status(400)

--- a/filter/src/builtins/http/payload_processing/mcp/tests.rs
+++ b/filter/src/builtins/http/payload_processing/mcp/tests.rs
@@ -608,8 +608,157 @@ async fn synthesize_injects_standard_mcp_headers() {
 }
 
 // -----------------------------------------------------------------------------
+// Required Name/URI Tests
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn tools_call_missing_name_rejected() {
+    let filter = make_default_filter();
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{}}"#;
+    let req = make_mcp_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    assert_invalid_params_rejection(&action, &serde_json::json!(1));
+}
+
+#[tokio::test]
+async fn tools_call_missing_params_rejected() {
+    let filter = make_default_filter();
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"tools/call"}"#;
+    let req = make_mcp_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    assert_invalid_params_rejection(&action, &serde_json::json!(1));
+}
+
+#[tokio::test]
+async fn tools_call_non_string_name_rejected() {
+    let filter = make_default_filter();
+    let body_str = r#"{"jsonrpc":"2.0","id":"req\"1","method":"tools/call","params":{"name":42}}"#;
+    let req = make_mcp_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    assert_invalid_params_rejection(&action, &serde_json::json!("req\"1"));
+}
+
+#[tokio::test]
+async fn prompts_get_missing_name_rejected() {
+    let filter = make_default_filter();
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"prompts/get","params":{}}"#;
+    let req = make_mcp_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    assert!(
+        matches!(action, FilterAction::Reject(_)),
+        "prompts/get without params.name should be rejected"
+    );
+}
+
+#[tokio::test]
+async fn resources_read_missing_uri_rejected() {
+    let filter = make_default_filter();
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"resources/read","params":{}}"#;
+    let req = make_mcp_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    assert!(
+        matches!(action, FilterAction::Reject(_)),
+        "resources/read without params.uri should be rejected"
+    );
+}
+
+#[tokio::test]
+async fn tools_call_missing_name_continues_when_on_invalid_continue() {
+    let filter = make_filter(r#"{"on_invalid": "continue"}"#);
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{}}"#;
+    let req = make_mcp_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "tools/call without name should continue without metadata when on_invalid: continue"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Spurious Header Tests
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn spurious_mcp_name_on_nameless_method_rejected() {
+    let filter = make_default_filter();
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#;
+    let req = make_mcp_request(&[("mcp-name", "evil")]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    assert!(
+        matches!(action, FilterAction::Reject(_)),
+        "spurious Mcp-Name on nameless method should be rejected"
+    );
+}
+
+#[tokio::test]
+async fn spurious_mcp_name_ignored_when_mismatch_ignore() {
+    let filter = make_filter(r#"{"header_validation": {"mismatch": "ignore"}}"#);
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#;
+    let req = make_mcp_request(&[("mcp-name", "evil")]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    assert!(
+        matches!(action, FilterAction::Release),
+        "spurious Mcp-Name should be ignored when mismatch: ignore"
+    );
+}
+
+// -----------------------------------------------------------------------------
 // Test Utilities
 // -----------------------------------------------------------------------------
+
+fn assert_invalid_params_rejection(action: &FilterAction, expected_id: &serde_json::Value) {
+    let FilterAction::Reject(rejection) = action else {
+        panic!("expected InvalidParams rejection, got {action:?}");
+    };
+    assert_eq!(rejection.status, 400, "InvalidParams rejection should use HTTP 400");
+
+    let body = rejection
+        .body
+        .as_ref()
+        .expect("InvalidParams rejection should include a JSON-RPC body");
+    let parsed: serde_json::Value =
+        serde_json::from_slice(body.as_ref()).expect("InvalidParams body should parse as JSON");
+
+    assert_eq!(parsed["jsonrpc"], "2.0", "InvalidParams body should be JSON-RPC 2.0");
+    assert_eq!(parsed["error"]["code"], -32602, "error code should be InvalidParams");
+    assert_eq!(
+        parsed["error"]["message"], "InvalidParams",
+        "error message should identify InvalidParams"
+    );
+    assert_eq!(&parsed["id"], expected_id, "response id should match request id");
+}
 
 fn make_default_filter() -> McpFilter {
     make_filter("{}")

--- a/tests/integration/tests/suite/mcp.rs
+++ b/tests/integration/tests/suite/mcp.rs
@@ -7,7 +7,7 @@ use std::{io::Write, net::TcpStream};
 
 use praxis_core::config::Config;
 use praxis_test_utils::{
-    free_port, http_send, parse_body, parse_status, start_backend_with_shutdown,
+    free_port, http_send, parse_body, parse_status, start_backend_with_shutdown, start_echo_backend_with_shutdown,
     start_header_echo_backend_with_shutdown, start_proxy,
 };
 
@@ -34,6 +34,32 @@ fn mcp_tools_call_routes_by_name() {
         parse_body(&raw),
         "weather-backend",
         "tools/call with name=get_weather should route to weather cluster"
+    );
+}
+
+#[test]
+fn mcp_tools_call_params_forwarded_to_backend() {
+    let backend_guard = start_echo_backend_with_shutdown();
+    let proxy_port = free_port();
+
+    let yaml = mcp_default_yaml(proxy_port, backend_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body = r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_weather","arguments":{"city":"Raleigh","units":"metric"}}}"#;
+    let request = json_post_with_mcp_headers("/mcp/", body, &[]);
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(parse_status(&raw), 200);
+    let echoed_body = parse_body(&raw);
+    let parsed: serde_json::Value = serde_json::from_str(&echoed_body).unwrap();
+    assert_eq!(
+        parsed["params"]["name"], "get_weather",
+        "tools/call params.name should reach backend unchanged"
+    );
+    assert_eq!(
+        parsed["params"]["arguments"]["city"], "Raleigh",
+        "tools/call params.arguments should reach backend unchanged"
     );
 }
 
@@ -226,6 +252,93 @@ fn mcp_standard_headers_preserved_internal_stripped() {
 }
 
 // -----------------------------------------------------------------------------
+// Required Name Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn mcp_tools_call_missing_name_rejected() {
+    let backend_guard = start_backend_with_shutdown("backend");
+    let proxy_port = free_port();
+
+    let yaml = mcp_default_yaml(proxy_port, backend_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body = r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{}}"#;
+    let request = json_post_with_mcp_headers("/mcp/", body, &[]);
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(
+        parse_status(&raw),
+        400,
+        "tools/call without params.name should be rejected"
+    );
+    assert_invalid_params_response(&raw, &serde_json::json!(1));
+}
+
+#[test]
+fn mcp_tools_call_missing_params_rejected() {
+    let backend_guard = start_backend_with_shutdown("backend");
+    let proxy_port = free_port();
+
+    let yaml = mcp_default_yaml(proxy_port, backend_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body = r#"{"jsonrpc":"2.0","id":1,"method":"tools/call"}"#;
+    let request = json_post_with_mcp_headers("/mcp/", body, &[]);
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(parse_status(&raw), 400, "tools/call without params should be rejected");
+    assert_invalid_params_response(&raw, &serde_json::json!(1));
+}
+
+#[test]
+fn mcp_tools_call_non_string_name_rejected() {
+    let backend_guard = start_backend_with_shutdown("backend");
+    let proxy_port = free_port();
+
+    let yaml = mcp_default_yaml(proxy_port, backend_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body = r#"{"jsonrpc":"2.0","id":"req\\1","method":"tools/call","params":{"name":42}}"#;
+    let request = json_post_with_mcp_headers("/mcp/", body, &[]);
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(
+        parse_status(&raw),
+        400,
+        "tools/call with non-string params.name should be rejected"
+    );
+    assert_invalid_params_response(&raw, &serde_json::json!("req\\1"));
+}
+
+// -----------------------------------------------------------------------------
+// Spurious Header Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn mcp_spurious_name_header_for_nameless_method_rejected() {
+    let backend_guard = start_backend_with_shutdown("backend");
+    let proxy_port = free_port();
+
+    let yaml = mcp_default_yaml(proxy_port, backend_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body = r#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#;
+    let request = json_post_with_mcp_headers("/mcp/", body, &[("Mcp-Method", "tools/list"), ("Mcp-Name", "evil")]);
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(
+        parse_status(&raw),
+        400,
+        "spurious Mcp-Name on nameless method should be rejected in default mode"
+    );
+}
+
+// -----------------------------------------------------------------------------
 // Fragmented / Oversized Body Tests
 // -----------------------------------------------------------------------------
 
@@ -316,6 +429,19 @@ fn json_post_with_mcp_headers(path: &str, body: &str, headers: &[(&str, &str)]) 
          {body}",
         body.len(),
     )
+}
+
+fn assert_invalid_params_response(raw: &str, expected_id: &serde_json::Value) {
+    let response_body = parse_body(raw);
+    let parsed: serde_json::Value = serde_json::from_str(&response_body).unwrap();
+
+    assert_eq!(parsed["jsonrpc"], "2.0", "response should be JSON-RPC 2.0");
+    assert_eq!(parsed["error"]["code"], -32602, "error code should be InvalidParams");
+    assert_eq!(
+        parsed["error"]["message"], "InvalidParams",
+        "error message should identify InvalidParams"
+    );
+    assert_eq!(&parsed["id"], expected_id, "response id should match request id");
 }
 
 fn mcp_routing_yaml(proxy_port: u16, weather_port: u16, default_port: u16) -> String {


### PR DESCRIPTION
This is the second PR for the MCP classifier filter to enforce stricter validation (was supposed to be closer to half but the first PR scope creeped):

- Reject `tools/call`, `prompts/get`, and `resources/read` when the required `params.name` or `params.uri` field is missing from the body (respects `on_invalid: continue` for pass-through pipelines)
- Reject spurious `Mcp-Name` headers on methods that have no body-derived name (e.g. `tools/list` with `Mcp-Name: evil`) under default `mismatch: reject`

  Refs praxis-proxy/ai#149