### PR TITLE
feat(filter): add prompt enrichment filter for LLM request bodies

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -390,6 +390,7 @@ supports TCP-level filters too.
 | `path_rewrite` | Transformation | HTTP |
 | `url_rewrite` | Transformation | HTTP |
 | `model_to_header` | AI / Inference | HTTP (requires `ai-inference` feature) |
+| `prompt_enrich` | AI / Inference | HTTP (requires `ai-inference` feature) |
 
 ### Router
 
@@ -836,6 +837,41 @@ enabled by default. See [compression.yaml].
 | `content_types` | list | see above | MIME type prefixes that qualify |
 
 At least one algorithm must be enabled.
+
+### Prompt Enrich
+
+Injects statically configured messages into
+OpenAI-compatible chat completion request bodies. The
+filter parses the JSON body, splices configured messages
+into the `messages` array, re-serializes, and updates
+`Content-Length`. Requires the `ai-inference` feature.
+See [prompt-enrichment.yaml].
+
+[prompt-enrichment.yaml]: ../examples/configs/ai/prompt-enrichment.yaml
+
+```yaml
+- filter: prompt_enrich
+  prepend:
+    - role: system
+      content: "You are a helpful assistant."
+  append:
+    - role: user
+      content: "Cite your sources."
+```
+
+| Field | Type | Default | Description |
+| ------- | ------ | --------- | ------------- |
+| `prepend` | list | `[]` | Messages inserted at the beginning of `messages` (system role only) |
+| `append` | list | `[]` | Messages added at the end of `messages` (system or user role) |
+| `on_invalid` | string | `"continue"` | `"continue"` passes non-JSON through; `"reject"` returns 400 |
+| `max_body_bytes` | integer | 10485760 | Maximum body size to buffer (10 MiB) |
+
+At least one of `prepend` or `append` must be non-empty.
+Each message has a `role` (system or user) and a
+non-empty `content` string. JSON is re-serialized, so
+byte-for-byte body identity is not preserved. In chains
+that also use `json_body_field` or `model_to_header`,
+place `prompt_enrich` first.
 
 ### Conditions
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -73,6 +73,11 @@
   bodies and promotes values to request headers, enabling
   AI inference model routing, content-based cluster
   selection, and request classification.
+- **Prompt enrichment**: inject system or user messages
+  into OpenAI-compatible chat completion request bodies
+  at the proxy layer. Static configured messages are
+  prepended or appended to the `messages` array before
+  forwarding upstream.
 - **Response compression**: gzip, brotli, and zstd
   response compression with per-algorithm levels,
   content type filtering, and minimum size thresholds.

--- a/docs/filters.md
+++ b/docs/filters.md
@@ -495,6 +495,7 @@ A filter can have both `conditions` (request phase) and
 | `path_rewrite` | Transformation | HTTP | `strip_prefix`, `add_prefix`, or `replace` (regex) on request path |
 | `url_rewrite` | Transformation | HTTP | `operations[]`: `regex_replace`, `strip_query_params`, `add_query_params` |
 | `model_to_header` | AI / Inference | HTTP | Extract JSON "model" field and promote to X-Model header. Requires `ai-inference` feature. |
+| `prompt_enrich` | AI / Inference | HTTP | Inject messages into OpenAI-compatible chat completion request bodies. Requires `ai-inference` feature. |
 
 For detailed configuration of each built-in filter, see
 [configuration.md](configuration.md).

--- a/examples/README.md
+++ b/examples/README.md
@@ -123,6 +123,7 @@ page.
 | ------ | ------------- |
 | [credential-injection.yaml](configs/ai/credential-injection.yaml) | Inject per-cluster API credentials and strip client tokens |
 | [model-to-header-routing.yaml](configs/ai/model-to-header-routing.yaml) | Route by model field in JSON body via X-Model header |
+| [prompt-enrichment.yaml](configs/ai/prompt-enrichment.yaml) | Inject system messages into chat completion requests |
 
 ### Branching
 

--- a/examples/configs/ai/prompt-enrichment.yaml
+++ b/examples/configs/ai/prompt-enrichment.yaml
@@ -1,0 +1,52 @@
+# Prompt Enrichment
+#
+# Requires the ai-inference feature:
+#   cargo build -p praxis --features ai-inference
+#
+# Injects system messages into OpenAI-compatible chat completion
+# requests before forwarding to the upstream provider. The system
+# prompt is defined at the proxy layer and cannot be overridden
+# by clients.
+#
+# Only static configured messages are supported. Prepend accepts
+# only system role; append accepts system or user roles.
+#
+# JSON is reserialized, so byte-for-byte body identity and key
+# order are not preserved.
+#
+# Example request:
+#
+#   curl -X POST http://localhost:8080/v1/chat/completions \
+#     -H "Content-Type: application/json" \
+#     -d '{"model":"gpt-4o","messages":[{"role":"user","content":"Hello"}]}'
+#
+# The upstream receives the request with the system message
+# prepended and the citation reminder appended.
+
+listeners:
+  - name: gateway
+    address: "0.0.0.0:8080" # dev value; binds all interfaces
+    filter_chains:
+      - enrich-and-route
+
+filter_chains:
+  - name: enrich-and-route
+    filters:
+      - filter: prompt_enrich
+        prepend:
+          - role: system
+            content: >-
+              You are a helpful assistant for Acme Corp.
+              Always be concise and professional.
+        append:
+          - role: user
+            content: "Remember to cite your sources."
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: provider
+      - filter: load_balancer
+        clusters:
+          - name: provider
+            endpoints:
+              - "127.0.0.1:3000"

--- a/filter/src/body/limits.rs
+++ b/filter/src/body/limits.rs
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Shared body-size defaults for built-in filters.
+
+// -----------------------------------------------------------------------------
+// Body Size Constants
+// -----------------------------------------------------------------------------
+
+/// Default maximum body size for generic JSON request-body inspection (10 MiB).
+pub(crate) const DEFAULT_JSON_BODY_MAX_BYTES: usize = 10 * 1024 * 1024;

--- a/filter/src/body/mod.rs
+++ b/filter/src/body/mod.rs
@@ -6,9 +6,11 @@
 mod access;
 mod buffer;
 mod builder;
+mod limits;
 mod mode;
 
 pub use access::BodyAccess;
 pub use buffer::{BodyBuffer, BodyBufferOverflow};
 pub use builder::BodyCapabilities;
+pub(crate) use limits::DEFAULT_JSON_BODY_MAX_BYTES;
 pub use mode::BodyMode;

--- a/filter/src/builtins/http/ai/mod.rs
+++ b/filter/src/builtins/http/ai/mod.rs
@@ -3,6 +3,12 @@
 
 //! AI filters for HTTP workloads.
 
+#[cfg(feature = "ai-inference")]
 mod inference;
+#[cfg(feature = "ai-inference")]
+mod prompt_enrich;
 
+#[cfg(feature = "ai-inference")]
 pub use inference::ModelToHeaderFilter;
+#[cfg(feature = "ai-inference")]
+pub use prompt_enrich::PromptEnrichFilter;

--- a/filter/src/builtins/http/ai/prompt_enrich/config.rs
+++ b/filter/src/builtins/http/ai/prompt_enrich/config.rs
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Deserialized YAML configuration types for the prompt enrichment filter.
+
+use serde::Deserialize;
+
+use crate::{FilterError, body::DEFAULT_JSON_BODY_MAX_BYTES};
+
+// -----------------------------------------------------------------------------
+// PromptEnrichConfig
+// -----------------------------------------------------------------------------
+
+/// Deserialized YAML config for the prompt enrichment filter.
+///
+/// ```yaml
+/// filter: prompt_enrich
+/// max_body_bytes: 10485760
+/// on_invalid: continue
+/// prepend:
+///   - role: system
+///     content: "You are a helpful assistant."
+/// append:
+///   - role: user
+///     content: "Remember to cite your sources."
+/// ```
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct PromptEnrichConfig {
+    /// Maximum request body size to buffer before parsing.
+    #[serde(default = "default_max_body_bytes")]
+    pub max_body_bytes: usize,
+
+    /// Behavior when the body is not valid JSON or lacks a
+    /// `messages` array.
+    #[serde(default)]
+    pub on_invalid: InvalidBodyBehavior,
+
+    /// Messages to prepend at the beginning of the `messages` array.
+    #[serde(default)]
+    pub prepend: Vec<MessageConfig>,
+
+    /// Messages to append at the end of the `messages` array.
+    #[serde(default)]
+    pub append: Vec<MessageConfig>,
+}
+
+/// Default for `max_body_bytes`.
+fn default_max_body_bytes() -> usize {
+    DEFAULT_JSON_BODY_MAX_BYTES
+}
+
+// -----------------------------------------------------------------------------
+// MessageConfig
+// -----------------------------------------------------------------------------
+
+/// A single message to inject into the `messages` array.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct MessageConfig {
+    /// Role for the injected message.
+    pub role: MessageRole,
+
+    /// Text content of the injected message.
+    pub content: String,
+}
+
+// -----------------------------------------------------------------------------
+// MessageRole
+// -----------------------------------------------------------------------------
+
+// v1 intentionally supports only roles requested by issue #137.
+
+/// Allowed roles for injected messages.
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub(super) enum MessageRole {
+    /// System role, allowed in both `prepend` and `append`.
+    System,
+
+    /// User role, allowed only in `append`.
+    User,
+}
+
+// -----------------------------------------------------------------------------
+// InvalidBodyBehavior
+// -----------------------------------------------------------------------------
+
+/// Behavior when the request body cannot be enriched.
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub(super) enum InvalidBodyBehavior {
+    /// Pass the original body through unchanged.
+    #[default]
+    Continue,
+
+    /// Return HTTP 400.
+    Reject,
+}
+
+// -----------------------------------------------------------------------------
+// Validation
+// -----------------------------------------------------------------------------
+
+/// Validate a parsed config, returning an error for invalid combinations.
+///
+/// # Errors
+///
+/// Returns [`FilterError`] if:
+/// - Both `prepend` and `append` are empty
+/// - Any message has empty `content`
+/// - `max_body_bytes` is zero
+/// - A `prepend` message uses a role other than `system`
+///
+/// [`FilterError`]: crate::FilterError
+pub(super) fn validate_config(cfg: &PromptEnrichConfig) -> Result<(), FilterError> {
+    if cfg.prepend.is_empty() && cfg.append.is_empty() {
+        return Err("prompt_enrich: at least one of 'prepend' or 'append' must be non-empty".into());
+    }
+
+    if cfg.max_body_bytes == 0 {
+        return Err("prompt_enrich: 'max_body_bytes' must be greater than zero".into());
+    }
+
+    for msg in &cfg.prepend {
+        if msg.content.is_empty() {
+            return Err("prompt_enrich: message 'content' must not be empty".into());
+        }
+        if msg.role != MessageRole::System {
+            return Err("prompt_enrich: 'prepend' messages must use role 'system'".into());
+        }
+    }
+
+    for msg in &cfg.append {
+        if msg.content.is_empty() {
+            return Err("prompt_enrich: message 'content' must not be empty".into());
+        }
+    }
+
+    Ok(())
+}
+
+// -----------------------------------------------------------------------------
+// Serialization Helpers
+// -----------------------------------------------------------------------------
+
+/// Convert a [`MessageConfig`] to a [`serde_json::Value`] for injection.
+pub(super) fn message_to_value(msg: &MessageConfig) -> serde_json::Value {
+    let role_str = match msg.role {
+        MessageRole::System => "system",
+        MessageRole::User => "user",
+    };
+    serde_json::json!({
+        "role": role_str,
+        "content": msg.content,
+    })
+}

--- a/filter/src/builtins/http/ai/prompt_enrich/mod.rs
+++ b/filter/src/builtins/http/ai/prompt_enrich/mod.rs
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Prompt enrichment filter: injects configured messages into
+//! OpenAI-compatible chat completion request bodies.
+
+mod config;
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    reason = "tests"
+)]
+mod tests;
+
+use std::borrow::Cow;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+
+use self::config::{InvalidBodyBehavior, PromptEnrichConfig, message_to_value, validate_config};
+use crate::{
+    FilterAction, FilterError, Rejection,
+    body::{BodyAccess, BodyMode},
+    factory::parse_filter_config,
+    filter::{HttpFilter, HttpFilterContext},
+};
+
+// -----------------------------------------------------------------------------
+// PromptEnrichFilter
+// -----------------------------------------------------------------------------
+
+/// Injects statically configured messages into the `messages`
+/// array of OpenAI-compatible chat completion request bodies.
+///
+/// Messages are pre-serialized at construction time. At
+/// request time, the filter parses the JSON body, splices
+/// prepend messages at the beginning and appends messages at
+/// the end, then re-serializes the modified body.
+///
+/// # YAML configuration
+///
+/// ```yaml
+/// filter: prompt_enrich
+/// max_body_bytes: 10485760
+/// on_invalid: continue
+/// prepend:
+///   - role: system
+///     content: "You are a helpful assistant."
+/// append:
+///   - role: user
+///     content: "Remember to cite your sources."
+/// ```
+///
+/// # Example
+///
+/// ```rust
+/// use praxis_filter::PromptEnrichFilter;
+///
+/// let yaml: serde_yaml::Value = serde_yaml::from_str(
+///     r#"
+/// prepend:
+///   - role: system
+///     content: "You are a helpful assistant."
+/// "#,
+/// )
+/// .unwrap();
+/// let filter = PromptEnrichFilter::from_config(&yaml).unwrap();
+/// assert_eq!(filter.name(), "prompt_enrich");
+/// ```
+pub struct PromptEnrichFilter {
+    /// Pre-serialized messages to append after existing messages.
+    append: Vec<serde_json::Value>,
+
+    /// Maximum request body size to buffer.
+    max_body_bytes: usize,
+
+    /// Behavior when the body cannot be enriched.
+    on_invalid: InvalidBodyBehavior,
+
+    /// Pre-serialized messages to prepend before existing messages.
+    prepend: Vec<serde_json::Value>,
+}
+
+impl PromptEnrichFilter {
+    /// Create from parsed YAML config.
+    ///
+    /// Validates the config and pre-serializes all configured
+    /// messages to [`serde_json::Value`] at construction time.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FilterError`] if config parsing or validation fails.
+    ///
+    /// [`FilterError`]: crate::FilterError
+    ///
+    /// ```rust
+    /// use praxis_filter::PromptEnrichFilter;
+    ///
+    /// let yaml: serde_yaml::Value =
+    ///     serde_yaml::from_str("prepend:\n  - role: system\n    content: \"Hello\"").unwrap();
+    /// let filter = PromptEnrichFilter::from_config(&yaml).unwrap();
+    /// assert_eq!(filter.name(), "prompt_enrich");
+    /// ```
+    pub fn from_config(config: &serde_yaml::Value) -> Result<Box<dyn HttpFilter>, FilterError> {
+        let cfg: PromptEnrichConfig = parse_filter_config("prompt_enrich", config)?;
+        validate_config(&cfg)?;
+
+        let prepend = cfg.prepend.iter().map(message_to_value).collect();
+        let append = cfg.append.iter().map(message_to_value).collect();
+
+        Ok(Box::new(Self {
+            append,
+            max_body_bytes: cfg.max_body_bytes,
+            on_invalid: cfg.on_invalid,
+            prepend,
+        }))
+    }
+}
+
+#[async_trait]
+impl HttpFilter for PromptEnrichFilter {
+    fn name(&self) -> &'static str {
+        "prompt_enrich"
+    }
+
+    async fn on_request(&self, _ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
+        Ok(FilterAction::Continue)
+    }
+
+    fn request_body_access(&self) -> BodyAccess {
+        BodyAccess::ReadWrite
+    }
+
+    fn request_body_mode(&self) -> BodyMode {
+        BodyMode::StreamBuffer {
+            max_bytes: Some(self.max_body_bytes),
+        }
+    }
+
+    async fn on_request_body(
+        &self,
+        ctx: &mut HttpFilterContext<'_>,
+        body: &mut Option<Bytes>,
+        end_of_stream: bool,
+    ) -> Result<FilterAction, FilterError> {
+        if !end_of_stream {
+            return Ok(FilterAction::Continue);
+        }
+
+        let Some(raw) = body.as_ref() else {
+            return Ok(FilterAction::Continue);
+        };
+
+        let mut value: serde_json::Value = match serde_json::from_slice(raw) {
+            Ok(v) => v,
+            Err(_) => return Ok(invalid_body_action(self.on_invalid, "invalid JSON body")),
+        };
+
+        let Some(messages) = value.get_mut("messages").and_then(serde_json::Value::as_array_mut) else {
+            return Ok(invalid_body_action(
+                self.on_invalid,
+                "missing or invalid messages array",
+            ));
+        };
+
+        messages.splice(0..0, self.prepend.iter().cloned());
+        messages.extend(self.append.iter().cloned());
+
+        let serialized =
+            serde_json::to_vec(&value).map_err(|e| -> FilterError { format!("prompt_enrich: {e}").into() })?;
+
+        let len = serialized.len();
+        *body = Some(Bytes::from(serialized));
+
+        ctx.extra_request_headers
+            .push((Cow::Borrowed("content-length"), len.to_string()));
+
+        Ok(FilterAction::Continue)
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Private Helpers
+// -----------------------------------------------------------------------------
+
+/// Map [`InvalidBodyBehavior`] to the appropriate [`FilterAction`].
+fn invalid_body_action(behavior: InvalidBodyBehavior, message: &'static str) -> FilterAction {
+    match behavior {
+        InvalidBodyBehavior::Continue => FilterAction::Continue,
+        InvalidBodyBehavior::Reject => FilterAction::Reject(
+            Rejection::status(400)
+                .with_header("content-type", "text/plain")
+                .with_body(message),
+        ),
+    }
+}

--- a/filter/src/builtins/http/ai/prompt_enrich/tests.rs
+++ b/filter/src/builtins/http/ai/prompt_enrich/tests.rs
@@ -1,0 +1,552 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Unit tests for the prompt enrichment filter.
+
+use bytes::Bytes;
+
+use super::PromptEnrichFilter;
+use crate::{
+    FilterAction,
+    body::{BodyAccess, BodyMode},
+};
+
+// -----------------------------------------------------------------------------
+// Config Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn from_config_minimal_prepend() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+prepend:
+  - role: system
+    content: "You are helpful."
+"#,
+    )
+    .unwrap();
+    let filter = PromptEnrichFilter::from_config(&yaml).unwrap();
+    assert_eq!(filter.name(), "prompt_enrich", "should produce prompt_enrich filter");
+}
+
+#[test]
+fn from_config_full() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+max_body_bytes: 1048576
+on_invalid: reject
+prepend:
+  - role: system
+    content: "Be concise."
+append:
+  - role: user
+    content: "Cite sources."
+  - role: system
+    content: "Respond in English."
+"#,
+    )
+    .unwrap();
+    let filter = PromptEnrichFilter::from_config(&yaml).unwrap();
+    assert_eq!(filter.name(), "prompt_enrich", "full config should parse");
+}
+
+#[test]
+fn from_config_rejects_empty_prepend_and_append() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str("{}").unwrap();
+    match PromptEnrichFilter::from_config(&yaml) {
+        Err(err) => assert!(
+            err.to_string().contains("at least one"),
+            "should reject empty prepend and append: {err}"
+        ),
+        Ok(_) => panic!("should reject empty prepend and append"),
+    }
+}
+
+#[test]
+fn from_config_rejects_empty_content() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+prepend:
+  - role: system
+    content: ""
+"#,
+    )
+    .unwrap();
+    match PromptEnrichFilter::from_config(&yaml) {
+        Err(err) => assert!(
+            err.to_string().contains("content"),
+            "should reject empty content: {err}"
+        ),
+        Ok(_) => panic!("should reject empty content"),
+    }
+}
+
+#[test]
+fn from_config_rejects_zero_max_body_bytes() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+max_body_bytes: 0
+prepend:
+  - role: system
+    content: "Hello"
+"#,
+    )
+    .unwrap();
+    match PromptEnrichFilter::from_config(&yaml) {
+        Err(err) => assert!(
+            err.to_string().contains("max_body_bytes"),
+            "should reject zero max_body_bytes: {err}"
+        ),
+        Ok(_) => panic!("should reject zero max_body_bytes"),
+    }
+}
+
+#[test]
+fn from_config_rejects_unknown_fields() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+unknown_field: true
+prepend:
+  - role: system
+    content: "Hello"
+"#,
+    )
+    .unwrap();
+    match PromptEnrichFilter::from_config(&yaml) {
+        Err(err) => assert!(
+            err.to_string().contains("unknown"),
+            "should reject unknown fields: {err}"
+        ),
+        Ok(_) => panic!("should reject unknown fields"),
+    }
+}
+
+#[test]
+fn from_config_rejects_invalid_role() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+prepend:
+  - role: tool
+    content: "Hello"
+"#,
+    )
+    .unwrap();
+    match PromptEnrichFilter::from_config(&yaml) {
+        Err(err) => assert!(
+            err.to_string().contains("prompt_enrich"),
+            "should reject invalid role: {err}"
+        ),
+        Ok(_) => panic!("should reject invalid role"),
+    }
+}
+
+#[test]
+fn from_config_rejects_user_in_prepend() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+prepend:
+  - role: user
+    content: "Hello"
+"#,
+    )
+    .unwrap();
+    match PromptEnrichFilter::from_config(&yaml) {
+        Err(err) => assert!(
+            err.to_string().contains("system"),
+            "should reject user role in prepend: {err}"
+        ),
+        Ok(_) => panic!("should reject user role in prepend"),
+    }
+}
+
+#[test]
+fn from_config_rejects_assistant_role() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+append:
+  - role: assistant
+    content: "Hello"
+"#,
+    )
+    .unwrap();
+    match PromptEnrichFilter::from_config(&yaml) {
+        Err(err) => assert!(
+            err.to_string().contains("prompt_enrich"),
+            "should reject assistant role: {err}"
+        ),
+        Ok(_) => panic!("should reject assistant role"),
+    }
+}
+
+#[test]
+fn from_config_allows_system_or_user_in_append() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+append:
+  - role: system
+    content: "Respond in English."
+  - role: user
+    content: "Cite sources."
+"#,
+    )
+    .unwrap();
+    let filter = PromptEnrichFilter::from_config(&yaml).unwrap();
+    assert_eq!(
+        filter.name(),
+        "prompt_enrich",
+        "both system and user should be allowed in append"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Body Behavior Tests
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn prepend_system_message() {
+    let filter = make_filter(Some(&[("system", "Be helpful.")]), None);
+    let (body, _ctx) = run_filter(
+        filter.as_ref(),
+        r#"{"model":"gpt-4o","messages":[{"role":"user","content":"Hi"}]}"#,
+    )
+    .await;
+
+    let messages = body["messages"].as_array().expect("messages should be an array");
+    assert_eq!(messages.len(), 2, "should have original + prepended message");
+    assert_eq!(messages[0]["role"], "system", "prepended message should be first");
+    assert_eq!(messages[0]["content"], "Be helpful.", "prepended content should match");
+    assert_eq!(messages[1]["role"], "user", "original message should follow");
+}
+
+#[tokio::test]
+async fn append_user_message() {
+    let filter = make_filter(None, Some(&[("user", "Cite sources.")]));
+    let (body, _ctx) = run_filter(filter.as_ref(), r#"{"messages":[{"role":"user","content":"Hi"}]}"#).await;
+
+    let messages = body["messages"].as_array().expect("messages should be an array");
+    assert_eq!(messages.len(), 2, "should have original + appended message");
+    assert_eq!(messages[1]["role"], "user", "appended message should be last");
+    assert_eq!(messages[1]["content"], "Cite sources.", "appended content should match");
+}
+
+#[tokio::test]
+async fn append_system_message() {
+    let filter = make_filter(None, Some(&[("system", "Respond in English.")]));
+    let (body, _ctx) = run_filter(filter.as_ref(), r#"{"messages":[{"role":"user","content":"Hi"}]}"#).await;
+
+    let messages = body["messages"].as_array().expect("messages should be an array");
+    assert_eq!(messages[1]["role"], "system", "appended system message should be last");
+}
+
+#[tokio::test]
+async fn prepend_and_append() {
+    let filter = make_filter(Some(&[("system", "Be concise.")]), Some(&[("user", "Cite sources.")]));
+    let (body, _ctx) = run_filter(filter.as_ref(), r#"{"messages":[{"role":"user","content":"Hello"}]}"#).await;
+
+    let messages = body["messages"].as_array().expect("messages should be an array");
+    assert_eq!(messages.len(), 3, "should have prepend + original + append");
+    assert_eq!(messages[0]["content"], "Be concise.", "prepend should be first");
+    assert_eq!(messages[1]["content"], "Hello", "original should be in middle");
+    assert_eq!(messages[2]["content"], "Cite sources.", "append should be last");
+}
+
+#[tokio::test]
+async fn multiple_prepend_messages_preserve_order() {
+    let filter = make_filter(Some(&[("system", "First."), ("system", "Second.")]), None);
+    let (body, _ctx) = run_filter(filter.as_ref(), r#"{"messages":[{"role":"user","content":"Hi"}]}"#).await;
+
+    let messages = body["messages"].as_array().expect("messages should be an array");
+    assert_eq!(messages.len(), 3, "should have two prepends + original");
+    assert_eq!(messages[0]["content"], "First.", "first prepend should maintain order");
+    assert_eq!(
+        messages[1]["content"], "Second.",
+        "second prepend should maintain order"
+    );
+}
+
+#[tokio::test]
+async fn empty_messages_array_is_enriched() {
+    let filter = make_filter(Some(&[("system", "Hello.")]), None);
+    let (body, _ctx) = run_filter(filter.as_ref(), r#"{"messages":[]}"#).await;
+
+    let messages = body["messages"].as_array().expect("messages should be an array");
+    assert_eq!(messages.len(), 1, "should have one injected message");
+    assert_eq!(messages[0]["content"], "Hello.", "injected message should be present");
+}
+
+#[tokio::test]
+async fn preserves_existing_system_messages() {
+    let filter = make_filter(Some(&[("system", "Injected.")]), None);
+    let (body, _ctx) = run_filter(
+        filter.as_ref(),
+        r#"{"messages":[{"role":"system","content":"Original."},{"role":"user","content":"Hi"}]}"#,
+    )
+    .await;
+
+    let messages = body["messages"].as_array().expect("messages should be an array");
+    assert_eq!(messages.len(), 3, "should have injected + original system + user");
+    assert_eq!(messages[0]["content"], "Injected.", "injected should be first");
+    assert_eq!(
+        messages[1]["content"], "Original.",
+        "original system should be preserved"
+    );
+}
+
+#[tokio::test]
+async fn preserves_other_fields() {
+    let filter = make_filter(Some(&[("system", "Hello.")]), None);
+    let (body, _ctx) = run_filter(
+        filter.as_ref(),
+        r#"{"model":"gpt-4o","temperature":0.7,"max_tokens":100,"stream":true,"messages":[{"role":"user","content":"Hi"}]}"#,
+    )
+    .await;
+
+    assert_eq!(body["model"], "gpt-4o", "model should be preserved");
+    assert_eq!(body["temperature"], 0.7, "temperature should be preserved");
+    assert_eq!(body["max_tokens"], 100, "max_tokens should be preserved");
+    assert_eq!(body["stream"], true, "stream should be preserved");
+}
+
+#[tokio::test]
+async fn invalid_json_continue_leaves_body_unchanged() {
+    let filter = make_filter_with_on_invalid(Some(&[("system", "Hello.")]), None, "continue");
+
+    let original = b"not valid json";
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from_static(original));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "should continue on invalid JSON"
+    );
+    assert_eq!(body.as_ref().unwrap().as_ref(), original, "body should be unchanged");
+}
+
+#[tokio::test]
+async fn invalid_json_rejects() {
+    let filter = make_filter_with_on_invalid(Some(&[("system", "Hello.")]), None, "reject");
+
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from_static(b"not json"));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    assert!(
+        matches!(action, FilterAction::Reject(ref r) if r.status == 400),
+        "should reject with 400 on invalid JSON"
+    );
+}
+
+#[tokio::test]
+async fn missing_messages_continue_leaves_body_unchanged() {
+    let filter = make_filter_with_on_invalid(Some(&[("system", "Hello.")]), None, "continue");
+
+    let original = br#"{"model":"gpt-4o"}"#;
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(original.to_vec()));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "should continue when messages missing"
+    );
+}
+
+#[tokio::test]
+async fn missing_messages_rejects() {
+    let filter = make_filter_with_on_invalid(Some(&[("system", "Hello.")]), None, "reject");
+
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from_static(br#"{"model":"gpt-4o"}"#));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    assert!(
+        matches!(action, FilterAction::Reject(ref r) if r.status == 400),
+        "should reject with 400 when messages missing"
+    );
+}
+
+#[tokio::test]
+async fn messages_not_array_continue_leaves_body_unchanged() {
+    let filter = make_filter_with_on_invalid(Some(&[("system", "Hello.")]), None, "continue");
+
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from_static(br#"{"messages":"not an array"}"#));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "should continue when messages is not an array"
+    );
+}
+
+#[tokio::test]
+async fn messages_not_array_rejects() {
+    let filter = make_filter_with_on_invalid(Some(&[("system", "Hello.")]), None, "reject");
+
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from_static(br#"{"messages":"not an array"}"#));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    assert!(
+        matches!(action, FilterAction::Reject(ref r) if r.status == 400),
+        "should reject with 400 when messages is not an array"
+    );
+}
+
+#[tokio::test]
+async fn no_op_before_eos() {
+    let filter = make_filter(Some(&[("system", "Hello.")]), None);
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from_static(br#"{"messages":[]}"#));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, false).await.unwrap();
+
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "should return Continue before end_of_stream"
+    );
+}
+
+#[tokio::test]
+async fn body_none_returns_continue() {
+    let filter = make_filter(Some(&[("system", "Hello.")]), None);
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body: Option<Bytes> = None;
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "should return Continue when body is None"
+    );
+}
+
+#[tokio::test]
+async fn updates_content_length_header() {
+    let filter = make_filter(Some(&[("system", "Injected system prompt.")]), None);
+    let (body, ctx) = run_filter(filter.as_ref(), r#"{"messages":[{"role":"user","content":"Hi"}]}"#).await;
+
+    let serialized = serde_json::to_vec(&body).unwrap();
+    assert_eq!(ctx.extra_request_headers.len(), 1, "should set content-length header");
+    let (ref name, ref value) = ctx.extra_request_headers[0];
+    assert_eq!(name, "content-length", "header name should be content-length");
+    assert_eq!(
+        value,
+        &serialized.len().to_string(),
+        "content-length should match serialized body size"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Trait Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn filter_name() {
+    let filter = make_filter(Some(&[("system", "Hello.")]), None);
+    assert_eq!(filter.name(), "prompt_enrich", "name should be prompt_enrich");
+}
+
+#[test]
+fn body_access_is_read_write() {
+    let filter = make_filter(Some(&[("system", "Hello.")]), None);
+    assert_eq!(
+        filter.request_body_access(),
+        BodyAccess::ReadWrite,
+        "body access should be ReadWrite"
+    );
+}
+
+#[test]
+fn body_mode_is_stream_buffer_with_configured_limit() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+max_body_bytes: 2097152
+prepend:
+  - role: system
+    content: "Hello"
+"#,
+    )
+    .unwrap();
+    let filter = PromptEnrichFilter::from_config(&yaml).unwrap();
+    assert!(
+        matches!(
+            filter.request_body_mode(),
+            BodyMode::StreamBuffer {
+                max_bytes: Some(2_097_152)
+            }
+        ),
+        "body mode should be StreamBuffer with configured limit"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Test Utilities
+// -----------------------------------------------------------------------------
+
+use crate::filter::{HttpFilter, HttpFilterContext};
+
+fn make_filter(prepend: Option<&[(&str, &str)]>, append: Option<&[(&str, &str)]>) -> Box<dyn HttpFilter> {
+    make_filter_with_on_invalid(prepend, append, "continue")
+}
+
+fn make_filter_with_on_invalid(
+    prepend: Option<&[(&str, &str)]>,
+    append: Option<&[(&str, &str)]>,
+    on_invalid: &str,
+) -> Box<dyn HttpFilter> {
+    let mut yaml_parts = vec![format!("on_invalid: {on_invalid}")];
+
+    if let Some(msgs) = prepend {
+        yaml_parts.push("prepend:".to_owned());
+        for (role, content) in msgs {
+            yaml_parts.push(format!("  - role: {role}"));
+            yaml_parts.push(format!("    content: \"{content}\""));
+        }
+    }
+
+    if let Some(msgs) = append {
+        yaml_parts.push("append:".to_owned());
+        for (role, content) in msgs {
+            yaml_parts.push(format!("  - role: {role}"));
+            yaml_parts.push(format!("    content: \"{content}\""));
+        }
+    }
+
+    let yaml_str = yaml_parts.join("\n");
+    let yaml: serde_yaml::Value = serde_yaml::from_str(&yaml_str).unwrap();
+    PromptEnrichFilter::from_config(&yaml).unwrap()
+}
+
+async fn run_filter(filter: &dyn HttpFilter, json_body: &str) -> (serde_json::Value, HttpFilterContext<'static>) {
+    let req = Box::leak(Box::new(crate::test_utils::make_request(
+        http::Method::POST,
+        "/v1/chat",
+    )));
+    let mut ctx = crate::test_utils::make_filter_context(req);
+    let mut body = Some(Bytes::from(json_body.to_owned()));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "enrichment should return Continue"
+    );
+
+    let parsed: serde_json::Value = serde_json::from_slice(body.as_ref().expect("body should be present")).unwrap();
+    (parsed, ctx)
+}

--- a/filter/src/builtins/http/mod.rs
+++ b/filter/src/builtins/http/mod.rs
@@ -10,7 +10,10 @@ mod security;
 mod traffic_management;
 mod transformation;
 
+#[cfg(feature = "ai-inference")]
 pub use ai::ModelToHeaderFilter;
+#[cfg(feature = "ai-inference")]
+pub use ai::PromptEnrichFilter;
 pub use observability::{AccessLogFilter, RequestIdFilter};
 pub use payload_processing::{CompressionFilter, JsonBodyFieldFilter, JsonRpcFilter, McpFilter};
 pub use security::{

--- a/filter/src/builtins/http/payload_processing/json_body_field/config.rs
+++ b/filter/src/builtins/http/payload_processing/json_body_field/config.rs
@@ -5,14 +5,7 @@
 
 use serde::Deserialize;
 
-use crate::FilterError;
-
-// -----------------------------------------------------------------------------
-// Body Constants
-// -----------------------------------------------------------------------------
-
-/// Default maximum request body size for `StreamBuffer` mode (10 MiB).
-pub(super) const DEFAULT_MAX_BODY_BYTES: usize = 10_485_760;
+use crate::{FilterError, body::DEFAULT_JSON_BODY_MAX_BYTES};
 
 // -----------------------------------------------------------------------------
 // JsonBodyFieldMapping
@@ -58,7 +51,7 @@ pub(super) struct JsonBodyFieldConfig {
 
 /// Default maximum body size (10 MiB).
 fn default_max_body_bytes() -> usize {
-    DEFAULT_MAX_BODY_BYTES
+    DEFAULT_JSON_BODY_MAX_BYTES
 }
 
 // -----------------------------------------------------------------------------

--- a/filter/src/builtins/http/payload_processing/json_body_field/tests.rs
+++ b/filter/src/builtins/http/payload_processing/json_body_field/tests.rs
@@ -310,13 +310,11 @@ fn body_access_is_read_only() {
 
 #[test]
 fn body_mode_is_stream_buffer_with_default_limit() {
-    use super::config::DEFAULT_MAX_BODY_BYTES;
-
     let filter = make_filter("f", "H");
     assert_eq!(
         filter.request_body_mode(),
         crate::body::BodyMode::StreamBuffer {
-            max_bytes: Some(DEFAULT_MAX_BODY_BYTES)
+            max_bytes: Some(crate::body::DEFAULT_JSON_BODY_MAX_BYTES)
         },
         "body mode should be StreamBuffer with 10 MiB default limit"
     );
@@ -561,7 +559,7 @@ async fn non_json_body_continues() {
 /// Build a single-mapping filter for testing.
 fn make_filter(field: &str, header: &str) -> JsonBodyFieldFilter {
     JsonBodyFieldFilter {
-        max_body_bytes: super::config::DEFAULT_MAX_BODY_BYTES,
+        max_body_bytes: crate::body::DEFAULT_JSON_BODY_MAX_BYTES,
         mappings: vec![(field.to_owned(), header.to_owned())],
     }
 }
@@ -569,7 +567,7 @@ fn make_filter(field: &str, header: &str) -> JsonBodyFieldFilter {
 /// Build a multi-mapping filter for testing.
 fn make_multi_filter(mappings: &[(&str, &str)]) -> JsonBodyFieldFilter {
     JsonBodyFieldFilter {
-        max_body_bytes: super::config::DEFAULT_MAX_BODY_BYTES,
+        max_body_bytes: crate::body::DEFAULT_JSON_BODY_MAX_BYTES,
         mappings: mappings
             .iter()
             .map(|(f, h)| ((*f).to_owned(), (*h).to_owned()))

--- a/filter/src/builtins/mod.rs
+++ b/filter/src/builtins/mod.rs
@@ -6,11 +6,15 @@
 pub(crate) mod http;
 mod tcp;
 
+#[cfg(feature = "ai-inference")]
+pub use http::ModelToHeaderFilter;
+#[cfg(feature = "ai-inference")]
+pub use http::PromptEnrichFilter;
 pub use http::{
     AccessLogFilter, CircuitBreakerFilter, CompressionFilter, CorsFilter, CredentialInjectionFilter, CsrfFilter,
     DisallowedOriginMode, ForwardedHeadersFilter, GuardrailsAction, GuardrailsFilter, HeaderFilter, IpAclFilter,
-    JsonBodyFieldFilter, JsonRpcFilter, LoadBalancerFilter, McpFilter, ModelToHeaderFilter, PathRewriteFilter,
-    RateLimitFilter, RateLimitMode, RedirectFilter, RedirectStatus, RequestIdFilter, RouterFilter, RuleTargetKind,
-    StaticResponseFilter, TimeoutFilter, UrlRewriteFilter, normalize_rewritten_path,
+    JsonBodyFieldFilter, JsonRpcFilter, LoadBalancerFilter, McpFilter, PathRewriteFilter, RateLimitFilter,
+    RateLimitMode, RedirectFilter, RedirectStatus, RequestIdFilter, RouterFilter, RuleTargetKind, StaticResponseFilter,
+    TimeoutFilter, UrlRewriteFilter, normalize_rewritten_path,
 };
 pub use tcp::{SniRouterFilter, TcpAccessLogFilter, TcpLoadBalancerFilter};

--- a/filter/src/lib.rs
+++ b/filter/src/lib.rs
@@ -24,6 +24,8 @@ mod tcp_filter;
 pub use actions::{FilterAction, Rejection};
 pub use any_filter::AnyFilter;
 pub use body::{BodyAccess, BodyBuffer, BodyBufferOverflow, BodyCapabilities, BodyMode};
+#[cfg(feature = "ai-inference")]
+pub use builtins::PromptEnrichFilter;
 pub use builtins::{
     CircuitBreakerFilter, CredentialInjectionFilter, DisallowedOriginMode, GuardrailsAction, GuardrailsFilter,
     LoadBalancerFilter, RateLimitMode, RedirectStatus, RouterFilter, RuleTargetKind,

--- a/filter/src/registry.rs
+++ b/filter/src/registry.rs
@@ -147,6 +147,12 @@ fn register_http_builtins(factories: &mut HashMap<String, FilterFactory>) {
         "model_to_header",
         crate::builtins::ModelToHeaderFilter::from_config,
     );
+    #[cfg(feature = "ai-inference")]
+    register_http(
+        factories,
+        "prompt_enrich",
+        crate::builtins::PromptEnrichFilter::from_config,
+    );
 }
 
 /// Register a single HTTP filter factory by name.
@@ -258,6 +264,8 @@ mod tests {
             names.contains(&"model_to_header"),
             "model_to_header should be registered"
         );
+        #[cfg(feature = "ai-inference")]
+        assert!(names.contains(&"prompt_enrich"), "prompt_enrich should be registered");
     }
 
     #[test]

--- a/tests/integration/tests/suite/examples/mod.rs
+++ b/tests/integration/tests/suite/examples/mod.rs
@@ -30,6 +30,8 @@ mod multi_listener;
 mod path_based_routing;
 mod path_rewriting;
 mod payload_processing;
+#[cfg(feature = "ai-inference")]
+mod prompt_enrichment;
 mod protocols;
 mod redirect;
 mod round_robin;

--- a/tests/integration/tests/suite/examples/prompt_enrichment.rs
+++ b/tests/integration/tests/suite/examples/prompt_enrichment.rs
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Tests for the prompt enrichment example configuration.
+
+use std::collections::HashMap;
+
+use praxis_test_utils::{
+    free_port, http_send, json_post, parse_body, parse_status, start_echo_backend_with_shutdown, start_proxy,
+};
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn prompt_enrichment_config_parses() {
+    let config = super::load_example_config(
+        "ai/prompt-enrichment.yaml",
+        29910,
+        HashMap::from([("127.0.0.1:3000", 29911_u16)]),
+    );
+
+    assert_eq!(config.listeners.len(), 1, "should have 1 listener");
+    assert_eq!(&*config.listeners[0].name, "gateway", "listener name should be gateway");
+}
+
+#[test]
+fn prompt_enrichment_prepends_and_appends() {
+    let backend_guard = start_echo_backend_with_shutdown();
+    let backend_port = backend_guard.port();
+    let proxy_port = free_port();
+
+    let config = super::load_example_config(
+        "ai/prompt-enrichment.yaml",
+        proxy_port,
+        HashMap::from([("127.0.0.1:3000", backend_port)]),
+    );
+
+    let proxy = start_proxy(&config);
+    let raw = http_send(
+        proxy.addr(),
+        &json_post(
+            "/v1/chat/completions",
+            r#"{"model":"gpt-4o","messages":[{"role":"user","content":"Hello"}]}"#,
+        ),
+    );
+
+    assert_eq!(parse_status(&raw), 200, "enrichment should return 200");
+    let body = parse_body(&raw);
+    let parsed: serde_json::Value = serde_json::from_str(&body).expect("backend should echo valid JSON");
+    let messages = parsed["messages"].as_array().expect("messages should be an array");
+    assert_eq!(messages.len(), 3, "should have prepend + original + append");
+    assert_eq!(messages[0]["role"], "system", "prepended message should be system");
+    assert!(
+        messages[0]["content"].as_str().unwrap().contains("Acme Corp"),
+        "prepended content should mention Acme Corp"
+    );
+    assert_eq!(messages[1]["role"], "user", "original message should be preserved");
+    assert_eq!(messages[1]["content"], "Hello", "original content should be preserved");
+    assert_eq!(messages[2]["role"], "user", "appended message should be user");
+    assert_eq!(
+        messages[2]["content"], "Remember to cite your sources.",
+        "appended content should match config"
+    );
+    assert_eq!(parsed["model"], "gpt-4o", "model should be preserved");
+}
+
+#[test]
+fn prompt_enrichment_passes_non_chat_traffic() {
+    let backend_guard = start_echo_backend_with_shutdown();
+    let backend_port = backend_guard.port();
+    let proxy_port = free_port();
+
+    let config = super::load_example_config(
+        "ai/prompt-enrichment.yaml",
+        proxy_port,
+        HashMap::from([("127.0.0.1:3000", backend_port)]),
+    );
+
+    let proxy = start_proxy(&config);
+    let raw = http_send(
+        proxy.addr(),
+        "POST /v1/embeddings HTTP/1.1\r\n\
+         Host: localhost\r\n\
+         Content-Type: application/json\r\n\
+         Content-Length: 23\r\n\
+         Connection: close\r\n\r\n\
+         {\"input\":\"hello world\"}",
+    );
+
+    assert_eq!(parse_status(&raw), 200, "non-chat traffic should pass through");
+    let body = parse_body(&raw);
+    assert!(
+        body.contains("hello world"),
+        "non-chat body should be forwarded unchanged: {body}"
+    );
+}

--- a/tests/integration/tests/suite/main.rs
+++ b/tests/integration/tests/suite/main.rs
@@ -55,6 +55,8 @@ mod mcp;
 mod path_rewrite;
 mod payload_processing;
 mod per_listener_pipeline;
+#[cfg(feature = "ai-inference")]
+mod prompt_enrich;
 mod rate_limit;
 mod retry;
 mod routing;

--- a/tests/integration/tests/suite/prompt_enrich.rs
+++ b/tests/integration/tests/suite/prompt_enrich.rs
@@ -1,0 +1,389 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Integration tests for the `prompt_enrich` filter.
+
+use praxis_core::config::Config;
+use praxis_test_utils::{
+    free_port, http_send, json_post, parse_body, parse_status, start_echo_backend_with_shutdown,
+    start_header_echo_backend_with_shutdown, start_proxy,
+};
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn prompt_enrichment_prepends_system_message() {
+    let backend_guard = start_echo_backend_with_shutdown();
+    let backend_port = backend_guard.port();
+    let proxy_port = free_port();
+    let yaml = prepend_yaml(proxy_port, backend_port);
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        &json_post(
+            "/v1/chat/completions",
+            r#"{"model":"gpt-4o","messages":[{"role":"user","content":"Hello"}]}"#,
+        ),
+    );
+
+    assert_eq!(parse_status(&raw), 200, "enrichment should return 200");
+    let body = parse_body(&raw);
+    let parsed: serde_json::Value = serde_json::from_str(&body).expect("backend should echo valid JSON");
+    let messages = parsed["messages"].as_array().expect("messages should be an array");
+    assert_eq!(messages.len(), 2, "should have injected + original message");
+    assert_eq!(messages[0]["role"], "system", "injected message should be first");
+    assert_eq!(
+        messages[0]["content"], "You are a helpful assistant.",
+        "injected content should match config"
+    );
+    assert_eq!(messages[1]["role"], "user", "original user message should follow");
+    assert_eq!(messages[1]["content"], "Hello", "original content should be preserved");
+    assert_eq!(parsed["model"], "gpt-4o", "model field should be preserved");
+}
+
+#[test]
+fn prompt_enrichment_appends_user_message() {
+    let backend_guard = start_echo_backend_with_shutdown();
+    let backend_port = backend_guard.port();
+    let proxy_port = free_port();
+    let yaml = append_yaml(proxy_port, backend_port);
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        &json_post(
+            "/v1/chat/completions",
+            r#"{"messages":[{"role":"user","content":"Hi"}]}"#,
+        ),
+    );
+
+    assert_eq!(parse_status(&raw), 200, "append enrichment should return 200");
+    let body = parse_body(&raw);
+    let parsed: serde_json::Value = serde_json::from_str(&body).expect("backend should echo valid JSON");
+    let messages = parsed["messages"].as_array().expect("messages should be an array");
+    assert_eq!(messages.len(), 2, "should have original + appended message");
+    assert_eq!(messages[0]["content"], "Hi", "original message should be first");
+    assert_eq!(messages[1]["role"], "user", "appended message should be last");
+    assert_eq!(
+        messages[1]["content"], "Cite your sources.",
+        "appended content should match config"
+    );
+}
+
+#[test]
+fn prompt_enrichment_preserves_non_chat_traffic_when_continue() {
+    let backend_guard = start_echo_backend_with_shutdown();
+    let backend_port = backend_guard.port();
+    let proxy_port = free_port();
+    let yaml = prepend_yaml(proxy_port, backend_port);
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        "POST /v1/chat/completions HTTP/1.1\r\n\
+         Host: localhost\r\n\
+         Content-Type: text/plain\r\n\
+         Content-Length: 11\r\n\
+         Connection: close\r\n\r\n\
+         hello world",
+    );
+
+    assert_eq!(parse_status(&raw), 200, "non-JSON body should pass through");
+    let body = parse_body(&raw);
+    assert!(
+        body.contains("hello world"),
+        "backend should receive original body: {body}"
+    );
+}
+
+#[test]
+fn prompt_enrichment_rejects_invalid_json_when_configured() {
+    let backend_guard = start_echo_backend_with_shutdown();
+    let backend_port = backend_guard.port();
+    let proxy_port = free_port();
+    let yaml = reject_yaml(proxy_port, backend_port);
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        "POST /v1/chat HTTP/1.1\r\n\
+         Host: localhost\r\n\
+         Content-Type: application/json\r\n\
+         Content-Length: 11\r\n\
+         Connection: close\r\n\r\n\
+         not json!!!",
+    );
+
+    assert_eq!(
+        parse_status(&raw),
+        400,
+        "invalid JSON should return 400 when on_invalid: reject"
+    );
+}
+
+#[test]
+fn prompt_enrichment_updates_content_length() {
+    let echo_guard = start_echo_backend_with_shutdown();
+    let echo_port = echo_guard.port();
+    let header_guard = start_header_echo_backend_with_shutdown();
+    let header_port = header_guard.port();
+    let proxy_port_echo = free_port();
+    let proxy_port_header = free_port();
+    let input_body = r#"{"messages":[{"role":"user","content":"Hi"}]}"#;
+
+    let echo_yaml = prepend_yaml(proxy_port_echo, echo_port);
+    let echo_config = Config::from_yaml(&echo_yaml).unwrap();
+    let echo_proxy = start_proxy(&echo_config);
+    let echo_raw = http_send(echo_proxy.addr(), &json_post("/v1/chat/completions", input_body));
+    assert_eq!(parse_status(&echo_raw), 200, "echo proxy should return 200");
+    let enriched_body = parse_body(&echo_raw);
+    let enriched_len = enriched_body.len();
+
+    let header_yaml = prepend_yaml(proxy_port_header, header_port);
+    let header_config = Config::from_yaml(&header_yaml).unwrap();
+    let header_proxy = start_proxy(&header_config);
+    let header_raw = http_send(header_proxy.addr(), &json_post("/v1/chat/completions", input_body));
+    assert_eq!(parse_status(&header_raw), 200, "header proxy should return 200");
+    let headers_body = parse_body(&header_raw);
+    let echoed_cl = headers_body
+        .lines()
+        .find_map(|line| {
+            let (key, value) = line.split_once(':')?;
+            if key.trim().eq_ignore_ascii_case("content-length") {
+                Some(value.trim().to_owned())
+            } else {
+                None
+            }
+        })
+        .expect("backend should echo content-length header");
+    let echoed_len: usize = echoed_cl
+        .parse()
+        .expect("echoed content-length should be a valid number");
+
+    assert_eq!(
+        echoed_len, enriched_len,
+        "echoed content-length ({echoed_len}) should match enriched body size ({enriched_len})"
+    );
+}
+
+#[test]
+fn prompt_enrichment_conditions_enable_per_route_behavior() {
+    let backend_guard = start_echo_backend_with_shutdown();
+    let backend_port = backend_guard.port();
+    let proxy_port = free_port();
+    let yaml = conditions_yaml(proxy_port, backend_port);
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let code_raw = http_send(
+        proxy.addr(),
+        &json_post("/code/chat", r#"{"messages":[{"role":"user","content":"Hi"}]}"#),
+    );
+    assert_eq!(parse_status(&code_raw), 200, "code route should return 200");
+    let code_body = parse_body(&code_raw);
+    let code_parsed: serde_json::Value = serde_json::from_str(&code_body).expect("code route should echo valid JSON");
+    let code_messages = code_parsed["messages"].as_array().expect("messages should be an array");
+    assert_eq!(
+        code_messages[0]["content"], "You are a code review assistant.",
+        "code route should get code-specific prompt"
+    );
+
+    let general_raw = http_send(
+        proxy.addr(),
+        &json_post("/general/chat", r#"{"messages":[{"role":"user","content":"Hi"}]}"#),
+    );
+    assert_eq!(parse_status(&general_raw), 200, "general route should return 200");
+    let general_body = parse_body(&general_raw);
+    let general_parsed: serde_json::Value =
+        serde_json::from_str(&general_body).expect("general route should echo valid JSON");
+    let general_messages = general_parsed["messages"]
+        .as_array()
+        .expect("messages should be an array");
+    assert_eq!(
+        general_messages[0]["content"], "You are a general assistant.",
+        "general route should get general prompt"
+    );
+}
+
+#[test]
+fn prompt_enrichment_before_model_to_header_composes() {
+    let header_guard = start_header_echo_backend_with_shutdown();
+    let header_port = header_guard.port();
+    let proxy_port = free_port();
+    let yaml = compose_yaml(proxy_port, header_port);
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        &json_post(
+            "/v1/chat/completions",
+            r#"{"model":"gpt-4o","messages":[{"role":"user","content":"Hi"}]}"#,
+        ),
+    );
+
+    assert_eq!(parse_status(&raw), 200, "compose test should return 200");
+    let body = parse_body(&raw);
+    assert!(
+        body.to_lowercase().contains("x-model: gpt-4o"),
+        "model_to_header should still extract the model; prompt_enrich composition needs StreamBuffer to keep buffering after early Release: {body}"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Test Utilities
+// -----------------------------------------------------------------------------
+
+fn prepend_yaml(proxy_port: u16, backend_port: u16) -> String {
+    format!(
+        r#"
+listeners:
+  - name: default
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: prompt_enrich
+        prepend:
+          - role: system
+            content: "You are a helpful assistant."
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: "backend"
+      - filter: load_balancer
+        clusters:
+          - name: "backend"
+            endpoints:
+              - "127.0.0.1:{backend_port}"
+"#
+    )
+}
+
+fn append_yaml(proxy_port: u16, backend_port: u16) -> String {
+    format!(
+        r#"
+listeners:
+  - name: default
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: prompt_enrich
+        append:
+          - role: user
+            content: "Cite your sources."
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: "backend"
+      - filter: load_balancer
+        clusters:
+          - name: "backend"
+            endpoints:
+              - "127.0.0.1:{backend_port}"
+"#
+    )
+}
+
+fn reject_yaml(proxy_port: u16, backend_port: u16) -> String {
+    format!(
+        r#"
+listeners:
+  - name: default
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: prompt_enrich
+        on_invalid: reject
+        prepend:
+          - role: system
+            content: "You are a helpful assistant."
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: "backend"
+      - filter: load_balancer
+        clusters:
+          - name: "backend"
+            endpoints:
+              - "127.0.0.1:{backend_port}"
+"#
+    )
+}
+
+fn conditions_yaml(proxy_port: u16, backend_port: u16) -> String {
+    format!(
+        r#"
+listeners:
+  - name: default
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: prompt_enrich
+        prepend:
+          - role: system
+            content: "You are a code review assistant."
+        conditions:
+          - when:
+              path_prefix: "/code/"
+      - filter: prompt_enrich
+        prepend:
+          - role: system
+            content: "You are a general assistant."
+        conditions:
+          - unless:
+              path_prefix: "/code/"
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: "backend"
+      - filter: load_balancer
+        clusters:
+          - name: "backend"
+            endpoints:
+              - "127.0.0.1:{backend_port}"
+"#
+    )
+}
+
+fn compose_yaml(proxy_port: u16, backend_port: u16) -> String {
+    format!(
+        r#"
+listeners:
+  - name: default
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: prompt_enrich
+        prepend:
+          - role: system
+            content: "You are a helpful assistant."
+      - filter: model_to_header
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: "backend"
+      - filter: load_balancer
+        clusters:
+          - name: "backend"
+            endpoints:
+              - "127.0.0.1:{backend_port}"
+"#
+    )
+}


### PR DESCRIPTION
Draft for working through praxis-proxy/ai#214 

Adds a `prompt_enrich` HTTP filter that injects system or user messages into OpenAI-compatible chat completion request bodies before forwarding to upstream providers.

  ## Summary

  - New `prompt_enrich` filter under `filter/src/builtins/http/ai/prompt_enrich/`
  - Prepends and/or appends configured messages to the `messages` array in JSON request bodies
  - Preserves all other request body fields (`model`, `temperature`, `max_tokens`, `stream`, etc.)
  - Configurable behavior for non-JSON or non-chat bodies (`on_invalid: continue` or `reject`)
  - Pre-serializes configured messages at construction time; one `splice` for prepends
  - Updates `Content-Length` via `extra_request_headers` after body mutation
  - Feature-gated behind `ai-inference` (matching `model_to_header`)
  - `prepend` accepts only `system` role; `append` accepts `system` or `user` (strict to issue praxis-proxy/ai#75 scope)

  ## Known Limitation

  `prompt_enrich` cannot be composed with `model_to_header` or `json_body_field` in the same pipeline. `json_body_field` releases the body stream before EOS, preventing `prompt_enrich` from receiving the complete buffered body it needs to mutate. This is a pipeline-level StreamBuffer issue tracked separately. `prompt_enrich` works correctly with all other filters.

  ## Test Plan

  - [x] 30 unit tests: config parsing, validation, body mutation, error handling, Content-Length
  - [x] 7 integration tests: prepend, append, non-chat passthrough, reject mode, Content-Length verification, per-route conditions, composition with `model_to_header`
  - [x] 3 example config integration tests: config parse, enrichment end-to-end, non-chat passthrough
  - [x] Registry test updated
  - [x] Example config: `examples/configs/ai/prompt-enrichment.yaml`
  - [x] Docs updated: `filters.md`, `features.md`, `configuration.md`, `examples/README.md`
  - [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero errors
  - [x] `cargo +nightly fmt --all --check` — zero diffs
  - [x] `cargo test -p praxis-proxy-filter --lib` — 1146 passed
  - [x] `cargo test -p praxis-tests-schema all_example_configs_parse` — passed

Refs praxis-proxy/ai#75 praxis-proxy/ai#214