### PR TITLE
test: add reusable MCP and A2A mock servers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2228,6 +2228,7 @@ dependencies = [
  "rcgen",
  "rustls",
  "rustls-pemfile",
+ "serde_json",
  "serde_yaml",
  "tempfile",
  "tokio",

--- a/tests/integration/tests/suite/agentic_mocks.rs
+++ b/tests/integration/tests/suite/agentic_mocks.rs
@@ -1,0 +1,735 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Tests for the reusable MCP and A2A mock servers.
+
+use praxis_test_utils::{
+    A2aMockConfig, McpMockConfig, McpToolFixture, http_send, parse_body, parse_header, parse_status,
+    start_a2a_mock_server, start_a2a_mock_server_with_config, start_mcp_mock_server, start_mcp_mock_server_with_config,
+};
+use serde_json::Value;
+
+// -----------------------------------------------------------------------------
+// MCP Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn mcp_mock_initialize_returns_session() {
+    let server = start_mcp_mock_server();
+    let body = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#;
+    let raw = json_post_raw(&server.endpoint(), server.path(), body, &[]);
+
+    let status = parse_status(&raw);
+    assert_eq!(status, 200, "initialize should return 200");
+
+    let json: Value = serde_json::from_str(&parse_body(&raw)).unwrap();
+    let result = &json["result"];
+    assert!(
+        result["protocolVersion"].is_string(),
+        "result should include protocolVersion"
+    );
+    assert!(result["capabilities"].is_object(), "result should include capabilities");
+    assert!(
+        result["serverInfo"]["name"].is_string(),
+        "result should include serverInfo.name"
+    );
+
+    let session_id = parse_header(&raw, "MCP-Session-Id");
+    assert_eq!(
+        session_id.as_deref(),
+        Some("mock-mcp-session-1"),
+        "stateful server should emit MCP-Session-Id"
+    );
+
+    assert_eq!(
+        server.method_count("initialize"),
+        1,
+        "should record exactly one initialize call"
+    );
+}
+
+#[test]
+fn mcp_mock_tools_list_returns_configured_tools() {
+    let config = McpMockConfig {
+        tools: vec![
+            McpToolFixture::new("get_weather").with_description("Get the weather"),
+            McpToolFixture::new("create_event"),
+        ],
+        ..McpMockConfig::default()
+    };
+    let server = start_mcp_mock_server_with_config(config);
+
+    let body = r#"{"jsonrpc":"2.0","id":2,"method":"tools/list"}"#;
+    let raw = json_post_raw(&server.endpoint(), server.path(), body, &[]);
+
+    let status = parse_status(&raw);
+    assert_eq!(status, 200, "tools/list should return 200");
+
+    let json: Value = serde_json::from_str(&parse_body(&raw)).unwrap();
+    let tools = json["result"]["tools"]
+        .as_array()
+        .expect("result.tools should be an array");
+    assert_eq!(tools.len(), 2, "should return exactly two tools");
+
+    for tool in tools {
+        assert!(tool["name"].is_string(), "each tool should have a name");
+        assert!(
+            tool["inputSchema"].is_object(),
+            "each tool should have an object inputSchema"
+        );
+    }
+
+    let names: Vec<&str> = tools.iter().filter_map(|t| t["name"].as_str()).collect();
+    assert!(names.contains(&"get_weather"), "should include get_weather");
+    assert!(names.contains(&"create_event"), "should include create_event");
+}
+
+#[test]
+fn mcp_mock_tools_call_records_body_and_headers() {
+    let config = McpMockConfig {
+        tools: vec![McpToolFixture::new("get_weather")],
+        ..McpMockConfig::default()
+    };
+    let server = start_mcp_mock_server_with_config(config);
+
+    let body = r#"{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"get_weather","arguments":{}}}"#;
+    let headers = [("MCP-Session-Id", "mock-mcp-session-1")];
+    let raw = json_post_raw(&server.endpoint(), server.path(), body, &headers);
+
+    let status = parse_status(&raw);
+    assert_eq!(status, 200, "tools/call should return 200");
+
+    assert_eq!(
+        server.last_tool_call_name().as_deref(),
+        Some("get_weather"),
+        "should record the tool name"
+    );
+
+    let reqs = server.received_requests();
+    let last = reqs.last().expect("should have at least one request");
+    let has_session_header = last
+        .headers
+        .iter()
+        .any(|(k, v)| k == "mcp-session-id" && v == "mock-mcp-session-1");
+    assert!(has_session_header, "recorded headers should include the session header");
+}
+
+#[test]
+fn mcp_mock_notification_returns_202() {
+    let server = start_mcp_mock_server();
+
+    let body = r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#;
+    let raw = json_post_raw(&server.endpoint(), server.path(), body, &[]);
+
+    let status = parse_status(&raw);
+    assert_eq!(status, 202, "notification should return 202");
+
+    let resp_body = parse_body(&raw);
+    assert!(resp_body.is_empty(), "notification should have no response body");
+}
+
+#[test]
+fn mcp_mock_query_path_matches() {
+    let server = start_mcp_mock_server();
+
+    let body = r#"{"jsonrpc":"2.0","id":4,"method":"ping"}"#;
+    let path_with_query = format!("{}?trace_id=abc", server.path());
+    let raw = json_post_raw(&server.endpoint(), &path_with_query, body, &[]);
+
+    let status = parse_status(&raw);
+    assert_eq!(status, 200, "query string should not prevent path matching");
+
+    let json: Value = serde_json::from_str(&parse_body(&raw)).unwrap();
+    assert!(json["result"].is_object(), "ping should return an object result");
+}
+
+#[test]
+fn mcp_mock_unknown_tool_returns_error() {
+    let server = start_mcp_mock_server();
+
+    let body = r#"{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"nonexistent","arguments":{}}}"#;
+    let raw = json_post_raw(&server.endpoint(), server.path(), body, &[]);
+
+    let status = parse_status(&raw);
+    assert_eq!(status, 200, "unknown tool should still return HTTP 200");
+
+    let json: Value = serde_json::from_str(&parse_body(&raw)).unwrap();
+    assert_eq!(
+        json["error"]["code"], -32602,
+        "unknown tool should return JSON-RPC error code -32602"
+    );
+}
+
+#[test]
+fn mcp_mock_unknown_method_returns_error() {
+    let server = start_mcp_mock_server();
+
+    let body = r#"{"jsonrpc":"2.0","id":6,"method":"bogus/method"}"#;
+    let raw = json_post_raw(&server.endpoint(), server.path(), body, &[]);
+
+    let status = parse_status(&raw);
+    assert_eq!(status, 200, "unknown method should return HTTP 200");
+
+    let json: Value = serde_json::from_str(&parse_body(&raw)).unwrap();
+    assert_eq!(
+        json["error"]["code"], -32601,
+        "unknown method should return JSON-RPC error code -32601"
+    );
+}
+
+#[test]
+fn mcp_mock_wrong_path_returns_404() {
+    let server = start_mcp_mock_server();
+
+    let body = r#"{"jsonrpc":"2.0","id":7,"method":"ping"}"#;
+    let raw = json_post_raw(&server.endpoint(), "/wrong", body, &[]);
+
+    let status = parse_status(&raw);
+    assert_eq!(status, 404, "wrong path should return 404");
+}
+
+#[test]
+fn mcp_mock_delete_returns_204() {
+    let server = start_mcp_mock_server();
+
+    let req = format!(
+        "DELETE {} HTTP/1.1\r\n\
+         Host: localhost\r\n\
+         Connection: close\r\n\r\n",
+        server.path()
+    );
+    let raw = http_send(&server.endpoint(), &req);
+
+    let status = parse_status(&raw);
+    assert_eq!(status, 204, "DELETE should return 204");
+}
+
+#[test]
+fn mcp_mock_get_method_rejected() {
+    let server = start_mcp_mock_server();
+
+    let req = format!(
+        "GET {} HTTP/1.1\r\n\
+         Host: localhost\r\n\
+         Connection: close\r\n\r\n",
+        server.path()
+    );
+    let raw = http_send(&server.endpoint(), &req);
+
+    let status = parse_status(&raw);
+    assert_eq!(status, 405, "GET should be rejected with 405");
+}
+
+#[test]
+fn mcp_mock_put_method_rejected() {
+    let server = start_mcp_mock_server();
+
+    let body = r#"{"jsonrpc":"2.0","id":1,"method":"ping"}"#;
+    let req = format!(
+        "PUT {} HTTP/1.1\r\n\
+         Host: localhost\r\n\
+         Content-Type: application/json\r\n\
+         Content-Length: {}\r\n\
+         Connection: close\r\n\r\n\
+         {body}",
+        server.path(),
+        body.len()
+    );
+    let raw = http_send(&server.endpoint(), &req);
+
+    let status = parse_status(&raw);
+    assert_eq!(status, 405, "PUT should be rejected with 405");
+}
+
+// -----------------------------------------------------------------------------
+// A2A Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn a2a_mock_send_message_returns_task() {
+    let server = start_a2a_mock_server();
+
+    let body = r#"{"jsonrpc":"2.0","id":1,"method":"SendMessage","params":{"message":{"role":"user","parts":[{"kind":"text","text":"hello"}]}}}"#;
+    let raw = json_post_raw(&server.endpoint(), server.path(), body, &[]);
+
+    let status = parse_status(&raw);
+    assert_eq!(status, 200, "SendMessage should return 200");
+
+    let json: Value = serde_json::from_str(&parse_body(&raw)).unwrap();
+    let result = &json["result"];
+    assert_eq!(result["id"], "mock-task-1", "should include mock task ID");
+    assert_eq!(result["contextId"], "mock-context-1", "should include mock context ID");
+    assert_eq!(result["status"]["state"], "completed", "should have completed status");
+}
+
+#[test]
+fn a2a_mock_send_streaming_message_returns_sse() {
+    let server = start_a2a_mock_server();
+
+    let body = r#"{"jsonrpc":"2.0","id":2,"method":"SendStreamingMessage","params":{"message":{"role":"user","parts":[{"kind":"text","text":"hello"}]}}}"#;
+    let raw = json_post_raw(&server.endpoint(), server.path(), body, &[]);
+
+    let status = parse_status(&raw);
+    assert_eq!(status, 200, "SendStreamingMessage should return 200");
+
+    let content_type = parse_header(&raw, "Content-Type");
+    assert_eq!(
+        content_type.as_deref(),
+        Some("text/event-stream"),
+        "should return SSE content type"
+    );
+
+    let resp_body = parse_body(&raw);
+    assert!(resp_body.starts_with("data: "), "SSE body should start with 'data: '");
+
+    let sse_data = resp_body.trim_start_matches("data: ").trim();
+    let json: Value = serde_json::from_str(sse_data).unwrap();
+    assert_eq!(json["result"]["final"], true, "SSE event should include final: true");
+    assert_eq!(
+        json["result"]["status"]["state"], "completed",
+        "SSE event should be completed"
+    );
+}
+
+#[test]
+fn a2a_mock_records_version_header() {
+    let server = start_a2a_mock_server();
+
+    let body = r#"{"jsonrpc":"2.0","id":3,"method":"SendMessage","params":{"message":{"role":"user","parts":[{"kind":"text","text":"hello"}]}}}"#;
+    let headers = [("A2A-Version", "0.3.0")];
+    let _raw = json_post_raw(&server.endpoint(), server.path(), body, &headers);
+
+    assert_eq!(
+        server.last_a2a_version().as_deref(),
+        Some("0.3.0"),
+        "should record A2A-Version header"
+    );
+}
+
+#[test]
+fn a2a_mock_query_path_matches() {
+    let server = start_a2a_mock_server();
+
+    let body = r#"{"jsonrpc":"2.0","id":4,"method":"SendMessage","params":{"message":{"role":"user","parts":[{"kind":"text","text":"hello"}]}}}"#;
+    let path_with_query = format!("{}?trace_id=abc", server.path());
+    let raw = json_post_raw(&server.endpoint(), &path_with_query, body, &[]);
+
+    let status = parse_status(&raw);
+    assert_eq!(status, 200, "query string should not prevent path matching");
+}
+
+#[test]
+fn a2a_mock_wrong_path_returns_404() {
+    let server = start_a2a_mock_server();
+
+    let body = r#"{"jsonrpc":"2.0","id":5,"method":"SendMessage","params":{}}"#;
+    let raw = json_post_raw(&server.endpoint(), "/wrong", body, &[]);
+
+    let status = parse_status(&raw);
+    assert_eq!(status, 404, "wrong path should return 404");
+}
+
+#[test]
+fn a2a_mock_cancel_task_returns_canceled() {
+    let server = start_a2a_mock_server();
+
+    let body = r#"{"jsonrpc":"2.0","id":6,"method":"CancelTask","params":{"id":"mock-task-1"}}"#;
+    let raw = json_post_raw(&server.endpoint(), server.path(), body, &[]);
+
+    let status = parse_status(&raw);
+    assert_eq!(status, 200, "CancelTask should return 200");
+
+    let json: Value = serde_json::from_str(&parse_body(&raw)).unwrap();
+    assert_eq!(
+        json["result"]["status"]["state"], "canceled",
+        "should return canceled status"
+    );
+}
+
+#[test]
+fn a2a_mock_custom_config() {
+    let config = A2aMockConfig {
+        context_id: "ctx-42".to_owned(),
+        path: "/custom-a2a".to_owned(),
+        task_id: "task-42".to_owned(),
+    };
+    let server = start_a2a_mock_server_with_config(config);
+
+    let body = r#"{"jsonrpc":"2.0","id":7,"method":"SendMessage","params":{"message":{"role":"user","parts":[{"kind":"text","text":"hello"}]}}}"#;
+    let raw = json_post_raw(&server.endpoint(), "/custom-a2a", body, &[]);
+
+    let status = parse_status(&raw);
+    assert_eq!(status, 200, "custom path should work");
+
+    let json: Value = serde_json::from_str(&parse_body(&raw)).unwrap();
+    assert_eq!(json["result"]["id"], "task-42", "should use custom task ID");
+    assert_eq!(json["result"]["contextId"], "ctx-42", "should use custom context ID");
+}
+
+#[test]
+fn a2a_mock_legacy_method_aliases() {
+    let server = start_a2a_mock_server();
+
+    let body = r#"{"jsonrpc":"2.0","id":1,"method":"message/send","params":{"message":{"role":"user","parts":[{"kind":"text","text":"hello"}]}}}"#;
+    let raw = json_post_raw(&server.endpoint(), server.path(), body, &[]);
+
+    let status = parse_status(&raw);
+    assert_eq!(status, 200, "legacy message/send should be accepted");
+
+    let json: Value = serde_json::from_str(&parse_body(&raw)).unwrap();
+    assert_eq!(
+        json["result"]["status"]["state"], "completed",
+        "legacy alias should work"
+    );
+}
+
+#[test]
+fn a2a_mock_get_method_rejected() {
+    let server = start_a2a_mock_server();
+
+    let req = format!(
+        "GET {} HTTP/1.1\r\n\
+         Host: localhost\r\n\
+         Connection: close\r\n\r\n",
+        server.path()
+    );
+    let raw = http_send(&server.endpoint(), &req);
+
+    let status = parse_status(&raw);
+    assert_eq!(status, 405, "GET should be rejected with 405");
+}
+
+#[test]
+fn a2a_mock_put_with_body_rejected() {
+    let server = start_a2a_mock_server();
+
+    let body = r#"{"jsonrpc":"2.0","id":1,"method":"SendMessage","params":{}}"#;
+    let req = format!(
+        "PUT {} HTTP/1.1\r\n\
+         Host: localhost\r\n\
+         Content-Type: application/json\r\n\
+         Content-Length: {}\r\n\
+         Connection: close\r\n\r\n\
+         {body}",
+        server.path(),
+        body.len()
+    );
+    let raw = http_send(&server.endpoint(), &req);
+
+    let status = parse_status(&raw);
+    assert_eq!(status, 405, "PUT should be rejected with 405");
+}
+
+#[test]
+fn a2a_mock_get_task_returns_completed() {
+    let server = start_a2a_mock_server();
+
+    let body = r#"{"jsonrpc":"2.0","id":1,"method":"GetTask","params":{"id":"mock-task-1"}}"#;
+    let raw = json_post_raw(&server.endpoint(), server.path(), body, &[]);
+
+    let status = parse_status(&raw);
+    assert_eq!(status, 200, "GetTask should return 200");
+
+    let json: Value = serde_json::from_str(&parse_body(&raw)).unwrap();
+    assert_eq!(
+        json["result"]["status"]["state"], "completed",
+        "GetTask should return completed status"
+    );
+    assert_eq!(
+        server.method_count("GetTask"),
+        1,
+        "should record exactly one GetTask call"
+    );
+}
+
+#[test]
+fn a2a_mock_legacy_tasks_get_alias() {
+    let server = start_a2a_mock_server();
+
+    let body = r#"{"jsonrpc":"2.0","id":1,"method":"tasks/get","params":{"id":"mock-task-1"}}"#;
+    let raw = json_post_raw(&server.endpoint(), server.path(), body, &[]);
+
+    let status = parse_status(&raw);
+    assert_eq!(status, 200, "legacy tasks/get should be accepted");
+
+    let json: Value = serde_json::from_str(&parse_body(&raw)).unwrap();
+    assert_eq!(
+        json["result"]["status"]["state"], "completed",
+        "legacy alias should return completed"
+    );
+
+    assert_eq!(
+        server.method_count("tasks/get"),
+        1,
+        "raw method name should be recorded, not canonical form"
+    );
+    assert_eq!(server.method_count("GetTask"), 0, "alias should not be canonicalized");
+}
+
+// -----------------------------------------------------------------------------
+// Config Validation Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+#[should_panic(expected = "must start with '/'")]
+fn mcp_mock_config_path_missing_slash_panics() {
+    let config = McpMockConfig {
+        path: "mcp".to_owned(),
+        ..McpMockConfig::default()
+    };
+    start_mcp_mock_server_with_config(config);
+}
+
+#[test]
+#[should_panic(expected = "must not contain a query string")]
+fn mcp_mock_config_path_with_query_panics() {
+    let config = McpMockConfig {
+        path: "/mcp?x=1".to_owned(),
+        ..McpMockConfig::default()
+    };
+    start_mcp_mock_server_with_config(config);
+}
+
+#[test]
+#[should_panic(expected = "must not contain a fragment")]
+fn mcp_mock_config_path_with_fragment_panics() {
+    let config = McpMockConfig {
+        path: "/mcp#frag".to_owned(),
+        ..McpMockConfig::default()
+    };
+    start_mcp_mock_server_with_config(config);
+}
+
+#[test]
+#[should_panic(expected = "must not contain an authority")]
+fn mcp_mock_config_path_with_authority_panics() {
+    let config = McpMockConfig {
+        path: "//example.com/mcp".to_owned(),
+        ..McpMockConfig::default()
+    };
+    start_mcp_mock_server_with_config(config);
+}
+
+#[test]
+#[should_panic(expected = "must start with '/'")]
+fn a2a_mock_config_path_missing_slash_panics() {
+    let config = A2aMockConfig {
+        path: "a2a".to_owned(),
+        ..A2aMockConfig::default()
+    };
+    start_a2a_mock_server_with_config(config);
+}
+
+#[test]
+#[should_panic(expected = "must not contain a query string")]
+fn a2a_mock_config_path_with_query_panics() {
+    let config = A2aMockConfig {
+        path: "/a2a?x=1".to_owned(),
+        ..A2aMockConfig::default()
+    };
+    start_a2a_mock_server_with_config(config);
+}
+
+#[test]
+#[should_panic(expected = "must not contain a fragment")]
+fn a2a_mock_config_path_with_fragment_panics() {
+    let config = A2aMockConfig {
+        path: "/a2a#frag".to_owned(),
+        ..A2aMockConfig::default()
+    };
+    start_a2a_mock_server_with_config(config);
+}
+
+#[test]
+#[should_panic(expected = "must not contain an authority")]
+fn a2a_mock_config_path_with_authority_panics() {
+    let config = A2aMockConfig {
+        path: "//example.com/a2a".to_owned(),
+        ..A2aMockConfig::default()
+    };
+    start_a2a_mock_server_with_config(config);
+}
+
+#[test]
+#[should_panic(expected = "must not contain whitespace")]
+fn mcp_mock_config_path_with_whitespace_panics() {
+    let config = McpMockConfig {
+        path: "/bad path".to_owned(),
+        ..McpMockConfig::default()
+    };
+    start_mcp_mock_server_with_config(config);
+}
+
+#[test]
+#[should_panic(expected = "inputSchema must be a JSON object")]
+fn mcp_mock_non_object_schema_panics() {
+    let _fixture = McpToolFixture::new("bad").with_input_schema(serde_json::json!("not-an-object"));
+}
+
+#[test]
+#[should_panic(expected = "must have \"type\": \"object\"")]
+fn mcp_mock_wrong_type_schema_panics() {
+    let _fixture = McpToolFixture::new("bad").with_input_schema(serde_json::json!({"type": "string"}));
+}
+
+#[test]
+#[should_panic(expected = "must have \"type\": \"object\"")]
+fn mcp_mock_direct_field_schema_validated_at_startup() {
+    let bad_tool = McpToolFixture {
+        description: None,
+        input_schema: serde_json::json!({"type": "string"}),
+        name: "bad".to_owned(),
+    };
+    let config = McpMockConfig {
+        tools: vec![bad_tool],
+        ..McpMockConfig::default()
+    };
+    start_mcp_mock_server_with_config(config);
+}
+
+// -----------------------------------------------------------------------------
+// HTTP Parser Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn mcp_mock_trailing_bytes_ignored() {
+    let server = start_mcp_mock_server();
+
+    let json_body = r#"{"jsonrpc":"2.0","id":1,"method":"ping"}"#;
+    let trailing = "GARBAGE_TRAILING_DATA";
+    let req = format!(
+        "POST {} HTTP/1.1\r\n\
+         Host: localhost\r\n\
+         Content-Type: application/json\r\n\
+         Content-Length: {}\r\n\
+         Connection: close\r\n\r\n\
+         {json_body}{trailing}",
+        server.path(),
+        json_body.len()
+    );
+    let raw = http_send(&server.endpoint(), &req);
+
+    let status = parse_status(&raw);
+    assert_eq!(
+        status, 200,
+        "should parse body using Content-Length, ignoring trailing bytes"
+    );
+
+    let reqs = server.received_requests();
+    let last = reqs.last().expect("should have at least one request");
+    assert_eq!(
+        last.body, json_body,
+        "recorded body should be exactly Content-Length bytes"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Behavioral Edge-Case Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn mcp_mock_stateless_omits_session_header() {
+    let config = McpMockConfig {
+        stateful_sessions: false,
+        ..McpMockConfig::default()
+    };
+    let server = start_mcp_mock_server_with_config(config);
+
+    let body = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#;
+    let raw = json_post_raw(&server.endpoint(), server.path(), body, &[]);
+
+    let status = parse_status(&raw);
+    assert_eq!(status, 200, "initialize should return 200");
+
+    let session_id = parse_header(&raw, "MCP-Session-Id");
+    assert!(session_id.is_none(), "stateless server should not emit MCP-Session-Id");
+}
+
+#[test]
+fn mcp_mock_tool_call_count_tracks_per_tool() {
+    let config = McpMockConfig {
+        tools: vec![McpToolFixture::new("get_weather"), McpToolFixture::new("create_event")],
+        ..McpMockConfig::default()
+    };
+    let server = start_mcp_mock_server_with_config(config);
+
+    let body = r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_weather","arguments":{}}}"#;
+    let _raw = json_post_raw(&server.endpoint(), server.path(), body, &[]);
+
+    assert_eq!(
+        server.tool_call_count("get_weather"),
+        1,
+        "should count one get_weather call"
+    );
+    assert_eq!(
+        server.tool_call_count("create_event"),
+        0,
+        "should count zero create_event calls"
+    );
+}
+
+#[test]
+fn a2a_mock_unknown_method_returns_error() {
+    let server = start_a2a_mock_server();
+
+    let body = r#"{"jsonrpc":"2.0","id":1,"method":"BogusMethod","params":{}}"#;
+    let raw = json_post_raw(&server.endpoint(), server.path(), body, &[]);
+
+    let status = parse_status(&raw);
+    assert_eq!(status, 200, "unknown A2A method should return HTTP 200");
+
+    let json: Value = serde_json::from_str(&parse_body(&raw)).unwrap();
+    assert_eq!(
+        json["error"]["code"], -32601,
+        "unknown A2A method should return JSON-RPC -32601"
+    );
+}
+
+#[test]
+fn mcp_mock_content_length_zero_records_empty_body() {
+    let server = start_mcp_mock_server();
+
+    let req = format!(
+        "POST {} HTTP/1.1\r\n\
+         Host: localhost\r\n\
+         Content-Type: application/json\r\n\
+         Content-Length: 0\r\n\
+         Connection: close\r\n\r\n\
+         {{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"ping\"}}",
+        server.path()
+    );
+    let raw = http_send(&server.endpoint(), &req);
+
+    let status = parse_status(&raw);
+    assert_eq!(status, 400, "Content-Length: 0 should result in empty body and 400");
+
+    let reqs = server.received_requests();
+    let last = reqs.last().expect("should have at least one request");
+    assert!(
+        last.body.is_empty(),
+        "recorded body should be empty when Content-Length is 0"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Test Utilities
+// -----------------------------------------------------------------------------
+
+fn json_post_raw(addr: &str, path: &str, body: &str, extra_headers: &[(&str, &str)]) -> String {
+    let mut req = format!(
+        "POST {path} HTTP/1.1\r\n\
+         Host: localhost\r\n\
+         Content-Type: application/json\r\n\
+         Content-Length: {}\r\n",
+        body.len()
+    );
+
+    for (name, value) in extra_headers {
+        req.push_str(&format!("{name}: {value}\r\n"));
+    }
+
+    req.push_str("Connection: close\r\n\r\n");
+    req.push_str(body);
+
+    http_send(addr, &req)
+}

--- a/tests/integration/tests/suite/main.rs
+++ b/tests/integration/tests/suite/main.rs
@@ -35,6 +35,7 @@
 )]
 
 mod adversarial;
+mod agentic_mocks;
 mod body;
 mod body_pipeline;
 mod compression;

--- a/tests/utils/Cargo.toml
+++ b/tests/utils/Cargo.toml
@@ -21,6 +21,7 @@ http = { workspace = true }
 rcgen = { workspace = true }
 rustls = { workspace = true }
 rustls-pemfile = { workspace = true }
+serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 tempfile = { workspace = true }
 async-trait = { workspace = true }

--- a/tests/utils/src/agentic/a2a.rs
+++ b/tests/utils/src/agentic/a2a.rs
@@ -1,0 +1,461 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! JSON-RPC/SSE A2A mock server for integration tests.
+//!
+//! Provides a deterministic [Agent-to-Agent][a2a] backend that
+//! records every inbound request for later assertion. The server
+//! runs on a background thread and shuts down when the returned
+//! [`A2aMockServerGuard`] is dropped.
+//!
+//! Supports both v1.0 `PascalCase` method names (default)
+//! and v0.3 slash-delimited legacy aliases.
+//!
+//! [a2a]: https://a2aproject.github.io/A2A/
+
+use std::{
+    io::Write,
+    net::TcpStream,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
+
+use serde_json::{Value, json};
+
+use super::http::{AgenticHttpRequest, parse_agentic_request, write_response};
+
+// -----------------------------------------------------------------------------
+// Constants
+// -----------------------------------------------------------------------------
+
+/// Default endpoint path.
+const DEFAULT_PATH: &str = "/a2a";
+
+/// Deterministic task ID.
+const DEFAULT_TASK_ID: &str = "mock-task-1";
+
+/// Deterministic context ID.
+const DEFAULT_CONTEXT_ID: &str = "mock-context-1";
+
+// -----------------------------------------------------------------------------
+// Configuration
+// -----------------------------------------------------------------------------
+
+/// Configuration for an A2A mock server instance.
+pub struct A2aMockConfig {
+    /// Deterministic context ID for task results.
+    pub context_id: String,
+
+    /// Endpoint path the server listens on.
+    pub path: String,
+
+    /// Deterministic task ID for task results.
+    pub task_id: String,
+}
+
+impl Default for A2aMockConfig {
+    fn default() -> Self {
+        Self {
+            context_id: DEFAULT_CONTEXT_ID.to_owned(),
+            path: DEFAULT_PATH.to_owned(),
+            task_id: DEFAULT_TASK_ID.to_owned(),
+        }
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Recorded Request
+// -----------------------------------------------------------------------------
+
+/// A single request captured by the A2A mock server.
+#[derive(Clone, Debug)]
+pub struct A2aRecordedRequest {
+    /// Value of the `A2A-Version` header, if present.
+    pub a2a_version: Option<String>,
+
+    /// Raw request body.
+    pub body: String,
+
+    /// Request headers as `(name, value)` pairs.
+    pub headers: Vec<(String, String)>,
+
+    /// HTTP method (e.g. `POST`).
+    pub http_method: String,
+
+    /// JSON-RPC `id` field, if present.
+    pub json_rpc_id: Option<Value>,
+
+    /// JSON-RPC `method` field, if present.
+    pub json_rpc_method: Option<String>,
+
+    /// URL path without query string.
+    pub path: String,
+
+    /// Full request URI including query string.
+    pub uri: String,
+}
+
+// -----------------------------------------------------------------------------
+// Server Guard
+// -----------------------------------------------------------------------------
+
+/// RAII handle for a running A2A mock server.
+///
+/// The background listener exits when this guard is
+/// dropped. Use the accessor methods to inspect
+/// captured request state after sending test traffic.
+pub struct A2aMockServerGuard {
+    /// The configured endpoint path.
+    path: String,
+
+    /// Listening port.
+    port: u16,
+
+    /// Shared shutdown flag.
+    shutdown: Arc<AtomicBool>,
+
+    /// Captured requests.
+    state: Arc<Mutex<Vec<A2aRecordedRequest>>>,
+}
+
+impl A2aMockServerGuard {
+    /// The `host:port` address string.
+    pub fn endpoint(&self) -> String {
+        format!("127.0.0.1:{}", self.port)
+    }
+
+    /// The most recent `A2A-Version` header value seen.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the state mutex is poisoned.
+    pub fn last_a2a_version(&self) -> Option<String> {
+        let reqs = self.state.lock().unwrap();
+        reqs.iter().rev().find_map(|r| r.a2a_version.clone())
+    }
+
+    /// Count of requests whose raw JSON-RPC `method`
+    /// field equals `method`. Aliases are not
+    /// canonicalized: `"SendMessage"` and
+    /// `"message/send"` are counted separately so
+    /// proxy-forwarding tests can assert the exact
+    /// method name the backend received.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the state mutex is poisoned.
+    pub fn method_count(&self, method: &str) -> usize {
+        let reqs = self.state.lock().unwrap();
+        reqs.iter()
+            .filter(|r| r.json_rpc_method.as_deref() == Some(method))
+            .count()
+    }
+
+    /// The configured endpoint path.
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+
+    /// The port the server is listening on.
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    /// Clone of all captured requests.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the state mutex is poisoned.
+    pub fn received_requests(&self) -> Vec<A2aRecordedRequest> {
+        self.state.lock().unwrap().clone()
+    }
+}
+
+impl Drop for A2aMockServerGuard {
+    fn drop(&mut self) {
+        self.shutdown.store(true, Ordering::Release);
+        let _ = TcpStream::connect(format!("127.0.0.1:{}", self.port));
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Server Lifecycle
+// -----------------------------------------------------------------------------
+
+/// Start an A2A mock server with default configuration.
+///
+/// # Panics
+///
+/// Panics if the server fails to bind or the config
+/// path is invalid.
+pub fn start_a2a_mock_server() -> A2aMockServerGuard {
+    start_a2a_mock_server_with_config(A2aMockConfig::default())
+}
+
+/// Start an A2A mock server with custom configuration.
+///
+/// # Panics
+///
+/// Panics if the server fails to bind or the config
+/// path is invalid.
+pub fn start_a2a_mock_server_with_config(config: A2aMockConfig) -> A2aMockServerGuard {
+    super::validate_config_path(&config.path);
+
+    let (listener, port) = crate::net::port::bind_unique_port();
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let state: Arc<Mutex<Vec<A2aRecordedRequest>>> = Arc::new(Mutex::new(Vec::new()));
+
+    let flag = Arc::clone(&shutdown);
+    let shared_state = Arc::clone(&state);
+    let path = config.path.clone();
+    let config = Arc::new(config);
+
+    std::thread::spawn(move || {
+        for stream in listener.incoming().flatten() {
+            if flag.load(Ordering::Acquire) {
+                break;
+            }
+            let cfg = Arc::clone(&config);
+            let st = Arc::clone(&shared_state);
+            std::thread::spawn(move || handle_connection(stream, &cfg, &st));
+        }
+    });
+
+    A2aMockServerGuard {
+        path,
+        port,
+        shutdown,
+        state,
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Connection Handler
+// -----------------------------------------------------------------------------
+
+/// Per-connection entry point for the listener thread.
+fn handle_connection(mut stream: TcpStream, config: &A2aMockConfig, state: &Mutex<Vec<A2aRecordedRequest>>) {
+    stream.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+
+    let Some(req) = parse_agentic_request(&mut stream) else {
+        return;
+    };
+
+    if let Some(status) = reject_early(&req, config) {
+        record_request(state, build_record(&req));
+        write_response(&mut stream, status, reason_for(status), &[], "");
+        return;
+    }
+
+    dispatch_json_rpc(&mut stream, config, state, &req);
+}
+
+/// `Some(status)` when the request is invalid before
+/// JSON-RPC parsing.
+fn reject_early(req: &AgenticHttpRequest, config: &A2aMockConfig) -> Option<u16> {
+    if req.method != "POST" {
+        return Some(405);
+    }
+    if !path_matches(&req.path, &config.path) {
+        return Some(404);
+    }
+    if req.body.is_empty() {
+        return Some(400);
+    }
+    None
+}
+
+/// Parse JSON-RPC, record, and route to a handler.
+fn dispatch_json_rpc(
+    stream: &mut TcpStream,
+    config: &A2aMockConfig,
+    state: &Mutex<Vec<A2aRecordedRequest>>,
+    req: &AgenticHttpRequest,
+) {
+    let Ok(json) = serde_json::from_str::<Value>(&req.body) else {
+        record_request(state, build_record(req));
+        write_response(stream, 400, "Bad Request", &[], "");
+        return;
+    };
+
+    let method = json.get("method").and_then(Value::as_str).map(str::to_owned);
+    let id = json.get("id").cloned();
+
+    let record = A2aRecordedRequest {
+        json_rpc_id: id.clone(),
+        json_rpc_method: method.clone(),
+        ..build_record(req)
+    };
+
+    record_request(state, record);
+    dispatch_by_method(stream, config, &id, method.as_deref());
+}
+
+/// v1.0 `PascalCase` names are primary; v0.3 slash
+/// names are accepted as aliases.
+fn dispatch_by_method(stream: &mut TcpStream, config: &A2aMockConfig, id: &Option<Value>, method: Option<&str>) {
+    match method {
+        Some("SendMessage" | "message/send") => handle_send_message(stream, config, id),
+        Some("SendStreamingMessage" | "message/stream") => handle_send_streaming_message(stream, config, id),
+        Some("GetTask" | "tasks/get") => handle_get_task(stream, config, id),
+        Some("CancelTask" | "tasks/cancel") => handle_cancel_task(stream, config, id),
+        _ => handle_unknown_method(stream, id),
+    }
+}
+
+/// HTTP reason phrase for early-rejection status codes.
+fn reason_for(status: u16) -> &'static str {
+    match status {
+        400 => "Bad Request",
+        404 => "Not Found",
+        405 => "Method Not Allowed",
+        _ => "Unknown",
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Method Handlers
+// -----------------------------------------------------------------------------
+
+/// Returns a deterministic completed task.
+fn handle_send_message(stream: &mut TcpStream, config: &A2aMockConfig, id: &Option<Value>) {
+    let body = completed_task_json(config, id).to_string();
+    write_response(
+        stream,
+        200,
+        "OK",
+        &[("Content-Type", "application/json".to_owned())],
+        &body,
+    );
+}
+
+/// Single SSE event with `final: true`.
+fn handle_send_streaming_message(stream: &mut TcpStream, config: &A2aMockConfig, id: &Option<Value>) {
+    let event = json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "result": {
+            "id": config.task_id,
+            "contextId": config.context_id,
+            "status": { "state": "completed" },
+            "final": true,
+        }
+    });
+
+    let sse_body = format!("data: {event}\n\n");
+
+    let resp = format!(
+        "HTTP/1.1 200 OK\r\n\
+         Content-Type: text/event-stream\r\n\
+         Cache-Control: no-cache\r\n\
+         Connection: close\r\n\
+         Content-Length: {}\r\n\
+         \r\n\
+         {sse_body}",
+        sse_body.len()
+    );
+
+    let _sent = stream.write_all(resp.as_bytes());
+}
+
+/// Same completed-task envelope as `SendMessage`.
+fn handle_get_task(stream: &mut TcpStream, config: &A2aMockConfig, id: &Option<Value>) {
+    let body = completed_task_json(config, id).to_string();
+    write_response(
+        stream,
+        200,
+        "OK",
+        &[("Content-Type", "application/json".to_owned())],
+        &body,
+    );
+}
+
+/// Task envelope with `"state": "canceled"`.
+fn handle_cancel_task(stream: &mut TcpStream, config: &A2aMockConfig, id: &Option<Value>) {
+    let result = json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "result": {
+            "id": config.task_id,
+            "contextId": config.context_id,
+            "status": { "state": "canceled" }
+        }
+    });
+
+    let body = result.to_string();
+    write_response(
+        stream,
+        200,
+        "OK",
+        &[("Content-Type", "application/json".to_owned())],
+        &body,
+    );
+}
+
+/// JSON-RPC `-32601` error for unrecognized methods.
+fn handle_unknown_method(stream: &mut TcpStream, id: &Option<Value>) {
+    let result = json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "error": {
+            "code": -32601,
+            "message": "Method not found",
+        }
+    });
+    let body = result.to_string();
+    write_response(
+        stream,
+        200,
+        "OK",
+        &[("Content-Type", "application/json".to_owned())],
+        &body,
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Utilities
+// -----------------------------------------------------------------------------
+
+/// Pre-populate non-JSON-RPC fields from the raw HTTP
+/// request; callers fill in method/id after parsing.
+fn build_record(req: &AgenticHttpRequest) -> A2aRecordedRequest {
+    A2aRecordedRequest {
+        a2a_version: req.header_value("a2a-version"),
+        body: req.body.clone(),
+        headers: req.headers.clone(),
+        http_method: req.method.clone(),
+        json_rpc_id: None,
+        json_rpc_method: None,
+        path: req.path.clone(),
+        uri: req.uri.clone(),
+    }
+}
+
+/// Deterministic completed-task envelope reused by
+/// `SendMessage` and `GetTask`.
+fn completed_task_json(config: &A2aMockConfig, id: &Option<Value>) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "result": {
+            "id": config.task_id,
+            "contextId": config.context_id,
+            "status": { "state": "completed" }
+        }
+    })
+}
+
+/// Query strings are stripped during parsing, so this
+/// is a plain equality check.
+fn path_matches(request_path: &str, config_path: &str) -> bool {
+    request_path == config_path
+}
+
+/// Lock is held only for the push; callers must
+/// not hold their own lock across this call.
+fn record_request(state: &Mutex<Vec<A2aRecordedRequest>>, record: A2aRecordedRequest) {
+    state.lock().unwrap().push(record);
+}

--- a/tests/utils/src/agentic/mcp.rs
+++ b/tests/utils/src/agentic/mcp.rs
@@ -1,0 +1,621 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Streamable HTTP MCP mock server for integration tests.
+//!
+//! Provides a deterministic [Model Context Protocol][mcp] backend
+//! that records every inbound request for later assertion. The
+//! server runs on a background thread and shuts down when the
+//! returned [`McpMockServerGuard`] is dropped.
+//!
+//! [mcp]: https://spec.modelcontextprotocol.io/
+
+use std::{
+    net::TcpStream,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
+
+use serde_json::{Value, json};
+
+use super::http::{AgenticHttpRequest, parse_agentic_request, write_response};
+
+// -----------------------------------------------------------------------------
+// Constants
+// -----------------------------------------------------------------------------
+
+/// Default endpoint path.
+const DEFAULT_PATH: &str = "/mcp";
+
+/// Default MCP protocol version.
+const DEFAULT_PROTOCOL_VERSION: &str = "2025-03-26";
+
+/// Default server name returned in `initialize` responses.
+const DEFAULT_SERVER_NAME: &str = "praxis-test-mcp";
+
+/// Default server version.
+const DEFAULT_SERVER_VERSION: &str = "0.0.0-test";
+
+/// Deterministic session ID for stateful sessions.
+const MOCK_SESSION_ID: &str = "mock-mcp-session-1";
+
+// -----------------------------------------------------------------------------
+// Configuration
+// -----------------------------------------------------------------------------
+
+/// Configuration for an MCP mock server instance.
+pub struct McpMockConfig {
+    /// Endpoint path the server listens on.
+    pub path: String,
+
+    /// Protocol version returned in `initialize` results.
+    pub protocol_version: String,
+
+    /// Server name returned in `initialize` results.
+    pub server_name: String,
+
+    /// Whether to emit `MCP-Session-Id` on `initialize`.
+    pub stateful_sessions: bool,
+
+    /// Tools advertised by `tools/list` and accepted
+    /// by `tools/call`.
+    pub tools: Vec<McpToolFixture>,
+}
+
+impl Default for McpMockConfig {
+    fn default() -> Self {
+        Self {
+            path: DEFAULT_PATH.to_owned(),
+            protocol_version: DEFAULT_PROTOCOL_VERSION.to_owned(),
+            server_name: DEFAULT_SERVER_NAME.to_owned(),
+            stateful_sessions: true,
+            tools: vec![McpToolFixture::new("echo")],
+        }
+    }
+}
+
+/// A tool fixture advertised by the mock MCP server.
+pub struct McpToolFixture {
+    /// Tool description shown in `tools/list`.
+    pub description: Option<String>,
+
+    /// JSON Schema for the tool's input parameters.
+    pub input_schema: Value,
+
+    /// Tool name used for matching in `tools/call`.
+    pub name: String,
+}
+
+impl McpToolFixture {
+    /// Create a fixture with the given name, an empty
+    /// object schema, and no description.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            description: None,
+            input_schema: json!({"type": "object", "additionalProperties": false}),
+            name: name.into(),
+        }
+    }
+
+    /// Set the tool description.
+    #[must_use]
+    pub fn with_description(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+
+    /// Set a custom input schema.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `schema` is not a JSON object with
+    /// `"type": "object"`, as required by the MCP spec.
+    #[must_use]
+    pub fn with_input_schema(mut self, schema: Value) -> Self {
+        assert!(schema.is_object(), "McpToolFixture inputSchema must be a JSON object");
+        assert!(
+            schema.get("type").and_then(Value::as_str) == Some("object"),
+            "McpToolFixture inputSchema must have \"type\": \"object\""
+        );
+        self.input_schema = schema;
+        self
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Recorded Request
+// -----------------------------------------------------------------------------
+
+/// A single request captured by the MCP mock server.
+#[derive(Clone, Debug)]
+pub struct McpRecordedRequest {
+    /// Raw request body.
+    pub body: String,
+
+    /// Request headers as `(name, value)` pairs.
+    pub headers: Vec<(String, String)>,
+
+    /// HTTP method (e.g. `POST`, `DELETE`).
+    pub http_method: String,
+
+    /// JSON-RPC `id` field, if present.
+    pub json_rpc_id: Option<Value>,
+
+    /// JSON-RPC `method` field, if present.
+    pub json_rpc_method: Option<String>,
+
+    /// URL path without query string.
+    pub path: String,
+
+    /// Tool name from `tools/call` params, if present.
+    pub tool_name: Option<String>,
+
+    /// Full request URI including query string.
+    pub uri: String,
+}
+
+// -----------------------------------------------------------------------------
+// Server Guard
+// -----------------------------------------------------------------------------
+
+/// RAII handle for a running MCP mock server.
+///
+/// The background listener exits when this guard is
+/// dropped. Use the accessor methods to inspect
+/// captured request state after sending test traffic.
+pub struct McpMockServerGuard {
+    /// The configured endpoint path.
+    path: String,
+
+    /// Listening port.
+    port: u16,
+
+    /// Shared shutdown flag.
+    shutdown: Arc<AtomicBool>,
+
+    /// Captured requests.
+    state: Arc<Mutex<Vec<McpRecordedRequest>>>,
+}
+
+impl McpMockServerGuard {
+    /// The `host:port` address string.
+    pub fn endpoint(&self) -> String {
+        format!("127.0.0.1:{}", self.port)
+    }
+
+    /// The last `tools/call` tool name received, if any.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the state mutex is poisoned.
+    pub fn last_tool_call_name(&self) -> Option<String> {
+        let reqs = self.state.lock().unwrap();
+        reqs.iter()
+            .rev()
+            .find(|r| r.json_rpc_method.as_deref() == Some("tools/call"))
+            .and_then(|r| r.tool_name.clone())
+    }
+
+    /// Count of requests with the given JSON-RPC method.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the state mutex is poisoned.
+    pub fn method_count(&self, method: &str) -> usize {
+        let reqs = self.state.lock().unwrap();
+        reqs.iter()
+            .filter(|r| r.json_rpc_method.as_deref() == Some(method))
+            .count()
+    }
+
+    /// The configured endpoint path.
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+
+    /// The port the server is listening on.
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    /// Clone of all captured requests.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the state mutex is poisoned.
+    pub fn received_requests(&self) -> Vec<McpRecordedRequest> {
+        self.state.lock().unwrap().clone()
+    }
+
+    /// Count of `tools/call` requests for the given
+    /// tool name.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the state mutex is poisoned.
+    pub fn tool_call_count(&self, tool_name: &str) -> usize {
+        let reqs = self.state.lock().unwrap();
+        reqs.iter()
+            .filter(|r| r.tool_name.as_deref() == Some(tool_name))
+            .count()
+    }
+}
+
+impl Drop for McpMockServerGuard {
+    fn drop(&mut self) {
+        self.shutdown.store(true, Ordering::Release);
+        let _ = TcpStream::connect(format!("127.0.0.1:{}", self.port));
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Server Lifecycle
+// -----------------------------------------------------------------------------
+
+/// Start an MCP mock server with default configuration.
+///
+/// # Panics
+///
+/// Panics if the server fails to bind or the config
+/// path is invalid.
+pub fn start_mcp_mock_server() -> McpMockServerGuard {
+    start_mcp_mock_server_with_config(McpMockConfig::default())
+}
+
+/// Start an MCP mock server with custom configuration.
+///
+/// # Panics
+///
+/// Panics if the server fails to bind, the config
+/// path is invalid, or any tool has a non-object
+/// `inputSchema`.
+pub fn start_mcp_mock_server_with_config(config: McpMockConfig) -> McpMockServerGuard {
+    super::validate_config_path(&config.path);
+    validate_tool_schemas(&config.tools);
+
+    let (listener, port) = crate::net::port::bind_unique_port();
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let state: Arc<Mutex<Vec<McpRecordedRequest>>> = Arc::new(Mutex::new(Vec::new()));
+
+    let flag = Arc::clone(&shutdown);
+    let shared_state = Arc::clone(&state);
+    let path = config.path.clone();
+    let config = Arc::new(config);
+
+    std::thread::spawn(move || {
+        for stream in listener.incoming().flatten() {
+            if flag.load(Ordering::Acquire) {
+                break;
+            }
+            let cfg = Arc::clone(&config);
+            let st = Arc::clone(&shared_state);
+            std::thread::spawn(move || handle_connection(stream, &cfg, &st));
+        }
+    });
+
+    McpMockServerGuard {
+        path,
+        port,
+        shutdown,
+        state,
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Connection Handler
+// -----------------------------------------------------------------------------
+
+/// Per-connection entry point; DELETE is special-cased
+/// before the POST-only gate.
+fn handle_connection(mut stream: TcpStream, config: &McpMockConfig, state: &Mutex<Vec<McpRecordedRequest>>) {
+    stream.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+
+    let Some(req) = parse_agentic_request(&mut stream) else {
+        return;
+    };
+
+    if req.method == "DELETE" {
+        record_request(state, build_record(&req));
+        handle_delete(&mut stream, &req, config);
+        return;
+    }
+
+    if let Some(status) = reject_early(&req, config) {
+        record_request(state, build_record(&req));
+        write_response(&mut stream, status, reason_for(status), &[], "");
+        return;
+    }
+
+    dispatch_json_rpc(&mut stream, config, state, &req);
+}
+
+/// `Some(status)` when the request is invalid before
+/// JSON-RPC parsing.
+fn reject_early(req: &AgenticHttpRequest, config: &McpMockConfig) -> Option<u16> {
+    if req.method != "POST" {
+        return Some(405);
+    }
+    if !path_matches(&req.path, &config.path) {
+        return Some(404);
+    }
+    if req.body.is_empty() {
+        return Some(400);
+    }
+    None
+}
+
+/// Parse JSON-RPC, record, and route to a handler.
+fn dispatch_json_rpc(
+    stream: &mut TcpStream,
+    config: &McpMockConfig,
+    state: &Mutex<Vec<McpRecordedRequest>>,
+    req: &AgenticHttpRequest,
+) {
+    let Ok(json) = serde_json::from_str::<Value>(&req.body) else {
+        record_request(state, build_record(req));
+        write_response(stream, 400, "Bad Request", &[], "");
+        return;
+    };
+
+    let method = json.get("method").and_then(Value::as_str).map(str::to_owned);
+    let id = json.get("id").cloned();
+    let tool_name = extract_tool_name(&json);
+
+    let record = McpRecordedRequest {
+        json_rpc_id: id.clone(),
+        json_rpc_method: method.clone(),
+        tool_name: tool_name.clone(),
+        ..build_record(req)
+    };
+
+    record_request(state, record);
+
+    match method.as_deref() {
+        Some("initialize") => handle_initialize(stream, config, &id),
+        Some("notifications/initialized") => handle_notification(stream),
+        Some("tools/list") => handle_tools_list(stream, config, &id),
+        Some("tools/call") => handle_tools_call(stream, config, &id, tool_name),
+        Some("ping") => handle_ping(stream, &id),
+        _ => handle_unknown_method(stream, &id),
+    }
+}
+
+/// HTTP reason phrase for early-rejection status codes.
+fn reason_for(status: u16) -> &'static str {
+    match status {
+        400 => "Bad Request",
+        404 => "Not Found",
+        405 => "Method Not Allowed",
+        _ => "Unknown",
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Method Handlers
+// -----------------------------------------------------------------------------
+
+/// Capabilities envelope; emits `MCP-Session-Id`
+/// when `stateful_sessions` is set.
+fn handle_initialize(stream: &mut TcpStream, config: &McpMockConfig, id: &Option<Value>) {
+    let result = json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "result": {
+            "protocolVersion": config.protocol_version,
+            "capabilities": { "tools": {} },
+            "serverInfo": {
+                "name": config.server_name,
+                "version": DEFAULT_SERVER_VERSION,
+            }
+        }
+    });
+
+    let body = result.to_string();
+    let mut headers: Vec<(&str, String)> = vec![("Content-Type", "application/json".to_owned())];
+
+    if config.stateful_sessions {
+        headers.push(("MCP-Session-Id", MOCK_SESSION_ID.to_owned()));
+    }
+
+    write_response(stream, 200, "OK", &headers, &body);
+}
+
+/// Notifications have no `id`, so the MCP spec
+/// requires 202 with no JSON-RPC body.
+fn handle_notification(stream: &mut TcpStream) {
+    write_response(stream, 202, "Accepted", &[], "");
+}
+
+/// Every emitted tool includes `inputSchema` to
+/// satisfy the MCP spec shape requirement.
+fn handle_tools_list(stream: &mut TcpStream, config: &McpMockConfig, id: &Option<Value>) {
+    let tools: Vec<Value> = config
+        .tools
+        .iter()
+        .map(|t| {
+            let mut tool = json!({
+                "name": t.name,
+                "inputSchema": t.input_schema,
+            });
+            if let Some(desc) = &t.description {
+                tool["description"] = json!(desc);
+            }
+            tool
+        })
+        .collect();
+
+    let result = json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "result": { "tools": tools }
+    });
+
+    let body = result.to_string();
+    write_response(
+        stream,
+        200,
+        "OK",
+        &[("Content-Type", "application/json".to_owned())],
+        &body,
+    );
+}
+
+/// Known tools get a content result; unknown tools
+/// get `-32602` so tests can distinguish.
+fn handle_tools_call(stream: &mut TcpStream, config: &McpMockConfig, id: &Option<Value>, tool_name: Option<String>) {
+    let name = tool_name.unwrap_or_default();
+    let known = config.tools.iter().any(|t| t.name == name);
+
+    if known {
+        write_known_tool_result(stream, id, &name);
+    } else {
+        write_unknown_tool_error(stream, id);
+    }
+}
+
+/// Empty result object per MCP spec.
+fn handle_ping(stream: &mut TcpStream, id: &Option<Value>) {
+    let result = json!({"jsonrpc": "2.0", "id": id, "result": {}});
+    let body = result.to_string();
+    write_response(
+        stream,
+        200,
+        "OK",
+        &[("Content-Type", "application/json".to_owned())],
+        &body,
+    );
+}
+
+/// Permissive 204 regardless of session state;
+/// stricter validation deferred to later PRs.
+fn handle_delete(stream: &mut TcpStream, req: &AgenticHttpRequest, config: &McpMockConfig) {
+    if !path_matches(&req.path, &config.path) {
+        write_response(stream, 404, "Not Found", &[], "");
+        return;
+    }
+    write_response(stream, 204, "No Content", &[], "");
+}
+
+/// JSON-RPC `-32601` error for unrecognized methods.
+fn handle_unknown_method(stream: &mut TcpStream, id: &Option<Value>) {
+    let result = json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "error": {
+            "code": -32601,
+            "message": "Method not found",
+        }
+    });
+    let body = result.to_string();
+    write_response(
+        stream,
+        200,
+        "OK",
+        &[("Content-Type", "application/json".to_owned())],
+        &body,
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Utilities
+// -----------------------------------------------------------------------------
+
+/// Pre-populate non-JSON-RPC fields from the raw HTTP
+/// request; callers fill in method/id/tool after parsing.
+fn build_record(req: &AgenticHttpRequest) -> McpRecordedRequest {
+    McpRecordedRequest {
+        body: req.body.clone(),
+        headers: req.headers.clone(),
+        http_method: req.method.clone(),
+        json_rpc_id: None,
+        json_rpc_method: None,
+        path: req.path.clone(),
+        tool_name: None,
+        uri: req.uri.clone(),
+    }
+}
+
+/// Catches schemas set directly via `pub input_schema`
+/// that bypass `with_input_schema` validation.
+fn validate_tool_schemas(tools: &[McpToolFixture]) {
+    for tool in tools {
+        assert!(
+            tool.input_schema.is_object(),
+            "tool '{}': inputSchema must be a JSON object",
+            tool.name
+        );
+        assert!(
+            tool.input_schema.get("type").and_then(Value::as_str) == Some("object"),
+            "tool '{}': inputSchema must have \"type\": \"object\"",
+            tool.name
+        );
+    }
+}
+
+/// `params.name` from a `tools/call` body.
+fn extract_tool_name(json: &Value) -> Option<String> {
+    json.get("params")
+        .and_then(|p| p.get("name"))
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+}
+
+/// Query strings are stripped during parsing, so this
+/// is a plain equality check.
+fn path_matches(request_path: &str, config_path: &str) -> bool {
+    request_path == config_path
+}
+
+/// Lock is held only for the push; callers must
+/// not hold their own lock across this call.
+fn record_request(state: &Mutex<Vec<McpRecordedRequest>>, record: McpRecordedRequest) {
+    state.lock().unwrap().push(record);
+}
+
+/// Successful `tools/call` content result.
+fn write_known_tool_result(stream: &mut TcpStream, id: &Option<Value>, name: &str) {
+    let result = json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "result": {
+            "content": [{
+                "type": "text",
+                "text": format!("mock result for {name}"),
+            }],
+            "isError": false,
+        }
+    });
+
+    let body = result.to_string();
+    write_response(
+        stream,
+        200,
+        "OK",
+        &[("Content-Type", "application/json".to_owned())],
+        &body,
+    );
+}
+
+/// JSON-RPC `-32602` error for unknown tool names.
+fn write_unknown_tool_error(stream: &mut TcpStream, id: &Option<Value>) {
+    let result = json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "error": {
+            "code": -32602,
+            "message": "Unknown tool",
+        }
+    });
+
+    let body = result.to_string();
+    write_response(
+        stream,
+        200,
+        "OK",
+        &[("Content-Type", "application/json".to_owned())],
+        &body,
+    );
+}

--- a/tests/utils/src/agentic/mod.rs
+++ b/tests/utils/src/agentic/mod.rs
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Agentic protocol mock servers for integration tests.
+//!
+//! Provides deterministic MCP and A2A backends that record
+//! inbound requests for assertion in integration tests.
+
+pub mod a2a;
+pub mod mcp;
+
+pub use a2a::{
+    A2aMockConfig, A2aMockServerGuard, A2aRecordedRequest, start_a2a_mock_server, start_a2a_mock_server_with_config,
+};
+pub use mcp::{
+    McpMockConfig, McpMockServerGuard, McpRecordedRequest, McpToolFixture, start_mcp_mock_server,
+    start_mcp_mock_server_with_config,
+};
+
+// -----------------------------------------------------------------------------
+// Path Validation
+// -----------------------------------------------------------------------------
+
+/// Rejects paths that are not plain absolute paths
+/// (no query, fragment, scheme, or authority).
+///
+/// # Panics
+///
+/// Panics if the path is malformed for use as a mock
+/// endpoint.
+fn validate_config_path(path: &str) {
+    assert!(
+        path.starts_with('/'),
+        "mock config path must start with '/', got: {path}"
+    );
+    assert!(
+        !path.starts_with("//"),
+        "mock config path must not contain an authority (//), got: {path}"
+    );
+    assert!(
+        !path.contains('?'),
+        "mock config path must not contain a query string, got: {path}"
+    );
+    assert!(
+        !path.contains('#'),
+        "mock config path must not contain a fragment, got: {path}"
+    );
+    assert!(
+        !path.contains("://"),
+        "mock config path must not contain a scheme, got: {path}"
+    );
+    assert!(
+        !path.contains(|c: char| c.is_whitespace() || c.is_control()),
+        "mock config path must not contain whitespace or control characters, got: {path}"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Shared HTTP Parsing
+// -----------------------------------------------------------------------------
+
+/// Internal module providing lightweight HTTP request
+/// parsing shared by both MCP and A2A mock servers.
+pub(super) mod http {
+    use std::{
+        io::{Read, Write},
+        net::TcpStream,
+    };
+
+    /// Parsed HTTP request used by agentic mock servers.
+    pub(crate) struct AgenticHttpRequest {
+        /// Raw request body.
+        pub(crate) body: String,
+
+        /// Request headers as `(lowercase-name, value)` pairs.
+        pub(crate) headers: Vec<(String, String)>,
+
+        /// HTTP method (e.g. `POST`, `DELETE`).
+        pub(crate) method: String,
+
+        /// URL path without query string.
+        pub(crate) path: String,
+
+        /// Full request URI including query string.
+        pub(crate) uri: String,
+    }
+
+    impl AgenticHttpRequest {
+        /// Case-insensitive header value lookup.
+        pub(crate) fn header_value(&self, name: &str) -> Option<String> {
+            let lower = name.to_lowercase();
+            self.headers.iter().find(|(k, _)| k == &lower).map(|(_, v)| v.clone())
+        }
+    }
+
+    /// Parse an HTTP request from a TCP stream.
+    ///
+    /// Returns `None` if the stream yields no usable data.
+    pub(crate) fn parse_agentic_request(stream: &mut TcpStream) -> Option<AgenticHttpRequest> {
+        let data = read_with_body(stream)?;
+        let (head, body) = split_and_slice_body(&data);
+
+        let mut lines = head.lines();
+        let request_line = lines.next()?;
+        let mut parts = request_line.split_whitespace();
+        let method = parts.next()?.to_owned();
+        let uri = parts.next()?.to_owned();
+
+        let path = uri.split_once('?').map_or(uri.as_str(), |(p, _)| p).to_owned();
+
+        let headers: Vec<(String, String)> = lines
+            .filter_map(|line| {
+                let (key, value) = line.split_once(':')?;
+                Some((key.trim().to_lowercase(), value.trim().to_owned()))
+            })
+            .collect();
+
+        Some(AgenticHttpRequest {
+            body,
+            headers,
+            method,
+            path,
+            uri,
+        })
+    }
+
+    /// Write a complete HTTP response to a TCP stream.
+    pub(crate) fn write_response(
+        stream: &mut TcpStream,
+        status: u16,
+        reason: &str,
+        headers: &[(&str, String)],
+        body: &str,
+    ) {
+        let mut resp = format!("HTTP/1.1 {status} {reason}\r\n");
+
+        for (name, value) in headers {
+            use std::fmt::Write as FmtWrite;
+            let _written = write!(resp, "{name}: {value}\r\n");
+        }
+
+        if !body.is_empty() {
+            use std::fmt::Write as FmtWrite;
+            let _written = write!(resp, "Content-Length: {}\r\n", body.len());
+        }
+
+        resp.push_str("Connection: close\r\n\r\n");
+        resp.push_str(body);
+
+        let _sent = stream.write_all(resp.as_bytes());
+    }
+
+    /// Slice body bytes to exactly `Content-Length`
+    /// before UTF-8 decoding to avoid panics on
+    /// multi-byte boundaries. `Content-Length: 0`
+    /// produces an empty body, not "read all remaining."
+    fn split_and_slice_body(data: &[u8]) -> (String, String) {
+        let Some(pos) = data.windows(4).position(|w| w == b"\r\n\r\n") else {
+            return (String::from_utf8_lossy(data).into_owned(), String::new());
+        };
+
+        let head = String::from_utf8_lossy(&data[..pos]).into_owned();
+        let body_start = pos + 4;
+        let remaining = data.len() - body_start;
+
+        let body_len = parse_content_length(&head).unwrap_or(remaining);
+        let body_end = body_start + body_len.min(remaining);
+
+        let body = String::from_utf8_lossy(&data[body_start..body_end]).into_owned();
+        (head, body)
+    }
+
+    /// Read headers + `Content-Length` bytes from a TCP
+    /// stream, returned as raw bytes.
+    fn read_with_body(stream: &mut TcpStream) -> Option<Vec<u8>> {
+        let mut data = Vec::new();
+        let mut buf = [0u8; 4096];
+
+        loop {
+            match stream.read(&mut buf) {
+                Ok(0) | Err(_) => break,
+                Ok(n) => data.extend_from_slice(&buf[..n]),
+            }
+
+            if let Some(header_end) = data.windows(4).position(|w| w == b"\r\n\r\n") {
+                let header_section = String::from_utf8_lossy(&data[..header_end]);
+                let cl = parse_content_length(&header_section).unwrap_or(0);
+                if data.len() >= header_end + 4 + cl {
+                    break;
+                }
+            }
+        }
+
+        if data.is_empty() {
+            return None;
+        }
+
+        Some(data)
+    }
+
+    /// `Some(n)` when `Content-Length` is present;
+    /// `None` when the header is absent, so callers
+    /// can distinguish "no header" from "zero."
+    fn parse_content_length(headers: &str) -> Option<usize> {
+        headers
+            .lines()
+            .find(|l| l.to_lowercase().starts_with("content-length:"))
+            .and_then(|l| l.split_once(':').map(|(_, v)| v))
+            .and_then(|v| v.trim().parse().ok())
+    }
+}

--- a/tests/utils/src/lib.rs
+++ b/tests/utils/src/lib.rs
@@ -14,10 +14,12 @@
 
 //! Shared test utilities for the Praxis workspace.
 
+pub mod agentic;
 pub mod example_config;
 pub mod net;
 pub mod proxy;
 
+pub use agentic::*;
 pub use example_config::{example_config_path, load_example_config, patch_yaml};
 pub use net::*;
 pub use proxy::{


### PR DESCRIPTION

  ## Summary

  Adds reusable MCP and A2A mock servers to `praxis-test-utils` so future agentic integration tests can use deterministic protocol-aware backends instead of ad hoc HTTP echo servers.

  This PR adds:

  - Streamable HTTP MCP mock server support for:
    - `initialize`
    - `notifications/initialized`
    - `tools/list`
    - `tools/call`
    - `ping`
    - `DELETE`
  - A2A JSON-RPC/SSE mock server support for:
    - `SendMessage`
    - `SendStreamingMessage`
    - `GetTask`
    - `CancelTask`
    - v0.3 slash-delimited aliases for compatibility
  - Captured request state so tests can assert forwarded paths, headers, methods, tool names, request bodies, and protocol version headers
  - Configurable MCP tool fixtures with spec-shaped `inputSchema`
  - Configurable mock paths, task IDs, context IDs, protocol versions, and MCP session behavior
  - Focused integration tests for protocol responses, wrong paths, wrong HTTP methods, query-string matching, config validation, schema validation, request recording, and Content-Length handling

  ## Scope

  This is test infrastructure only. It does not change production filters, protocol handling, gateway behavior, routing behavior, or StreamBuffer behavior.

  ## Why

  The agentic epic needs repeatable MCP and A2A integration tests across classifier, gateway, routing, and streaming work. These helpers provide stable protocol fixtures that later PRs can reuse without duplicating backend setup or relying on external MCP/A2A services.

  ## Test Plan

  - [x] MCP mock server integration coverage
  - [x] A2A mock server integration coverage
  - [x] Config validation and schema validation tests
  - [x] Request recording and Content-Length edge-case tests
  - [x] `cargo test -p praxis-tests-integration agentic_mocks`
  - [x] `cargo test -p praxis-test-utils agentic`
  - [x] `cargo clippy -p praxis-test-utils --all-targets -- -D warnings`
  - [x] `cargo clippy -p praxis-tests-integration --all-targets -- -D warnings`
  - [x] `cargo +nightly fmt --all --check`

ref praxis-proxy/ai#153 