### PR TITLE
fix(tests): patch default config listener port rewrite

### DIFF
--- a/tests/integration/tests/suite/examples/default_config.rs
+++ b/tests/integration/tests/suite/examples/default_config.rs
@@ -3,8 +3,10 @@
 
 //! Tests for the default example configuration.
 
+use std::collections::HashMap;
+
 use praxis_core::config::Config;
-use praxis_test_utils::{free_port, http_get, start_proxy};
+use praxis_test_utils::{free_port, http_get, patch_yaml, start_proxy};
 use serde_json::Value;
 
 // -----------------------------------------------------------------------------
@@ -22,9 +24,7 @@ const DEFAULT_CONFIG: &str = praxis_core::config::DEFAULT_CONFIG;
 fn default_config_root_returns_200() {
     let proxy_port = free_port();
     let admin_port = free_port();
-    let yaml = DEFAULT_CONFIG
-        .replace("0.0.0.0:8080", &format!("127.0.0.1:{proxy_port}"))
-        .replace("127.0.0.1:9901", &format!("127.0.0.1:{admin_port}"));
+    let yaml = default_config_with_test_ports(proxy_port, admin_port);
     let config = Config::from_yaml(&yaml).unwrap();
     let proxy = start_proxy(&config);
     let (status, body) = http_get(proxy.addr(), "/", None);
@@ -38,12 +38,23 @@ fn default_config_root_returns_200() {
 fn default_config_other_path_returns_404() {
     let proxy_port = free_port();
     let admin_port = free_port();
-    let yaml = DEFAULT_CONFIG
-        .replace("0.0.0.0:8080", &format!("127.0.0.1:{proxy_port}"))
-        .replace("127.0.0.1:9901", &format!("127.0.0.1:{admin_port}"));
+    let yaml = default_config_with_test_ports(proxy_port, admin_port);
     let config = Config::from_yaml(&yaml).unwrap();
     let proxy = start_proxy(&config);
     let (status, body) = http_get(proxy.addr(), "/anything", None);
     assert_eq!(status, 404, "non-root path should return 404");
     assert!(body.contains("not found"), "404 body should contain 'not found'");
+}
+
+// -----------------------------------------------------------------------------
+// Test Utilities
+// -----------------------------------------------------------------------------
+
+/// Return the embedded default config with per-test listener and admin ports.
+///
+/// `patch_yaml` handles known default listener forms. The admin listener is
+/// patched separately because it is not an endpoint.
+fn default_config_with_test_ports(proxy_port: u16, admin_port: u16) -> String {
+    patch_yaml(DEFAULT_CONFIG, proxy_port, &HashMap::new())
+        .replace("127.0.0.1:9901", &format!("127.0.0.1:{admin_port}"))
 }

--- a/tests/schema/tests/suite/examples/pipeline/default_config.rs
+++ b/tests/schema/tests/suite/examples/pipeline/default_config.rs
@@ -3,8 +3,10 @@
 
 //! Default pipeline config example tests.
 
+use std::collections::HashMap;
+
 use praxis_core::config::Config;
-use praxis_test_utils::{free_port, http_get, start_proxy};
+use praxis_test_utils::{free_port, http_get, patch_yaml, start_proxy};
 use serde_json::Value;
 
 // -----------------------------------------------------------------------------
@@ -21,7 +23,8 @@ const DEFAULT_CONFIG: &str = praxis_core::config::DEFAULT_CONFIG;
 #[test]
 fn default_config_root_returns_200() {
     let proxy_port = free_port();
-    let yaml = DEFAULT_CONFIG.replace("0.0.0.0:8080", &format!("127.0.0.1:{proxy_port}"));
+    let admin_port = free_port();
+    let yaml = default_config_with_test_ports(proxy_port, admin_port);
     let config = Config::from_yaml(&yaml).unwrap();
     let proxy = start_proxy(&config);
     let (status, body) = http_get(proxy.addr(), "/", None);
@@ -34,10 +37,24 @@ fn default_config_root_returns_200() {
 #[test]
 fn default_config_other_path_returns_404() {
     let proxy_port = free_port();
-    let yaml = DEFAULT_CONFIG.replace("0.0.0.0:8080", &format!("127.0.0.1:{proxy_port}"));
+    let admin_port = free_port();
+    let yaml = default_config_with_test_ports(proxy_port, admin_port);
     let config = Config::from_yaml(&yaml).unwrap();
     let proxy = start_proxy(&config);
     let (status, body) = http_get(proxy.addr(), "/anything", None);
     assert_eq!(status, 404, "non-root path should return 404");
     assert!(body.contains("not found"), "404 body should contain 'not found'");
+}
+
+// -----------------------------------------------------------------------------
+// Test Utilities
+// -----------------------------------------------------------------------------
+
+/// Return the embedded default config with per-test listener and admin ports.
+///
+/// `patch_yaml` handles known default listener forms. The admin listener is
+/// patched separately because it is not an endpoint.
+fn default_config_with_test_ports(proxy_port: u16, admin_port: u16) -> String {
+    patch_yaml(DEFAULT_CONFIG, proxy_port, &HashMap::new())
+        .replace("127.0.0.1:9901", &format!("127.0.0.1:{admin_port}"))
 }


### PR DESCRIPTION
  ## Summary

  Fixes the default config example tests so they patch the current embedded listener address before starting a test proxy. Fixes current breakage in main.

  The default config now binds `127.0.0.1:8080`, but these tests only rewrote `0.0.0.0:8080`. In parallel test runs that left the proxy on port `8080`, which could hit another listener and return `501`.

  This updates the integration and schema default config tests to:
  - reuse the existing `patch_yaml` helper, which handles both `0.0.0.0:8080` and `127.0.0.1:8080`
  - keep assigning a free admin port for `127.0.0.1:9901`

  ## Verification

  Before patch:
  - `cargo +nightly test -p praxis-tests-integration --test suite -- examples::default_config`
  - failed: 2 failed, both returned `501`

  After patch:
  - `cargo +nightly fmt --check`
  - `cargo +nightly test -p praxis-tests-integration --test suite -- examples::default_config`
  - `cargo +nightly test -p praxis-tests-schema --test suite -- examples::pipeline::default_config`
  - `cargo +nightly test -p praxis-tests-integration --test suite`

  Full integration result: `467 passed; 0 failed`.
