### PR TITLE
Add responses_format classifier filter for AI API body-aware routing

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -127,6 +127,7 @@ page.
 | [mcp-classifier-routing.yaml](configs/ai/mcp-classifier-routing.yaml) | Route MCP requests by body-derived method and tool name |
 | [model-to-header-routing.yaml](configs/ai/model-to-header-routing.yaml) | Route by model field in JSON body via X-Model header |
 | [prompt-enrichment.yaml](configs/ai/prompt-enrichment.yaml) | Inject system messages into chat completion requests |
+| [format-routing.yaml](configs/ai/openai/responses/format-routing.yaml) | Route by AI API format (Responses vs Chat Completions) |
 
 ### Branching
 

--- a/examples/configs/ai/openai/responses/format-routing.yaml
+++ b/examples/configs/ai/openai/responses/format-routing.yaml
@@ -1,0 +1,56 @@
+# Responses Format Routing
+#
+# Routes AI API traffic by detected body format. The `responses_format`
+# filter parses JSON request bodies and classifies them as `responses`
+# (Responses API), `chat_completions` (Chat Completions API), or
+# `unknown` (valid JSON but unrecognized format).
+#
+# Classification facts are promoted to internal routing headers
+# (x-praxis-ai-*) that the router matches for cluster selection.
+# These internal headers are stripped before upstream by header hygiene.
+#
+# Non-JSON, invalid JSON, and unrecognized JSON bodies continue by
+# default so mixed-traffic listeners do not reject non-AI requests.
+# Set `on_invalid: reject` for listeners that only accept AI API
+# traffic (rejects anything without `input` or `messages`).
+
+listeners:
+  - name: ai-gateway
+    address: "127.0.0.1:8080"
+    filter_chains: [ai-routing]
+
+filter_chains:
+  - name: ai-routing
+    filters:
+      - filter: responses_format
+        on_invalid: continue
+        max_body_bytes: 67108864
+        headers:
+          format: x-praxis-ai-format
+          model: x-praxis-ai-model
+          stream: x-praxis-ai-stream
+
+      - filter: router
+        routes:
+          - path: "/v1/responses"
+            headers:
+              x-praxis-ai-format: "responses"
+            cluster: "responses-backend"
+          - path: "/v1/chat/completions"
+            headers:
+              x-praxis-ai-format: "chat_completions"
+            cluster: "chat-backend"
+          - path_prefix: "/"
+            cluster: "default-backend"
+
+      - filter: load_balancer
+        clusters:
+          - name: "responses-backend"
+            endpoints:
+              - "127.0.0.1:3001"
+          - name: "chat-backend"
+            endpoints:
+              - "127.0.0.1:3002"
+          - name: "default-backend"
+            endpoints:
+              - "127.0.0.1:3003"

--- a/filter/src/builtins/http/ai/agentic/a2a/mod.rs
+++ b/filter/src/builtins/http/ai/agentic/a2a/mod.rs
@@ -32,8 +32,9 @@ use self::{
 use crate::{
     FilterAction, FilterError, Rejection,
     body::{BodyAccess, BodyMode},
-    builtins::http::ai::agentic::json_rpc::{
-        config::JsonRpcConfig, contains_control_chars, envelope::parse_json_rpc_value,
+    builtins::http::{
+        ai::agentic::json_rpc::{config::JsonRpcConfig, envelope::parse_json_rpc_value},
+        value_safety::contains_control_chars,
     },
     factory::parse_filter_config,
     filter::{HttpFilter, HttpFilterContext},

--- a/filter/src/builtins/http/ai/agentic/json_rpc/mod.rs
+++ b/filter/src/builtins/http/ai/agentic/json_rpc/mod.rs
@@ -254,7 +254,4 @@ fn set_id_results(
     Ok(())
 }
 
-/// Check whether a string contains control characters.
-pub(crate) fn contains_control_chars(s: &str) -> bool {
-    s.bytes().any(|b| (b < 0x20 && b != 0x09) || b == 0x7F)
-}
+use crate::builtins::http::value_safety::contains_control_chars;

--- a/filter/src/builtins/http/ai/agentic/mcp/broker/mod.rs
+++ b/filter/src/builtins/http/ai/agentic/mcp/broker/mod.rs
@@ -28,10 +28,12 @@ use self::config::{CatalogTool, McpBrokerConfig, build_config};
 use crate::{
     FilterAction, FilterError, Rejection,
     body::{BodyAccess, BodyMode},
-    builtins::http::ai::agentic::json_rpc::{
-        config::JsonRpcConfig,
-        contains_control_chars,
-        envelope::{JsonRpcEnvelope, JsonRpcIdKind, JsonRpcKind, parse_json_rpc_value},
+    builtins::http::{
+        ai::agentic::json_rpc::{
+            config::JsonRpcConfig,
+            envelope::{JsonRpcEnvelope, JsonRpcIdKind, JsonRpcKind, parse_json_rpc_value},
+        },
+        value_safety::contains_control_chars,
     },
     factory::parse_filter_config,
     filter::{HttpFilter, HttpFilterContext},

--- a/filter/src/builtins/http/ai/agentic/mcp/mod.rs
+++ b/filter/src/builtins/http/ai/agentic/mcp/mod.rs
@@ -30,10 +30,11 @@ use self::{
     config::{InvalidMcpBehavior, McpConfig, MismatchBehavior, MissingHeaderBehavior, build_config},
     envelope::{McpEnvelope, extract_mcp_envelope},
 };
-use super::json_rpc::{config::JsonRpcConfig, contains_control_chars, envelope::parse_json_rpc_value};
+use super::json_rpc::{config::JsonRpcConfig, envelope::parse_json_rpc_value};
 use crate::{
     FilterAction, FilterError, Rejection,
     body::{BodyAccess, BodyMode},
+    builtins::http::value_safety::contains_control_chars,
     factory::parse_filter_config,
     filter::{HttpFilter, HttpFilterContext},
 };

--- a/filter/src/builtins/http/ai/mod.rs
+++ b/filter/src/builtins/http/ai/mod.rs
@@ -8,10 +8,14 @@ pub(crate) mod agentic;
 #[cfg(feature = "ai-inference")]
 mod inference;
 #[cfg(feature = "ai-inference")]
+pub(crate) mod openai;
+#[cfg(feature = "ai-inference")]
 mod prompt_enrich;
 
 pub use agentic::{A2aFilter, JsonRpcFilter, McpFilter};
 #[cfg(feature = "ai-inference")]
 pub use inference::ModelToHeaderFilter;
+#[cfg(feature = "ai-inference")]
+pub use openai::ResponsesFormatFilter;
 #[cfg(feature = "ai-inference")]
 pub use prompt_enrich::PromptEnrichFilter;

--- a/filter/src/builtins/http/ai/openai/mod.rs
+++ b/filter/src/builtins/http/ai/openai/mod.rs
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! `OpenAI` protocol filters.
+
+pub(crate) mod responses;
+
+pub use responses::ResponsesFormatFilter;

--- a/filter/src/builtins/http/ai/openai/responses/classify.rs
+++ b/filter/src/builtins/http/ai/openai/responses/classify.rs
@@ -1,0 +1,429 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Pure request body classifier for Responses API versus Chat Completions.
+
+// -----------------------------------------------------------------------------
+// AiRequestFormat
+// -----------------------------------------------------------------------------
+
+/// Classified request body format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AiRequestFormat {
+    /// `OpenAI` Responses API (has `input` field).
+    Responses,
+    /// Chat Completions API (has `messages` field).
+    ChatCompletions,
+    /// Valid JSON but neither recognized format.
+    UnknownJson,
+    /// Body is not valid JSON.
+    InvalidJson,
+    /// Body is empty or absent.
+    NonJson,
+}
+
+impl AiRequestFormat {
+    /// Stable string representation for headers, metadata, and filter results.
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Responses => "responses",
+            Self::ChatCompletions => "chat_completions",
+            Self::UnknownJson => "unknown",
+            Self::InvalidJson => "invalid_json",
+            Self::NonJson => "non_json",
+        }
+    }
+}
+
+// -----------------------------------------------------------------------------
+// ClassifiedRequest
+// -----------------------------------------------------------------------------
+
+/// Extracted facts from a classified request body.
+#[derive(Debug)]
+pub(crate) struct ClassifiedRequest {
+    /// Detected body format.
+    pub format: AiRequestFormat,
+    /// Extracted `model` field value, if present.
+    pub model: Option<String>,
+    /// Extracted `stream` field value, if present.
+    pub stream: Option<bool>,
+    /// Extracted `store` field value, if present.
+    pub store: Option<bool>,
+    /// Extracted `background` field value, if present.
+    pub background: Option<bool>,
+    /// Whether `previous_response_id` is present and non-null.
+    pub has_previous_response_id: bool,
+    /// Whether `conversation` is present and non-null.
+    pub has_conversation: bool,
+}
+
+// -----------------------------------------------------------------------------
+// Classification
+// -----------------------------------------------------------------------------
+
+/// Classify a request body and extract routing facts.
+///
+/// This function is pure: no I/O, no side effects, no mutation of
+/// the input bytes.
+///
+/// ```ignore
+/// let body = br#"{"model":"gpt-4.1","input":"Hello"}"#;
+/// let result = classify_request_body(body);
+/// assert_eq!(result.format.as_str(), "responses");
+/// assert_eq!(result.model.as_deref(), Some("gpt-4.1"));
+/// ```
+pub(crate) fn classify_request_body(body: &[u8]) -> ClassifiedRequest {
+    if body.is_empty() {
+        return empty_result(AiRequestFormat::NonJson);
+    }
+
+    let Ok(value) = serde_json::from_slice::<serde_json::Value>(body) else {
+        return empty_result(AiRequestFormat::InvalidJson);
+    };
+
+    let Some(obj) = value.as_object() else {
+        return empty_result(AiRequestFormat::InvalidJson);
+    };
+
+    let format = classify_format(obj);
+
+    ClassifiedRequest {
+        format,
+        model: extract_string(obj, "model"),
+        stream: obj.get("stream").and_then(serde_json::Value::as_bool),
+        store: obj.get("store").and_then(serde_json::Value::as_bool),
+        background: obj.get("background").and_then(serde_json::Value::as_bool),
+        has_previous_response_id: obj.get("previous_response_id").is_some_and(|v| !v.is_null()),
+        has_conversation: obj.get("conversation").is_some_and(|v| !v.is_null()),
+    }
+}
+
+/// Determine format from top-level keys. When both `input` and
+/// `messages` are present, `input` takes precedence (Responses API).
+fn classify_format(obj: &serde_json::Map<String, serde_json::Value>) -> AiRequestFormat {
+    if obj.contains_key("input") {
+        AiRequestFormat::Responses
+    } else if obj.contains_key("messages") {
+        AiRequestFormat::ChatCompletions
+    } else {
+        AiRequestFormat::UnknownJson
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------------
+
+/// Build a result with no extracted facts.
+fn empty_result(format: AiRequestFormat) -> ClassifiedRequest {
+    ClassifiedRequest {
+        format,
+        model: None,
+        stream: None,
+        store: None,
+        background: None,
+        has_previous_response_id: false,
+        has_conversation: false,
+    }
+}
+
+/// Extract a string field from a JSON object, converting numbers/booleans
+/// to their string representation.
+fn extract_string(obj: &serde_json::Map<String, serde_json::Value>, key: &str) -> Option<String> {
+    obj.get(key).and_then(|v| match v {
+        serde_json::Value::String(s) => Some(s.clone()),
+        serde_json::Value::Number(n) => Some(n.to_string()),
+        serde_json::Value::Bool(b) => Some(b.to_string()),
+        _ => None,
+    })
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    clippy::needless_raw_strings,
+    clippy::needless_raw_string_hashes,
+    reason = "tests"
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn responses_string_input() {
+        let body = br#"{"model":"gpt-4.1-mini","input":"Hello, world!"}"#;
+        let result = classify_request_body(body);
+
+        assert_eq!(
+            result.format,
+            AiRequestFormat::Responses,
+            "string input should classify as responses"
+        );
+        assert_eq!(
+            result.model.as_deref(),
+            Some("gpt-4.1-mini"),
+            "model should be extracted"
+        );
+    }
+
+    #[test]
+    fn responses_array_input() {
+        let body = br#"{"model":"gpt-4.1","input":[{"type":"message","role":"user","content":"Hi"}]}"#;
+        let result = classify_request_body(body);
+
+        assert_eq!(
+            result.format,
+            AiRequestFormat::Responses,
+            "array input should classify as responses"
+        );
+        assert_eq!(result.model.as_deref(), Some("gpt-4.1"), "model should be extracted");
+    }
+
+    #[test]
+    fn responses_null_input_classifies_as_responses() {
+        let body = br#"{"model":"gpt-4.1","input":null}"#;
+        let result = classify_request_body(body);
+
+        assert_eq!(
+            result.format,
+            AiRequestFormat::Responses,
+            "input key should classify as responses even when input is null"
+        );
+        assert_eq!(result.model.as_deref(), Some("gpt-4.1"), "model should be extracted");
+    }
+
+    #[test]
+    fn responses_with_stream_store_previous_response_id() {
+        let body =
+            br#"{"model":"gpt-4.1","input":"test","stream":true,"store":false,"background":true,"previous_response_id":"resp_abc"}"#;
+        let result = classify_request_body(body);
+
+        assert_eq!(result.format, AiRequestFormat::Responses, "should be responses");
+        assert_eq!(result.stream, Some(true), "stream should be extracted");
+        assert_eq!(result.store, Some(false), "store should be extracted");
+        assert_eq!(result.background, Some(true), "background should be extracted");
+        assert!(
+            result.has_previous_response_id,
+            "previous_response_id should be detected"
+        );
+    }
+
+    #[test]
+    fn responses_with_conversation() {
+        let body = br#"{"model":"gpt-4.1","input":"test","conversation":{"id":"conv_123"}}"#;
+        let result = classify_request_body(body);
+
+        assert_eq!(result.format, AiRequestFormat::Responses, "should be responses");
+        assert!(result.has_conversation, "conversation should be detected");
+        assert!(!result.has_previous_response_id, "no previous_response_id");
+    }
+
+    #[test]
+    fn chat_completions_messages() {
+        let body = br#"{"model":"gpt-4","messages":[{"role":"user","content":"Hi"}]}"#;
+        let result = classify_request_body(body);
+
+        assert_eq!(
+            result.format,
+            AiRequestFormat::ChatCompletions,
+            "messages array should classify as chat_completions"
+        );
+        assert_eq!(result.model.as_deref(), Some("gpt-4"), "model should be extracted");
+    }
+
+    #[test]
+    fn chat_completions_with_stream() {
+        let body = br#"{"model":"gpt-4","messages":[],"stream":true}"#;
+        let result = classify_request_body(body);
+
+        assert_eq!(
+            result.format,
+            AiRequestFormat::ChatCompletions,
+            "should be chat_completions"
+        );
+        assert_eq!(result.stream, Some(true), "stream should be extracted");
+    }
+
+    #[test]
+    fn unknown_json_no_input_no_messages() {
+        let body = br#"{"model":"gpt-4","prompt":"hello"}"#;
+        let result = classify_request_body(body);
+
+        assert_eq!(
+            result.format,
+            AiRequestFormat::UnknownJson,
+            "JSON without input or messages should be unknown"
+        );
+        assert_eq!(
+            result.model.as_deref(),
+            Some("gpt-4"),
+            "model should still be extracted"
+        );
+    }
+
+    #[test]
+    fn invalid_json() {
+        let body = b"not json at all {{{";
+        let result = classify_request_body(body);
+
+        assert_eq!(
+            result.format,
+            AiRequestFormat::InvalidJson,
+            "garbage should be invalid_json"
+        );
+        assert!(result.model.is_none(), "no model from invalid JSON");
+    }
+
+    #[test]
+    fn empty_body() {
+        let result = classify_request_body(b"");
+
+        assert_eq!(result.format, AiRequestFormat::NonJson, "empty body should be non_json");
+    }
+
+    #[test]
+    fn json_array_is_invalid() {
+        let body = b"[1, 2, 3]";
+        let result = classify_request_body(body);
+
+        assert_eq!(
+            result.format,
+            AiRequestFormat::InvalidJson,
+            "JSON array should be invalid (not an object)"
+        );
+    }
+
+    #[test]
+    fn null_previous_response_id_not_detected() {
+        let body = br#"{"model":"gpt-4.1","input":"test","previous_response_id":null}"#;
+        let result = classify_request_body(body);
+
+        assert!(
+            !result.has_previous_response_id,
+            "null previous_response_id should not be detected as present"
+        );
+    }
+
+    #[test]
+    fn null_conversation_not_detected() {
+        let body = br#"{"model":"gpt-4.1","input":"test","conversation":null}"#;
+        let result = classify_request_body(body);
+
+        assert!(
+            !result.has_conversation,
+            "null conversation should not be detected as present"
+        );
+    }
+
+    #[test]
+    fn missing_model_returns_none() {
+        let body = br#"{"input":"test"}"#;
+        let result = classify_request_body(body);
+
+        assert_eq!(
+            result.format,
+            AiRequestFormat::Responses,
+            "should still classify as responses"
+        );
+        assert!(result.model.is_none(), "missing model should return None");
+    }
+
+    #[test]
+    fn stream_and_store_absent_returns_none() {
+        let body = br#"{"model":"gpt-4.1","input":"test"}"#;
+        let result = classify_request_body(body);
+
+        assert!(result.stream.is_none(), "absent stream should be None");
+        assert!(result.store.is_none(), "absent store should be None");
+        assert!(result.background.is_none(), "absent background should be None");
+    }
+
+    #[test]
+    fn background_false_extracted() {
+        let body = br#"{"model":"gpt-4.1","input":"test","background":false}"#;
+        let result = classify_request_body(body);
+
+        assert_eq!(
+            result.background,
+            Some(false),
+            "top-level boolean background:false should be extracted"
+        );
+    }
+
+    #[test]
+    fn null_background_not_detected() {
+        let body = br#"{"model":"gpt-4.1","input":"test","background":null}"#;
+        let result = classify_request_body(body);
+
+        assert!(
+            result.background.is_none(),
+            "null background should not be detected as present"
+        );
+    }
+
+    #[test]
+    fn non_boolean_background_not_detected() {
+        let body = br#"{"model":"gpt-4.1","input":"test","background":"true"}"#;
+        let result = classify_request_body(body);
+
+        assert!(
+            result.background.is_none(),
+            "non-boolean background should not be detected as present"
+        );
+    }
+
+    #[test]
+    fn nested_background_not_detected() {
+        let body = br#"{"model":"gpt-4.1","input":[{"type":"input_image","background":true}]}"#;
+        let result = classify_request_body(body);
+
+        assert!(
+            result.background.is_none(),
+            "nested background fields should not be detected as top-level background"
+        );
+    }
+
+    #[test]
+    fn oversized_model_extracted() {
+        let long_model = "x".repeat(1024);
+        let body = format!(r#"{{"model":"{long_model}","input":"test"}}"#);
+        let result = classify_request_body(body.as_bytes());
+
+        assert_eq!(
+            result.model.as_deref(),
+            Some(long_model.as_str()),
+            "oversized model should still be extracted by classifier"
+        );
+    }
+
+    #[test]
+    fn both_input_and_messages_classifies_as_responses() {
+        let body = br#"{"model":"gpt-4.1","input":"test","messages":[{"role":"user","content":"Hi"}]}"#;
+        let result = classify_request_body(body);
+
+        assert_eq!(
+            result.format,
+            AiRequestFormat::Responses,
+            "input takes precedence when both input and messages are present"
+        );
+    }
+
+    #[test]
+    fn control_char_model_extracted() {
+        let body = b"{\"model\":\"bad\\nmodel\",\"input\":\"test\"}";
+        let result = classify_request_body(body);
+
+        assert_eq!(
+            result.model.as_deref(),
+            Some("bad\nmodel"),
+            "model with control chars should still be extracted by classifier"
+        );
+    }
+}

--- a/filter/src/builtins/http/ai/openai/responses/config.rs
+++ b/filter/src/builtins/http/ai/openai/responses/config.rs
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Configuration types for the Responses format classifier filter.
+
+use serde::Deserialize;
+
+use crate::FilterError;
+
+// -----------------------------------------------------------------------------
+// Constants
+// -----------------------------------------------------------------------------
+
+/// Default maximum request body size for `StreamBuffer` mode (64 MiB).
+///
+/// This keeps buffering bounded while covering common inline Responses
+/// payloads such as one large file and one large image data URL.
+const DEFAULT_MAX_BODY_BYTES: usize = 67_108_864; // 64 MiB
+
+// -----------------------------------------------------------------------------
+// Behavior Enums
+// -----------------------------------------------------------------------------
+
+/// Behavior when the request body is not a recognized AI API format.
+///
+/// When set to `reject`, bodies that are not valid Responses or Chat
+/// Completions requests are rejected with HTTP 400. This includes
+/// invalid JSON, non-JSON bodies, and valid JSON that does not
+/// contain `input` or `messages`.
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum OnInvalidBehavior {
+    /// Continue processing. Classification facts are still recorded
+    /// for any format that can be determined.
+    #[default]
+    Continue,
+
+    /// Reject the request with HTTP 400.
+    Reject,
+}
+
+// -----------------------------------------------------------------------------
+// ResponsesFormatHeaders
+// -----------------------------------------------------------------------------
+
+/// Configurable header names for promoted classification facts.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ResponsesFormatHeaders {
+    /// Header name for the detected format (e.g. `responses`, `chat_completions`).
+    #[serde(default = "default_format_header")]
+    pub format: Option<String>,
+
+    /// Header name for the extracted model value.
+    #[serde(default = "default_model_header")]
+    pub model: Option<String>,
+
+    /// Header name for the extracted stream flag.
+    #[serde(default = "default_stream_header")]
+    pub stream: Option<String>,
+}
+
+impl Default for ResponsesFormatHeaders {
+    fn default() -> Self {
+        Self {
+            format: default_format_header(),
+            model: default_model_header(),
+            stream: default_stream_header(),
+        }
+    }
+}
+
+/// Default format header name.
+#[allow(
+    clippy::unnecessary_wraps,
+    reason = "serde default functions require Option return type"
+)]
+fn default_format_header() -> Option<String> {
+    Some("x-praxis-ai-format".to_owned())
+}
+
+/// Default model header name.
+#[allow(
+    clippy::unnecessary_wraps,
+    reason = "serde default functions require Option return type"
+)]
+fn default_model_header() -> Option<String> {
+    Some("x-praxis-ai-model".to_owned())
+}
+
+/// Default stream header name.
+#[allow(
+    clippy::unnecessary_wraps,
+    reason = "serde default functions require Option return type"
+)]
+fn default_stream_header() -> Option<String> {
+    Some("x-praxis-ai-stream".to_owned())
+}
+
+// -----------------------------------------------------------------------------
+// ResponsesFormatConfig
+// -----------------------------------------------------------------------------
+
+/// YAML configuration for the [`ResponsesFormatFilter`].
+///
+/// [`ResponsesFormatFilter`]: super::ResponsesFormatFilter
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ResponsesFormatConfig {
+    /// Behavior when the body cannot be classified.
+    #[serde(default)]
+    pub on_invalid: OnInvalidBehavior,
+
+    /// Maximum body size in bytes for `StreamBuffer` mode.
+    #[serde(default = "default_max_body_bytes")]
+    pub max_body_bytes: usize,
+
+    /// Header names for promoted classification facts.
+    #[serde(default)]
+    pub headers: ResponsesFormatHeaders,
+}
+
+/// Default max body bytes.
+fn default_max_body_bytes() -> usize {
+    DEFAULT_MAX_BODY_BYTES
+}
+
+// -----------------------------------------------------------------------------
+// Config Validation
+// -----------------------------------------------------------------------------
+
+/// Validate the parsed configuration.
+pub(crate) fn build_config(cfg: ResponsesFormatConfig) -> Result<ResponsesFormatConfig, FilterError> {
+    if cfg.max_body_bytes == 0 {
+        return Err("responses_format: 'max_body_bytes' must be greater than 0".into());
+    }
+
+    validate_header_name("format", cfg.headers.format.as_deref())?;
+    validate_header_name("model", cfg.headers.model.as_deref())?;
+    validate_header_name("stream", cfg.headers.stream.as_deref())?;
+
+    Ok(cfg)
+}
+
+/// Validate a configured header name using the HTTP header-name parser.
+fn validate_header_name(field: &str, header_name: Option<&str>) -> Result<(), FilterError> {
+    let Some(header_name) = header_name else {
+        return Ok(());
+    };
+    if header_name.is_empty() {
+        return Err(format!("responses_format: {field} header name must not be empty").into());
+    }
+    if http::HeaderName::from_bytes(header_name.as_bytes()).is_err() {
+        return Err(format!("responses_format: {field} header name is not a valid HTTP header name").into());
+    }
+    Ok(())
+}

--- a/filter/src/builtins/http/ai/openai/responses/mod.rs
+++ b/filter/src/builtins/http/ai/openai/responses/mod.rs
@@ -1,0 +1,278 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Responses API format classifier filter.
+//!
+//! Classifies request bodies as Responses API, Chat Completions,
+//! unknown JSON, invalid JSON, or non-JSON. Promotes classification
+//! facts to configurable headers, durable metadata, and filter
+//! results for routing. Does not mutate the request body.
+
+pub(crate) mod classify;
+mod config;
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    clippy::needless_raw_strings,
+    clippy::needless_raw_string_hashes,
+    clippy::too_many_lines,
+    reason = "tests"
+)]
+mod tests;
+
+use std::borrow::Cow;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use tracing::{debug, trace};
+
+use self::{
+    classify::{AiRequestFormat, classify_request_body},
+    config::{OnInvalidBehavior, ResponsesFormatConfig, build_config},
+};
+
+// -----------------------------------------------------------------------------
+// Constants
+// -----------------------------------------------------------------------------
+
+/// Maximum length of a body-derived value promoted to headers or filter results.
+const MAX_PROMOTED_VALUE_LEN: usize = 256;
+use crate::{
+    FilterAction, FilterError, Rejection,
+    body::{BodyAccess, BodyMode},
+    builtins::http::value_safety::is_safe_promoted_value,
+    factory::parse_filter_config,
+    filter::{HttpFilter, HttpFilterContext},
+};
+
+// -----------------------------------------------------------------------------
+// ResponsesFormatFilter
+// -----------------------------------------------------------------------------
+
+/// Classifies AI API request bodies and promotes routing facts to
+/// headers, metadata, and filter results without mutating the body.
+///
+/// # YAML
+///
+/// ```yaml
+/// filter: responses_format
+/// ```
+///
+/// # Full YAML
+///
+/// ```yaml
+/// filter: responses_format
+/// on_invalid: continue
+/// max_body_bytes: 67108864
+/// headers:
+///   format: x-praxis-ai-format
+///   model: x-praxis-ai-model
+///   stream: x-praxis-ai-stream
+/// ```
+pub struct ResponsesFormatFilter {
+    /// Parsed and validated configuration.
+    config: ResponsesFormatConfig,
+}
+
+impl ResponsesFormatFilter {
+    /// Create a filter from parsed YAML config.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FilterError`] if the YAML config is invalid.
+    ///
+    /// [`FilterError`]: crate::FilterError
+    pub fn from_config(config: &serde_yaml::Value) -> Result<Box<dyn HttpFilter>, FilterError> {
+        let cfg: ResponsesFormatConfig = parse_filter_config("responses_format", config)?;
+        let validated = build_config(cfg)?;
+        Ok(Box::new(Self { config: validated }))
+    }
+}
+
+#[async_trait]
+impl HttpFilter for ResponsesFormatFilter {
+    fn name(&self) -> &'static str {
+        "responses_format"
+    }
+
+    fn request_body_access(&self) -> BodyAccess {
+        BodyAccess::ReadOnly
+    }
+
+    fn request_body_mode(&self) -> BodyMode {
+        BodyMode::StreamBuffer {
+            max_bytes: Some(self.config.max_body_bytes),
+        }
+    }
+
+    async fn on_request(&self, _ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
+        Ok(FilterAction::Continue)
+    }
+
+    async fn on_request_body(
+        &self,
+        ctx: &mut HttpFilterContext<'_>,
+        body: &mut Option<Bytes>,
+        end_of_stream: bool,
+    ) -> Result<FilterAction, FilterError> {
+        if !end_of_stream {
+            return Ok(FilterAction::Continue);
+        }
+
+        let bytes = match body.as_ref() {
+            Some(b) => b.as_ref(),
+            None => &[],
+        };
+
+        let classified = classify_request_body(bytes);
+
+        debug!(
+            format = classified.format.as_str(),
+            model = ?classified.model,
+            "classified request body"
+        );
+
+        if let Some(action) = handle_invalid_format(classified.format, &self.config) {
+            return Ok(action);
+        }
+
+        write_metadata(ctx, &classified);
+        promote_headers(ctx, &classified, &self.config);
+        promote_filter_results(ctx, &classified)?;
+
+        Ok(FilterAction::Release)
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------------
+
+/// Check whether the format requires rejection.
+fn handle_invalid_format(format: AiRequestFormat, config: &ResponsesFormatConfig) -> Option<FilterAction> {
+    match config.on_invalid {
+        OnInvalidBehavior::Continue => None,
+        OnInvalidBehavior::Reject => {
+            let message = match format {
+                AiRequestFormat::InvalidJson => "invalid JSON body",
+                AiRequestFormat::NonJson => "request body is not JSON",
+                AiRequestFormat::UnknownJson => "unrecognized AI API format",
+                AiRequestFormat::Responses | AiRequestFormat::ChatCompletions => return None,
+            };
+
+            trace!(reason = message, "rejecting unrecognized body");
+            Some(FilterAction::Reject(
+                Rejection::status(400)
+                    .with_header("content-type", "application/json")
+                    .with_body(Bytes::from(format!(
+                        r#"{{"error":{{"message":"{message}","type":"invalid_request_error"}}}}"#
+                    ))),
+            ))
+        },
+    }
+}
+
+/// Write durable metadata that persists across all Pingora lifecycle phases.
+fn write_metadata(ctx: &mut HttpFilterContext<'_>, classified: &classify::ClassifiedRequest) {
+    let format_str = classified.format.as_str();
+    ctx.set_metadata("responses_format.format", format_str);
+
+    if let Some(model) = &classified.model
+        && is_safe_promoted_value(model)
+    {
+        ctx.set_metadata("responses_format.model", model.clone());
+    }
+
+    if let Some(stream) = classified.stream {
+        ctx.set_metadata("responses_format.stream", if stream { "true" } else { "false" });
+    }
+
+    if let Some(store) = classified.store {
+        ctx.set_metadata("responses_format.store", if store { "true" } else { "false" });
+    }
+
+    if let Some(background) = classified.background {
+        ctx.set_metadata("responses_format.background", if background { "true" } else { "false" });
+    }
+
+    if classified.has_previous_response_id {
+        ctx.set_metadata("responses_format.has_previous_response_id", "true");
+    }
+
+    if classified.has_conversation {
+        ctx.set_metadata("responses_format.has_conversation", "true");
+    }
+}
+
+/// Promote classification facts to configurable request headers.
+fn promote_headers(
+    ctx: &mut HttpFilterContext<'_>,
+    classified: &classify::ClassifiedRequest,
+    config: &ResponsesFormatConfig,
+) {
+    if let Some(header) = &config.headers.format {
+        let format_str = classified.format.as_str();
+        ctx.extra_request_headers
+            .push((Cow::Owned(header.clone()), format_str.to_owned()));
+    }
+
+    if let Some(header) = &config.headers.model
+        && let Some(model) = &classified.model
+        && is_safe_promoted_value(model)
+        && model.len() <= MAX_PROMOTED_VALUE_LEN
+    {
+        ctx.extra_request_headers
+            .push((Cow::Owned(header.clone()), model.clone()));
+    }
+
+    if let Some(header) = &config.headers.stream
+        && let Some(stream) = classified.stream
+    {
+        let val = if stream { "true" } else { "false" };
+        ctx.extra_request_headers
+            .push((Cow::Owned(header.clone()), val.to_owned()));
+    }
+}
+
+/// Promote classification facts to filter results for branch conditions.
+fn promote_filter_results(
+    ctx: &mut HttpFilterContext<'_>,
+    classified: &classify::ClassifiedRequest,
+) -> Result<(), FilterError> {
+    let results = ctx.filter_results.entry("responses_format").or_default();
+
+    results.set("format", classified.format.as_str())?;
+
+    if let Some(model) = &classified.model
+        && is_safe_promoted_value(model)
+        && model.len() <= MAX_PROMOTED_VALUE_LEN
+    {
+        results.set("model", model.clone())?;
+    }
+
+    if let Some(stream) = classified.stream {
+        results.set("stream", if stream { "true" } else { "false" })?;
+    }
+
+    if let Some(store) = classified.store {
+        results.set("store", if store { "true" } else { "false" })?;
+    }
+
+    if let Some(background) = classified.background {
+        results.set("background", if background { "true" } else { "false" })?;
+    }
+
+    if classified.has_previous_response_id {
+        results.set("has_previous_response_id", "true")?;
+    }
+
+    if classified.has_conversation {
+        results.set("has_conversation", "true")?;
+    }
+
+    Ok(())
+}

--- a/filter/src/builtins/http/ai/openai/responses/tests.rs
+++ b/filter/src/builtins/http/ai/openai/responses/tests.rs
@@ -1,0 +1,446 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Unit tests for the `responses_format` filter.
+
+use bytes::Bytes;
+
+use super::*;
+
+// -----------------------------------------------------------------------------
+// Config Parsing
+// -----------------------------------------------------------------------------
+
+#[test]
+fn default_config_parses() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str("{}").unwrap();
+    let filter = ResponsesFormatFilter::from_config(&yaml).unwrap();
+    assert_eq!(
+        filter.name(),
+        "responses_format",
+        "filter name should be responses_format"
+    );
+}
+
+#[test]
+fn full_config_parses() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+on_invalid: reject
+max_body_bytes: 65536
+headers:
+  format: x-custom-format
+  model: x-custom-model
+  stream: x-custom-stream
+"#,
+    )
+    .unwrap();
+
+    let filter = ResponsesFormatFilter::from_config(&yaml).unwrap();
+    assert_eq!(
+        filter.name(),
+        "responses_format",
+        "filter name should be responses_format"
+    );
+}
+
+#[test]
+fn on_invalid_continue_parses() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str("on_invalid: continue").unwrap();
+    let filter = ResponsesFormatFilter::from_config(&yaml).unwrap();
+    assert_eq!(filter.name(), "responses_format", "continue mode should parse");
+}
+
+#[test]
+fn on_invalid_reject_parses() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str("on_invalid: reject").unwrap();
+    let filter = ResponsesFormatFilter::from_config(&yaml).unwrap();
+    assert_eq!(filter.name(), "responses_format", "reject mode should parse");
+}
+
+#[test]
+fn deny_unknown_fields_rejects_typo() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str("on_invlid: continue").unwrap();
+    let result = ResponsesFormatFilter::from_config(&yaml);
+    assert!(result.is_err(), "typo in config field should be rejected");
+}
+
+#[test]
+fn zero_max_body_bytes_rejected() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str("max_body_bytes: 0").unwrap();
+    let result = ResponsesFormatFilter::from_config(&yaml);
+    assert!(result.is_err(), "zero max_body_bytes should be rejected");
+}
+
+#[test]
+fn invalid_header_name_rejected() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+headers:
+  format: "invalid header name with spaces"
+"#,
+    )
+    .unwrap();
+    let result = ResponsesFormatFilter::from_config(&yaml);
+    assert!(result.is_err(), "header name with spaces should be rejected");
+}
+
+#[test]
+fn empty_header_name_rejected() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+headers:
+  model: ""
+"#,
+    )
+    .unwrap();
+    let result = ResponsesFormatFilter::from_config(&yaml);
+    assert!(result.is_err(), "empty header name should be rejected");
+}
+
+#[test]
+fn null_header_disables_promotion() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+headers:
+  format: null
+  model: null
+  stream: null
+"#,
+    )
+    .unwrap();
+    let filter = ResponsesFormatFilter::from_config(&yaml).unwrap();
+    assert_eq!(
+        filter.name(),
+        "responses_format",
+        "null headers should disable promotion"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Body Access
+// -----------------------------------------------------------------------------
+
+#[test]
+fn body_access_is_read_only() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str("{}").unwrap();
+    let filter = ResponsesFormatFilter::from_config(&yaml).unwrap();
+    assert_eq!(
+        filter.request_body_access(),
+        BodyAccess::ReadOnly,
+        "classifier must not mutate the body"
+    );
+}
+
+#[test]
+fn body_mode_is_stream_buffer() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str("{}").unwrap();
+    let filter = ResponsesFormatFilter::from_config(&yaml).unwrap();
+    match filter.request_body_mode() {
+        BodyMode::StreamBuffer { max_bytes } => {
+            assert_eq!(
+                max_bytes,
+                Some(67_108_864),
+                "StreamBuffer should default to a bounded 64 MiB limit"
+            );
+        },
+        other => panic!("expected StreamBuffer, got {other:?}"),
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Handle Invalid Format
+// -----------------------------------------------------------------------------
+
+#[test]
+fn invalid_json_continue_returns_none() {
+    let cfg: ResponsesFormatConfig = serde_yaml::from_str("on_invalid: continue").unwrap();
+    let result = handle_invalid_format(AiRequestFormat::InvalidJson, &cfg);
+    assert!(result.is_none(), "continue mode should return None for invalid JSON");
+}
+
+#[test]
+fn invalid_json_reject_returns_reject() {
+    let cfg: ResponsesFormatConfig = serde_yaml::from_str("on_invalid: reject").unwrap();
+    let result = handle_invalid_format(AiRequestFormat::InvalidJson, &cfg);
+    assert!(result.is_some(), "reject mode should return Reject for invalid JSON");
+}
+
+#[test]
+fn non_json_continue_returns_none() {
+    let cfg: ResponsesFormatConfig = serde_yaml::from_str("on_invalid: continue").unwrap();
+    let result = handle_invalid_format(AiRequestFormat::NonJson, &cfg);
+    assert!(result.is_none(), "continue mode should return None for non-JSON");
+}
+
+#[test]
+fn non_json_reject_returns_reject() {
+    let cfg: ResponsesFormatConfig = serde_yaml::from_str("on_invalid: reject").unwrap();
+    let result = handle_invalid_format(AiRequestFormat::NonJson, &cfg);
+    assert!(result.is_some(), "reject mode should return Reject for non-JSON");
+}
+
+#[test]
+fn responses_format_not_rejected() {
+    let cfg: ResponsesFormatConfig = serde_yaml::from_str("on_invalid: reject").unwrap();
+    let result = handle_invalid_format(AiRequestFormat::Responses, &cfg);
+    assert!(result.is_none(), "responses format should not be rejected");
+}
+
+#[test]
+fn chat_completions_not_rejected() {
+    let cfg: ResponsesFormatConfig = serde_yaml::from_str("on_invalid: reject").unwrap();
+    let result = handle_invalid_format(AiRequestFormat::ChatCompletions, &cfg);
+    assert!(result.is_none(), "chat_completions format should not be rejected");
+}
+
+#[test]
+fn unknown_json_rejected_in_reject_mode() {
+    let cfg: ResponsesFormatConfig = serde_yaml::from_str("on_invalid: reject").unwrap();
+    let result = handle_invalid_format(AiRequestFormat::UnknownJson, &cfg);
+    assert!(result.is_some(), "unknown JSON should be rejected in reject mode");
+}
+
+#[test]
+fn unknown_json_continues_in_continue_mode() {
+    let cfg: ResponsesFormatConfig = serde_yaml::from_str("on_invalid: continue").unwrap();
+    let result = handle_invalid_format(AiRequestFormat::UnknownJson, &cfg);
+    assert!(result.is_none(), "unknown JSON should continue in continue mode");
+}
+
+// -----------------------------------------------------------------------------
+// Full Reject-Path Tests (on_request_body)
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn on_request_body_rejects_unknown_json() {
+    let action = run_filter_raw("on_invalid: reject", r#"{"prompt":"hello"}"#).await;
+    assert!(
+        matches!(action, FilterAction::Reject(_)),
+        "unknown JSON should be rejected"
+    );
+}
+
+#[tokio::test]
+async fn on_request_body_rejects_invalid_json() {
+    let action = run_filter_raw("on_invalid: reject", "not json {{{").await;
+    assert!(
+        matches!(action, FilterAction::Reject(_)),
+        "invalid JSON should be rejected"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Promotion Tests (on_request_body)
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn promotes_headers_for_full_responses_request() {
+    let ctx = run_filter("{}", FULL_RESPONSES_BODY).await;
+    let headers = collect_headers(&ctx);
+
+    assert_eq!(headers.get("x-praxis-ai-format"), Some(&"responses"), "format header");
+    assert_eq!(headers.get("x-praxis-ai-model"), Some(&"gpt-4.1"), "model header");
+    assert_eq!(headers.get("x-praxis-ai-stream"), Some(&"true"), "stream header");
+    assert!(
+        !headers.contains_key("x-praxis-ai-background"),
+        "background should not have a default header"
+    );
+}
+
+#[tokio::test]
+async fn promotes_metadata_for_full_responses_request() {
+    let ctx = run_filter("{}", FULL_RESPONSES_BODY).await;
+
+    assert_eq!(
+        ctx.filter_metadata.get("responses_format.format").map(String::as_str),
+        Some("responses")
+    );
+    assert_eq!(
+        ctx.filter_metadata.get("responses_format.model").map(String::as_str),
+        Some("gpt-4.1")
+    );
+    assert_eq!(
+        ctx.filter_metadata.get("responses_format.stream").map(String::as_str),
+        Some("true")
+    );
+    assert_eq!(
+        ctx.filter_metadata.get("responses_format.store").map(String::as_str),
+        Some("false")
+    );
+    assert_eq!(
+        ctx.filter_metadata
+            .get("responses_format.background")
+            .map(String::as_str),
+        Some("true")
+    );
+    assert_eq!(
+        ctx.filter_metadata
+            .get("responses_format.has_previous_response_id")
+            .map(String::as_str),
+        Some("true")
+    );
+    assert_eq!(
+        ctx.filter_metadata
+            .get("responses_format.has_conversation")
+            .map(String::as_str),
+        Some("true")
+    );
+}
+
+#[tokio::test]
+async fn promotes_filter_results_for_full_responses_request() {
+    let ctx = run_filter("{}", FULL_RESPONSES_BODY).await;
+    let results = ctx.filter_results.get("responses_format").unwrap();
+
+    assert_eq!(results.get("format"), Some("responses"));
+    assert_eq!(results.get("model"), Some("gpt-4.1"));
+    assert_eq!(results.get("stream"), Some("true"));
+    assert_eq!(results.get("store"), Some("false"));
+    assert_eq!(results.get("background"), Some("true"));
+    assert_eq!(results.get("has_previous_response_id"), Some("true"));
+    assert_eq!(results.get("has_conversation"), Some("true"));
+}
+
+#[tokio::test]
+async fn missing_optional_facts_not_promoted() {
+    let ctx = run_filter("{}", r#"{"input":"test"}"#).await;
+    let headers = collect_headers(&ctx);
+
+    assert_eq!(
+        headers.get("x-praxis-ai-format"),
+        Some(&"responses"),
+        "format still promoted"
+    );
+    assert!(!headers.contains_key("x-praxis-ai-model"), "model header absent");
+    assert!(!headers.contains_key("x-praxis-ai-stream"), "stream header absent");
+    assert!(
+        !ctx.filter_metadata.contains_key("responses_format.model"),
+        "model metadata absent"
+    );
+    assert!(
+        !ctx.filter_metadata.contains_key("responses_format.stream"),
+        "stream metadata absent"
+    );
+    assert!(
+        !ctx.filter_metadata.contains_key("responses_format.store"),
+        "store metadata absent"
+    );
+    assert!(
+        !ctx.filter_metadata.contains_key("responses_format.background"),
+        "background metadata absent"
+    );
+    assert!(
+        !ctx.filter_metadata
+            .contains_key("responses_format.has_previous_response_id"),
+        "prev_id metadata absent"
+    );
+    assert!(
+        !ctx.filter_metadata.contains_key("responses_format.has_conversation"),
+        "conversation metadata absent"
+    );
+}
+
+#[tokio::test]
+async fn oversized_model_not_promoted_to_header_or_results() {
+    let long_model = "x".repeat(300);
+    let body_str = format!(r#"{{"model":"{long_model}","input":"test"}}"#);
+    let ctx = run_filter("{}", &body_str).await;
+    let headers = collect_headers(&ctx);
+
+    assert!(
+        !headers.contains_key("x-praxis-ai-model"),
+        "oversized model not in header"
+    );
+    let results = ctx.filter_results.get("responses_format").unwrap();
+    assert!(results.get("model").is_none(), "oversized model not in results");
+}
+
+#[tokio::test]
+async fn control_char_model_not_promoted() {
+    let ctx = run_filter("{}", "{\"model\":\"bad\\nmodel\",\"input\":\"test\"}").await;
+    let headers = collect_headers(&ctx);
+
+    assert!(
+        !headers.contains_key("x-praxis-ai-model"),
+        "control-char model not in header"
+    );
+}
+
+#[tokio::test]
+async fn custom_headers_emitted_at_runtime() {
+    let cfg = "headers:\n  format: x-custom-fmt\n  model: x-custom-mdl\n  stream: x-custom-strm";
+    let ctx = run_filter(cfg, r#"{"model":"gpt-4.1","input":"test","stream":true}"#).await;
+    let headers = collect_headers(&ctx);
+
+    assert_eq!(headers.get("x-custom-fmt"), Some(&"responses"), "custom format");
+    assert_eq!(headers.get("x-custom-mdl"), Some(&"gpt-4.1"), "custom model");
+    assert_eq!(headers.get("x-custom-strm"), Some(&"true"), "custom stream");
+    assert!(
+        !headers.contains_key("x-praxis-ai-format"),
+        "default not emitted when overridden"
+    );
+}
+
+#[tokio::test]
+async fn null_headers_suppress_emission() {
+    let cfg = "headers:\n  format: null\n  model: null\n  stream: null";
+    let ctx = run_filter(cfg, r#"{"model":"gpt-4.1","input":"test","stream":true}"#).await;
+
+    assert!(
+        ctx.extra_request_headers.is_empty(),
+        "null headers suppress all emission"
+    );
+    assert_eq!(
+        ctx.filter_metadata.get("responses_format.format").map(String::as_str),
+        Some("responses"),
+        "metadata still written with null headers"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Test Utilities
+// -----------------------------------------------------------------------------
+
+/// Full Responses body with all optional fields for promotion tests.
+const FULL_RESPONSES_BODY: &str = r#"{"model":"gpt-4.1","input":"test","stream":true,"store":false,"background":true,"previous_response_id":"resp_abc","conversation":{"id":"conv_1"}}"#;
+
+/// Run the filter's `on_request_body` and return the resulting context.
+async fn run_filter(config_yaml: &str, body_str: &str) -> HttpFilterContext<'static> {
+    let filter = make_filter(config_yaml);
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+
+    let req: &'static crate::context::Request = Box::leak(Box::new(req));
+    let mut ctx = crate::test_utils::make_filter_context(req);
+    let mut body = Some(Bytes::from(body_str.to_owned()));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(matches!(action, FilterAction::Release), "filter should release");
+    ctx
+}
+
+/// Collect extra request headers into a map for assertion.
+fn collect_headers<'a>(ctx: &'a HttpFilterContext<'_>) -> std::collections::HashMap<&'a str, &'a str> {
+    ctx.extra_request_headers
+        .iter()
+        .map(|(k, v)| (k.as_ref(), v.as_str()))
+        .collect()
+}
+
+/// Run the filter's `on_request_body` and return the raw action.
+async fn run_filter_raw(config_yaml: &str, body_str: &str) -> FilterAction {
+    let filter = make_filter(config_yaml);
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+
+    let req: &'static crate::context::Request = Box::leak(Box::new(req));
+    let mut ctx = crate::test_utils::make_filter_context(req);
+    let mut body = Some(Bytes::from(body_str.to_owned()));
+
+    filter.on_request_body(&mut ctx, &mut body, true).await.unwrap()
+}
+
+/// Build a `ResponsesFormatFilter` from a YAML snippet.
+fn make_filter(yaml_str: &str) -> Box<dyn HttpFilter> {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(yaml_str).unwrap();
+    ResponsesFormatFilter::from_config(&yaml).unwrap()
+}

--- a/filter/src/builtins/http/mod.rs
+++ b/filter/src/builtins/http/mod.rs
@@ -9,11 +9,14 @@ pub(crate) mod payload_processing;
 mod security;
 mod traffic_management;
 mod transformation;
+pub(crate) mod value_safety;
 
 #[cfg(feature = "ai-inference")]
 pub use ai::ModelToHeaderFilter;
 #[cfg(feature = "ai-inference")]
 pub use ai::PromptEnrichFilter;
+#[cfg(feature = "ai-inference")]
+pub use ai::ResponsesFormatFilter;
 pub use ai::{A2aFilter, JsonRpcFilter, McpFilter};
 pub use observability::{AccessLogFilter, RequestIdFilter};
 pub use payload_processing::{CompressionFilter, JsonBodyFieldFilter};

--- a/filter/src/builtins/http/payload_processing/json_body_field/extract.rs
+++ b/filter/src/builtins/http/payload_processing/json_body_field/extract.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2024 Shane Utt
 
-//! Field extraction logic and control character validation.
+//! Field extraction logic and header-value validation.
 
 use std::borrow::Cow;
 
@@ -12,7 +12,7 @@ use tracing::{trace, warn};
 // -----------------------------------------------------------------------------
 
 /// Extract mapped JSON fields into request headers, skipping values
-/// with control characters. Returns `true` if any field was promoted.
+/// that are not safe header values. Returns `true` if any field was promoted.
 pub(super) fn extract_fields(
     mappings: &[(String, String)],
     value: &serde_json::Value,
@@ -29,7 +29,7 @@ pub(super) fn extract_fields(
                 warn!(
                     field = %field,
                     header = %header,
-                    "skipping header injection: value contains control characters"
+                    "skipping header injection: value is not safe for header promotion"
                 );
                 continue;
             }
@@ -47,7 +47,7 @@ pub(super) fn extract_fields(
 }
 
 // -----------------------------------------------------------------------------
-// Control Character Validation
+// Header Value Validation
 // -----------------------------------------------------------------------------
 
-pub(super) use crate::builtins::http::ai::agentic::json_rpc::contains_control_chars;
+pub(super) use crate::builtins::http::value_safety::contains_control_chars;

--- a/filter/src/builtins/http/value_safety.rs
+++ b/filter/src/builtins/http/value_safety.rs
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Shared value-safety helpers for HTTP body-derived data promotion.
+
+// -----------------------------------------------------------------------------
+// Header Value Safety
+// -----------------------------------------------------------------------------
+
+/// Returns `true` if `s` is safe to promote to an HTTP header value.
+///
+/// Body-derived values that are promoted to metadata or filter results use
+/// the same rule as headers so every promotion sink has one safety policy.
+pub(crate) fn is_safe_promoted_value(s: &str) -> bool {
+    http::HeaderValue::from_str(s).is_ok()
+}
+
+/// Returns `true` if `s` is unsafe to promote to headers or metadata.
+pub(crate) fn contains_control_chars(s: &str) -> bool {
+    !is_safe_promoted_value(s)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn promoted_value_allows_visible_ascii() {
+        assert!(is_safe_promoted_value("gpt-4.1-mini"));
+    }
+
+    #[test]
+    fn promoted_value_rejects_newline() {
+        assert!(!is_safe_promoted_value("bad\nvalue"));
+    }
+
+    #[test]
+    fn promoted_value_allows_tab() {
+        assert!(is_safe_promoted_value("bad\tvalue"));
+    }
+}

--- a/filter/src/builtins/mod.rs
+++ b/filter/src/builtins/mod.rs
@@ -10,6 +10,8 @@ mod tcp;
 pub use http::ModelToHeaderFilter;
 #[cfg(feature = "ai-inference")]
 pub use http::PromptEnrichFilter;
+#[cfg(feature = "ai-inference")]
+pub use http::ResponsesFormatFilter;
 pub use http::{
     A2aFilter, AccessLogFilter, CircuitBreakerFilter, CompressionFilter, CorsFilter, CredentialInjectionFilter,
     CsrfFilter, DisallowedOriginMode, ForwardedHeadersFilter, GrpcDetectionFilter, GuardrailsAction, GuardrailsFilter,

--- a/filter/src/lib.rs
+++ b/filter/src/lib.rs
@@ -26,6 +26,8 @@ pub use any_filter::AnyFilter;
 pub use body::{BodyAccess, BodyBuffer, BodyBufferOverflow, BodyCapabilities, BodyMode};
 #[cfg(feature = "ai-inference")]
 pub use builtins::PromptEnrichFilter;
+#[cfg(feature = "ai-inference")]
+pub use builtins::ResponsesFormatFilter;
 pub use builtins::{
     CircuitBreakerFilter, CredentialInjectionFilter, DisallowedOriginMode, GuardrailsAction, GuardrailsFilter,
     LoadBalancerFilter, RateLimitMode, RedirectStatus, RouterFilter, RuleTargetKind, has_dot_dot_traversal,

--- a/filter/src/registry.rs
+++ b/filter/src/registry.rs
@@ -155,6 +155,12 @@ fn register_http_builtins(factories: &mut HashMap<String, FilterFactory>) {
         "prompt_enrich",
         crate::builtins::PromptEnrichFilter::from_config,
     );
+    #[cfg(feature = "ai-inference")]
+    register_http(
+        factories,
+        "responses_format",
+        crate::builtins::ResponsesFormatFilter::from_config,
+    );
 }
 
 /// Register a single HTTP filter factory by name.
@@ -270,6 +276,11 @@ mod tests {
         );
         #[cfg(feature = "ai-inference")]
         assert!(names.contains(&"prompt_enrich"), "prompt_enrich should be registered");
+        #[cfg(feature = "ai-inference")]
+        assert!(
+            names.contains(&"responses_format"),
+            "responses_format should be registered"
+        );
     }
 
     #[test]

--- a/protocol/src/http/pingora/context.rs
+++ b/protocol/src/http/pingora/context.rs
@@ -75,6 +75,13 @@ pub struct PingoraRequestCtx {
     /// before Pingora sends headers to the backend.
     pub mutated_request_body_len: Option<usize>,
 
+    /// Filter results from body pre-read. Carried into the next
+    /// [`HttpFilterContext`] so that branch chains attached to the
+    /// first `on_request` filter can evaluate body-derived results.
+    ///
+    /// [`HttpFilterContext`]: praxis_filter::HttpFilterContext
+    pub filter_results: std::collections::HashMap<&'static str, praxis_filter::FilterResultSet>,
+
     /// Cluster name snapshot retained for metrics emission in the
     /// `logging()` hook, after `cluster` has been consumed by filter
     /// context construction.
@@ -185,7 +192,7 @@ macro_rules! filter_context {
             request_headers_to_remove: Vec::new(),
             request_headers_to_set: Vec::new(),
             filter_metadata: std::mem::take(&mut $ctx.filter_metadata),
-            filter_results: std::collections::HashMap::new(),
+            filter_results: std::mem::take(&mut $ctx.filter_results),
             health_registry: $pipeline.health_registry(),
             kv_stores: $pipeline.kv_stores(),
             request: $request,
@@ -273,6 +280,10 @@ impl PingoraRequestCtx {
 }
 
 impl Default for PingoraRequestCtx {
+    #[allow(
+        clippy::too_many_lines,
+        reason = "context default enumerates all lifecycle fields explicitly"
+    )]
     fn default() -> Self {
         Self {
             _connection_permit: None,
@@ -283,6 +294,7 @@ impl Default for PingoraRequestCtx {
             downstream_tls: false,
             filter_metadata: std::collections::HashMap::new(),
             mutated_request_body_len: None,
+            filter_results: std::collections::HashMap::new(),
             metrics_cluster: None,
             pre_read_body: None,
             request_body_buffer: None,

--- a/protocol/src/http/pingora/handler/request_filter/stream_buffer.rs
+++ b/protocol/src/http/pingora/handler/request_filter/stream_buffer.rs
@@ -167,6 +167,7 @@ pub(super) async fn pre_read_body(
         ctx.rewritten_path = filter_ctx.rewritten_path;
         ctx.upstream = filter_ctx.upstream;
         ctx.filter_metadata = filter_ctx.filter_metadata;
+        ctx.filter_results = filter_ctx.filter_results;
         all_extra_headers.extend(filter_ctx.extra_request_headers);
 
         match action {

--- a/tests/integration/tests/suite/examples/mod.rs
+++ b/tests/integration/tests/suite/examples/mod.rs
@@ -36,6 +36,8 @@ mod payload_processing;
 mod prompt_enrichment;
 mod protocols;
 mod redirect;
+#[cfg(feature = "ai-inference")]
+mod responses_format;
 mod round_robin;
 mod session_affinity;
 mod static_response;

--- a/tests/integration/tests/suite/examples/responses_format.rs
+++ b/tests/integration/tests/suite/examples/responses_format.rs
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Functional tests for the OpenAI Responses format-routing example config.
+
+use std::collections::HashMap;
+
+use praxis_test_utils::{
+    free_port, http_send, json_post, load_example_config, parse_body, parse_status, start_backend_with_shutdown,
+    start_proxy,
+};
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn responses_format_routing_example_routes_responses_input() {
+    let responses_guard = start_backend_with_shutdown("responses-backend");
+    let chat_guard = start_backend_with_shutdown("chat-backend");
+    let default_guard = start_backend_with_shutdown("default-backend");
+    let proxy_port = free_port();
+
+    let config = load_example_config(
+        "ai/openai/responses/format-routing.yaml",
+        proxy_port,
+        HashMap::from([
+            ("127.0.0.1:3001", responses_guard.port()),
+            ("127.0.0.1:3002", chat_guard.port()),
+            ("127.0.0.1:3003", default_guard.port()),
+        ]),
+    );
+    let proxy = start_proxy(&config);
+
+    let body = r#"{"model":"gpt-4.1-mini","input":"Hello, world!"}"#;
+    let raw = http_send(proxy.addr(), &json_post("/v1/responses", body));
+
+    assert_eq!(parse_status(&raw), 200, "responses request should return 200");
+    assert_eq!(
+        parse_body(&raw),
+        "responses-backend",
+        "responses input should route to responses-backend cluster"
+    );
+}
+
+#[test]
+fn responses_format_routing_example_routes_chat_completions() {
+    let responses_guard = start_backend_with_shutdown("responses-backend");
+    let chat_guard = start_backend_with_shutdown("chat-backend");
+    let default_guard = start_backend_with_shutdown("default-backend");
+    let proxy_port = free_port();
+
+    let config = load_example_config(
+        "ai/openai/responses/format-routing.yaml",
+        proxy_port,
+        HashMap::from([
+            ("127.0.0.1:3001", responses_guard.port()),
+            ("127.0.0.1:3002", chat_guard.port()),
+            ("127.0.0.1:3003", default_guard.port()),
+        ]),
+    );
+    let proxy = start_proxy(&config);
+
+    let body = r#"{"model":"gpt-4","messages":[{"role":"user","content":"Hi"}]}"#;
+    let raw = http_send(proxy.addr(), &json_post("/v1/chat/completions", body));
+
+    assert_eq!(parse_status(&raw), 200, "chat completions should return 200");
+    assert_eq!(
+        parse_body(&raw),
+        "chat-backend",
+        "chat completions should route to chat-backend cluster"
+    );
+}
+
+#[test]
+fn responses_format_routing_example_unknown_falls_to_default() {
+    let responses_guard = start_backend_with_shutdown("responses-backend");
+    let chat_guard = start_backend_with_shutdown("chat-backend");
+    let default_guard = start_backend_with_shutdown("default-backend");
+    let proxy_port = free_port();
+
+    let config = load_example_config(
+        "ai/openai/responses/format-routing.yaml",
+        proxy_port,
+        HashMap::from([
+            ("127.0.0.1:3001", responses_guard.port()),
+            ("127.0.0.1:3002", chat_guard.port()),
+            ("127.0.0.1:3003", default_guard.port()),
+        ]),
+    );
+    let proxy = start_proxy(&config);
+
+    let body = r#"{"prompt":"hello"}"#;
+    let raw = http_send(proxy.addr(), &json_post("/other/path", body));
+
+    assert_eq!(parse_status(&raw), 200, "unknown path should return 200");
+    assert_eq!(
+        parse_body(&raw),
+        "default-backend",
+        "unrecognized path should fall to default cluster"
+    );
+}

--- a/tests/integration/tests/suite/main.rs
+++ b/tests/integration/tests/suite/main.rs
@@ -61,6 +61,8 @@ mod per_listener_pipeline;
 #[cfg(feature = "ai-inference")]
 mod prompt_enrich;
 mod rate_limit;
+#[cfg(feature = "ai-inference")]
+mod responses_format;
 mod retry;
 mod routing;
 mod security;

--- a/tests/integration/tests/suite/responses_format.rs
+++ b/tests/integration/tests/suite/responses_format.rs
@@ -1,0 +1,787 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Integration tests for the `responses_format` classifier filter.
+
+use praxis_core::config::Config;
+use praxis_test_utils::{
+    free_port, http_send, json_post, parse_body, parse_status, start_backend_with_shutdown,
+    start_echo_backend_with_shutdown, start_header_echo_backend_with_shutdown, start_proxy,
+};
+
+// -----------------------------------------------------------------------------
+// Classification and Routing Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn responses_request_routes_to_responses_cluster() {
+    let responses_guard = start_backend_with_shutdown("responses-backend");
+    let chat_guard = start_backend_with_shutdown("chat-backend");
+    let default_guard = start_backend_with_shutdown("default-backend");
+    let proxy_port = free_port();
+
+    let yaml = routing_yaml(
+        proxy_port,
+        responses_guard.port(),
+        chat_guard.port(),
+        default_guard.port(),
+    );
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body = r#"{"model":"gpt-4.1-mini","input":"Hello, world!"}"#;
+    let raw = http_send(proxy.addr(), &json_post("/v1/responses", body));
+
+    assert_eq!(parse_status(&raw), 200, "responses request should return 200");
+    assert_eq!(
+        parse_body(&raw),
+        "responses-backend",
+        "responses request should route to responses cluster"
+    );
+}
+
+#[test]
+fn responses_array_input_routes_to_responses_cluster() {
+    let responses_guard = start_backend_with_shutdown("responses-backend");
+    let chat_guard = start_backend_with_shutdown("chat-backend");
+    let default_guard = start_backend_with_shutdown("default-backend");
+    let proxy_port = free_port();
+
+    let yaml = routing_yaml(
+        proxy_port,
+        responses_guard.port(),
+        chat_guard.port(),
+        default_guard.port(),
+    );
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body = r#"{"model":"gpt-4.1","input":[{"type":"message","role":"user","content":"Hi"}]}"#;
+    let raw = http_send(proxy.addr(), &json_post("/v1/responses", body));
+
+    assert_eq!(parse_status(&raw), 200, "array input should return 200");
+    assert_eq!(
+        parse_body(&raw),
+        "responses-backend",
+        "array input request should route to responses cluster"
+    );
+}
+
+#[test]
+fn chat_completions_routes_to_chat_cluster() {
+    let responses_guard = start_backend_with_shutdown("responses-backend");
+    let chat_guard = start_backend_with_shutdown("chat-backend");
+    let default_guard = start_backend_with_shutdown("default-backend");
+    let proxy_port = free_port();
+
+    let yaml = routing_yaml(
+        proxy_port,
+        responses_guard.port(),
+        chat_guard.port(),
+        default_guard.port(),
+    );
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body = r#"{"model":"gpt-4","messages":[{"role":"user","content":"Hi"}]}"#;
+    let raw = http_send(proxy.addr(), &json_post("/v1/chat/completions", body));
+
+    assert_eq!(parse_status(&raw), 200, "chat completions should return 200");
+    assert_eq!(
+        parse_body(&raw),
+        "chat-backend",
+        "chat completions should route to chat cluster"
+    );
+}
+
+#[test]
+fn unknown_json_routes_to_default_cluster() {
+    let responses_guard = start_backend_with_shutdown("responses-backend");
+    let chat_guard = start_backend_with_shutdown("chat-backend");
+    let default_guard = start_backend_with_shutdown("default-backend");
+    let proxy_port = free_port();
+
+    let yaml = routing_yaml(
+        proxy_port,
+        responses_guard.port(),
+        chat_guard.port(),
+        default_guard.port(),
+    );
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body = r#"{"model":"gpt-4","prompt":"hello"}"#;
+    let raw = http_send(proxy.addr(), &json_post("/v1/responses", body));
+
+    assert_eq!(parse_status(&raw), 200, "unknown JSON should return 200");
+    assert_eq!(
+        parse_body(&raw),
+        "default-backend",
+        "unknown JSON should route to default cluster"
+    );
+}
+
+#[test]
+fn non_json_continues_by_default() {
+    let default_guard = start_backend_with_shutdown("default-backend");
+    let proxy_port = free_port();
+
+    let yaml = continue_yaml(proxy_port, default_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let request = format!(
+        "POST /v1/responses HTTP/1.1\r\n\
+         Host: localhost:{proxy_port}\r\n\
+         Content-Type: text/plain\r\n\
+         Content-Length: 11\r\n\
+         \r\n\
+         hello world"
+    );
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(parse_status(&raw), 200, "non-JSON should continue to default cluster");
+    assert_eq!(parse_body(&raw), "default-backend", "non-JSON should reach backend");
+}
+
+#[test]
+fn unknown_json_rejected_when_configured() {
+    let default_guard = start_backend_with_shutdown("default-backend");
+    let proxy_port = free_port();
+
+    let yaml = reject_yaml(proxy_port, default_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body = r#"{"model":"gpt-4","prompt":"hello"}"#;
+    let raw = http_send(proxy.addr(), &json_post("/v1/responses", body));
+
+    assert_eq!(
+        parse_status(&raw),
+        400,
+        "unknown JSON should be rejected when on_invalid: reject"
+    );
+    let response_body = parse_body(&raw);
+    assert!(
+        response_body.contains("unrecognized AI API format"),
+        "rejection should mention unrecognized format, got: {response_body}"
+    );
+}
+
+#[test]
+fn invalid_json_rejected_when_configured() {
+    let default_guard = start_backend_with_shutdown("default-backend");
+    let proxy_port = free_port();
+
+    let yaml = reject_yaml(proxy_port, default_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(proxy.addr(), &json_post("/v1/responses", "not valid json {{{"));
+
+    assert_eq!(parse_status(&raw), 400, "invalid JSON should be rejected");
+    let body = parse_body(&raw);
+    assert!(
+        body.contains("invalid JSON body") || body.contains("invalid_request_error"),
+        "rejection should mention invalid JSON, got: {body}"
+    );
+}
+
+#[test]
+fn non_json_rejected_when_configured() {
+    let default_guard = start_backend_with_shutdown("default-backend");
+    let proxy_port = free_port();
+
+    let yaml = reject_yaml(proxy_port, default_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let request = format!(
+        "POST /v1/responses HTTP/1.1\r\n\
+         Host: localhost:{proxy_port}\r\n\
+         Content-Type: text/plain\r\n\
+         Content-Length: 11\r\n\
+         \r\n\
+         hello world"
+    );
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(
+        parse_status(&raw),
+        400,
+        "non-JSON should be rejected when on_invalid: reject"
+    );
+    let body = parse_body(&raw);
+    assert!(
+        body.contains("not JSON") || body.contains("invalid_request_error"),
+        "rejection should mention non-JSON, got: {body}"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Header Promotion for Routing
+// -----------------------------------------------------------------------------
+
+#[test]
+fn model_header_routes_to_specific_backend() {
+    let model_a_guard = start_backend_with_shutdown("model-a-backend");
+    let model_b_guard = start_backend_with_shutdown("model-b-backend");
+    let default_guard = start_backend_with_shutdown("default-backend");
+    let proxy_port = free_port();
+
+    let yaml = model_routing_yaml(
+        proxy_port,
+        model_a_guard.port(),
+        model_b_guard.port(),
+        default_guard.port(),
+    );
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body = r#"{"model":"model-a","input":"test"}"#;
+    let raw = http_send(proxy.addr(), &json_post("/v1/responses", body));
+
+    assert_eq!(parse_status(&raw), 200, "model-a should return 200");
+    assert_eq!(
+        parse_body(&raw),
+        "model-a-backend",
+        "model-a should route to model-a-backend via promoted x-praxis-ai-model header"
+    );
+
+    let body_b = r#"{"model":"model-b","input":"test"}"#;
+    let raw_b = http_send(proxy.addr(), &json_post("/v1/responses", body_b));
+
+    assert_eq!(parse_status(&raw_b), 200, "model-b should return 200");
+    assert_eq!(
+        parse_body(&raw_b),
+        "model-b-backend",
+        "model-b should route to model-b-backend via promoted x-praxis-ai-model header"
+    );
+}
+
+#[test]
+fn stream_header_routes_streaming_traffic() {
+    let stream_guard = start_backend_with_shutdown("stream-backend");
+    let default_guard = start_backend_with_shutdown("default-backend");
+    let proxy_port = free_port();
+
+    let yaml = stream_routing_yaml(proxy_port, stream_guard.port(), default_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body = r#"{"model":"gpt-4.1","input":"test","stream":true}"#;
+    let raw = http_send(proxy.addr(), &json_post("/v1/responses", body));
+
+    assert_eq!(parse_status(&raw), 200, "streaming request should return 200");
+    assert_eq!(
+        parse_body(&raw),
+        "stream-backend",
+        "stream:true should route to stream-backend via promoted x-praxis-ai-stream header"
+    );
+
+    let body_no_stream = r#"{"model":"gpt-4.1","input":"test"}"#;
+    let raw_no_stream = http_send(proxy.addr(), &json_post("/v1/responses", body_no_stream));
+
+    assert_eq!(parse_status(&raw_no_stream), 200, "non-streaming should return 200");
+    assert_eq!(
+        parse_body(&raw_no_stream),
+        "default-backend",
+        "request without stream should route to default-backend"
+    );
+}
+
+#[test]
+fn reserved_headers_stripped_before_upstream() {
+    let backend_guard = start_header_echo_backend_with_shutdown();
+    let proxy_port = free_port();
+
+    let yaml = header_echo_yaml(proxy_port, backend_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body = r#"{"model":"gpt-4.1","input":"test","stream":true}"#;
+    let raw = http_send(proxy.addr(), &json_post("/v1/responses", body));
+
+    assert_eq!(parse_status(&raw), 200, "should return 200");
+    let echoed = parse_body(&raw).to_lowercase();
+    assert!(
+        !echoed.contains("x-praxis-ai-format"),
+        "x-praxis-ai-format should be stripped before upstream (reserved header)"
+    );
+    assert!(
+        !echoed.contains("x-praxis-ai-model"),
+        "x-praxis-ai-model should be stripped before upstream (reserved header)"
+    );
+    assert!(
+        !echoed.contains("x-praxis-ai-stream"),
+        "x-praxis-ai-stream should be stripped before upstream (reserved header)"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Bounded Value Promotion Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn oversized_model_not_promoted_to_header() {
+    let model_guard = start_backend_with_shutdown("model-backend");
+    let default_guard = start_backend_with_shutdown("default-backend");
+    let proxy_port = free_port();
+
+    let long_model = "x".repeat(300);
+    let yaml = model_routing_yaml(proxy_port, model_guard.port(), model_guard.port(), default_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body = format!(r#"{{"model":"{long_model}","input":"test"}}"#);
+    let raw = http_send(proxy.addr(), &json_post("/v1/responses", &body));
+
+    assert_eq!(parse_status(&raw), 200, "oversized model should still return 200");
+    assert_eq!(
+        parse_body(&raw),
+        "default-backend",
+        "oversized model (>256 bytes) should not match a route, falling to default"
+    );
+}
+
+#[test]
+fn control_char_model_not_promoted_to_header() {
+    let model_guard = start_backend_with_shutdown("model-backend");
+    let default_guard = start_backend_with_shutdown("default-backend");
+    let proxy_port = free_port();
+
+    let yaml = model_routing_yaml(proxy_port, model_guard.port(), model_guard.port(), default_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body = r#"{"model":"bad\nmodel","input":"test"}"#;
+    let raw = http_send(proxy.addr(), &json_post("/v1/responses", body));
+
+    assert_eq!(parse_status(&raw), 200, "control-char model should still return 200");
+    assert_eq!(
+        parse_body(&raw),
+        "default-backend",
+        "model with control chars should not be promoted, falling to default"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Filter Results Branch Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn filter_results_enable_branch_routing() {
+    let responses_guard = start_backend_with_shutdown("responses-branch-hit");
+    let default_guard = start_backend_with_shutdown("default-branch-miss");
+    let proxy_port = free_port();
+
+    let yaml = branch_yaml(proxy_port, responses_guard.port(), default_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body = r#"{"model":"gpt-4.1","input":"test"}"#;
+    let raw = http_send(proxy.addr(), &json_post("/v1/responses", body));
+
+    assert_eq!(parse_status(&raw), 200, "responses request should return 200");
+    assert_eq!(
+        parse_body(&raw),
+        "responses-branch-hit",
+        "branch on_result should fire for responses format and route to branch cluster"
+    );
+
+    let chat_body = r#"{"model":"gpt-4","messages":[]}"#;
+    let raw_chat = http_send(proxy.addr(), &json_post("/v1/chat/completions", chat_body));
+
+    assert_eq!(parse_status(&raw_chat), 200, "chat request should return 200");
+    assert_eq!(
+        parse_body(&raw_chat),
+        "default-branch-miss",
+        "branch should not fire for chat_completions, falling through to default"
+    );
+}
+
+#[test]
+fn background_filter_result_enables_branch_routing() {
+    let background_guard = start_backend_with_shutdown("background-branch-hit");
+    let default_guard = start_backend_with_shutdown("default-branch-miss");
+    let proxy_port = free_port();
+
+    let yaml = background_branch_yaml(proxy_port, background_guard.port(), default_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body = r#"{"model":"gpt-4.1","input":"test","background":true,"store":false,"stream":true}"#;
+    let raw = http_send(proxy.addr(), &json_post("/v1/responses", body));
+
+    assert_eq!(
+        parse_status(&raw),
+        200,
+        "background request should route without protocol validation"
+    );
+    assert_eq!(
+        parse_body(&raw),
+        "background-branch-hit",
+        "branch on_result should fire for background:true"
+    );
+
+    let foreground_body = r#"{"model":"gpt-4.1","input":"test","background":false}"#;
+    let foreground_raw = http_send(proxy.addr(), &json_post("/v1/responses", foreground_body));
+
+    assert_eq!(
+        parse_status(&foreground_raw),
+        200,
+        "foreground request should return 200"
+    );
+    assert_eq!(
+        parse_body(&foreground_raw),
+        "default-branch-miss",
+        "background:false should not match the background:true branch"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Body Preservation Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn body_unchanged_after_classification() {
+    let backend_guard = start_echo_backend_with_shutdown();
+    let proxy_port = free_port();
+
+    let yaml = echo_yaml(proxy_port, backend_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body = r#"{"model":"gpt-4.1-mini","input":"Hello, world!","stream":false,"store":true}"#;
+    let raw = http_send(proxy.addr(), &json_post("/v1/responses", body));
+
+    assert_eq!(parse_status(&raw), 200, "should return 200");
+    let echoed = parse_body(&raw);
+    assert_eq!(
+        echoed, body,
+        "body should be byte-for-byte unchanged after classification"
+    );
+}
+
+#[test]
+fn large_body_over_64k_classified_and_forwarded() {
+    let backend_guard = start_echo_backend_with_shutdown();
+    let proxy_port = free_port();
+
+    let yaml = echo_yaml(proxy_port, backend_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let padding = "x".repeat(65_536); // 64 KiB of padding
+    let body = format!(r#"{{"model":"gpt-4.1","input":"{padding}"}}"#);
+    let raw = http_send(proxy.addr(), &json_post("/v1/responses", &body));
+
+    assert_eq!(parse_status(&raw), 200, "large body should return 200");
+    let echoed = parse_body(&raw);
+    assert_eq!(echoed, body, "large body should be byte-for-byte unchanged");
+}
+
+// -----------------------------------------------------------------------------
+// Test Utilities
+// -----------------------------------------------------------------------------
+
+/// YAML config for routing by classified format using header matching.
+fn routing_yaml(proxy_port: u16, responses_port: u16, chat_port: u16, default_port: u16) -> String {
+    format!(
+        r#"
+listeners:
+  - name: default
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: responses_format
+        on_invalid: continue
+      - filter: router
+        routes:
+          - path: "/v1/responses"
+            headers:
+              x-praxis-ai-format: "responses"
+            cluster: "responses"
+          - path: "/v1/chat/completions"
+            headers:
+              x-praxis-ai-format: "chat_completions"
+            cluster: "chat"
+          - path_prefix: "/"
+            cluster: "default"
+      - filter: load_balancer
+        clusters:
+          - name: "responses"
+            endpoints:
+              - "127.0.0.1:{responses_port}"
+          - name: "chat"
+            endpoints:
+              - "127.0.0.1:{chat_port}"
+          - name: "default"
+            endpoints:
+              - "127.0.0.1:{default_port}"
+"#
+    )
+}
+
+/// YAML config with on_invalid: continue and a catch-all default backend.
+fn continue_yaml(proxy_port: u16, default_port: u16) -> String {
+    format!(
+        r#"
+listeners:
+  - name: default
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: responses_format
+        on_invalid: continue
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: "default"
+      - filter: load_balancer
+        clusters:
+          - name: "default"
+            endpoints:
+              - "127.0.0.1:{default_port}"
+"#
+    )
+}
+
+/// YAML config with on_invalid: reject.
+fn reject_yaml(proxy_port: u16, default_port: u16) -> String {
+    format!(
+        r#"
+listeners:
+  - name: default
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: responses_format
+        on_invalid: reject
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: "default"
+      - filter: load_balancer
+        clusters:
+          - name: "default"
+            endpoints:
+              - "127.0.0.1:{default_port}"
+"#
+    )
+}
+
+/// YAML config that routes all traffic to a header-echo backend.
+fn header_echo_yaml(proxy_port: u16, backend_port: u16) -> String {
+    format!(
+        r#"
+listeners:
+  - name: default
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: responses_format
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: "backend"
+      - filter: load_balancer
+        clusters:
+          - name: "backend"
+            endpoints:
+              - "127.0.0.1:{backend_port}"
+"#
+    )
+}
+
+/// YAML config that routes all traffic to an echo (body) backend.
+fn echo_yaml(proxy_port: u16, backend_port: u16) -> String {
+    format!(
+        r#"
+listeners:
+  - name: default
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: responses_format
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: "backend"
+      - filter: load_balancer
+        clusters:
+          - name: "backend"
+            endpoints:
+              - "127.0.0.1:{backend_port}"
+"#
+    )
+}
+
+/// YAML config for branch-based routing using filter results.
+fn branch_yaml(proxy_port: u16, responses_port: u16, default_port: u16) -> String {
+    format!(
+        r#"
+listeners:
+  - name: default
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: responses_format
+        branch_chains:
+          - name: responses_branch
+            on_result:
+              filter: responses_format
+              key: format
+              result: responses
+            rejoin: terminal
+            chains:
+              - name: responses_chain
+                filters:
+                  - filter: router
+                    routes:
+                      - path_prefix: "/"
+                        cluster: "responses"
+                  - filter: load_balancer
+                    clusters:
+                      - name: "responses"
+                        endpoints:
+                          - "127.0.0.1:{responses_port}"
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: "default"
+      - filter: load_balancer
+        clusters:
+          - name: "default"
+            endpoints:
+              - "127.0.0.1:{default_port}"
+"#
+    )
+}
+
+/// YAML config for branch-based routing using the background filter result.
+fn background_branch_yaml(proxy_port: u16, background_port: u16, default_port: u16) -> String {
+    format!(
+        r#"
+listeners:
+  - name: default
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: responses_format
+        branch_chains:
+          - name: background_branch
+            on_result:
+              filter: responses_format
+              key: background
+              result: true
+            rejoin: terminal
+            chains:
+              - name: background_chain
+                filters:
+                  - filter: router
+                    routes:
+                      - path_prefix: "/"
+                        cluster: "background"
+                  - filter: load_balancer
+                    clusters:
+                      - name: "background"
+                        endpoints:
+                          - "127.0.0.1:{background_port}"
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: "default"
+      - filter: load_balancer
+        clusters:
+          - name: "default"
+            endpoints:
+              - "127.0.0.1:{default_port}"
+"#
+    )
+}
+
+/// YAML config for routing by promoted model header.
+fn model_routing_yaml(proxy_port: u16, model_a_port: u16, model_b_port: u16, default_port: u16) -> String {
+    format!(
+        r#"
+listeners:
+  - name: default
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: responses_format
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            headers:
+              x-praxis-ai-model: "model-a"
+            cluster: "model-a"
+          - path_prefix: "/"
+            headers:
+              x-praxis-ai-model: "model-b"
+            cluster: "model-b"
+          - path_prefix: "/"
+            cluster: "default"
+      - filter: load_balancer
+        clusters:
+          - name: "model-a"
+            endpoints:
+              - "127.0.0.1:{model_a_port}"
+          - name: "model-b"
+            endpoints:
+              - "127.0.0.1:{model_b_port}"
+          - name: "default"
+            endpoints:
+              - "127.0.0.1:{default_port}"
+"#
+    )
+}
+
+/// YAML config for routing by promoted stream header.
+fn stream_routing_yaml(proxy_port: u16, stream_port: u16, default_port: u16) -> String {
+    format!(
+        r#"
+listeners:
+  - name: default
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: responses_format
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            headers:
+              x-praxis-ai-stream: "true"
+            cluster: "stream"
+          - path_prefix: "/"
+            cluster: "default"
+      - filter: load_balancer
+        clusters:
+          - name: "stream"
+            endpoints:
+              - "127.0.0.1:{stream_port}"
+          - name: "default"
+            endpoints:
+              - "127.0.0.1:{default_port}"
+"#
+    )
+}


### PR DESCRIPTION
  ## Summary

  This is the first in a stacked implementation for Epic praxis-proxy/ai#93, “Responses API and Agentic Loop Orchestration.” It establishes the body-aware routing foundation that later PRs will build on for Responses orchestration, state, tool calls, and streaming. This is long but want to add some framing here.

  - Adds `responses_format` built-in HTTP filter that classifies request bodies as Responses API (`input`), Chat Completions (`messages`), unknown JSON, invalid JSON, or non-JSON
  - Promotes classification facts (`format`, `model`, `stream`, `store`, `previous_response_id` presence, `conversation` presence) to internal routing headers
  (`x-praxis-ai-*`), durable metadata, and filter results
  - Carries body-derived `filter_results` from pre-read body inspection into request-phase branch evaluation so `on_result` can route using classifier output
  - Does not mutate the request body: uses `ReadOnly` access with `StreamBuffer`
  - Bounds body-derived promoted values and suppresses control-character values before header/result promotion
  - `on_invalid` defaults to `continue` for mixed-traffic listeners; configurable to `reject` for AI-only listeners

 ## Architectural callouts worth mentioning:

- This PR lays the pre-upstream classification and policy-routing groundwork for a future agentic Responses orchestrator, while keeping the actual model/tool.
  loop out of branch re-entry because that lifecycle needs response-aware orchestration.
  - This PR is the routing/classification foundation, not the agent loop itself. It intentionally stops at request-body classification and promotion so later stacked PRs can build orchestration, state, tool execution, and streaming on top.
  - Body-derived filter_results now cross from the pre-read body phase into request-phase branch evaluation. That is an architectural change to the Pingora request context, not just a filter-local change.
  - The filter uses StreamBuffer + ReadOnly: Praxis buffers enough body to classify it, but does not mutate or rewrite the body. That keeps this PR safe for pass-through routing.
  - on_invalid: continue is the default to support mixed-traffic listeners. on_invalid: reject is intended for AI-only listeners and now rejects valid JSON that is not Responses or Chat Completions.
  - Promotion is deliberately split across three surfaces:
    x-praxis-ai-* internal headers for router matching, durable metadata for later lifecycle phases, and filter_results for branch-chain decisions.
  - Body-derived promoted values are bounded/sanitized before header/result promotion. This avoids turning model names or other request fields into oversized or unsafe synthetic headers.
  - This PR relies on existing internal header hygiene: x-praxis-ai-* headers are usable inside Praxis for routing but stripped before upstream.
 
  ## Test plan

  - [x] Unit: Responses with string input classified as `responses`
  - [x] Unit: Responses with item-array input classified as `responses`
  - [x] Unit: Chat Completions with `messages` classified as `chat_completions`
  - [x] Unit: Unknown JSON classified as `unknown`
  - [x] Unit/integration: Unknown JSON rejects when `on_invalid: reject`
  - [x] Unit: Non-JSON continues/rejects according to `on_invalid`
  - [x] Unit/integration: Invalid JSON rejects when `on_invalid: reject`
  - [x] Unit: All extracted facts promoted to headers, durable metadata, and filter results
  - [x] Unit: Missing optional facts are not promoted
  - [x] Unit/integration: Oversized and control-character `model` values are not promoted
  - [x] Integration: Route by classifier result (`responses` vs `chat_completions` vs default)
  - [x] Integration: Route by promoted model header
  - [x] Integration: Route by promoted stream header
  - [x] Integration: Route by body-derived `filter_results` via `on_result`
  - [x] Integration: Reserved `x-praxis-ai-*` headers stripped before upstream
  - [x] Integration: Body byte-for-byte unchanged after classification
  - [x] Integration: Large body over 64 KiB classified and forwarded
  - [x] Schema: Example config parses (`all_example_configs_parse`)
  - [x] Functional: Example config routes Responses, Chat Completions, and unknown traffic
  - [x] Full suites: filter, protocol, integration, schema, and nightly fmt pass

  Issues: praxis-proxy/ai#220, partial praxis-proxy/ai#94, part of praxis-proxy/ai#93