### PR TITLE
feat(filter): add stateless/stateful mode routing for Responses API

### DIFF
--- a/docs/proposals/00354_responses-api-filters.md
+++ b/docs/proposals/00354_responses-api-filters.md
@@ -1,5 +1,6 @@
 ---
 issue: https://github.com/praxis-proxy/praxis/issues/354
+discussion: https://github.com/praxis-proxy/praxis/pull/445
 status: proposed
 authors:
   - leseb
@@ -161,8 +162,8 @@ Request arrives at POST /v1/responses
     - tools array is non-empty
     - store = true (default)
     - background = true
-    - conversation_id is set
-    - prompt_id is set
+    - conversation is set
+    - prompt.id is set
 
   IF none are true AND backend speaks Responses API → PASS-THROUGH:
     - Forward request body unchanged to backend /v1/responses
@@ -175,7 +176,7 @@ Request arrives at POST /v1/responses
 
 **What #361 promotes to headers for downstream routing:**
 - `x-praxis-api-format: openai_responses | openai_chat_completions` — detected API format
-- `x-praxis-responses-mode: passthrough | stateful` — routing decision
+- `x-praxis-responses-mode: stateless | stateful` — routing decision
 - Model name extracted from body for cluster routing
 
 **Pass-through config example:**
@@ -198,7 +199,7 @@ routes:
     cluster: vllm-backend
 ```
 
-When `mode=stateful`, traffic enters our filter chain. When `mode=passthrough` (default/no match), Praxis proxies directly to the vLLM cluster — no filters touch the request or response.
+When `mode=stateful`, traffic enters our filter chain. When `mode=stateless` (default/no match), Praxis proxies directly to the vLLM cluster — no filters touch the request or response.
 
 ---
 
@@ -290,7 +291,7 @@ Proxy-needed fields (read and act upon):
 - `store` + `background` — reject `background=true && store=false`
 - `model` — read for routing decisions (use default if null/omitted)
 - `previous_response_id` — triggers rehydration in downstream filters
-- `conversation_id` — triggers conversation context loading
+- `conversation` — triggers conversation context loading
 - `tools` — proxy needs to read tool types to know which tool backends to invoke
 - `tool_choice` — proxy reads to determine tool dispatch behavior
 - `instructions` — preserved in state (do NOT inject as system message — in pass-through mode the inference server handles it; in conversion mode `responses_proxy` injects it during Responses → Chat Completions transformation)
@@ -365,7 +366,7 @@ database_url: ${DATABASE_URL}  # e.g. postgres://user:pass@host:5432/db or sqlit
 
 #### Filter 2: `rehydrate`
 
-**Purpose:** Load conversation context from `previous_response_id` or `conversation_id`. Reconstruct message history. Recover MCP tool listings from previous responses.
+**Purpose:** Load conversation context from `previous_response_id` or `conversation`. Reconstruct message history. Recover MCP tool listings from previous responses.
 
 **Praxis trait methods:**
 - `on_request` — read metadata, fetch from store, write enriched messages
@@ -378,7 +379,7 @@ database_url: ${DATABASE_URL}  # e.g. postgres://user:pass@host:5432/db or sqlit
   - Extract `previous_usage` for auto-compaction
   - Recover MCP tool listings from previous output items
   - Concatenate previous input + output, then append current input — the inference server sees exactly the same items it produced as output on the previous turn, plus the new user content
-- If `conversation_id` (no previous_response_id): fetch stored conversation messages, append current input
+- If `conversation` (no previous_response_id): fetch stored conversation messages, append current input
 - If neither: pass current input through as-is
 - Fallback: if stored messages missing (backward compat), reconstruct from public objects
 
@@ -998,7 +999,7 @@ Build order, each tier produces a working system:
 | Tier | Filters | What works after | External deps |
 |------|---------|-----------------|---------------|
 | 0 | `request_validate`, `response_store`, `responses_proxy`, `stream_events` | Stateless proxy with persistence. Text streaming. CRUD works. | Inference backend, SQL |
-| 1 | + `rehydrate` | Multi-turn via `previous_response_id` and `conversation_id`. | None (reads from response_store) |
+| 1 | + `rehydrate` | Multi-turn via `previous_response_id` and `conversation`. | None (reads from response_store) |
 | 2 | + `tool_parse`, `tool_dispatch` | Tool definitions parsed, loop control. Client-side function tools. | None |
 | 3 | + `web_search` | Server-side web search tool execution. | Search API (Brave/Tavily) |
 | 4 | + `mcp_tool` | MCP server-side tool execution with session reuse and approval. | MCP servers, #24 foundation |
@@ -1189,7 +1190,7 @@ The following filters are part of the full Responses API vision but require back
 
 #### `prompt_resolve`
 
-**Purpose:** Resolve `prompt_id` (with optional version) to system instructions. Handle variable substitution and media variables.
+**Purpose:** Resolve `prompt.id` (with optional version) to system instructions. Handle variable substitution and media variables.
 
 **Requires:** A Prompts API service that stores prompt templates with versions, variables, and media content. Praxis needs either a built-in prompt store or an external Prompts API endpoint.
 
@@ -1201,7 +1202,7 @@ The following filters are part of the full Responses API vision but require back
 - For media variables: insert `[Image: var_name]` placeholder in system message, append actual media as separate user message
 - Prompt system message prepended before `instructions` system message
 
-**MVP workaround:** Users pass `instructions` directly in the request instead of referencing a `prompt_id`. The `request_validate` filter already handles `instructions` injection as a system message.
+**MVP workaround:** Users pass `instructions` directly in the request instead of referencing `prompt.id`. The `request_validate` filter already handles `instructions` injection as a system message.
 
 
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -129,6 +129,7 @@ page.
 | [model-to-header-routing.yaml](configs/ai/model-to-header-routing.yaml) | Route by model field in JSON body via X-Model header |
 | [prompt-enrichment.yaml](configs/ai/prompt-enrichment.yaml) | Inject system messages into chat completion requests |
 | [format-routing.yaml](configs/ai/openai/responses/format-routing.yaml) | Route by AI API format (Responses vs Chat Completions) |
+| [responses-routing.yaml](configs/ai/openai/responses/responses-routing.yaml) | Route Responses API by mode (stateless vs stateful) |
 
 ### Branching
 

--- a/examples/configs/ai/openai/responses/responses-routing.yaml
+++ b/examples/configs/ai/openai/responses/responses-routing.yaml
@@ -1,0 +1,69 @@
+# Responses API Mode Routing
+#
+# Routes Responses API traffic by detected mode. The `openai_responses_format`
+# filter classifies requests as `stateless` (simple inference, no
+# state management) or `stateful` (needs conversation history, tools,
+# or persistence).
+#
+# Both modes use the same inference backend. The difference is whether
+# the request passes through the stateful filter chain (orchestration,
+# persistence, tool dispatch) or bypasses it entirely.
+#
+# A request is stateful if any of:
+# - previous_response_id is set
+# - tools array is non-empty
+# - store is true (the OpenAI spec default when omitted)
+# - background is true
+# - conversation is set
+# - prompt_id is set
+#
+# Stateless requires store=false and no other stateful markers.
+
+listeners:
+  - name: ai-gateway
+    address: "127.0.0.1:8080"
+    filter_chains: [responses-routing]
+
+filter_chains:
+  - name: responses-routing
+    filters:
+      - filter: openai_responses_format
+        on_invalid: reject
+        branch_chains:
+          - name: stateful
+            on_result:
+              filter: openai_responses_format
+              key: mode
+              result: stateful
+            chains:
+              - name: stateful-chain
+                filters:
+                  # Placeholder: the full stateful chain would include
+                  # request_validate, response_store, rehydrate,
+                  # tool_parse, responses_proxy, stream_events,
+                  # tool_dispatch, reasoning, etc.
+                  #
+                  # For now, proxy to the same backend. Future
+                  # filters will be inserted here as they land.
+                  - filter: router
+                    routes:
+                      - path_prefix: "/"
+                        cluster: "inference-backend"
+                  - filter: load_balancer
+                    clusters:
+                      - name: "inference-backend"
+                        endpoints:
+                          - "127.0.0.1:3001"
+            rejoin: terminal
+
+      # Stateless: no branch matched — proxy directly to backend
+      # with zero additional filter processing.
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: "inference-backend"
+      - filter: load_balancer
+        clusters:
+          - name: "inference-backend"
+            endpoints:
+              - "127.0.0.1:3001"

--- a/filter/src/builtins/http/ai/openai/responses/classifier/mod.rs
+++ b/filter/src/builtins/http/ai/openai/responses/classifier/mod.rs
@@ -41,6 +41,7 @@ impl AiRequestFormat {
 
 /// Extracted facts from a classified request body.
 #[derive(Debug)]
+#[allow(clippy::struct_excessive_bools, reason = "independent presence flags from JSON body")]
 pub(crate) struct ClassifiedRequest {
     /// Extracted `background` field value, if present.
     pub background: Option<bool>,
@@ -50,6 +51,10 @@ pub(crate) struct ClassifiedRequest {
     pub has_conversation: bool,
     /// Whether `previous_response_id` is present and non-null.
     pub has_previous_response_id: bool,
+    /// Whether `prompt.id` is present and non-null.
+    pub has_prompt_id: bool,
+    /// Whether `tools` is a non-empty array.
+    pub has_tools: bool,
     /// Extracted `model` field value, if present.
     pub model: Option<String>,
     /// Extracted `store` field value, if present.
@@ -121,6 +126,14 @@ pub(crate) fn classify_request_body(body: &[u8]) -> ClassifiedRequest {
         format,
         has_conversation: obj.get("conversation").is_some_and(|v| !v.is_null()),
         has_previous_response_id: obj.get("previous_response_id").is_some_and(|v| !v.is_null()),
+        has_prompt_id: obj
+            .get("prompt")
+            .and_then(serde_json::Value::as_object)
+            .and_then(|prompt| prompt.get("prompt_id"))
+            .is_some_and(|v| !v.is_null()),
+        has_tools: obj
+            .get("tools")
+            .is_some_and(|v| v.as_array().is_some_and(|a| !a.is_empty())),
         model: extract_string(obj, "model"),
         store: obj.get("store").and_then(serde_json::Value::as_bool),
         stream: obj.get("stream").and_then(serde_json::Value::as_bool),
@@ -129,8 +142,10 @@ pub(crate) fn classify_request_body(body: &[u8]) -> ClassifiedRequest {
 
 /// Determine format from top-level keys. When both `input` and
 /// `messages` are present, `input` takes precedence (Responses API).
+/// A `prompt` object also indicates a Responses API request (prompt
+/// template usage per `OpenAI` Prompts guide).
 fn classify_format(obj: &serde_json::Map<String, serde_json::Value>) -> AiRequestFormat {
-    if obj.contains_key("input") {
+    if obj.contains_key("input") || obj.get("prompt").is_some_and(serde_json::Value::is_object) {
         AiRequestFormat::Responses
     } else if obj.contains_key("messages") {
         AiRequestFormat::ChatCompletions
@@ -150,6 +165,8 @@ pub(crate) fn empty_result(format: AiRequestFormat) -> ClassifiedRequest {
         format,
         has_conversation: false,
         has_previous_response_id: false,
+        has_prompt_id: false,
+        has_tools: false,
         model: None,
         store: None,
         stream: None,
@@ -393,6 +410,119 @@ mod tests {
         assert!(
             result.background.is_none(),
             "null background should not be detected as present"
+        );
+    }
+
+    #[test]
+    fn tools_non_empty_array_detected() {
+        let body = br#"{"model":"gpt-4.1","input":"test","tools":[{"type":"function"}]}"#;
+        let result = classify_request_body(body);
+
+        assert!(result.has_tools, "non-empty tools array should be detected");
+    }
+
+    #[test]
+    fn tools_empty_array_not_detected() {
+        let body = br#"{"model":"gpt-4.1","input":"test","tools":[]}"#;
+        let result = classify_request_body(body);
+
+        assert!(!result.has_tools, "empty tools array should not be detected");
+    }
+
+    #[test]
+    fn tools_absent_not_detected() {
+        let body = br#"{"model":"gpt-4.1","input":"test"}"#;
+        let result = classify_request_body(body);
+
+        assert!(!result.has_tools, "absent tools should not be detected");
+    }
+
+    #[test]
+    fn tools_null_not_detected() {
+        let body = br#"{"model":"gpt-4.1","input":"test","tools":null}"#;
+        let result = classify_request_body(body);
+
+        assert!(!result.has_tools, "null tools should not be detected");
+    }
+
+    #[test]
+    fn prompt_id_nested_detected() {
+        let body = br#"{"model":"gpt-4.1","input":"test","prompt":{"prompt_id":"pmpt_123"}}"#;
+        let result = classify_request_body(body);
+
+        assert!(result.has_prompt_id, "nested prompt.prompt_id should be detected");
+    }
+
+    #[test]
+    fn prompt_id_absent_not_detected() {
+        let body = br#"{"model":"gpt-4.1","input":"test"}"#;
+        let result = classify_request_body(body);
+
+        assert!(!result.has_prompt_id, "absent prompt should not be detected");
+    }
+
+    #[test]
+    fn prompt_id_null_not_detected() {
+        let body = br#"{"model":"gpt-4.1","input":"test","prompt":{"prompt_id":null}}"#;
+        let result = classify_request_body(body);
+
+        assert!(!result.has_prompt_id, "null prompt_id should not be detected");
+    }
+
+    #[test]
+    fn prompt_object_without_prompt_id_not_detected() {
+        let body = br#"{"model":"gpt-4.1","input":"test","prompt":{"variables":{"city":"SF"}}}"#;
+        let result = classify_request_body(body);
+
+        assert!(
+            !result.has_prompt_id,
+            "prompt object without id should not set has_prompt_id"
+        );
+    }
+
+    #[test]
+    fn prompt_object_prompt_id_field_detected() {
+        let body = br#"{"model":"gpt-4.1","input":"test","prompt":{"prompt_id":"pmpt_123"}}"#;
+        let result = classify_request_body(body);
+
+        assert!(
+            result.has_prompt_id,
+            "prompt.prompt_id should be detected as the prompt identifier"
+        );
+    }
+
+    #[test]
+    fn prompt_string_not_detected_as_prompt_id() {
+        let body = br#"{"model":"gpt-4.1","input":"test","prompt":"some string"}"#;
+        let result = classify_request_body(body);
+
+        assert!(
+            !result.has_prompt_id,
+            "string prompt should not be treated as prompt object"
+        );
+    }
+
+    #[test]
+    fn prompt_object_classifies_as_responses() {
+        let body = br#"{"model":"gpt-4.1","prompt":{"prompt_id":"pmpt_123","variables":{"city":"SF"}}}"#;
+        let result = classify_request_body(body);
+
+        assert_eq!(
+            result.format,
+            AiRequestFormat::Responses,
+            "prompt object should classify as responses even without input"
+        );
+        assert!(result.has_prompt_id, "prompt_id should be detected");
+    }
+
+    #[test]
+    fn top_level_prompt_id_not_detected() {
+        let body = br#"{"model":"gpt-4.1","input":"test","prompt_id":"pmpt_123"}"#;
+        let result = classify_request_body(body);
+
+        assert!(
+            !result.has_prompt_id,
+            "top-level prompt_id should not be detected (must be nested in prompt object)"
         );
     }
 

--- a/filter/src/builtins/http/ai/openai/responses/config.rs
+++ b/filter/src/builtins/http/ai/openai/responses/config.rs
@@ -58,6 +58,10 @@ pub(crate) struct ResponsesFormatHeaders {
     /// Header name for the extracted stream flag.
     #[serde(default = "default_stream_header")]
     pub stream: Option<String>,
+
+    /// Header name for the computed mode (`stateless` or `stateful`).
+    #[serde(default = "default_mode_header")]
+    pub mode: Option<String>,
 }
 
 impl Default for ResponsesFormatHeaders {
@@ -66,6 +70,7 @@ impl Default for ResponsesFormatHeaders {
             format: default_format_header(),
             model: default_model_header(),
             stream: default_stream_header(),
+            mode: default_mode_header(),
         }
     }
 }
@@ -95,6 +100,15 @@ fn default_model_header() -> Option<String> {
 )]
 fn default_stream_header() -> Option<String> {
     Some("x-praxis-ai-stream".to_owned())
+}
+
+/// Default mode header name.
+#[allow(
+    clippy::unnecessary_wraps,
+    reason = "serde default functions require Option return type"
+)]
+fn default_mode_header() -> Option<String> {
+    Some("x-praxis-responses-mode".to_owned())
 }
 
 // -----------------------------------------------------------------------------
@@ -146,6 +160,7 @@ pub(crate) fn build_config(cfg: ResponsesFormatConfig) -> Result<ResponsesFormat
     validate_header_name("format", cfg.headers.format.as_deref())?;
     validate_header_name("model", cfg.headers.model.as_deref())?;
     validate_header_name("stream", cfg.headers.stream.as_deref())?;
+    validate_header_name("mode", cfg.headers.mode.as_deref())?;
 
     Ok(cfg)
 }

--- a/filter/src/builtins/http/ai/openai/responses/mod.rs
+++ b/filter/src/builtins/http/ai/openai/responses/mod.rs
@@ -78,6 +78,7 @@ use crate::{
 ///   format: x-praxis-ai-format
 ///   model: x-praxis-ai-model
 ///   stream: x-praxis-ai-stream
+///   mode: x-praxis-responses-mode
 /// ```
 pub struct ResponsesFormatFilter {
     /// Parsed and validated configuration.
@@ -155,9 +156,11 @@ impl HttpFilter for ResponsesFormatFilter {
             return Ok(action);
         }
 
-        write_metadata(ctx, &classified);
-        promote_headers(ctx, &classified, &self.config);
-        promote_filter_results(ctx, &classified)?;
+        let mode = compute_mode(&classified);
+
+        write_metadata(ctx, &classified, mode);
+        promote_headers(ctx, &classified, &self.config, mode);
+        promote_filter_results(ctx, &classified, mode)?;
 
         Ok(FilterAction::Release)
     }
@@ -191,11 +194,39 @@ fn handle_invalid_format(format: AiRequestFormat, config: &ResponsesFormatConfig
     }
 }
 
-/// Write durable metadata that persists across all Pingora lifecycle phases.
-fn write_metadata(ctx: &mut HttpFilterContext<'_>, classified: &classifier::ClassifiedRequest) {
-    let format_str = classified.format.as_str();
-    ctx.set_metadata("openai_responses_format.format", format_str);
+/// Determine the routing mode for a Responses API request.
+///
+/// Returns `Some("stateful")` when the request needs orchestration
+/// (conversation history, tools, persistence, or background processing)
+/// and `Some("stateless")` when it can be forwarded directly to a
+/// native Responses backend. Returns `None` for non-Responses formats.
+fn compute_mode(classified: &classifier::ClassifiedRequest) -> Option<&'static str> {
+    if classified.format != AiRequestFormat::Responses {
+        return None;
+    }
+    // OpenAI spec: store defaults to true when omitted
+    let stateful = classified.has_previous_response_id
+        || classified.has_tools
+        || classified.store.unwrap_or(true)
+        || classified.background == Some(true)
+        || classified.has_conversation
+        || classified.has_prompt_id;
+    Some(if stateful { "stateful" } else { "stateless" })
+}
 
+/// Write durable metadata that persists across all Pingora lifecycle phases.
+fn write_metadata(ctx: &mut HttpFilterContext<'_>, classified: &classifier::ClassifiedRequest, mode: Option<&str>) {
+    ctx.set_metadata("openai_responses_format.format", classified.format.as_str());
+    write_optional_metadata(ctx, classified);
+    write_boolean_metadata(ctx, classified);
+
+    if let Some(m) = mode {
+        ctx.set_metadata("openai_responses_format.mode", m);
+    }
+}
+
+/// Write optional string and boolean-option metadata fields.
+fn write_optional_metadata(ctx: &mut HttpFilterContext<'_>, classified: &classifier::ClassifiedRequest) {
     if let Some(model) = &classified.model
         && is_safe_promoted_value(model)
     {
@@ -216,13 +247,21 @@ fn write_metadata(ctx: &mut HttpFilterContext<'_>, classified: &classifier::Clas
             if background { "true" } else { "false" },
         );
     }
+}
 
+/// Write boolean presence flags to metadata.
+fn write_boolean_metadata(ctx: &mut HttpFilterContext<'_>, classified: &classifier::ClassifiedRequest) {
     if classified.has_previous_response_id {
         ctx.set_metadata("openai_responses_format.has_previous_response_id", "true");
     }
-
     if classified.has_conversation {
         ctx.set_metadata("openai_responses_format.has_conversation", "true");
+    }
+    if classified.has_tools {
+        ctx.set_metadata("openai_responses_format.has_tools", "true");
+    }
+    if classified.has_prompt_id {
+        ctx.set_metadata("openai_responses_format.has_prompt_id", "true");
     }
 }
 
@@ -231,6 +270,7 @@ fn promote_headers(
     ctx: &mut HttpFilterContext<'_>,
     classified: &classifier::ClassifiedRequest,
     config: &ResponsesFormatConfig,
+    mode: Option<&str>,
 ) {
     if let Some(header) = &config.headers.format {
         let format_str = classified.format.as_str();
@@ -254,17 +294,39 @@ fn promote_headers(
         ctx.extra_request_headers
             .push((Cow::Owned(header.clone()), val.to_owned()));
     }
+
+    if let Some(header) = &config.headers.mode
+        && let Some(m) = mode
+    {
+        ctx.extra_request_headers
+            .push((Cow::Owned(header.clone()), m.to_owned()));
+    }
 }
 
 /// Promote classification facts to filter results for branch conditions.
 fn promote_filter_results(
     ctx: &mut HttpFilterContext<'_>,
     classified: &classifier::ClassifiedRequest,
+    mode: Option<&'static str>,
 ) -> Result<(), FilterError> {
     let results = ctx.filter_results.entry("openai_responses_format").or_default();
 
     results.set("format", classified.format.as_str())?;
+    promote_optional_results(results, classified)?;
+    promote_boolean_results(results, classified)?;
 
+    if let Some(m) = mode {
+        results.set("mode", m)?;
+    }
+
+    Ok(())
+}
+
+/// Promote optional string and boolean-option fields to filter results.
+fn promote_optional_results(
+    results: &mut crate::results::FilterResultSet,
+    classified: &classifier::ClassifiedRequest,
+) -> Result<(), FilterError> {
     if let Some(model) = &classified.model
         && is_safe_promoted_value(model)
         && model.len() <= MAX_PROMOTED_VALUE_LEN
@@ -284,12 +346,25 @@ fn promote_filter_results(
         results.set("background", if background { "true" } else { "false" })?;
     }
 
+    Ok(())
+}
+
+/// Promote boolean presence flags to filter results.
+fn promote_boolean_results(
+    results: &mut crate::results::FilterResultSet,
+    classified: &classifier::ClassifiedRequest,
+) -> Result<(), FilterError> {
     if classified.has_previous_response_id {
         results.set("has_previous_response_id", "true")?;
     }
-
     if classified.has_conversation {
         results.set("has_conversation", "true")?;
+    }
+    if classified.has_tools {
+        results.set("has_tools", "true")?;
+    }
+    if classified.has_prompt_id {
+        results.set("has_prompt_id", "true")?;
     }
 
     Ok(())

--- a/filter/src/builtins/http/ai/openai/responses/tests.rs
+++ b/filter/src/builtins/http/ai/openai/responses/tests.rs
@@ -263,6 +263,7 @@ async fn promotes_headers_for_full_responses_request() {
         !headers.contains_key("x-praxis-ai-background"),
         "background should not have a default header"
     );
+    assert_eq!(headers.get("x-praxis-responses-mode"), Some(&"stateful"), "mode header");
 }
 
 #[tokio::test]
@@ -311,6 +312,24 @@ async fn promotes_metadata_for_full_responses_request() {
             .map(String::as_str),
         Some("true")
     );
+    assert_eq!(
+        ctx.filter_metadata
+            .get("openai_responses_format.has_tools")
+            .map(String::as_str),
+        Some("true")
+    );
+    assert_eq!(
+        ctx.filter_metadata
+            .get("openai_responses_format.has_prompt_id")
+            .map(String::as_str),
+        Some("true")
+    );
+    assert_eq!(
+        ctx.filter_metadata
+            .get("openai_responses_format.mode")
+            .map(String::as_str),
+        Some("stateful")
+    );
 }
 
 #[tokio::test]
@@ -325,6 +344,9 @@ async fn promotes_filter_results_for_full_responses_request() {
     assert_eq!(results.get("background"), Some("true"));
     assert_eq!(results.get("has_previous_response_id"), Some("true"));
     assert_eq!(results.get("has_conversation"), Some("true"));
+    assert_eq!(results.get("has_tools"), Some("true"));
+    assert_eq!(results.get("has_prompt_id"), Some("true"));
+    assert_eq!(results.get("mode"), Some("stateful"));
 }
 
 #[tokio::test]
@@ -364,6 +386,22 @@ async fn missing_optional_facts_not_promoted() {
         !ctx.filter_metadata
             .contains_key("openai_responses_format.has_conversation"),
         "conversation metadata absent"
+    );
+    assert!(
+        !ctx.filter_metadata.contains_key("openai_responses_format.has_tools"),
+        "tools metadata absent"
+    );
+    assert!(
+        !ctx.filter_metadata
+            .contains_key("openai_responses_format.has_prompt_id"),
+        "prompt_id metadata absent"
+    );
+    assert_eq!(
+        ctx.filter_metadata
+            .get("openai_responses_format.mode")
+            .map(String::as_str),
+        Some("stateful"),
+        "mode should be stateful when store is omitted (defaults to true)"
     );
 }
 
@@ -410,7 +448,7 @@ async fn custom_headers_emitted_at_runtime() {
 
 #[tokio::test]
 async fn null_headers_suppress_emission() {
-    let cfg = "headers:\n  format: null\n  model: null\n  stream: null";
+    let cfg = "headers:\n  format: null\n  model: null\n  stream: null\n  mode: null";
     let ctx = run_filter(cfg, r#"{"model":"gpt-4.1","input":"test","stream":true}"#).await;
 
     assert!(
@@ -616,11 +654,163 @@ async fn post_v1_responses_classifies_body_normally() {
 }
 
 // -----------------------------------------------------------------------------
+// Mode Computation
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn mode_stateless_when_store_false_no_stateful_markers() {
+    let ctx = run_filter("{}", r#"{"input":"test","store":false}"#).await;
+    let results = ctx.filter_results.get("openai_responses_format").unwrap();
+
+    assert_eq!(results.get("mode"), Some("stateless"));
+    assert_eq!(
+        ctx.filter_metadata
+            .get("openai_responses_format.mode")
+            .map(String::as_str),
+        Some("stateless")
+    );
+    let headers = collect_headers(&ctx);
+    assert_eq!(headers.get("x-praxis-responses-mode"), Some(&"stateless"));
+}
+
+#[tokio::test]
+async fn mode_stateful_when_store_omitted() {
+    let ctx = run_filter("{}", r#"{"input":"test"}"#).await;
+    let results = ctx.filter_results.get("openai_responses_format").unwrap();
+
+    assert_eq!(
+        results.get("mode"),
+        Some("stateful"),
+        "omitted store defaults to true (stateful)"
+    );
+}
+
+#[tokio::test]
+async fn mode_stateful_when_store_true() {
+    let ctx = run_filter("{}", r#"{"input":"test","store":true}"#).await;
+    let results = ctx.filter_results.get("openai_responses_format").unwrap();
+
+    assert_eq!(results.get("mode"), Some("stateful"));
+}
+
+#[tokio::test]
+async fn mode_stateful_when_previous_response_id() {
+    let ctx = run_filter(
+        "{}",
+        r#"{"input":"test","store":false,"previous_response_id":"resp_1"}"#,
+    )
+    .await;
+    let results = ctx.filter_results.get("openai_responses_format").unwrap();
+
+    assert_eq!(results.get("mode"), Some("stateful"));
+}
+
+#[tokio::test]
+async fn mode_stateful_when_tools_present() {
+    let ctx = run_filter("{}", r#"{"input":"test","store":false,"tools":[{"type":"function"}]}"#).await;
+    let results = ctx.filter_results.get("openai_responses_format").unwrap();
+
+    assert_eq!(results.get("mode"), Some("stateful"));
+}
+
+#[tokio::test]
+async fn mode_stateful_when_background_true() {
+    let ctx = run_filter("{}", r#"{"input":"test","store":false,"background":true}"#).await;
+    let results = ctx.filter_results.get("openai_responses_format").unwrap();
+
+    assert_eq!(results.get("mode"), Some("stateful"));
+}
+
+#[tokio::test]
+async fn mode_stateful_when_conversation_present() {
+    let ctx = run_filter("{}", r#"{"input":"test","store":false,"conversation":{"id":"conv_1"}}"#).await;
+    let results = ctx.filter_results.get("openai_responses_format").unwrap();
+
+    assert_eq!(results.get("mode"), Some("stateful"));
+}
+
+#[tokio::test]
+async fn mode_stateful_when_prompt_id_present() {
+    let ctx = run_filter(
+        "{}",
+        r#"{"input":"test","store":false,"prompt":{"prompt_id":"pmpt_123"}}"#,
+    )
+    .await;
+    let results = ctx.filter_results.get("openai_responses_format").unwrap();
+
+    assert_eq!(results.get("mode"), Some("stateful"));
+}
+
+#[tokio::test]
+async fn mode_not_set_for_chat_completions() {
+    let ctx = run_filter("{}", r#"{"messages":[{"role":"user","content":"Hi"}]}"#).await;
+    let results = ctx.filter_results.get("openai_responses_format").unwrap();
+
+    assert!(
+        results.get("mode").is_none(),
+        "mode should not be set for chat_completions"
+    );
+    assert!(
+        !ctx.filter_metadata.contains_key("openai_responses_format.mode"),
+        "mode metadata absent for chat_completions"
+    );
+    let headers = collect_headers(&ctx);
+    assert!(
+        !headers.contains_key("x-praxis-responses-mode"),
+        "mode header absent for chat_completions"
+    );
+}
+
+#[tokio::test]
+async fn mode_stateless_with_store_false_and_empty_tools() {
+    let ctx = run_filter("{}", r#"{"input":"test","store":false,"tools":[]}"#).await;
+    let results = ctx.filter_results.get("openai_responses_format").unwrap();
+
+    assert_eq!(
+        results.get("mode"),
+        Some("stateless"),
+        "empty tools should not trigger stateful"
+    );
+}
+
+#[tokio::test]
+async fn mode_header_uses_custom_name() {
+    let cfg = "headers:\n  mode: x-custom-mode";
+    let ctx = run_filter(cfg, r#"{"input":"test","store":false}"#).await;
+    let headers = collect_headers(&ctx);
+
+    assert_eq!(headers.get("x-custom-mode"), Some(&"stateless"));
+    assert!(
+        !headers.contains_key("x-praxis-responses-mode"),
+        "default mode header should not be emitted when overridden"
+    );
+}
+
+#[tokio::test]
+async fn mode_header_suppressed_when_null() {
+    let cfg = "headers:\n  mode: null";
+    let ctx = run_filter(cfg, r#"{"input":"test","store":false}"#).await;
+    let headers = collect_headers(&ctx);
+
+    assert!(
+        !headers.contains_key("x-praxis-responses-mode"),
+        "null mode header should suppress emission"
+    );
+    assert_eq!(
+        ctx.filter_metadata
+            .get("openai_responses_format.mode")
+            .map(String::as_str),
+        Some("stateless"),
+        "metadata still written with null mode header"
+    );
+}
+
+// -----------------------------------------------------------------------------
 // Test Utilities
 // -----------------------------------------------------------------------------
 
 /// Full Responses body with all optional fields for promotion tests.
-const FULL_RESPONSES_BODY: &str = r#"{"model":"gpt-4.1","input":"test","stream":true,"store":false,"background":true,"previous_response_id":"resp_abc","conversation":{"id":"conv_1"}}"#;
+const FULL_RESPONSES_BODY: &str = r#"{"model":"gpt-4.1","input":"test","stream":true,"store":false,"background":true,"previous_response_id":"resp_abc","conversation":{"id":"conv_1"},"tools":[{"type":"function"}],"prompt":{"prompt_id":"pmpt_123"}}"#;
 
 /// Run the filter's `on_request_body` and return the resulting context.
 async fn run_filter(config_yaml: &str, body_str: &str) -> HttpFilterContext<'static> {

--- a/tests/integration/tests/suite/examples/mod.rs
+++ b/tests/integration/tests/suite/examples/mod.rs
@@ -39,6 +39,8 @@ mod payload_processing;
 mod prompt_enrichment;
 mod protocols;
 mod redirect;
+#[cfg(feature = "ai-inference")]
+mod responses_routing;
 mod round_robin;
 mod session_affinity;
 mod static_response;

--- a/tests/integration/tests/suite/examples/responses_routing.rs
+++ b/tests/integration/tests/suite/examples/responses_routing.rs
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Functional tests for the OpenAI Responses routing example config.
+
+use std::collections::HashMap;
+
+use praxis_test_utils::{
+    free_port, http_send, json_post, load_example_config, parse_body, parse_status, start_echo_backend, start_proxy,
+};
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn responses_routing_example_forwards_stateless_to_backend() {
+    let backend_guard = start_echo_backend();
+    let proxy_port = free_port();
+
+    let config = load_example_config(
+        "ai/openai/responses/responses-routing.yaml",
+        proxy_port,
+        HashMap::from([("127.0.0.1:3001", backend_guard.port())]),
+    );
+
+    let proxy = start_proxy(&config);
+
+    let body = r#"{"model":"gpt-4.1","input":"Hello","store":false}"#;
+    let raw = http_send(proxy.addr(), &json_post("/v1/responses", body));
+
+    assert_eq!(parse_status(&raw), 200, "stateless should return 200");
+    assert_eq!(
+        parse_body(&raw),
+        body,
+        "stateless should forward request body unchanged"
+    );
+}
+
+#[test]
+fn responses_routing_example_forwards_stateful_to_backend() {
+    let backend_guard = start_echo_backend();
+    let proxy_port = free_port();
+
+    let config = load_example_config(
+        "ai/openai/responses/responses-routing.yaml",
+        proxy_port,
+        HashMap::from([("127.0.0.1:3001", backend_guard.port())]),
+    );
+
+    let proxy = start_proxy(&config);
+
+    let body = r#"{"model":"gpt-4.1","input":"Hello"}"#;
+    let raw = http_send(proxy.addr(), &json_post("/v1/responses", body));
+
+    assert_eq!(parse_status(&raw), 200, "stateful should return 200");
+    assert_eq!(
+        parse_body(&raw),
+        body,
+        "stateful should also reach the backend (same backend, different filter path)"
+    );
+}

--- a/tests/integration/tests/suite/main.rs
+++ b/tests/integration/tests/suite/main.rs
@@ -64,6 +64,8 @@ mod per_listener_pipeline;
 #[cfg(feature = "ai-inference")]
 mod prompt_enrich;
 mod rate_limit;
+#[cfg(feature = "ai-inference")]
+mod responses_routing;
 mod retry;
 mod routing;
 mod security;

--- a/tests/integration/tests/suite/responses_routing.rs
+++ b/tests/integration/tests/suite/responses_routing.rs
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Integration tests for the `openai_responses_format` mode routing.
+
+use praxis_core::config::Config;
+use praxis_test_utils::{
+    free_port, http_send, json_post, parse_body, parse_status, start_backend_with_shutdown, start_echo_backend,
+    start_proxy,
+};
+
+// -----------------------------------------------------------------------------
+// Mode Routing
+// -----------------------------------------------------------------------------
+
+#[test]
+fn mode_branch_routes_stateful_conditions_to_stateful_path() {
+    let cases = [
+        (
+            "store omitted (defaults to true)",
+            r#"{"model":"gpt-4.1","input":"Hello"}"#,
+        ),
+        ("store=true", r#"{"model":"gpt-4.1","input":"Hello","store":true}"#),
+        (
+            "previous_response_id",
+            r#"{"model":"gpt-4.1","input":"Hello","store":false,"previous_response_id":"resp_abc"}"#,
+        ),
+        (
+            "non-empty tools",
+            r#"{"model":"gpt-4.1","input":"Hello","store":false,"tools":[{"type":"function","function":{"name":"get_weather"}}]}"#,
+        ),
+        (
+            "background=true",
+            r#"{"model":"gpt-4.1","input":"Hello","store":false,"background":true}"#,
+        ),
+        (
+            "conversation present",
+            r#"{"model":"gpt-4.1","input":"Hello","store":false,"conversation":{"id":"conv_123"}}"#,
+        ),
+        (
+            "prompt_id present",
+            r#"{"model":"gpt-4.1","input":"Hello","store":false,"prompt":{"prompt_id":"pmpt_123"}}"#,
+        ),
+    ];
+
+    for (label, body) in cases {
+        assert_routes_to("stateful-path", label, body);
+    }
+}
+
+#[test]
+fn mode_branch_routes_stateless_conditions_to_default_path() {
+    let cases = [
+        (
+            "store=false, no stateful markers",
+            r#"{"model":"gpt-4.1","input":"Hello","store":false}"#,
+        ),
+        (
+            "store=false with empty tools",
+            r#"{"model":"gpt-4.1","input":"Hello","store":false,"tools":[]}"#,
+        ),
+    ];
+
+    for (label, body) in cases {
+        assert_routes_to("stateless-path", label, body);
+    }
+}
+
+#[test]
+fn mode_branch_stateless_body_not_mutated() {
+    let echo_guard = start_echo_backend();
+    let stateful_guard = start_backend_with_shutdown("stateful-path");
+    let proxy_port = free_port();
+
+    let config = Config::from_yaml(&mode_branch_yaml(proxy_port, stateful_guard.port(), echo_guard.port())).unwrap();
+
+    let proxy = start_proxy(&config);
+
+    let body = r#"{"model":"gpt-4.1","input":"Hello, world!","store":false,"temperature":0.7}"#;
+    let raw = http_send(proxy.addr(), &json_post("/v1/responses", body));
+
+    assert_eq!(parse_status(&raw), 200, "echo should return 200");
+    assert_eq!(
+        parse_body(&raw),
+        body,
+        "stateless should forward request body unchanged"
+    );
+}
+
+#[test]
+fn mode_branch_chat_completions_skips_branch() {
+    let stateless_guard = start_backend_with_shutdown("stateless-path");
+    let stateful_guard = start_backend_with_shutdown("stateful-path");
+    let proxy_port = free_port();
+
+    let config = Config::from_yaml(&mode_branch_yaml(
+        proxy_port,
+        stateful_guard.port(),
+        stateless_guard.port(),
+    ))
+    .unwrap();
+
+    let proxy = start_proxy(&config);
+
+    let body = r#"{"model":"gpt-4","messages":[{"role":"user","content":"Hi"}]}"#;
+    let raw = http_send(proxy.addr(), &json_post("/v1/chat/completions", body));
+
+    assert_eq!(parse_status(&raw), 200, "default should return 200");
+    assert_eq!(
+        parse_body(&raw),
+        "stateless-path",
+        "chat completions should skip mode branch (no mode set) and fall through"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Test Utilities
+// -----------------------------------------------------------------------------
+
+/// Assert that a request body routes to the expected backend.
+fn assert_routes_to(expected_backend: &str, label: &str, body: &str) {
+    let stateless_guard = start_backend_with_shutdown("stateless-path");
+    let stateful_guard = start_backend_with_shutdown("stateful-path");
+    let proxy_port = free_port();
+
+    let config = Config::from_yaml(&mode_branch_yaml(
+        proxy_port,
+        stateful_guard.port(),
+        stateless_guard.port(),
+    ))
+    .unwrap();
+
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(proxy.addr(), &json_post("/v1/responses", body));
+
+    assert_eq!(parse_status(&raw), 200, "{label}: expected 200");
+    assert_eq!(
+        parse_body(&raw),
+        expected_backend,
+        "{label}: expected {expected_backend} routing"
+    );
+}
+
+/// YAML config with mode-based branch chain routing.
+///
+/// Stateful requests (mode=stateful) enter the branch chain and route
+/// to `stateful_port`. Stateless requests (mode=stateless) or
+/// non-Responses requests fall through to `default_port`.
+fn mode_branch_yaml(proxy_port: u16, stateful_port: u16, default_port: u16) -> String {
+    format!(
+        r#"
+listeners:
+  - name: default
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: openai_responses_format
+        on_invalid: continue
+        branch_chains:
+          - name: stateful_branch
+            on_result:
+              filter: openai_responses_format
+              key: mode
+              result: stateful
+            rejoin: terminal
+            chains:
+              - name: stateful_chain
+                filters:
+                  - filter: router
+                    routes:
+                      - path_prefix: "/"
+                        cluster: "stateful"
+                  - filter: load_balancer
+                    clusters:
+                      - name: "stateful"
+                        endpoints:
+                          - "127.0.0.1:{stateful_port}"
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: "default"
+      - filter: load_balancer
+        clusters:
+          - name: "default"
+            endpoints:
+              - "127.0.0.1:{default_port}"
+"#
+    )
+}


### PR DESCRIPTION
## Summary

- Enhances the `openai_responses_format` filter to compute a combined `mode` (`stateless` | `stateful`) from request body fields, enabling single-condition branch chain routing for the Responses API fast path
- Adds `has_tools` and `has_prompt_id` detection to the classifier (reads nested `prompt.prompt_id` per OpenAI Prompts guide), promotes `mode` to metadata, filter_results, and a configurable `x-praxis-responses-mode` header
- A `prompt` object in the request body is now recognized as a Responses API format indicator
- Adds `responses-routing.yaml` example config demonstrating branch chain routing with a single backend
- Adds unit tests and integration tests covering all stateful conditions, stateless edge cases, and body-not-mutated verification
- Fixes proposal doc terminology: `conversation_id` → `conversation` (per OpenAI/OpenResponses spec)

Closes praxis-proxy/ai#217
Closes praxis-proxy/ai#94

## Test plan

- [x] `cargo test -p praxis-proxy-filter -- openai` — all unit tests pass
- [x] `cargo test -p praxis-tests-integration --test suite -- responses_routing` — 6 integration tests pass
- [x] `make lint` — clean
- [x] `make build` — clean
- [x] `make doc` — clean