### PR TITLE
refactor(filter): prefix API format values and filter name with openai_

### DIFF
--- a/docs/proposals/00354_responses-api-filters.md
+++ b/docs/proposals/00354_responses-api-filters.md
@@ -76,7 +76,7 @@ need to support this protocol whether their backends
 speak it natively or only support Chat Completions.
 
 Praxis already classifies Responses API requests via
-the `responses_format` filter (#372). The next step
+the `openai_responses_format` filter (#372). The next step
 is processing them: parsing requests, managing
 conversation state, calling inference, transforming
 streaming responses, dispatching tools, and looping
@@ -174,7 +174,7 @@ Request arrives at POST /v1/responses
 **Pass-through is the fast path.** A simple `POST /v1/responses` with `store=false` and a string input hits vLLM directly with sub-millisecond proxy overhead. The filter chain only activates when the request actually needs stateful processing.
 
 **What #361 promotes to headers for downstream routing:**
-- `x-praxis-api-format: responses | chat_completions` — detected API format
+- `x-praxis-api-format: openai_responses | openai_chat_completions` — detected API format
 - `x-praxis-responses-mode: passthrough | stateful` — routing decision
 - Model name extracted from body for cluster routing
 
@@ -255,7 +255,7 @@ struct ResponsesState {
 
 Filters access the orchestrator state via a well-known handle. Since filters run sequentially within a request, a full `Mutex` may not be necessary — simpler interior mutability (e.g., `RefCell` or just `&mut` access) could suffice. The exact synchronization primitive can be determined during implementation.
 
-**Relationship to #372 (`responses_format` classifier):** The #372 classifier runs upstream of our filter chain. It uses `StreamBuffer` in read-only mode to classify the request format (Responses vs Chat Completions) and promotes routing facts to metadata/headers/filter_results, but does NOT retain the parsed body. Our `request_validate` filter parses the body independently via its own `StreamBuffer`, creates `ResponsesState`, and makes it available to the rest of the chain. This means the JSON body is parsed twice (once by #372 for classification, once by `request_validate` for validation) — sub-millisecond cost, clean separation of concerns.
+**Relationship to #372 (`openai_responses_format` classifier):** The #372 classifier runs upstream of our filter chain. It uses `StreamBuffer` in read-only mode to classify the request format (Responses vs Chat Completions) and promotes routing facts to metadata/headers/filter_results, but does NOT retain the parsed body. Our `request_validate` filter parses the body independently via its own `StreamBuffer`, creates `ResponsesState`, and makes it available to the rest of the chain. This means the JSON body is parsed twice (once by #372 for classification, once by `request_validate` for validation) — sub-millisecond cost, clean separation of concerns.
 
 ### Filter Specifications
 

--- a/examples/configs/ai/openai/responses/format-routing.yaml
+++ b/examples/configs/ai/openai/responses/format-routing.yaml
@@ -1,8 +1,8 @@
 # Responses Format Routing
 #
-# Routes AI API traffic by detected body format. The `responses_format`
-# filter parses JSON request bodies and classifies them as `responses`
-# (Responses API), `chat_completions` (Chat Completions API), or
+# Routes AI API traffic by detected body format. The `openai_responses_format`
+# filter parses JSON request bodies and classifies them as `openai_responses`
+# (Responses API), `openai_chat_completions` (Chat Completions API), or
 # `unknown` (valid JSON but unrecognized format).
 #
 # Classification facts are promoted to internal routing headers
@@ -22,7 +22,7 @@ listeners:
 filter_chains:
   - name: ai-routing
     filters:
-      - filter: responses_format
+      - filter: openai_responses_format
         on_invalid: continue
         max_body_bytes: 67108864
         headers:
@@ -34,11 +34,11 @@ filter_chains:
         routes:
           - path: "/v1/responses"
             headers:
-              x-praxis-ai-format: "responses"
+              x-praxis-ai-format: "openai_responses"
             cluster: "responses-backend"
           - path: "/v1/chat/completions"
             headers:
-              x-praxis-ai-format: "chat_completions"
+              x-praxis-ai-format: "openai_chat_completions"
             cluster: "chat-backend"
           - path_prefix: "/"
             cluster: "default-backend"

--- a/filter/src/builtins/http/ai/openai/responses/classifier/mod.rs
+++ b/filter/src/builtins/http/ai/openai/responses/classifier/mod.rs
@@ -26,8 +26,8 @@ impl AiRequestFormat {
     /// Stable string representation for headers, metadata, and filter results.
     pub(crate) fn as_str(self) -> &'static str {
         match self {
-            Self::Responses => "responses",
-            Self::ChatCompletions => "chat_completions",
+            Self::Responses => "openai_responses",
+            Self::ChatCompletions => "openai_chat_completions",
             Self::UnknownJson => "unknown",
             Self::InvalidJson => "invalid_json",
             Self::NonJson => "non_json",
@@ -226,7 +226,7 @@ mod tests {
         assert_eq!(
             result.format,
             AiRequestFormat::ChatCompletions,
-            "messages array should classify as chat_completions"
+            "messages array should classify as openai_chat_completions"
         );
         assert_eq!(result.model.as_deref(), Some("gpt-4"), "model should be extracted");
     }
@@ -239,7 +239,7 @@ mod tests {
         assert_eq!(
             result.format,
             AiRequestFormat::ChatCompletions,
-            "should be chat_completions"
+            "should be openai_chat_completions"
         );
         assert_eq!(result.stream, Some(true), "stream should be extracted");
     }

--- a/filter/src/builtins/http/ai/openai/responses/config.rs
+++ b/filter/src/builtins/http/ai/openai/responses/config.rs
@@ -47,7 +47,7 @@ pub(crate) enum OnInvalidBehavior {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct ResponsesFormatHeaders {
-    /// Header name for the detected format (e.g. `responses`, `chat_completions`).
+    /// Header name for the detected format (e.g. `openai_responses`, `openai_chat_completions`).
     #[serde(default = "default_format_header")]
     pub format: Option<String>,
 
@@ -132,7 +132,7 @@ fn default_max_body_bytes() -> usize {
 /// Validate the parsed configuration.
 pub(crate) fn build_config(cfg: ResponsesFormatConfig) -> Result<ResponsesFormatConfig, FilterError> {
     if cfg.max_body_bytes == 0 {
-        return Err("responses_format: 'max_body_bytes' must be greater than 0".into());
+        return Err("openai_responses_format: 'max_body_bytes' must be greater than 0".into());
     }
 
     validate_header_name("format", cfg.headers.format.as_deref())?;
@@ -148,10 +148,10 @@ fn validate_header_name(field: &str, header_name: Option<&str>) -> Result<(), Fi
         return Ok(());
     };
     if header_name.is_empty() {
-        return Err(format!("responses_format: {field} header name must not be empty").into());
+        return Err(format!("openai_responses_format: {field} header name must not be empty").into());
     }
     if http::HeaderName::from_bytes(header_name.as_bytes()).is_err() {
-        return Err(format!("responses_format: {field} header name is not a valid HTTP header name").into());
+        return Err(format!("openai_responses_format: {field} header name is not a valid HTTP header name").into());
     }
     Ok(())
 }

--- a/filter/src/builtins/http/ai/openai/responses/mod.rs
+++ b/filter/src/builtins/http/ai/openai/responses/mod.rs
@@ -59,13 +59,13 @@ use crate::{
 /// # YAML
 ///
 /// ```yaml
-/// filter: responses_format
+/// filter: openai_responses_format
 /// ```
 ///
 /// # Full YAML
 ///
 /// ```yaml
-/// filter: responses_format
+/// filter: openai_responses_format
 /// on_invalid: continue
 /// max_body_bytes: 67108864
 /// headers:
@@ -87,7 +87,7 @@ impl ResponsesFormatFilter {
     ///
     /// [`FilterError`]: crate::FilterError
     pub fn from_config(config: &serde_yaml::Value) -> Result<Box<dyn HttpFilter>, FilterError> {
-        let cfg: ResponsesFormatConfig = parse_filter_config("responses_format", config)?;
+        let cfg: ResponsesFormatConfig = parse_filter_config("openai_responses_format", config)?;
         let validated = build_config(cfg)?;
         Ok(Box::new(Self { config: validated }))
     }
@@ -96,7 +96,7 @@ impl ResponsesFormatFilter {
 #[async_trait]
 impl HttpFilter for ResponsesFormatFilter {
     fn name(&self) -> &'static str {
-        "responses_format"
+        "openai_responses_format"
     }
 
     fn request_body_access(&self) -> BodyAccess {
@@ -179,32 +179,35 @@ fn handle_invalid_format(format: AiRequestFormat, config: &ResponsesFormatConfig
 /// Write durable metadata that persists across all Pingora lifecycle phases.
 fn write_metadata(ctx: &mut HttpFilterContext<'_>, classified: &classifier::ClassifiedRequest) {
     let format_str = classified.format.as_str();
-    ctx.set_metadata("responses_format.format", format_str);
+    ctx.set_metadata("openai_responses_format.format", format_str);
 
     if let Some(model) = &classified.model
         && is_safe_promoted_value(model)
     {
-        ctx.set_metadata("responses_format.model", model.clone());
+        ctx.set_metadata("openai_responses_format.model", model.clone());
     }
 
     if let Some(stream) = classified.stream {
-        ctx.set_metadata("responses_format.stream", if stream { "true" } else { "false" });
+        ctx.set_metadata("openai_responses_format.stream", if stream { "true" } else { "false" });
     }
 
     if let Some(store) = classified.store {
-        ctx.set_metadata("responses_format.store", if store { "true" } else { "false" });
+        ctx.set_metadata("openai_responses_format.store", if store { "true" } else { "false" });
     }
 
     if let Some(background) = classified.background {
-        ctx.set_metadata("responses_format.background", if background { "true" } else { "false" });
+        ctx.set_metadata(
+            "openai_responses_format.background",
+            if background { "true" } else { "false" },
+        );
     }
 
     if classified.has_previous_response_id {
-        ctx.set_metadata("responses_format.has_previous_response_id", "true");
+        ctx.set_metadata("openai_responses_format.has_previous_response_id", "true");
     }
 
     if classified.has_conversation {
-        ctx.set_metadata("responses_format.has_conversation", "true");
+        ctx.set_metadata("openai_responses_format.has_conversation", "true");
     }
 }
 
@@ -243,7 +246,7 @@ fn promote_filter_results(
     ctx: &mut HttpFilterContext<'_>,
     classified: &classifier::ClassifiedRequest,
 ) -> Result<(), FilterError> {
-    let results = ctx.filter_results.entry("responses_format").or_default();
+    let results = ctx.filter_results.entry("openai_responses_format").or_default();
 
     results.set("format", classified.format.as_str())?;
 

--- a/filter/src/builtins/http/ai/openai/responses/tests.rs
+++ b/filter/src/builtins/http/ai/openai/responses/tests.rs
@@ -181,7 +181,7 @@ fn non_json_reject_returns_reject() {
 }
 
 #[test]
-fn responses_format_not_rejected() {
+fn openai_responses_format_not_rejected() {
     let cfg: ResponsesFormatConfig = serde_yaml::from_str("on_invalid: reject").unwrap();
     let result = handle_invalid_format(AiRequestFormat::Responses, &cfg);
     assert!(result.is_none(), "responses format should not be rejected");

--- a/filter/src/builtins/http/ai/openai/responses/tests.rs
+++ b/filter/src/builtins/http/ai/openai/responses/tests.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Praxis Contributors
 
-//! Unit tests for the `responses_format` filter.
+//! Unit tests for the `openai_responses_format` filter.
 
 use bytes::Bytes;
 
@@ -17,8 +17,8 @@ fn default_config_parses() {
     let filter = ResponsesFormatFilter::from_config(&yaml).unwrap();
     assert_eq!(
         filter.name(),
-        "responses_format",
-        "filter name should be responses_format"
+        "openai_responses_format",
+        "filter name should be openai_responses_format"
     );
 }
 
@@ -39,8 +39,8 @@ headers:
     let filter = ResponsesFormatFilter::from_config(&yaml).unwrap();
     assert_eq!(
         filter.name(),
-        "responses_format",
-        "filter name should be responses_format"
+        "openai_responses_format",
+        "filter name should be openai_responses_format"
     );
 }
 
@@ -48,14 +48,14 @@ headers:
 fn on_invalid_continue_parses() {
     let yaml: serde_yaml::Value = serde_yaml::from_str("on_invalid: continue").unwrap();
     let filter = ResponsesFormatFilter::from_config(&yaml).unwrap();
-    assert_eq!(filter.name(), "responses_format", "continue mode should parse");
+    assert_eq!(filter.name(), "openai_responses_format", "continue mode should parse");
 }
 
 #[test]
 fn on_invalid_reject_parses() {
     let yaml: serde_yaml::Value = serde_yaml::from_str("on_invalid: reject").unwrap();
     let filter = ResponsesFormatFilter::from_config(&yaml).unwrap();
-    assert_eq!(filter.name(), "responses_format", "reject mode should parse");
+    assert_eq!(filter.name(), "openai_responses_format", "reject mode should parse");
 }
 
 #[test]
@@ -112,7 +112,7 @@ headers:
     let filter = ResponsesFormatFilter::from_config(&yaml).unwrap();
     assert_eq!(
         filter.name(),
-        "responses_format",
+        "openai_responses_format",
         "null headers should disable promotion"
     );
 }
@@ -191,7 +191,10 @@ fn responses_format_not_rejected() {
 fn chat_completions_not_rejected() {
     let cfg: ResponsesFormatConfig = serde_yaml::from_str("on_invalid: reject").unwrap();
     let result = handle_invalid_format(AiRequestFormat::ChatCompletions, &cfg);
-    assert!(result.is_none(), "chat_completions format should not be rejected");
+    assert!(
+        result.is_none(),
+        "openai_chat_completions format should not be rejected"
+    );
 }
 
 #[test]
@@ -239,7 +242,11 @@ async fn promotes_headers_for_full_responses_request() {
     let ctx = run_filter("{}", FULL_RESPONSES_BODY).await;
     let headers = collect_headers(&ctx);
 
-    assert_eq!(headers.get("x-praxis-ai-format"), Some(&"responses"), "format header");
+    assert_eq!(
+        headers.get("x-praxis-ai-format"),
+        Some(&"openai_responses"),
+        "format header"
+    );
     assert_eq!(headers.get("x-praxis-ai-model"), Some(&"gpt-4.1"), "model header");
     assert_eq!(headers.get("x-praxis-ai-stream"), Some(&"true"), "stream header");
     assert!(
@@ -253,36 +260,44 @@ async fn promotes_metadata_for_full_responses_request() {
     let ctx = run_filter("{}", FULL_RESPONSES_BODY).await;
 
     assert_eq!(
-        ctx.filter_metadata.get("responses_format.format").map(String::as_str),
-        Some("responses")
+        ctx.filter_metadata
+            .get("openai_responses_format.format")
+            .map(String::as_str),
+        Some("openai_responses")
     );
     assert_eq!(
-        ctx.filter_metadata.get("responses_format.model").map(String::as_str),
+        ctx.filter_metadata
+            .get("openai_responses_format.model")
+            .map(String::as_str),
         Some("gpt-4.1")
     );
     assert_eq!(
-        ctx.filter_metadata.get("responses_format.stream").map(String::as_str),
+        ctx.filter_metadata
+            .get("openai_responses_format.stream")
+            .map(String::as_str),
         Some("true")
     );
     assert_eq!(
-        ctx.filter_metadata.get("responses_format.store").map(String::as_str),
+        ctx.filter_metadata
+            .get("openai_responses_format.store")
+            .map(String::as_str),
         Some("false")
     );
     assert_eq!(
         ctx.filter_metadata
-            .get("responses_format.background")
+            .get("openai_responses_format.background")
             .map(String::as_str),
         Some("true")
     );
     assert_eq!(
         ctx.filter_metadata
-            .get("responses_format.has_previous_response_id")
+            .get("openai_responses_format.has_previous_response_id")
             .map(String::as_str),
         Some("true")
     );
     assert_eq!(
         ctx.filter_metadata
-            .get("responses_format.has_conversation")
+            .get("openai_responses_format.has_conversation")
             .map(String::as_str),
         Some("true")
     );
@@ -291,9 +306,9 @@ async fn promotes_metadata_for_full_responses_request() {
 #[tokio::test]
 async fn promotes_filter_results_for_full_responses_request() {
     let ctx = run_filter("{}", FULL_RESPONSES_BODY).await;
-    let results = ctx.filter_results.get("responses_format").unwrap();
+    let results = ctx.filter_results.get("openai_responses_format").unwrap();
 
-    assert_eq!(results.get("format"), Some("responses"));
+    assert_eq!(results.get("format"), Some("openai_responses"));
     assert_eq!(results.get("model"), Some("gpt-4.1"));
     assert_eq!(results.get("stream"), Some("true"));
     assert_eq!(results.get("store"), Some("false"));
@@ -309,34 +324,35 @@ async fn missing_optional_facts_not_promoted() {
 
     assert_eq!(
         headers.get("x-praxis-ai-format"),
-        Some(&"responses"),
+        Some(&"openai_responses"),
         "format still promoted"
     );
     assert!(!headers.contains_key("x-praxis-ai-model"), "model header absent");
     assert!(!headers.contains_key("x-praxis-ai-stream"), "stream header absent");
     assert!(
-        !ctx.filter_metadata.contains_key("responses_format.model"),
+        !ctx.filter_metadata.contains_key("openai_responses_format.model"),
         "model metadata absent"
     );
     assert!(
-        !ctx.filter_metadata.contains_key("responses_format.stream"),
+        !ctx.filter_metadata.contains_key("openai_responses_format.stream"),
         "stream metadata absent"
     );
     assert!(
-        !ctx.filter_metadata.contains_key("responses_format.store"),
+        !ctx.filter_metadata.contains_key("openai_responses_format.store"),
         "store metadata absent"
     );
     assert!(
-        !ctx.filter_metadata.contains_key("responses_format.background"),
+        !ctx.filter_metadata.contains_key("openai_responses_format.background"),
         "background metadata absent"
     );
     assert!(
         !ctx.filter_metadata
-            .contains_key("responses_format.has_previous_response_id"),
+            .contains_key("openai_responses_format.has_previous_response_id"),
         "prev_id metadata absent"
     );
     assert!(
-        !ctx.filter_metadata.contains_key("responses_format.has_conversation"),
+        !ctx.filter_metadata
+            .contains_key("openai_responses_format.has_conversation"),
         "conversation metadata absent"
     );
 }
@@ -352,7 +368,7 @@ async fn oversized_model_not_promoted_to_header_or_results() {
         !headers.contains_key("x-praxis-ai-model"),
         "oversized model not in header"
     );
-    let results = ctx.filter_results.get("responses_format").unwrap();
+    let results = ctx.filter_results.get("openai_responses_format").unwrap();
     assert!(results.get("model").is_none(), "oversized model not in results");
 }
 
@@ -373,7 +389,7 @@ async fn custom_headers_emitted_at_runtime() {
     let ctx = run_filter(cfg, r#"{"model":"gpt-4.1","input":"test","stream":true}"#).await;
     let headers = collect_headers(&ctx);
 
-    assert_eq!(headers.get("x-custom-fmt"), Some(&"responses"), "custom format");
+    assert_eq!(headers.get("x-custom-fmt"), Some(&"openai_responses"), "custom format");
     assert_eq!(headers.get("x-custom-mdl"), Some(&"gpt-4.1"), "custom model");
     assert_eq!(headers.get("x-custom-strm"), Some(&"true"), "custom stream");
     assert!(
@@ -392,8 +408,10 @@ async fn null_headers_suppress_emission() {
         "null headers suppress all emission"
     );
     assert_eq!(
-        ctx.filter_metadata.get("responses_format.format").map(String::as_str),
-        Some("responses"),
+        ctx.filter_metadata
+            .get("openai_responses_format.format")
+            .map(String::as_str),
+        Some("openai_responses"),
         "metadata still written with null headers"
     );
 }

--- a/filter/src/registry.rs
+++ b/filter/src/registry.rs
@@ -158,7 +158,7 @@ fn register_http_builtins(factories: &mut HashMap<String, FilterFactory>) {
     #[cfg(feature = "ai-inference")]
     register_http(
         factories,
-        "responses_format",
+        "openai_responses_format",
         crate::builtins::ResponsesFormatFilter::from_config,
     );
 }
@@ -278,8 +278,8 @@ mod tests {
         assert!(names.contains(&"prompt_enrich"), "prompt_enrich should be registered");
         #[cfg(feature = "ai-inference")]
         assert!(
-            names.contains(&"responses_format"),
-            "responses_format should be registered"
+            names.contains(&"openai_responses_format"),
+            "openai_responses_format should be registered"
         );
     }
 

--- a/tests/integration/tests/suite/examples/mod.rs
+++ b/tests/integration/tests/suite/examples/mod.rs
@@ -29,6 +29,8 @@ mod max_connections;
 #[cfg(feature = "ai-inference")]
 mod model_to_header;
 mod multi_listener;
+#[cfg(feature = "ai-inference")]
+mod openai_responses_format;
 mod p2c;
 mod path_based_routing;
 mod path_rewriting;
@@ -37,8 +39,6 @@ mod payload_processing;
 mod prompt_enrichment;
 mod protocols;
 mod redirect;
-#[cfg(feature = "ai-inference")]
-mod responses_format;
 mod round_robin;
 mod session_affinity;
 mod static_response;

--- a/tests/integration/tests/suite/examples/openai_responses_format.rs
+++ b/tests/integration/tests/suite/examples/openai_responses_format.rs
@@ -15,7 +15,7 @@ use praxis_test_utils::{
 // -----------------------------------------------------------------------------
 
 #[test]
-fn responses_format_routing_example_routes_responses_input() {
+fn openai_responses_format_routing_example_routes_responses_input() {
     let responses_guard = start_backend_with_shutdown("responses-backend");
     let chat_guard = start_backend_with_shutdown("chat-backend");
     let default_guard = start_backend_with_shutdown("default-backend");
@@ -44,7 +44,7 @@ fn responses_format_routing_example_routes_responses_input() {
 }
 
 #[test]
-fn responses_format_routing_example_routes_chat_completions() {
+fn openai_responses_format_routing_example_routes_chat_completions() {
     let responses_guard = start_backend_with_shutdown("responses-backend");
     let chat_guard = start_backend_with_shutdown("chat-backend");
     let default_guard = start_backend_with_shutdown("default-backend");
@@ -73,7 +73,7 @@ fn responses_format_routing_example_routes_chat_completions() {
 }
 
 #[test]
-fn responses_format_routing_example_unknown_falls_to_default() {
+fn openai_responses_format_routing_example_unknown_falls_to_default() {
     let responses_guard = start_backend_with_shutdown("responses-backend");
     let chat_guard = start_backend_with_shutdown("chat-backend");
     let default_guard = start_backend_with_shutdown("default-backend");

--- a/tests/integration/tests/suite/main.rs
+++ b/tests/integration/tests/suite/main.rs
@@ -55,14 +55,14 @@ mod json_body_field;
 mod json_rpc;
 mod mcp;
 mod mcp_broker;
+#[cfg(feature = "ai-inference")]
+mod openai_responses_format;
 mod path_rewrite;
 mod payload_processing;
 mod per_listener_pipeline;
 #[cfg(feature = "ai-inference")]
 mod prompt_enrich;
 mod rate_limit;
-#[cfg(feature = "ai-inference")]
-mod responses_format;
 mod retry;
 mod routing;
 mod security;

--- a/tests/integration/tests/suite/openai_responses_format.rs
+++ b/tests/integration/tests/suite/openai_responses_format.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Praxis Contributors
 
-//! Integration tests for the `responses_format` classifier filter.
+//! Integration tests for the `openai_responses_format` classifier filter.
 
 use praxis_core::config::Config;
 use praxis_test_utils::{
@@ -396,7 +396,7 @@ fn filter_results_enable_branch_routing() {
     assert_eq!(
         parse_body(&raw_chat),
         "default-branch-miss",
-        "branch should not fire for chat_completions, falling through to default"
+        "branch should not fire for openai_chat_completions, falling through to default"
     );
 }
 
@@ -496,17 +496,17 @@ listeners:
 filter_chains:
   - name: main
     filters:
-      - filter: responses_format
+      - filter: openai_responses_format
         on_invalid: continue
       - filter: router
         routes:
           - path: "/v1/responses"
             headers:
-              x-praxis-ai-format: "responses"
+              x-praxis-ai-format: "openai_responses"
             cluster: "responses"
           - path: "/v1/chat/completions"
             headers:
-              x-praxis-ai-format: "chat_completions"
+              x-praxis-ai-format: "openai_chat_completions"
             cluster: "chat"
           - path_prefix: "/"
             cluster: "default"
@@ -536,7 +536,7 @@ listeners:
 filter_chains:
   - name: main
     filters:
-      - filter: responses_format
+      - filter: openai_responses_format
         on_invalid: continue
       - filter: router
         routes:
@@ -562,7 +562,7 @@ listeners:
 filter_chains:
   - name: main
     filters:
-      - filter: responses_format
+      - filter: openai_responses_format
         on_invalid: reject
       - filter: router
         routes:
@@ -588,7 +588,7 @@ listeners:
 filter_chains:
   - name: main
     filters:
-      - filter: responses_format
+      - filter: openai_responses_format
       - filter: router
         routes:
           - path_prefix: "/"
@@ -613,7 +613,7 @@ listeners:
 filter_chains:
   - name: main
     filters:
-      - filter: responses_format
+      - filter: openai_responses_format
       - filter: router
         routes:
           - path_prefix: "/"
@@ -638,13 +638,13 @@ listeners:
 filter_chains:
   - name: main
     filters:
-      - filter: responses_format
+      - filter: openai_responses_format
         branch_chains:
           - name: responses_branch
             on_result:
-              filter: responses_format
+              filter: openai_responses_format
               key: format
-              result: responses
+              result: openai_responses
             rejoin: terminal
             chains:
               - name: responses_chain
@@ -682,11 +682,11 @@ listeners:
 filter_chains:
   - name: main
     filters:
-      - filter: responses_format
+      - filter: openai_responses_format
         branch_chains:
           - name: background_branch
             on_result:
-              filter: responses_format
+              filter: openai_responses_format
               key: background
               result: true
             rejoin: terminal
@@ -726,7 +726,7 @@ listeners:
 filter_chains:
   - name: main
     filters:
-      - filter: responses_format
+      - filter: openai_responses_format
       - filter: router
         routes:
           - path_prefix: "/"
@@ -765,7 +765,7 @@ listeners:
 filter_chains:
   - name: main
     filters:
-      - filter: responses_format
+      - filter: openai_responses_format
       - filter: router
         routes:
           - path_prefix: "/"


### PR DESCRIPTION
## Summary

- Rename `responses_format` filter to `openai_responses_format` across registry, filter name, metadata keys, filter results, error messages, YAML configs, and tests
- Rename format string values from `responses`/`chat_completions` to `openai_responses`/`openai_chat_completions` in `AiRequestFormat::as_str()`
- Rename integration test files from `responses_format.rs` to `openai_responses_format.rs` with updated `mod` declarations
- Update example config, proposal doc, and all test assertions to match the new names

This namespaces the filter and its output values under the OpenAI provider as multi-provider support expands.

## Test plan
- [x] All 1423 filter unit tests pass
- [x] All 159 schema tests pass
- [x] Clippy clean, `make lint` passes
- [x] `make build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)