### PR TITLE
feat(store): add SqliteResponseStore backend and tests

### DIFF
--- a/filter/src/builtins/http/ai/openai/responses/mod.rs
+++ b/filter/src/builtins/http/ai/openai/responses/mod.rs
@@ -19,6 +19,11 @@
 
 pub(crate) mod classifier;
 mod config;
+#[allow(
+    dead_code,
+    reason = "store utilities for GET (#458) and DELETE (#459) response endpoints"
+)]
+pub(crate) mod store;
 
 #[cfg(test)]
 #[allow(

--- a/filter/src/builtins/http/ai/openai/responses/store/input_items.rs
+++ b/filter/src/builtins/http/ai/openai/responses/store/input_items.rs
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Input item pagination for the `OpenAI` Responses API.
+
+use crate::builtins::http::ai::store::{ResponseRecord, StoreError};
+
+// -----------------------------------------------------------------------------
+// Constants
+// -----------------------------------------------------------------------------
+
+/// Default page size for input item list operations (matches `OpenAI` default).
+const DEFAULT_PAGE_LIMIT: u32 = 20;
+
+/// Maximum page size for input item list operations (matches `OpenAI` maximum).
+const MAX_PAGE_LIMIT: u32 = 100;
+
+// -----------------------------------------------------------------------------
+// Order
+// -----------------------------------------------------------------------------
+
+/// Sort order for input item listing.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum Order {
+    /// Oldest first (natural input order).
+    Ascending,
+
+    /// Newest first (reversed input order).
+    #[default]
+    Descending,
+}
+
+// -----------------------------------------------------------------------------
+// ListParams
+// -----------------------------------------------------------------------------
+
+/// Cursor-based pagination parameters for input item listing.
+#[derive(Debug, Clone)]
+pub struct ListParams {
+    /// Opaque cursor for the next page. `None` starts from the
+    /// beginning.
+    pub cursor: Option<String>,
+
+    /// Maximum number of items to return (clamped to
+    /// `1..=[MAX_PAGE_LIMIT]`).
+    pub limit: u32,
+
+    /// Sort order.
+    pub order: Order,
+}
+
+impl Default for ListParams {
+    fn default() -> Self {
+        Self {
+            cursor: None,
+            limit: DEFAULT_PAGE_LIMIT,
+            order: Order::default(),
+        }
+    }
+}
+
+impl ListParams {
+    /// Return the effective limit, clamped to `1..=[MAX_PAGE_LIMIT]`.
+    fn effective_limit(&self) -> u32 {
+        self.limit.clamp(1, MAX_PAGE_LIMIT)
+    }
+}
+
+// -----------------------------------------------------------------------------
+// InputItemPage
+// -----------------------------------------------------------------------------
+
+/// A page of input items from an `OpenAI` Responses API response.
+pub struct InputItemPage {
+    /// Input items as JSON values (heterogeneous types).
+    pub data: Vec<serde_json::Value>,
+
+    /// Cursor for the next page (`None` when no more pages).
+    pub next_cursor: Option<String>,
+
+    /// Whether more pages exist beyond this one.
+    pub has_more: bool,
+}
+
+// -----------------------------------------------------------------------------
+// Input Item Pagination
+// -----------------------------------------------------------------------------
+
+/// Extract and paginate input items from a [`ResponseRecord`].
+///
+/// Items are extracted from the stored `input` JSON column and
+/// paginated in memory using an offset-based cursor. This is
+/// specific to the `OpenAI` Responses API `/v1/responses/{id}/input_items`
+/// endpoint.
+///
+/// # Errors
+///
+/// Returns [`StoreError::Database`] if the cursor is malformed
+/// or overflows while calculating the page window. Uses the
+/// `Database` variant as a pragmatic fit until a dedicated
+/// input-validation variant is added to [`StoreError`].
+pub fn list_input_items(record: &ResponseRecord, params: &ListParams) -> Result<InputItemPage, StoreError> {
+    let mut items = match &record.input {
+        serde_json::Value::Array(arr) => arr.clone(),
+        other => vec![other.clone()],
+    };
+    if params.order == Order::Descending {
+        items.reverse();
+    }
+
+    let offset = params
+        .cursor
+        .as_deref()
+        .map(str::parse::<usize>)
+        .transpose()
+        .map_err(|e| StoreError::Database(format!("invalid input_items cursor: {e}")))?
+        .unwrap_or(0);
+
+    let limit = usize::try_from(params.effective_limit()).map_err(|e| StoreError::Database(e.to_string()))?;
+    let end = offset
+        .checked_add(limit)
+        .ok_or_else(|| StoreError::Database("input_items cursor offset overflow".to_owned()))?
+        .min(items.len());
+    let has_more = end < items.len();
+
+    let data: Vec<serde_json::Value> = items.into_iter().skip(offset).take(limit).collect();
+
+    let next_cursor = if has_more { Some(end.to_string()) } else { None };
+
+    Ok(InputItemPage {
+        data,
+        next_cursor,
+        has_more,
+    })
+}

--- a/filter/src/builtins/http/ai/openai/responses/store/mod.rs
+++ b/filter/src/builtins/http/ai/openai/responses/store/mod.rs
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! `OpenAI` Responses API store utilities.
+//!
+//! Helpers that operate on the generic [`ResponseStore`] but are
+//! specific to the `OpenAI` Responses API (e.g., input item
+//! pagination for the `/v1/responses/{id}/input_items` endpoint).
+//!
+//! [`ResponseStore`]: crate::builtins::http::ai::store::ResponseStore
+
+mod input_items;
+
+#[allow(
+    unused_imports,
+    reason = "re-exports for GET (#458) and DELETE (#459) response endpoints"
+)]
+pub use input_items::{InputItemPage, ListParams, Order, list_input_items};

--- a/filter/src/builtins/http/ai/store/mod.rs
+++ b/filter/src/builtins/http/ai/store/mod.rs
@@ -3,15 +3,29 @@
 
 //! Response store persistence layer for AI API filters.
 //!
-//! Provides the [`ResponseStore`] async trait and supporting
-//! types. Used by Responses API filters for persisting response
-//! records and conversation history.
+//! Provides the [`ResponseStore`] async trait, [`SqliteResponseStore`]
+//! backend, and supporting types. Used by AI API filters for
+//! persisting response records and conversation history.
 
+mod schemas;
+mod sqlite;
 mod trait_def;
 mod types;
 
-#[allow(unused_imports, reason = "re-exports for upcoming store backend and filter")]
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    clippy::too_many_lines,
+    reason = "tests"
+)]
+mod tests;
+
+#[allow(unused_imports, reason = "re-exports for upcoming store filter and registry")]
 pub use self::{
+    sqlite::SqliteResponseStore,
     trait_def::ResponseStore,
     types::{ConversationRecord, ResponseRecord, StoreError},
 };

--- a/filter/src/builtins/http/ai/store/schemas.rs
+++ b/filter/src/builtins/http/ai/store/schemas.rs
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! SQL schema generation for the response store.
+
+use super::types::StoreError;
+
+// -----------------------------------------------------------------------------
+// Table Names
+// -----------------------------------------------------------------------------
+
+/// Resolved table names for a store instance.
+///
+/// Table names are configured via YAML (e.g.,
+/// `openai_responses`, `google_interactions`). Each provider
+/// chooses its own names.
+pub(crate) struct TableNames {
+    /// Responses table name.
+    pub responses: String,
+    /// Conversation messages table name.
+    pub conversations: String,
+}
+
+// -----------------------------------------------------------------------------
+// Schema DDL
+// -----------------------------------------------------------------------------
+
+/// Generate DDL statements for the given table names.
+///
+/// Each statement uses `IF NOT EXISTS` so it is safe to run on
+/// every startup. The schema uses TEXT for JSON columns (standard
+/// `SQLite` pattern).
+///
+/// # Errors
+///
+/// Returns [`StoreError::Database`] if table names contain
+/// invalid characters.
+pub(crate) fn generate_ddl(tables: &TableNames) -> Result<Vec<String>, StoreError> {
+    let (r, c) = validate_table_names(tables)?;
+
+    Ok(vec![
+        format!(
+            "CREATE TABLE IF NOT EXISTS {r} (
+                tenant_id       TEXT NOT NULL,
+                id              TEXT NOT NULL,
+                created_at      INTEGER NOT NULL,
+                model           TEXT NOT NULL,
+                response_object TEXT NOT NULL,
+                input           TEXT NOT NULL,
+                messages        TEXT NOT NULL,
+                PRIMARY KEY (tenant_id, id)
+            )"
+        ),
+        format!(
+            "CREATE TABLE IF NOT EXISTS {c} (
+                conversation_id TEXT NOT NULL,
+                tenant_id       TEXT NOT NULL,
+                messages        TEXT NOT NULL,
+                PRIMARY KEY (conversation_id, tenant_id)
+            )"
+        ),
+        format!("CREATE INDEX IF NOT EXISTS idx_{c}_tenant_id ON {c}(tenant_id)"),
+    ])
+}
+
+/// Validate the configured table names and return them as borrowed identifiers.
+fn validate_table_names(tables: &TableNames) -> Result<(&str, &str), StoreError> {
+    let r = tables.responses.as_str();
+    let c = tables.conversations.as_str();
+
+    validate_identifier(r)?;
+    validate_identifier(c)?;
+    if r.eq_ignore_ascii_case(c) {
+        return Err(StoreError::Database(format!(
+            "response and conversation table names must be distinct: {r}"
+        )));
+    }
+    Ok((r, c))
+}
+
+/// Maximum length for a table name identifier.
+/// SQLite has no identifier length limit, but we cap table names
+/// to prevent pathological DDL strings from config input.
+const MAX_IDENTIFIER_LEN: usize = 128;
+
+/// Reject identifiers that could cause SQL injection or invalid DDL.
+fn validate_identifier(name: &str) -> Result<(), StoreError> {
+    if name.is_empty() {
+        return Err(StoreError::Database("table name must not be empty".to_owned()));
+    }
+    if name.len() > MAX_IDENTIFIER_LEN {
+        return Err(StoreError::Database(format!(
+            "table name exceeds {MAX_IDENTIFIER_LEN} characters: {name}"
+        )));
+    }
+    if !name.starts_with(|c: char| c.is_ascii_alphabetic() || c == '_') {
+        return Err(StoreError::Database(format!(
+            "table name must start with a letter or underscore: {name}"
+        )));
+    }
+    // Hyphens are valid in quoted SQLite identifiers but we
+    // interpolate table names unquoted in SQL statements, so
+    // restrict to alphanumeric + underscore to avoid quoting.
+    if !name.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'_') {
+        return Err(StoreError::Database(format!(
+            "table name contains invalid characters: {name}"
+        )));
+    }
+    Ok(())
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing, reason = "tests")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_table_name() {
+        validate_identifier("openai_responses").expect("valid name should pass");
+    }
+
+    #[test]
+    fn valid_name_with_underscore_prefix() {
+        validate_identifier("_internal").expect("underscore prefix should pass");
+    }
+
+    #[test]
+    fn reject_empty_name() {
+        let err = validate_identifier("").unwrap_err();
+        assert!(err.to_string().contains("empty"), "should reject empty name: {err}");
+    }
+
+    #[test]
+    fn reject_name_starting_with_digit() {
+        let err = validate_identifier("123responses").unwrap_err();
+        assert!(
+            err.to_string().contains("start with"),
+            "should reject digit prefix: {err}"
+        );
+    }
+
+    #[test]
+    fn reject_special_characters() {
+        let err = validate_identifier("drop; DROP TABLE").unwrap_err();
+        assert!(
+            err.to_string().contains("invalid characters"),
+            "should reject special chars: {err}"
+        );
+    }
+
+    #[test]
+    fn reject_hyphen() {
+        let err = validate_identifier("my-table").unwrap_err();
+        assert!(
+            err.to_string().contains("invalid characters"),
+            "should reject hyphen: {err}"
+        );
+    }
+
+    #[test]
+    fn reject_excessively_long_name() {
+        let long = "a".repeat(MAX_IDENTIFIER_LEN + 1);
+        let err = validate_identifier(&long).unwrap_err();
+        assert!(err.to_string().contains("exceeds"), "should reject long name: {err}");
+    }
+
+    #[test]
+    fn generate_ddl_produces_valid_statements() {
+        let tables = TableNames {
+            responses: "test_responses".to_owned(),
+            conversations: "test_conversations".to_owned(),
+        };
+        let ddl = generate_ddl(&tables).expect("valid names should produce DDL");
+        assert_eq!(ddl.len(), 3, "should produce 3 DDL statements");
+        assert!(
+            ddl[0].contains("test_responses"),
+            "first statement should reference responses table"
+        );
+    }
+
+    #[test]
+    fn generate_ddl_rejects_invalid_name() {
+        let tables = TableNames {
+            responses: "valid_name".to_owned(),
+            conversations: "1invalid".to_owned(),
+        };
+        let err = generate_ddl(&tables).unwrap_err();
+        assert!(
+            err.to_string().contains("start with"),
+            "should reject invalid conversation table name: {err}"
+        );
+    }
+
+    #[test]
+    fn generate_ddl_rejects_duplicate_names() {
+        let tables = TableNames {
+            responses: "same_table".to_owned(),
+            conversations: "same_table".to_owned(),
+        };
+        let err = generate_ddl(&tables).unwrap_err();
+        assert!(
+            err.to_string().contains("distinct"),
+            "should reject duplicate table names: {err}"
+        );
+    }
+
+    #[test]
+    fn generate_ddl_rejects_case_insensitive_duplicate_names() {
+        let tables = TableNames {
+            responses: "Responses".to_owned(),
+            conversations: "responses".to_owned(),
+        };
+        let err = generate_ddl(&tables).unwrap_err();
+        assert!(
+            err.to_string().contains("distinct"),
+            "should reject case-insensitive duplicate table names: {err}"
+        );
+    }
+}

--- a/filter/src/builtins/http/ai/store/sqlite.rs
+++ b/filter/src/builtins/http/ai/store/sqlite.rs
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! [`SqliteResponseStore`] — `SQLite` backend for the response store.
+
+use async_trait::async_trait;
+use sqlx::{
+    Row, SqlitePool,
+    sqlite::{SqliteConnectOptions, SqlitePoolOptions},
+};
+use tracing::info;
+
+use super::{
+    schemas::{TableNames, generate_ddl},
+    trait_def::ResponseStore,
+    types::{ConversationRecord, ResponseRecord, StoreError},
+};
+
+// -----------------------------------------------------------------------------
+// SqliteResponseStore
+// -----------------------------------------------------------------------------
+
+/// SQLite-backed response store.
+///
+/// Uses [`sqlx::SqlitePool`] for async connection pooling. Table
+/// names are configurable per provider (e.g., `openai_responses`,
+/// `google_interactions`) to isolate data per provider.
+pub struct SqliteResponseStore {
+    /// Connection pool.
+    pool: SqlitePool,
+    /// Configured table names.
+    tables: TableNames,
+}
+
+impl SqliteResponseStore {
+    /// Create a new store and initialize the schema.
+    ///
+    /// The `database_url` is a `SQLite` connection string. Use
+    /// `"sqlite::memory:"` for in-memory databases (testing) or
+    /// `"sqlite:///path/to/db.sqlite?mode=rwc"` for file-backed.
+    ///
+    /// `responses_table` and `conversations_table` are the SQL
+    /// table names to use. These come from the filter's YAML
+    /// config (e.g., `openai_responses`).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError::Database`] if the connection, schema
+    /// initialization, or table name validation fails.
+    pub async fn new(database_url: &str, responses_table: &str, conversations_table: &str) -> Result<Self, StoreError> {
+        let tables = TableNames {
+            responses: responses_table.to_owned(),
+            conversations: conversations_table.to_owned(),
+        };
+        let ddl = generate_ddl(&tables)?;
+
+        let options: SqliteConnectOptions = database_url
+            .parse()
+            .map_err(|e: sqlx::Error| StoreError::Database(e.to_string()))?;
+
+        let pool = sqlite_pool_options(database_url)
+            .connect_with(options.create_if_missing(true))
+            .await
+            .map_err(|e| StoreError::Database(e.to_string()))?;
+        for statement in &ddl {
+            sqlx::query(statement)
+                .execute(&pool)
+                .await
+                .map_err(|e| StoreError::Database(e.to_string()))?;
+        }
+
+        info!(
+            responses = responses_table,
+            conversations = conversations_table,
+            "response store initialized"
+        );
+        Ok(Self { pool, tables })
+    }
+}
+
+/// Build pool options for the requested `SQLite` database URL.
+fn sqlite_pool_options(database_url: &str) -> SqlitePoolOptions {
+    if is_memory_database_url(database_url) {
+        SqlitePoolOptions::new()
+            .max_connections(1)
+            .min_connections(1)
+            .idle_timeout(None)
+            .max_lifetime(None)
+    } else {
+        SqlitePoolOptions::new()
+    }
+}
+
+/// Return whether the database URL targets an in-memory `SQLite` database.
+fn is_memory_database_url(database_url: &str) -> bool {
+    let url = database_url.trim();
+    if url == "sqlite::memory:" || url == "sqlite://:memory:" {
+        return true;
+    }
+    let query = url.split_once('?').map_or("", |(_, q)| q);
+    query
+        .split('&')
+        .any(|param| param == "mode=memory" || param.starts_with("mode=memory&"))
+}
+
+#[async_trait]
+impl ResponseStore for SqliteResponseStore {
+    async fn upsert_response(&self, record: &ResponseRecord) -> Result<(), StoreError> {
+        let response_object =
+            serde_json::to_string(&record.response_object).map_err(|e| StoreError::Serialization(e.to_string()))?;
+        let input = serde_json::to_string(&record.input).map_err(|e| StoreError::Serialization(e.to_string()))?;
+        let messages = serde_json::to_string(&record.messages).map_err(|e| StoreError::Serialization(e.to_string()))?;
+
+        let sql = format!(
+            "INSERT OR REPLACE INTO {} \
+             (id, tenant_id, created_at, model, response_object, input, messages) \
+             VALUES (?, ?, ?, ?, ?, ?, ?)",
+            self.tables.responses
+        );
+
+        sqlx::query(&sql)
+            .bind(&record.id)
+            .bind(&record.tenant_id)
+            .bind(record.created_at)
+            .bind(&record.model)
+            .bind(&response_object)
+            .bind(&input)
+            .bind(&messages)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| StoreError::Database(e.to_string()))?;
+
+        Ok(())
+    }
+
+    async fn get_response(&self, tenant_id: &str, id: &str) -> Result<Option<ResponseRecord>, StoreError> {
+        let sql = format!(
+            "SELECT id, tenant_id, created_at, model, \
+                    response_object, input, messages \
+             FROM {} \
+             WHERE id = ? AND tenant_id = ?",
+            self.tables.responses
+        );
+
+        let row = sqlx::query(&sql)
+            .bind(id)
+            .bind(tenant_id)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|e| StoreError::Database(e.to_string()))?;
+
+        row.map(|r| row_to_response_record(&r)).transpose()
+    }
+
+    async fn delete_response(&self, tenant_id: &str, id: &str) -> Result<bool, StoreError> {
+        let sql = format!("DELETE FROM {} WHERE id = ? AND tenant_id = ?", self.tables.responses);
+
+        let result = sqlx::query(&sql)
+            .bind(id)
+            .bind(tenant_id)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| StoreError::Database(e.to_string()))?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
+    async fn upsert_conversation(&self, record: &ConversationRecord) -> Result<(), StoreError> {
+        let messages = serde_json::to_string(&record.messages).map_err(|e| StoreError::Serialization(e.to_string()))?;
+
+        let sql = format!(
+            "INSERT OR REPLACE INTO {} \
+             (conversation_id, tenant_id, messages) \
+             VALUES (?, ?, ?)",
+            self.tables.conversations
+        );
+
+        sqlx::query(&sql)
+            .bind(&record.conversation_id)
+            .bind(&record.tenant_id)
+            .bind(&messages)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| StoreError::Database(e.to_string()))?;
+
+        Ok(())
+    }
+
+    async fn get_conversation(
+        &self,
+        tenant_id: &str,
+        conversation_id: &str,
+    ) -> Result<Option<ConversationRecord>, StoreError> {
+        let sql = format!(
+            "SELECT conversation_id, tenant_id, messages \
+             FROM {} \
+             WHERE conversation_id = ? AND tenant_id = ?",
+            self.tables.conversations
+        );
+
+        let row = sqlx::query(&sql)
+            .bind(conversation_id)
+            .bind(tenant_id)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|e| StoreError::Database(e.to_string()))?;
+
+        row.map(|r| row_to_conversation_record(&r)).transpose()
+    }
+
+    async fn delete_conversation(&self, tenant_id: &str, conversation_id: &str) -> Result<bool, StoreError> {
+        let sql = format!(
+            "DELETE FROM {} WHERE conversation_id = ? AND tenant_id = ?",
+            self.tables.conversations
+        );
+
+        let result = sqlx::query(&sql)
+            .bind(conversation_id)
+            .bind(tenant_id)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| StoreError::Database(e.to_string()))?;
+
+        Ok(result.rows_affected() > 0)
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Row Conversion
+// -----------------------------------------------------------------------------
+
+/// Convert a sqlx row to a [`ResponseRecord`].
+fn row_to_response_record(row: &sqlx::sqlite::SqliteRow) -> Result<ResponseRecord, StoreError> {
+    let response_object_json: String = row
+        .try_get("response_object")
+        .map_err(|e| StoreError::Database(e.to_string()))?;
+    let input_json: String = row.try_get("input").map_err(|e| StoreError::Database(e.to_string()))?;
+    let messages_json: String = row
+        .try_get("messages")
+        .map_err(|e| StoreError::Database(e.to_string()))?;
+
+    Ok(ResponseRecord {
+        id: row.try_get("id").map_err(|e| StoreError::Database(e.to_string()))?,
+        tenant_id: row
+            .try_get("tenant_id")
+            .map_err(|e| StoreError::Database(e.to_string()))?,
+        created_at: row
+            .try_get("created_at")
+            .map_err(|e| StoreError::Database(e.to_string()))?,
+        model: row.try_get("model").map_err(|e| StoreError::Database(e.to_string()))?,
+        response_object: serde_json::from_str(&response_object_json)
+            .map_err(|e| StoreError::Serialization(e.to_string()))?,
+        input: serde_json::from_str(&input_json).map_err(|e| StoreError::Serialization(e.to_string()))?,
+        messages: serde_json::from_str(&messages_json).map_err(|e| StoreError::Serialization(e.to_string()))?,
+    })
+}
+
+/// Convert a sqlx row to a [`ConversationRecord`].
+fn row_to_conversation_record(row: &sqlx::sqlite::SqliteRow) -> Result<ConversationRecord, StoreError> {
+    let messages_json: String = row
+        .try_get("messages")
+        .map_err(|e| StoreError::Database(e.to_string()))?;
+
+    Ok(ConversationRecord {
+        conversation_id: row
+            .try_get("conversation_id")
+            .map_err(|e| StoreError::Database(e.to_string()))?,
+        tenant_id: row
+            .try_get("tenant_id")
+            .map_err(|e| StoreError::Database(e.to_string()))?,
+        messages: serde_json::from_str(&messages_json).map_err(|e| StoreError::Serialization(e.to_string()))?,
+    })
+}

--- a/filter/src/builtins/http/ai/store/tests.rs
+++ b/filter/src/builtins/http/ai/store/tests.rs
@@ -1,0 +1,558 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Tests for the response store persistence layer.
+
+use serde_json::json;
+
+use super::{ConversationRecord, ResponseRecord, SqliteResponseStore, trait_def::ResponseStore};
+use crate::builtins::http::ai::openai::responses::store::{ListParams, Order, list_input_items};
+
+// -----------------------------------------------------------------------------
+// Schema Initialization
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn sqlite_store_initializes_schema() {
+    let store = SqliteResponseStore::new("sqlite::memory:", "test_responses", "test_conversation_messages")
+        .await
+        .expect("store creation should succeed");
+
+    let result = store
+        .get_response("tenant_a", "nonexistent")
+        .await
+        .expect("get should succeed");
+
+    assert!(result.is_none(), "empty store should return None");
+}
+
+// -----------------------------------------------------------------------------
+// Response CRUD
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn upsert_and_get_response() {
+    let store = make_store().await;
+    let record = make_response_record("resp_1", "tenant_a", 1000);
+
+    store.upsert_response(&record).await.expect("upsert should succeed");
+
+    let fetched = store
+        .get_response("tenant_a", "resp_1")
+        .await
+        .expect("get should succeed")
+        .expect("record should exist");
+
+    assert_eq!(fetched.id, "resp_1", "ID should match");
+    assert_eq!(fetched.tenant_id, "tenant_a", "tenant should match");
+    assert_eq!(fetched.created_at, 1000, "created_at should match");
+    assert_eq!(fetched.model, "gpt-4.1", "model should match");
+    assert_eq!(
+        fetched.response_object,
+        json!({"status": "completed"}),
+        "response_object should match"
+    );
+    assert_eq!(
+        fetched.input,
+        json!("test input"),
+        "input should survive JSON round-trip"
+    );
+    assert_eq!(
+        fetched.messages,
+        json!([{"role": "user", "content": "hello"}]),
+        "messages should survive JSON round-trip"
+    );
+}
+
+#[tokio::test]
+async fn upsert_overwrites_existing_response() {
+    let store = make_store().await;
+    let record = make_response_record("resp_1", "tenant_a", 1000);
+    store
+        .upsert_response(&record)
+        .await
+        .expect("first upsert should succeed");
+
+    let updated = ResponseRecord {
+        model: "gpt-4.1-mini".to_owned(),
+        response_object: json!({"status": "incomplete"}),
+        ..make_response_record("resp_1", "tenant_a", 1000)
+    };
+    store
+        .upsert_response(&updated)
+        .await
+        .expect("second upsert should succeed");
+
+    let fetched = store
+        .get_response("tenant_a", "resp_1")
+        .await
+        .expect("get should succeed")
+        .expect("record should exist");
+
+    assert_eq!(fetched.model, "gpt-4.1-mini", "model should be updated");
+    assert_eq!(
+        fetched.response_object,
+        json!({"status": "incomplete"}),
+        "response_object should be updated"
+    );
+}
+
+#[tokio::test]
+async fn get_missing_response_returns_none() {
+    let store = make_store().await;
+
+    let result = store
+        .get_response("tenant_a", "nonexistent")
+        .await
+        .expect("get should succeed");
+
+    assert!(result.is_none(), "missing record should return None");
+}
+
+#[tokio::test]
+async fn delete_existing_response() {
+    let store = make_store().await;
+    let record = make_response_record("resp_1", "tenant_a", 1000);
+    store.upsert_response(&record).await.expect("upsert should succeed");
+
+    let deleted = store
+        .delete_response("tenant_a", "resp_1")
+        .await
+        .expect("delete should succeed");
+
+    assert!(deleted, "delete should return true for existing record");
+
+    let fetched = store
+        .get_response("tenant_a", "resp_1")
+        .await
+        .expect("get should succeed");
+
+    assert!(fetched.is_none(), "deleted record should not be retrievable");
+}
+
+#[tokio::test]
+async fn delete_missing_response_returns_false() {
+    let store = make_store().await;
+
+    let deleted = store
+        .delete_response("tenant_a", "nonexistent")
+        .await
+        .expect("delete should succeed");
+
+    assert!(!deleted, "delete should return false for missing record");
+}
+
+// -----------------------------------------------------------------------------
+// Tenant Isolation
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn tenant_isolation_on_get() {
+    let store = make_store().await;
+    let record = make_response_record("resp_1", "tenant_a", 1000);
+    store.upsert_response(&record).await.expect("upsert should succeed");
+
+    let result = store
+        .get_response("tenant_b", "resp_1")
+        .await
+        .expect("get should succeed");
+
+    assert!(result.is_none(), "tenant_b should not see tenant_a records");
+}
+
+#[tokio::test]
+async fn tenant_isolation_on_delete() {
+    let store = make_store().await;
+    let record = make_response_record("resp_1", "tenant_a", 1000);
+    store.upsert_response(&record).await.expect("upsert should succeed");
+
+    let deleted = store
+        .delete_response("tenant_b", "resp_1")
+        .await
+        .expect("delete should succeed");
+
+    assert!(!deleted, "tenant_b should not be able to delete tenant_a records");
+
+    let still_exists = store
+        .get_response("tenant_a", "resp_1")
+        .await
+        .expect("get should succeed");
+
+    assert!(
+        still_exists.is_some(),
+        "record should still exist after cross-tenant delete attempt"
+    );
+}
+
+#[tokio::test]
+async fn same_response_id_can_exist_in_multiple_tenants() {
+    let store = make_store().await;
+    store
+        .upsert_response(&make_response_record("resp_shared", "tenant_a", 1000))
+        .await
+        .expect("tenant_a upsert should succeed");
+    store
+        .upsert_response(&make_response_record("resp_shared", "tenant_b", 2000))
+        .await
+        .expect("tenant_b upsert should succeed");
+
+    let tenant_a = store
+        .get_response("tenant_a", "resp_shared")
+        .await
+        .expect("tenant_a get should succeed")
+        .expect("tenant_a record should exist");
+    let tenant_b = store
+        .get_response("tenant_b", "resp_shared")
+        .await
+        .expect("tenant_b get should succeed")
+        .expect("tenant_b record should exist");
+
+    assert_eq!(tenant_a.tenant_id, "tenant_a", "tenant_a record should be isolated");
+    assert_eq!(tenant_b.tenant_id, "tenant_b", "tenant_b record should be isolated");
+    assert_eq!(tenant_a.created_at, 1000, "tenant_a record should not be overwritten");
+    assert_eq!(tenant_b.created_at, 2000, "tenant_b record should not be overwritten");
+}
+
+// -----------------------------------------------------------------------------
+// Input Items
+// -----------------------------------------------------------------------------
+
+#[test]
+fn input_items_from_array_input() {
+    let record = ResponseRecord {
+        input: json!([
+            {"type": "message", "role": "user", "content": "Hello"},
+            {"type": "message", "role": "user", "content": "World"},
+            {"type": "message", "role": "user", "content": "!"}
+        ]),
+        ..make_response_record("resp_1", "tenant_a", 1000)
+    };
+
+    let page = list_input_items(
+        &record,
+        &ListParams {
+            limit: 2,
+            ..ListParams::default()
+        },
+    )
+    .expect("list should succeed");
+
+    assert_eq!(page.data.len(), 2, "should return 2 items");
+    assert!(page.has_more, "should have more items");
+    assert_eq!(
+        page.next_cursor.as_deref(),
+        Some("2"),
+        "cursor should be the next offset"
+    );
+
+    let page2 = list_input_items(
+        &record,
+        &ListParams {
+            cursor: page.next_cursor,
+            limit: 2,
+            ..ListParams::default()
+        },
+    )
+    .expect("list should succeed");
+
+    assert_eq!(page2.data.len(), 1, "should return remaining 1 item");
+    assert!(!page2.has_more, "should have no more items");
+}
+
+#[test]
+fn input_items_from_string_input() {
+    let record = ResponseRecord {
+        input: json!("Hello, world!"),
+        ..make_response_record("resp_1", "tenant_a", 1000)
+    };
+
+    let page = list_input_items(&record, &ListParams::default()).expect("list should succeed");
+
+    assert_eq!(page.data.len(), 1, "string input should yield 1 item");
+    assert_eq!(page.data[0], json!("Hello, world!"), "item should be the string");
+}
+
+#[test]
+fn input_items_honors_sort_order() {
+    let record = ResponseRecord {
+        input: json!(["first", "second", "third"]),
+        ..make_response_record("resp_1", "tenant_a", 1000)
+    };
+
+    let ascending = list_input_items(
+        &record,
+        &ListParams {
+            order: Order::Ascending,
+            ..ListParams::default()
+        },
+    )
+    .expect("ascending list should succeed");
+    let descending = list_input_items(&record, &ListParams::default()).expect("descending list should succeed");
+
+    assert_eq!(
+        ascending.data,
+        vec![json!("first"), json!("second"), json!("third")],
+        "ascending order should preserve input order"
+    );
+    assert_eq!(
+        descending.data,
+        vec![json!("third"), json!("second"), json!("first")],
+        "descending order should reverse input order"
+    );
+}
+
+#[test]
+fn input_items_limit_zero_clamps_to_one() {
+    let record = ResponseRecord {
+        input: json!([
+            {"type": "message", "role": "user", "content": "Hello"},
+            {"type": "message", "role": "user", "content": "World"}
+        ]),
+        ..make_response_record("resp_1", "tenant_a", 1000)
+    };
+
+    let page1 = list_input_items(
+        &record,
+        &ListParams {
+            limit: 0,
+            ..ListParams::default()
+        },
+    )
+    .expect("list should succeed");
+
+    assert_eq!(page1.data.len(), 1, "limit 0 should clamp to one item");
+    assert!(page1.has_more, "first page should indicate remaining items");
+    assert_eq!(page1.next_cursor.as_deref(), Some("1"), "cursor should advance by one");
+
+    let page2 = list_input_items(
+        &record,
+        &ListParams {
+            cursor: page1.next_cursor,
+            limit: 0,
+            ..ListParams::default()
+        },
+    )
+    .expect("list should succeed");
+
+    assert_eq!(page2.data.len(), 1, "second page should return the remaining item");
+    assert!(!page2.has_more, "second page should complete pagination");
+    assert!(page2.next_cursor.is_none(), "second page should not provide a cursor");
+}
+
+#[test]
+fn input_items_rejects_overflowing_cursor() {
+    let record = ResponseRecord {
+        input: json!([{"type": "message", "role": "user", "content": "Hello"}]),
+        ..make_response_record("resp_1", "tenant_a", 1000)
+    };
+
+    let result = list_input_items(
+        &record,
+        &ListParams {
+            cursor: Some(usize::MAX.to_string()),
+            limit: 1,
+            ..ListParams::default()
+        },
+    );
+
+    let Err(err) = result else {
+        panic!("overflowing cursor should be rejected");
+    };
+
+    assert!(
+        err.to_string().contains("overflow"),
+        "error should explain cursor overflow: {err}"
+    );
+}
+
+#[test]
+fn input_items_from_empty_array() {
+    let record = ResponseRecord {
+        input: json!([]),
+        ..make_response_record("resp_1", "tenant_a", 1000)
+    };
+
+    let page = list_input_items(&record, &ListParams::default()).expect("list should succeed");
+
+    assert!(page.data.is_empty(), "empty array should return no items");
+    assert!(!page.has_more, "should have no more items");
+    assert!(page.next_cursor.is_none(), "should have no cursor");
+}
+
+// -----------------------------------------------------------------------------
+// Conversation CRUD
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn upsert_and_get_conversation() {
+    let store = make_store().await;
+    let record = ConversationRecord {
+        conversation_id: "conv_1".to_owned(),
+        tenant_id: "tenant_a".to_owned(),
+        messages: json!([{"role": "user", "content": "Hi"}]),
+    };
+
+    store.upsert_conversation(&record).await.expect("upsert should succeed");
+
+    let fetched = store
+        .get_conversation("tenant_a", "conv_1")
+        .await
+        .expect("get should succeed")
+        .expect("record should exist");
+
+    assert_eq!(fetched.conversation_id, "conv_1", "conversation_id should match");
+    assert_eq!(
+        fetched.messages,
+        json!([{"role": "user", "content": "Hi"}]),
+        "messages should match"
+    );
+}
+
+#[tokio::test]
+async fn upsert_conversation_overwrites() {
+    let store = make_store().await;
+    let record = ConversationRecord {
+        conversation_id: "conv_1".to_owned(),
+        tenant_id: "tenant_a".to_owned(),
+        messages: json!([{"role": "user", "content": "v1"}]),
+    };
+    store.upsert_conversation(&record).await.expect("upsert should succeed");
+
+    let updated = ConversationRecord {
+        messages: json!([{"role": "user", "content": "v2"}]),
+        ..record
+    };
+    store
+        .upsert_conversation(&updated)
+        .await
+        .expect("second upsert should succeed");
+
+    let fetched = store
+        .get_conversation("tenant_a", "conv_1")
+        .await
+        .expect("get should succeed")
+        .expect("record should exist");
+
+    assert_eq!(
+        fetched.messages,
+        json!([{"role": "user", "content": "v2"}]),
+        "messages should be updated"
+    );
+}
+
+#[tokio::test]
+async fn get_missing_conversation_returns_none() {
+    let store = make_store().await;
+
+    let result = store
+        .get_conversation("tenant_a", "nonexistent")
+        .await
+        .expect("get should succeed");
+
+    assert!(result.is_none(), "missing conversation should return None");
+}
+
+#[tokio::test]
+async fn conversation_tenant_isolation() {
+    let store = make_store().await;
+    let record = ConversationRecord {
+        conversation_id: "conv_1".to_owned(),
+        tenant_id: "tenant_a".to_owned(),
+        messages: json!([]),
+    };
+    store.upsert_conversation(&record).await.expect("upsert should succeed");
+
+    let result = store
+        .get_conversation("tenant_b", "conv_1")
+        .await
+        .expect("get should succeed");
+
+    assert!(result.is_none(), "tenant_b should not see tenant_a conversation");
+}
+
+#[tokio::test]
+async fn delete_existing_conversation() {
+    let store = make_store().await;
+    let record = ConversationRecord {
+        conversation_id: "conv_1".to_owned(),
+        tenant_id: "tenant_a".to_owned(),
+        messages: json!([]),
+    };
+    store.upsert_conversation(&record).await.expect("upsert should succeed");
+
+    let deleted = store
+        .delete_conversation("tenant_a", "conv_1")
+        .await
+        .expect("delete should succeed");
+
+    assert!(deleted, "delete should return true for existing conversation");
+
+    let fetched = store
+        .get_conversation("tenant_a", "conv_1")
+        .await
+        .expect("get should succeed");
+
+    assert!(fetched.is_none(), "deleted conversation should not be retrievable");
+}
+
+#[tokio::test]
+async fn delete_missing_conversation_returns_false() {
+    let store = make_store().await;
+
+    let deleted = store
+        .delete_conversation("tenant_a", "nonexistent")
+        .await
+        .expect("delete should succeed");
+
+    assert!(!deleted, "delete should return false for missing conversation");
+}
+
+#[tokio::test]
+async fn delete_conversation_tenant_isolation() {
+    let store = make_store().await;
+    let record = ConversationRecord {
+        conversation_id: "conv_1".to_owned(),
+        tenant_id: "tenant_a".to_owned(),
+        messages: json!([]),
+    };
+    store.upsert_conversation(&record).await.expect("upsert should succeed");
+
+    let deleted = store
+        .delete_conversation("tenant_b", "conv_1")
+        .await
+        .expect("delete should succeed");
+
+    assert!(!deleted, "tenant_b should not be able to delete tenant_a conversation");
+
+    let still_exists = store
+        .get_conversation("tenant_a", "conv_1")
+        .await
+        .expect("get should succeed");
+
+    assert!(
+        still_exists.is_some(),
+        "conversation should still exist after cross-tenant delete attempt"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Test Utilities
+// -----------------------------------------------------------------------------
+
+async fn make_store() -> SqliteResponseStore {
+    SqliteResponseStore::new("sqlite::memory:", "test_responses", "test_conversation_messages")
+        .await
+        .expect("store creation should succeed")
+}
+
+fn make_response_record(id: &str, tenant_id: &str, created_at: i64) -> ResponseRecord {
+    ResponseRecord {
+        id: id.to_owned(),
+        tenant_id: tenant_id.to_owned(),
+        created_at,
+        model: "gpt-4.1".to_owned(),
+        response_object: json!({"status": "completed"}),
+        input: json!("test input"),
+        messages: json!([{"role": "user", "content": "hello"}]),
+    }
+}


### PR DESCRIPTION
## Summary

Implement the SQLite backend for the `ResponseStore` trait with configurable table names, schema auto-initialization, and in-memory pool capping.

- `SqliteResponseStore` with `INSERT OR REPLACE` upserts and configurable table names
- SQL schema generation with table name validation against SQL injection
- OpenAI-specific input item pagination (`ListParams`, `Order`, `InputItemPage`, `list_input_items`)
- 22 unit tests covering CRUD, tenant isolation, input items, and schema validation

Depends on praxis-proxy/praxis#491 (trait + types) and praxis-proxy/praxis#490 (clippy + sqlx).

Closes: https://github.com/praxis-proxy/ai/issues/9
Part of praxis-proxy/ai#19, praxis-proxy/ai#93.

## Test plan

- [x] `cargo test -p praxis-proxy-filter --features ai-inference -- store::tests` — 22 tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean