### PR TITLE
feat(store): add ResponseStoreRegistry and context wiring

### DIFF
--- a/benchmarks/microbenchmarks/common.rs
+++ b/benchmarks/microbenchmarks/common.rs
@@ -46,6 +46,7 @@ pub(crate) fn make_ctx(req: &Request) -> HttpFilterContext<'_> {
         filter_results: std::collections::HashMap::new(),
         health_registry: None,
         kv_stores: None,
+        response_stores: None,
         request: req,
         request_body_bytes: 0,
         request_body_mode: praxis_filter::BodyMode::Stream,

--- a/filter/src/builtins/http/ai/mod.rs
+++ b/filter/src/builtins/http/ai/mod.rs
@@ -27,3 +27,5 @@ pub use openai::OpenaiResponsesValidateFilter;
 pub use openai::ResponsesFormatFilter;
 #[cfg(feature = "ai-inference")]
 pub use prompt_enrich::PromptEnrichFilter;
+#[cfg(feature = "ai-inference")]
+pub use store::ResponseStoreRegistry;

--- a/filter/src/builtins/http/ai/store/mod.rs
+++ b/filter/src/builtins/http/ai/store/mod.rs
@@ -23,9 +23,69 @@ mod types;
 )]
 mod tests;
 
-#[allow(unused_imports, reason = "re-exports for upcoming store filter and registry")]
+use std::sync::Arc;
+
+use dashmap::{DashMap, mapref::entry::Entry};
+
+#[allow(unused_imports, reason = "re-exports for upcoming store filter")]
 pub use self::{
     sqlite::SqliteResponseStore,
     trait_def::ResponseStore,
     types::{ConversationRecord, ResponseRecord, StoreError},
 };
+
+// -----------------------------------------------------------------------------
+// ResponseStoreRegistry
+// -----------------------------------------------------------------------------
+
+/// Thread-safe registry of named `ResponseStore` backends.
+///
+/// Each listener can own a registry populated at startup. Filters
+/// look up stores by name at request time through the
+/// [`HttpFilterContext`].
+///
+/// [`HttpFilterContext`]: crate::HttpFilterContext
+pub struct ResponseStoreRegistry {
+    /// Named store backends.
+    #[allow(clippy::type_complexity, reason = "DashMap of trait objects is inherently verbose")]
+    stores: Arc<DashMap<Arc<str>, Arc<dyn ResponseStore>>>,
+}
+
+impl ResponseStoreRegistry {
+    /// Create an empty registry.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            stores: Arc::new(DashMap::new()),
+        }
+    }
+
+    /// Register a named store backend.
+    ///
+    /// # Errors
+    ///
+    /// Returns `StoreError::Unavailable` if a store with the
+    /// same name is already registered.
+    pub fn register(&self, name: &Arc<str>, store: Arc<dyn ResponseStore>) -> Result<(), StoreError> {
+        match self.stores.entry(Arc::clone(name)) {
+            Entry::Vacant(entry) => {
+                entry.insert(store);
+                Ok(())
+            },
+            Entry::Occupied(_) => Err(StoreError::Unavailable(format!(
+                "response store '{name}' is already registered"
+            ))),
+        }
+    }
+
+    /// Look up a store by name.
+    pub fn get(&self, name: &str) -> Option<Arc<dyn ResponseStore>> {
+        self.stores.get(name).map(|r| Arc::clone(r.value()))
+    }
+}
+
+impl Default for ResponseStoreRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/filter/src/builtins/http/ai/store/tests.rs
+++ b/filter/src/builtins/http/ai/store/tests.rs
@@ -3,9 +3,14 @@
 
 //! Tests for the response store persistence layer.
 
+use std::sync::Arc;
+
 use serde_json::json;
 
-use super::{ConversationRecord, ResponseRecord, SqliteResponseStore, trait_def::ResponseStore};
+use super::{
+    ConversationRecord, ResponseRecord, ResponseStoreRegistry, SqliteResponseStore, StoreError,
+    trait_def::ResponseStore,
+};
 use crate::builtins::http::ai::openai::responses::store::{ListParams, Order, list_input_items};
 
 // -----------------------------------------------------------------------------
@@ -532,6 +537,56 @@ async fn delete_conversation_tenant_isolation() {
     assert!(
         still_exists.is_some(),
         "conversation should still exist after cross-tenant delete attempt"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Registry
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn registry_register_and_get() {
+    let registry = ResponseStoreRegistry::new();
+    let store: Arc<dyn ResponseStore> = Arc::new(make_store().await);
+    registry
+        .register(&Arc::from("primary"), Arc::clone(&store))
+        .expect("register should succeed");
+
+    let fetched = registry.get("primary");
+    assert!(fetched.is_some(), "registered store should be retrievable");
+}
+
+#[test]
+fn registry_get_missing_returns_none() {
+    let registry = ResponseStoreRegistry::new();
+    assert!(
+        registry.get("nonexistent").is_none(),
+        "get on empty registry should return None"
+    );
+}
+
+#[tokio::test]
+async fn registry_duplicate_registration_fails() {
+    let registry = ResponseStoreRegistry::new();
+    let store: Arc<dyn ResponseStore> = Arc::new(make_store().await);
+    let name = Arc::from("dup");
+    registry
+        .register(&name, Arc::clone(&store))
+        .expect("first register should succeed");
+
+    let result = registry.register(&name, store);
+    assert!(
+        matches!(result, Err(StoreError::Unavailable(_))),
+        "duplicate registration should return StoreError::Unavailable"
+    );
+}
+
+#[test]
+fn registry_default_is_empty() {
+    let registry = ResponseStoreRegistry::default();
+    assert!(
+        registry.get("anything").is_none(),
+        "default registry should have no stores"
     );
 }
 

--- a/filter/src/builtins/http/mod.rs
+++ b/filter/src/builtins/http/mod.rs
@@ -18,6 +18,8 @@ pub use ai::OpenaiResponsesValidateFilter;
 #[cfg(feature = "ai-inference")]
 pub use ai::PromptEnrichFilter;
 #[cfg(feature = "ai-inference")]
+pub use ai::ResponseStoreRegistry;
+#[cfg(feature = "ai-inference")]
 pub use ai::ResponsesFormatFilter;
 pub use ai::{A2aFilter, JsonRpcFilter, McpFilter};
 pub use observability::{AccessLogFilter, RequestIdFilter};

--- a/filter/src/builtins/mod.rs
+++ b/filter/src/builtins/mod.rs
@@ -13,6 +13,8 @@ pub use http::OpenaiResponsesValidateFilter;
 #[cfg(feature = "ai-inference")]
 pub use http::PromptEnrichFilter;
 #[cfg(feature = "ai-inference")]
+pub use http::ResponseStoreRegistry;
+#[cfg(feature = "ai-inference")]
 pub use http::ResponsesFormatFilter;
 pub use http::{
     A2aFilter, AccessLogFilter, CircuitBreakerFilter, CompressionFilter, ContainsValue, CorsFilter,

--- a/filter/src/context.rs
+++ b/filter/src/context.rs
@@ -82,6 +82,10 @@ pub struct HttpFilterContext<'a> {
     /// Named key-value stores for runtime mappings.
     pub kv_stores: Option<&'a KvStoreRegistry>,
 
+    /// Named response store backends for AI API persistence.
+    #[cfg(feature = "ai-inference")]
+    pub response_stores: Option<&'a crate::builtins::http::ai::store::ResponseStoreRegistry>,
+
     /// Transport-agnostic request headers, URI, and method.
     pub request: &'a Request,
 

--- a/filter/src/lib.rs
+++ b/filter/src/lib.rs
@@ -29,6 +29,8 @@ pub use builtins::OpenaiResponsesValidateFilter;
 #[cfg(feature = "ai-inference")]
 pub use builtins::PromptEnrichFilter;
 #[cfg(feature = "ai-inference")]
+pub use builtins::ResponseStoreRegistry;
+#[cfg(feature = "ai-inference")]
 pub use builtins::ResponsesFormatFilter;
 pub use builtins::{
     CircuitBreakerFilter, ContainsValue, CredentialInjectionFilter, DisallowedOriginMode, GuardrailsAction,
@@ -268,6 +270,8 @@ pub(crate) mod test_utils {
             filter_results: std::collections::HashMap::new(),
             health_registry: None,
             kv_stores: None,
+            #[cfg(feature = "ai-inference")]
+            response_stores: None,
             request: req,
             request_body_bytes: 0,
             request_body_mode: crate::body::BodyMode::Stream,

--- a/filter/src/pipeline/build.rs
+++ b/filter/src/pipeline/build.rs
@@ -24,6 +24,7 @@ impl FilterPipeline {
     /// # Errors
     ///
     /// Returns [`FilterError`] if any filter fails to instantiate.
+    #[allow(clippy::too_many_lines, reason = "cfg attribute inflates line count")]
     pub fn build(entries: &mut [FilterEntry], registry: &FilterRegistry) -> Result<Self, FilterError> {
         let mut filters = Vec::with_capacity(entries.len());
         for entry in entries.iter_mut() {
@@ -53,6 +54,8 @@ impl FilterPipeline {
             filters,
             health_registry: None,
             kv_stores: None,
+            #[cfg(feature = "ai-inference")]
+            response_stores: None,
             time_source: Arc::new(SystemTimeSource),
         })
     }
@@ -83,6 +86,8 @@ impl FilterPipeline {
             filters,
             health_registry: None,
             kv_stores: None,
+            #[cfg(feature = "ai-inference")]
+            response_stores: None,
             time_source: Arc::new(SystemTimeSource),
         })
     }

--- a/filter/src/pipeline/mod.rs
+++ b/filter/src/pipeline/mod.rs
@@ -42,6 +42,8 @@ use praxis_core::{
 use tracing::warn;
 
 use self::filter::PipelineFilter;
+#[cfg(feature = "ai-inference")]
+use crate::builtins::http::ai::store::ResponseStoreRegistry;
 use crate::{
     FilterError,
     body::{BodyCapabilities, BodyMode},
@@ -76,6 +78,10 @@ pub struct FilterPipeline {
 
     /// Named key-value stores for runtime mappings.
     kv_stores: Option<KvStoreRegistry>,
+
+    /// Named response store backends for AI API persistence.
+    #[cfg(feature = "ai-inference")]
+    response_stores: Option<ResponseStoreRegistry>,
 
     /// Wall-clock time source for filters that need timestamps.
     time_source: Arc<dyn TimeSource>,
@@ -178,6 +184,18 @@ impl FilterPipeline {
     /// Set the shared [`KvStoreRegistry`] for this pipeline.
     pub fn set_kv_stores(&mut self, stores: KvStoreRegistry) {
         self.kv_stores = Some(stores);
+    }
+
+    /// The shared response store registry, if set.
+    #[cfg(feature = "ai-inference")]
+    pub fn response_stores(&self) -> Option<&ResponseStoreRegistry> {
+        self.response_stores.as_ref()
+    }
+
+    /// Set the shared [`ResponseStoreRegistry`] for this pipeline.
+    #[cfg(feature = "ai-inference")]
+    pub fn set_response_stores(&mut self, stores: ResponseStoreRegistry) {
+        self.response_stores = Some(stores);
     }
 
     /// The wall-clock time source.

--- a/filter/src/pipeline/tcp.rs
+++ b/filter/src/pipeline/tcp.rs
@@ -445,6 +445,8 @@ mod tests {
             filters,
             health_registry: None,
             kv_stores: None,
+            #[cfg(feature = "ai-inference")]
+            response_stores: None,
             time_source: Arc::new(praxis_core::time::SystemTimeSource),
         }
     }

--- a/filter/src/pipeline/tests.rs
+++ b/filter/src/pipeline/tests.rs
@@ -640,6 +640,8 @@ fn apply_body_limits_no_limits_leaves_stream_mode() {
         filters: vec![],
         health_registry: None,
         kv_stores: None,
+        #[cfg(feature = "ai-inference")]
+        response_stores: None,
         time_source: Arc::new(praxis_core::time::SystemTimeSource),
     };
     pipeline.apply_body_limits(None, None, false).unwrap();
@@ -673,6 +675,8 @@ fn apply_body_limits_converts_default_stream_to_size_limit() {
         filters: vec![],
         health_registry: None,
         kv_stores: None,
+        #[cfg(feature = "ai-inference")]
+        response_stores: None,
         time_source: Arc::new(praxis_core::time::SystemTimeSource),
     };
     pipeline
@@ -715,6 +719,8 @@ fn apply_body_limits_preserves_filter_declared_stream() {
         filters: vec![],
         health_registry: None,
         kv_stores: None,
+        #[cfg(feature = "ai-inference")]
+        response_stores: None,
         time_source: Arc::new(praxis_core::time::SystemTimeSource),
     };
     pipeline
@@ -1288,6 +1294,8 @@ fn apply_body_limits_default_stream_becomes_size_limit() {
         filters: vec![],
         health_registry: None,
         kv_stores: None,
+        #[cfg(feature = "ai-inference")]
+        response_stores: None,
         time_source: Arc::new(praxis_core::time::SystemTimeSource),
     };
     pipeline.apply_body_limits(Some(4096), Some(8192), false).unwrap();
@@ -1314,6 +1322,8 @@ fn apply_body_limits_filter_stricter_than_config() {
         filters: vec![],
         health_registry: None,
         kv_stores: None,
+        #[cfg(feature = "ai-inference")]
+        response_stores: None,
         time_source: Arc::new(praxis_core::time::SystemTimeSource),
     };
     pipeline.apply_body_limits(Some(1000), None, false).unwrap();
@@ -1337,6 +1347,8 @@ fn apply_body_limits_config_stricter_than_filter() {
         filters: vec![],
         health_registry: None,
         kv_stores: None,
+        #[cfg(feature = "ai-inference")]
+        response_stores: None,
         time_source: Arc::new(praxis_core::time::SystemTimeSource),
     };
     pipeline.apply_body_limits(Some(1000), None, false).unwrap();
@@ -1360,6 +1372,8 @@ fn apply_body_limits_rejects_unbounded_stream_buffer() {
         filters: vec![],
         health_registry: None,
         kv_stores: None,
+        #[cfg(feature = "ai-inference")]
+        response_stores: None,
         time_source: Arc::new(praxis_core::time::SystemTimeSource),
     };
     let err = pipeline.apply_body_limits(None, None, false).unwrap_err();
@@ -1382,6 +1396,8 @@ fn apply_body_limits_clamps_unbounded_stream_buffer_with_override() {
         filters: vec![],
         health_registry: None,
         kv_stores: None,
+        #[cfg(feature = "ai-inference")]
+        response_stores: None,
         time_source: Arc::new(praxis_core::time::SystemTimeSource),
     };
     pipeline
@@ -1597,6 +1613,8 @@ async fn skip_to_excludes_skipped_filters_from_response() {
         filters: vec![filter_a, filter_b, filter_c],
         health_registry: None,
         kv_stores: None,
+        #[cfg(feature = "ai-inference")]
+        response_stores: None,
         time_source: Arc::new(praxis_core::time::SystemTimeSource),
     };
 
@@ -1641,6 +1659,8 @@ async fn all_executed_filters_run_on_response() {
         ],
         health_registry: None,
         kv_stores: None,
+        #[cfg(feature = "ai-inference")]
+        response_stores: None,
         time_source: Arc::new(praxis_core::time::SystemTimeSource),
     };
 
@@ -1692,6 +1712,8 @@ async fn skipped_filter_skips_its_branches() {
         filters: vec![parent],
         health_registry: None,
         kv_stores: None,
+        #[cfg(feature = "ai-inference")]
+        response_stores: None,
         time_source: Arc::new(praxis_core::time::SystemTimeSource),
     };
 
@@ -2741,6 +2763,8 @@ fn make_pipeline(filters: Vec<Box<dyn HttpFilter>>) -> FilterPipeline {
         filters,
         health_registry: None,
         kv_stores: None,
+        #[cfg(feature = "ai-inference")]
+        response_stores: None,
         time_source: Arc::new(praxis_core::time::SystemTimeSource),
     }
 }
@@ -2761,6 +2785,8 @@ fn make_pipeline_with_conditions(
         filters,
         health_registry: None,
         kv_stores: None,
+        #[cfg(feature = "ai-inference")]
+        response_stores: None,
         time_source: Arc::new(praxis_core::time::SystemTimeSource),
     }
 }
@@ -2781,6 +2807,8 @@ fn make_pipeline_with_response_conditions(
         filters,
         health_registry: None,
         kv_stores: None,
+        #[cfg(feature = "ai-inference")]
+        response_stores: None,
         time_source: Arc::new(praxis_core::time::SystemTimeSource),
     }
 }

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -13,6 +13,10 @@ publish = true
 [lib]
 name = "praxis_protocol"
 
+[features]
+default = ["ai-inference"]
+ai-inference = ["praxis-filter/ai-inference"]
+
 [lints]
 workspace = true
 

--- a/protocol/src/http/pingora/context.rs
+++ b/protocol/src/http/pingora/context.rs
@@ -208,6 +208,8 @@ macro_rules! filter_context {
             filter_results: std::mem::take(&mut $ctx.filter_results),
             health_registry: $pipeline.health_registry(),
             kv_stores: $pipeline.kv_stores(),
+            #[cfg(feature = "ai-inference")]
+            response_stores: $pipeline.response_stores(),
             request: $request,
             request_body_bytes: $ctx.request_body_bytes,
             request_body_mode: $ctx.request_body_mode,

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -42,6 +42,6 @@ tempfile = { workspace = true }
 
 [features]
 default = ["ai-inference"]
-ai-inference = ["praxis-filter/ai-inference"]
+ai-inference = ["praxis-filter/ai-inference", "praxis-protocol/ai-inference"]
 ext-proc = ["praxis-filter/ext-proc"]
 

--- a/tests/fuzz/fuzz_targets/fuzz_filter_pipeline.rs
+++ b/tests/fuzz/fuzz_targets/fuzz_filter_pipeline.rs
@@ -59,6 +59,7 @@ fuzz_target!(|data: &str| {
             filter_results: std::collections::HashMap::new(),
             health_registry: None,
             kv_stores: None,
+            response_stores: None,
             request: &request,
             request_body_bytes: 0,
             request_body_mode: praxis_filter::BodyMode::Stream,


### PR DESCRIPTION
## Summary

Add the `ResponseStoreRegistry` (DashMap-backed named store instances) and wire it through the filter pipeline so AI filters can access configured stores.

- `ResponseStoreRegistry` with explicit registration, duplicate rejection, and named lookup
- `HttpFilterContext.response_stores` field for filter access
- `FilterPipeline` threading for response stores
- Re-exports from public crate API (`praxis_filter::ResponseStore`, etc.)
- 4 registry tests + pipeline context wiring

Depends on praxis-proxy/praxis#492 (SQLite backend) and praxis-proxy/praxis#491 (trait).

Closes: https://github.com/praxis-proxy/ai/issues/8
Part of praxis-proxy/ai#19, praxis-proxy/ai#93.

## Test plan

- [x] `cargo test -p praxis-proxy-filter --features ai-inference -- store::tests` — 26 tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean