### PR TITLE
refactor: use shared IdGenerator for all filter ID generation

### DIFF
--- a/filter/src/builtins/http/ai/agentic/mcp/broker/mod.rs
+++ b/filter/src/builtins/http/ai/agentic/mcp/broker/mod.rs
@@ -21,7 +21,6 @@ mod tests;
 
 use async_trait::async_trait;
 use bytes::Bytes;
-use rand::{TryRngCore, rngs::OsRng};
 use tracing::{debug, trace};
 
 use self::config::{CatalogTool, McpBrokerConfig, build_config};
@@ -297,6 +296,7 @@ fn handle_delete(ctx: &HttpFilterContext<'_>) -> FilterAction {
 
 /// Generates a new MCP session and returns MCP capabilities.
 /// Does not initialize backends, that belongs to follow-up backend session work.
+#[allow(clippy::unnecessary_wraps, reason = "signature matches sibling handle_* fns")]
 fn handle_initialize(
     ctx: &mut HttpFilterContext<'_>,
     value: &serde_json::Value,
@@ -306,7 +306,7 @@ fn handle_initialize(
 ) -> Result<FilterAction, FilterError> {
     record_client_protocol_version(ctx, value);
     let response_version = negotiate_protocol_version(value, supported_versions, default_version);
-    let session_id = generate_session_id()?;
+    let session_id = format!("mcp-{}", ctx.id_generator.generate(ctx.time_source));
 
     debug!(session_id_len = session_id.len(), "MCP initialize");
     ctx.set_metadata("mcp.session_id", session_id.clone());
@@ -485,20 +485,6 @@ fn json_rpc_error_action_with_id(id_json: &str, code: i32, message: &str) -> Fil
 /// path. Uses exact match on the path component only.
 fn request_path_matches(uri: &http::Uri, public_path: &str) -> bool {
     uri.path() == public_path
-}
-
-// -----------------------------------------------------------------------------
-// Session ID
-// -----------------------------------------------------------------------------
-
-/// Generate a cryptographically random MCP session ID.
-fn generate_session_id() -> Result<String, FilterError> {
-    let mut bytes = [0u8; 16];
-    let mut rng = OsRng;
-    rng.try_fill_bytes(&mut bytes)
-        .map_err(|e| FilterError::from(format!("mcp: failed to generate session id: {e}")))?;
-    let hex: String = bytes.iter().map(|b| format!("{b:02x}")).collect();
-    Ok(format!("mcp-{hex}"))
 }
 
 // -----------------------------------------------------------------------------

--- a/filter/src/builtins/http/ai/agentic/mcp/broker/tests.rs
+++ b/filter/src/builtins/http/ai/agentic/mcp/broker/tests.rs
@@ -532,10 +532,7 @@ async fn initialize_returns_session_and_id() {
                 parsed["result"]["serverInfo"].get("version").is_none(),
                 "serverInfo should not leak version"
             );
-            assert!(
-                rejection.headers.iter().any(|(k, _)| k == "mcp-session-id"),
-                "should contain mcp-session-id header"
-            );
+            assert_session_id_format(rejection);
         },
         _ => panic!("expected Reject with 200"),
     }
@@ -1413,6 +1410,24 @@ servers: []
 // -----------------------------------------------------------------------------
 // Test Utilities
 // -----------------------------------------------------------------------------
+
+fn assert_session_id_format(rejection: &Rejection) {
+    let session_id = rejection
+        .headers
+        .iter()
+        .find(|(k, _)| k == "mcp-session-id")
+        .map(|(_, v)| v.as_str())
+        .expect("mcp-session-id header should be present");
+    assert!(
+        session_id.starts_with("mcp-"),
+        "session ID should have mcp- prefix: {session_id}"
+    );
+    assert_eq!(
+        session_id.len(),
+        36,
+        "session ID should be mcp- + 32 hex chars: {session_id}"
+    );
+}
 
 const BROKER_SERVERS_YAML: &str = r#"
 servers:

--- a/filter/src/builtins/http/ai/openai/responses/validate/mod.rs
+++ b/filter/src/builtins/http/ai/openai/responses/validate/mod.rs
@@ -22,9 +22,13 @@
 
 mod rules;
 
+use std::{
+    sync::atomic::{AtomicU64, Ordering},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
 use async_trait::async_trait;
 use bytes::Bytes;
-use rand::{TryRngCore, rngs::OsRng};
 use tracing::{debug, trace};
 
 use self::rules::validate_request;
@@ -53,8 +57,18 @@ const MAX_BODY_BYTES: usize = 67_108_864; // 64 MiB
 ///
 /// This filter has no configuration, body buffering is handled by
 /// the upstream `openai_responses_format` classifier.
-#[derive(Default)]
-pub struct OpenaiResponsesValidateFilter;
+pub struct OpenaiResponsesValidateFilter {
+    /// Monotonic counter for unique ID generation.
+    counter: AtomicU64,
+}
+
+impl Default for OpenaiResponsesValidateFilter {
+    fn default() -> Self {
+        Self {
+            counter: AtomicU64::new(0),
+        }
+    }
+}
 
 impl OpenaiResponsesValidateFilter {
     /// Create a filter from YAML config.
@@ -70,40 +84,35 @@ impl OpenaiResponsesValidateFilter {
     /// [`FilterFactory`]: crate::FilterFactory
     #[allow(clippy::unnecessary_wraps, reason = "signature required by FilterFactory")]
     pub fn from_config(_config: &serde_yaml::Value) -> Result<Box<dyn HttpFilter>, FilterError> {
-        Ok(Box::new(Self))
+        Ok(Box::new(Self::default()))
     }
 
     /// Generate a response ID with `resp_` prefix.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`FilterError`] if the system CSPRNG fails.
-    fn generate_response_id() -> Result<String, FilterError> {
-        let id = Self::generate_raw_id()?;
-        Ok(format!("resp_{id}"))
+    fn generate_response_id(&self) -> String {
+        let id = self.generate_raw_id();
+        format!("resp_{id}")
     }
 
     /// Generate a conversation ID with `conv_` prefix.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`FilterError`] if the system CSPRNG fails.
-    fn generate_conversation_id() -> Result<String, FilterError> {
-        let id = Self::generate_raw_id()?;
-        Ok(format!("conv_{id}"))
+    fn generate_conversation_id(&self) -> String {
+        let id = self.generate_raw_id();
+        format!("conv_{id}")
     }
 
-    /// Generate a cryptographically random hex ID (128 bits).
-    ///
-    /// # Errors
-    ///
-    /// Returns [`FilterError`] if the system CSPRNG fails.
-    fn generate_raw_id() -> Result<String, FilterError> {
-        let mut bytes = [0u8; 16];
-        OsRng
-            .try_fill_bytes(&mut bytes)
-            .map_err(|e| FilterError::from(format!("failed to generate ID: {e}")))?;
-        Ok(bytes.iter().map(|b| format!("{b:02x}")).collect())
+    // TODO(#460): replace with shared IdGenerator that includes
+    // per-instance entropy to avoid collisions across instances.
+    /// Generate a raw hex ID from timestamp and counter.
+    fn generate_raw_id(&self) -> String {
+        #[allow(clippy::cast_possible_truncation, reason = "micros fit u64")]
+        let micros = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_micros()
+            .min(u128::from(u64::MAX)) as u64;
+
+        let seq = self.counter.fetch_add(1, Ordering::Relaxed);
+
+        format!("{micros:016x}{seq:04x}")
     }
 }
 
@@ -147,12 +156,12 @@ impl HttpFilter for OpenaiResponsesValidateFilter {
             Err(action) => return Ok(action),
         };
 
-        let response_id = Self::generate_response_id()?;
+        let response_id = self.generate_response_id();
         let conversation_id = if let Some(id) = extract_conversation_id(&parsed) {
             trace!(conversation_id = %id, "conversation ID extracted from request");
             id
         } else {
-            let id = Self::generate_conversation_id()?;
+            let id = self.generate_conversation_id();
             trace!(conversation_id = %id, "conversation ID generated");
             id
         };
@@ -278,7 +287,7 @@ mod tests {
 
     #[test]
     fn body_access_is_read_only() {
-        let filter = OpenaiResponsesValidateFilter;
+        let filter = OpenaiResponsesValidateFilter::default();
         assert_eq!(
             filter.request_body_access(),
             BodyAccess::ReadOnly,
@@ -288,33 +297,16 @@ mod tests {
 
     #[test]
     fn response_id_has_prefix() {
-        let id = OpenaiResponsesValidateFilter::generate_response_id().unwrap();
+        let filter = OpenaiResponsesValidateFilter::default();
+        let id = filter.generate_response_id();
         assert!(id.starts_with("resp_"), "response ID should start with resp_");
     }
 
     #[test]
     fn conversation_id_has_prefix() {
-        let id = OpenaiResponsesValidateFilter::generate_conversation_id().unwrap();
+        let filter = OpenaiResponsesValidateFilter::default();
+        let id = filter.generate_conversation_id();
         assert!(id.starts_with("conv_"), "conversation ID should start with conv_");
-    }
-
-    #[test]
-    fn raw_id_is_32_hex_chars() {
-        let id = OpenaiResponsesValidateFilter::generate_raw_id().unwrap();
-        assert_eq!(id.len(), 32, "raw ID should be 32 hex characters (128 bits)");
-        assert!(
-            id.chars().all(|c| c.is_ascii_hexdigit()),
-            "raw ID should contain only hex digits"
-        );
-    }
-
-    #[test]
-    fn generated_ids_are_unique() {
-        let ids: Vec<String> = (0..1000)
-            .map(|_| OpenaiResponsesValidateFilter::generate_raw_id().unwrap())
-            .collect();
-        let unique: std::collections::HashSet<&String> = ids.iter().collect();
-        assert_eq!(ids.len(), unique.len(), "all generated IDs should be unique");
     }
 
     #[tokio::test]
@@ -541,7 +533,7 @@ mod tests {
 
     #[tokio::test]
     async fn not_end_of_stream_continues() {
-        let filter = OpenaiResponsesValidateFilter;
+        let filter = OpenaiResponsesValidateFilter::default();
         let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
         let mut ctx = crate::test_utils::make_filter_context(&req);
         let mut body = Some(Bytes::from(r#"{"input": "partial"}"#));

--- a/filter/src/builtins/http/ai/openai/responses/validate/mod.rs
+++ b/filter/src/builtins/http/ai/openai/responses/validate/mod.rs
@@ -22,11 +22,6 @@
 
 mod rules;
 
-use std::{
-    sync::atomic::{AtomicU64, Ordering},
-    time::{SystemTime, UNIX_EPOCH},
-};
-
 use async_trait::async_trait;
 use bytes::Bytes;
 use tracing::{debug, trace};
@@ -57,18 +52,8 @@ const MAX_BODY_BYTES: usize = 67_108_864; // 64 MiB
 ///
 /// This filter has no configuration, body buffering is handled by
 /// the upstream `openai_responses_format` classifier.
-pub struct OpenaiResponsesValidateFilter {
-    /// Monotonic counter for unique ID generation.
-    counter: AtomicU64,
-}
-
-impl Default for OpenaiResponsesValidateFilter {
-    fn default() -> Self {
-        Self {
-            counter: AtomicU64::new(0),
-        }
-    }
-}
+#[derive(Default)]
+pub struct OpenaiResponsesValidateFilter;
 
 impl OpenaiResponsesValidateFilter {
     /// Create a filter from YAML config.
@@ -84,35 +69,7 @@ impl OpenaiResponsesValidateFilter {
     /// [`FilterFactory`]: crate::FilterFactory
     #[allow(clippy::unnecessary_wraps, reason = "signature required by FilterFactory")]
     pub fn from_config(_config: &serde_yaml::Value) -> Result<Box<dyn HttpFilter>, FilterError> {
-        Ok(Box::new(Self::default()))
-    }
-
-    /// Generate a response ID with `resp_` prefix.
-    fn generate_response_id(&self) -> String {
-        let id = self.generate_raw_id();
-        format!("resp_{id}")
-    }
-
-    /// Generate a conversation ID with `conv_` prefix.
-    fn generate_conversation_id(&self) -> String {
-        let id = self.generate_raw_id();
-        format!("conv_{id}")
-    }
-
-    // TODO(#460): replace with shared IdGenerator that includes
-    // per-instance entropy to avoid collisions across instances.
-    /// Generate a raw hex ID from timestamp and counter.
-    fn generate_raw_id(&self) -> String {
-        #[allow(clippy::cast_possible_truncation, reason = "micros fit u64")]
-        let micros = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_micros()
-            .min(u128::from(u64::MAX)) as u64;
-
-        let seq = self.counter.fetch_add(1, Ordering::Relaxed);
-
-        format!("{micros:016x}{seq:04x}")
+        Ok(Box::new(Self))
     }
 }
 
@@ -156,12 +113,12 @@ impl HttpFilter for OpenaiResponsesValidateFilter {
             Err(action) => return Ok(action),
         };
 
-        let response_id = self.generate_response_id();
+        let response_id = format!("resp_{}", ctx.id_generator.generate(ctx.time_source));
         let conversation_id = if let Some(id) = extract_conversation_id(&parsed) {
             trace!(conversation_id = %id, "conversation ID extracted from request");
             id
         } else {
-            let id = self.generate_conversation_id();
+            let id = format!("conv_{}", ctx.id_generator.generate(ctx.time_source));
             trace!(conversation_id = %id, "conversation ID generated");
             id
         };
@@ -287,26 +244,12 @@ mod tests {
 
     #[test]
     fn body_access_is_read_only() {
-        let filter = OpenaiResponsesValidateFilter::default();
+        let filter = OpenaiResponsesValidateFilter;
         assert_eq!(
             filter.request_body_access(),
             BodyAccess::ReadOnly,
             "filter should use read-only body access"
         );
-    }
-
-    #[test]
-    fn response_id_has_prefix() {
-        let filter = OpenaiResponsesValidateFilter::default();
-        let id = filter.generate_response_id();
-        assert!(id.starts_with("resp_"), "response ID should start with resp_");
-    }
-
-    #[test]
-    fn conversation_id_has_prefix() {
-        let filter = OpenaiResponsesValidateFilter::default();
-        let id = filter.generate_conversation_id();
-        assert!(id.starts_with("conv_"), "conversation ID should start with conv_");
     }
 
     #[tokio::test]
@@ -533,7 +476,7 @@ mod tests {
 
     #[tokio::test]
     async fn not_end_of_stream_continues() {
-        let filter = OpenaiResponsesValidateFilter::default();
+        let filter = OpenaiResponsesValidateFilter;
         let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
         let mut ctx = crate::test_utils::make_filter_context(&req);
         let mut body = Some(Bytes::from(r#"{"input": "partial"}"#));

--- a/filter/src/builtins/http/ai/openai/responses/validate/mod.rs
+++ b/filter/src/builtins/http/ai/openai/responses/validate/mod.rs
@@ -259,12 +259,14 @@ mod tests {
         assert!(
             ctx.filter_metadata
                 .get("responses.response_id")
-                .is_some_and(|v| v.starts_with("resp_")),
-            "response_id should be set with resp_ prefix"
+                .is_some_and(|v| v.starts_with("resp_") && v.len() == 37),
+            "response_id should be resp_ + 32 hex chars"
         );
         assert!(
-            ctx.filter_metadata.contains_key("responses.conversation_id"),
-            "conversation_id should be set"
+            ctx.filter_metadata
+                .get("responses.conversation_id")
+                .is_some_and(|v| v.starts_with("conv_") && v.len() == 37),
+            "conversation_id should be conv_ + 32 hex chars"
         );
         assert_eq!(
             ctx.filter_metadata.get("responses.store").map(String::as_str),
@@ -334,8 +336,8 @@ mod tests {
         assert!(
             ctx.filter_metadata
                 .get("responses.conversation_id")
-                .is_some_and(|v| v.starts_with("conv_")),
-            "conversation_id should be generated with conv_ prefix"
+                .is_some_and(|v| v.starts_with("conv_") && v.len() == 37),
+            "conversation_id should be conv_ + 32 hex chars"
         );
     }
 


### PR DESCRIPTION
## Summary

Introduces a shared `IdGenerator` in `praxis-core` that combines a wall-clock timestamp, a random 16-bit per-instance seed, and a 48-bit atomic counter to produce probabilistically unique 32-char hex IDs across multiple Praxis instances. Reverts the CSPRNG-based approach (591b4a9) in `openai_responses_validate` and migrates all three ID generation sites (`request_id`, `openai_responses_validate`, MCP broker) to the shared generator via `ctx.id_generator`.

Closes praxis-proxy/ai#219

## Test plan

- [x] `cargo test -p praxis-proxy-core -- id` — 6 unit tests + doctest
- [x] `cargo test -p praxis-proxy-filter -- request_id` — 6 filter tests
- [x] `cargo test -p praxis-proxy-filter -- request_validate` — 22 tests
- [x] `cargo test -p praxis-proxy-filter -- mcp` — 124 tests
- [x] `make lint` — clean
- [x] `make build` — clean