### PR TITLE
feat(a2a): capture task routes from streaming SSE responses

### DIFF
--- a/examples/configs/ai/a2a-task-routing.yaml
+++ b/examples/configs/ai/a2a-task-routing.yaml
@@ -1,17 +1,21 @@
 # A2A Task Routing
 #
-# Captures task ownership from non-streaming JSON SendMessage responses
-# and routes follow-up task operations back to the backend cluster that
-# created the task.
+# Captures task ownership from SendMessage JSON responses and
+# SendStreamingMessage / SubscribeToTask SSE responses, then routes
+# follow-up task operations back to the backend cluster that created
+# the task.
 #
 # This example uses `local` storage mode. This is useful for development and
 # testing or single-instance deployments of Praxis, but multi-replica task routing
-# requires the an external state store (e.g. Valkey).
+# requires an external state store (e.g. Valkey).
 #
 # Flow:
-# 1. SendMessage is routed to agent-a by static router rules.
-# 2. The a2a filter captures task IDs from the JSON response body
-#    and records task_id -> cluster_name in a local in-process store.
+# 1. SendMessage and SendStreamingMessage are routed to agent-a by
+#    static router rules.
+# 2. The a2a filter captures task IDs from JSON response bodies
+#    (SendMessage) and SSE data frames (SendStreamingMessage,
+#    SubscribeToTask), recording task_id -> cluster_name in a
+#    local in-process store.
 # 3. Follow-up GetTask, CancelTask, SubscribeToTask, or push-notification
 #    config calls with a known task ID inject x-praxis-a2a-route-cluster,
 #    which the router matches to select the owning cluster.

--- a/filter/src/builtins/http/ai/agentic/a2a/mod.rs
+++ b/filter/src/builtins/http/ai/agentic/a2a/mod.rs
@@ -5,6 +5,7 @@
 
 pub(crate) mod config;
 pub(crate) mod envelope;
+pub(crate) mod sse;
 pub(crate) mod task_routing;
 
 #[cfg(test)]
@@ -20,7 +21,7 @@ pub(crate) mod task_routing;
 )]
 mod tests;
 
-use std::{borrow::Cow, sync::Arc};
+use std::{borrow::Cow, fmt::Write, sync::Arc};
 
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -212,13 +213,11 @@ impl HttpFilter for A2aFilter {
             return Ok(FilterAction::Continue);
         }
 
-        // Task route capture only runs for non-streaming SendMessage
-        // responses. Terminal TTL only applies here; GetTask and other
-        // task-routable methods do not update stored TTLs. SSE response
-        // capture is a follow-up.
-        let is_send_message = ctx.get_metadata("a2a.method").is_some_and(|m| m == "SendMessage");
+        let method = ctx.get_metadata("a2a.method");
+        let is_send_message = method.is_some_and(|m| m == "SendMessage");
+        let is_sse_capable = method.is_some_and(|m| m == "SendStreamingMessage" || m == "SubscribeToTask");
 
-        if !is_send_message {
+        if !is_send_message && !is_sse_capable {
             return Ok(FilterAction::Continue);
         }
 
@@ -234,6 +233,18 @@ impl HttpFilter for A2aFilter {
             .and_then(|r| r.headers.get("content-type"))
             .and_then(|v| v.to_str().ok())
             .is_some_and(is_event_stream_content_type);
+
+        if is_sse_capable {
+            if is_sse {
+                let cluster = ctx.cluster_name().map(str::to_owned);
+                if let Some(cluster) = cluster {
+                    ctx.filter_metadata
+                        .insert("a2a.response.sse_capture_enabled".to_owned(), "true".to_owned());
+                    ctx.filter_metadata.insert("a2a.response.cluster".to_owned(), cluster);
+                }
+            }
+            return Ok(FilterAction::Continue);
+        }
 
         if is_sse {
             ctx.filter_metadata
@@ -261,17 +272,25 @@ impl HttpFilter for A2aFilter {
             return Ok(FilterAction::Continue);
         };
 
-        if ctx.get_metadata("a2a.response.capture_enabled") != Some("true") {
+        if ctx.get_metadata("a2a.response.capture_enabled") == Some("true") {
+            if let Some(chunk) = body.as_ref()
+                && !accumulate_response_hex(ctx, chunk, self.config.task_routing.max_response_body_bytes)
+            {
+                return Ok(FilterAction::Continue);
+            }
+
+            try_capture_from_buffer(ctx, store, &self.config.task_routing, end_of_stream);
             return Ok(FilterAction::Continue);
         }
 
-        if let Some(chunk) = body.as_ref()
-            && !accumulate_response_hex(ctx, chunk, self.config.task_routing.max_response_body_bytes)
-        {
-            return Ok(FilterAction::Continue);
+        if ctx.get_metadata("a2a.response.sse_capture_enabled") == Some("true") {
+            if let Some(chunk) = body.as_ref() {
+                process_sse_response_chunk(ctx, chunk, store, &self.config.task_routing);
+            }
+            if end_of_stream {
+                clear_sse_capture_metadata(ctx);
+            }
         }
-
-        try_capture_from_buffer(ctx, store, &self.config.task_routing, end_of_stream);
 
         Ok(FilterAction::Continue)
     }
@@ -419,7 +438,6 @@ fn accumulate_response_hex(ctx: &mut HttpFilterContext<'_>, chunk: &[u8], max_by
         .entry("a2a.response.buffer_hex".to_owned())
         .or_default();
     for byte in chunk {
-        use std::fmt::Write;
         let _ = write!(hex_buf, "{byte:02x}");
     }
 
@@ -453,6 +471,139 @@ fn hex_digit(b: u8) -> Option<u8> {
         b'a'..=b'f' => Some(b - b'a' + 10),
         _ => None,
     }
+}
+
+/// Runs inside the synchronous `on_response_body` hook, so it cannot
+/// await or write to external stores — state persists via `filter_metadata`
+/// hex encoding between calls.
+fn process_sse_response_chunk(
+    ctx: &mut HttpFilterContext<'_>,
+    chunk: &[u8],
+    store: &LocalTaskRouteStore,
+    config: &config::TaskRoutingConfig,
+) {
+    let mut state = load_sse_scan_state(ctx);
+
+    let result = sse::scan_sse_chunk(&mut state, chunk, config.max_response_body_bytes);
+
+    for payload in &result.payloads {
+        try_extract_task_from_sse_payload(payload, ctx, store, config);
+    }
+
+    if result.overflowed {
+        debug!(
+            scratch_bytes = state.scratch_bytes,
+            max_bytes = config.max_response_body_bytes,
+            "SSE scratch exceeds capture limit, disabling streaming capture"
+        );
+        clear_sse_capture_metadata(ctx);
+    } else {
+        save_sse_scan_state(ctx, &state);
+    }
+}
+
+/// Invalid UTF-8 or unparseable JSON silently skips — the proxy must
+/// never fail on arbitrary SSE payloads.
+fn try_extract_task_from_sse_payload(
+    data: &[u8],
+    ctx: &HttpFilterContext<'_>,
+    store: &LocalTaskRouteStore,
+    config: &config::TaskRoutingConfig,
+) {
+    let Ok(value) = serde_json::from_slice::<serde_json::Value>(data) else {
+        return;
+    };
+
+    let Some(cluster) = ctx.filter_metadata.get("a2a.response.cluster") else {
+        return;
+    };
+
+    store_task_route(&value, cluster, store, config);
+}
+
+/// Reconstructs scanner state from hex-encoded `filter_metadata` keys.
+/// Metadata bypasses the 256-byte dynamic-value helper because the
+/// scanner buffers raw SSE line/data bytes that can exceed that limit.
+fn load_sse_scan_state(ctx: &HttpFilterContext<'_>) -> sse::SseScanState {
+    let line_buf = ctx
+        .filter_metadata
+        .get("a2a.response.sse_line_buf_hex")
+        .and_then(|hex| decode_hex(hex))
+        .unwrap_or_default();
+
+    let data_buf = ctx
+        .filter_metadata
+        .get("a2a.response.sse_data_hex")
+        .and_then(|hex| decode_hex(hex))
+        .unwrap_or_default();
+
+    let has_data = ctx
+        .filter_metadata
+        .get("a2a.response.sse_has_data")
+        .is_some_and(|v| v == "true");
+
+    let prev_cr = ctx
+        .filter_metadata
+        .get("a2a.response.sse_prev_cr")
+        .is_some_and(|v| v == "true");
+
+    let scratch_bytes: usize = ctx
+        .filter_metadata
+        .get("a2a.response.sse_scratch_bytes")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+
+    sse::SseScanState {
+        line_buf,
+        data_buf,
+        has_data,
+        prev_cr,
+        scratch_bytes,
+    }
+}
+
+/// Persists scanner state back to `filter_metadata` for the next chunk.
+fn save_sse_scan_state(ctx: &mut HttpFilterContext<'_>, state: &sse::SseScanState) {
+    set_hex_metadata(ctx, "a2a.response.sse_line_buf_hex", &state.line_buf);
+    set_hex_metadata(ctx, "a2a.response.sse_data_hex", &state.data_buf);
+
+    ctx.filter_metadata.insert(
+        "a2a.response.sse_has_data".to_owned(),
+        if state.has_data { "true" } else { "false" }.to_owned(),
+    );
+    ctx.filter_metadata.insert(
+        "a2a.response.sse_prev_cr".to_owned(),
+        if state.prev_cr { "true" } else { "false" }.to_owned(),
+    );
+    ctx.filter_metadata.insert(
+        "a2a.response.sse_scratch_bytes".to_owned(),
+        state.scratch_bytes.to_string(),
+    );
+}
+
+/// Hex-encodes raw bytes into a metadata value, or removes the key if empty.
+fn set_hex_metadata(ctx: &mut HttpFilterContext<'_>, key: &str, data: &[u8]) {
+    if data.is_empty() {
+        ctx.filter_metadata.remove(key);
+    } else {
+        let mut hex = String::with_capacity(data.len() * 2);
+        for byte in data {
+            let _ = write!(hex, "{byte:02x}");
+        }
+        ctx.filter_metadata.insert(key.to_owned(), hex);
+    }
+}
+
+/// Called on overflow, end-of-stream, or error to ensure no stale
+/// scanner state leaks into later requests on the same connection.
+fn clear_sse_capture_metadata(ctx: &mut HttpFilterContext<'_>) {
+    ctx.filter_metadata.remove("a2a.response.sse_capture_enabled");
+    ctx.filter_metadata.remove("a2a.response.sse_line_buf_hex");
+    ctx.filter_metadata.remove("a2a.response.sse_data_hex");
+    ctx.filter_metadata.remove("a2a.response.sse_has_data");
+    ctx.filter_metadata.remove("a2a.response.sse_prev_cr");
+    ctx.filter_metadata.remove("a2a.response.sse_scratch_bytes");
+    ctx.filter_metadata.remove("a2a.response.cluster");
 }
 
 /// Whether a content-type header value indicates `text/event-stream`.

--- a/filter/src/builtins/http/ai/agentic/a2a/sse.rs
+++ b/filter/src/builtins/http/ai/agentic/a2a/sse.rs
@@ -1,0 +1,472 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Bounded incremental SSE scanner for A2A streaming task-route capture.
+//!
+//! Processes `text/event-stream` response body chunks, extracts completed
+//! `data:` payloads from SSE frames, and returns them for task-route
+//! extraction. Handles arbitrary chunk boundaries, multi-line `data:`
+//! fields, CRLF/LF/CR line endings, and comment lines.
+//!
+//! The scanner never modifies response bytes. It inspects chunks and
+//! yields completed payloads; the caller passes bytes through unchanged.
+
+// -----------------------------------------------------------------------------
+// SseScanState
+// -----------------------------------------------------------------------------
+
+/// Incremental SSE parser state carried across response body chunks.
+///
+/// Stored in `filter_metadata` via hex encoding between
+/// [`on_response_body`] calls.
+///
+/// [`on_response_body`]: crate::filter::HttpFilter::on_response_body
+#[derive(Default)]
+pub(crate) struct SseScanState {
+    /// Bytes of an incomplete line from the previous chunk.
+    pub line_buf: Vec<u8>,
+
+    /// Accumulated `data:` field values for the current SSE event,
+    /// joined with `\n` per the SSE specification.
+    pub data_buf: Vec<u8>,
+
+    /// Whether any `data:` field has been seen for the current event.
+    /// Distinguishes "no data lines" from "data lines with empty value".
+    pub has_data: bool,
+
+    /// Whether the previous chunk ended with CR, so a leading LF
+    /// in the next chunk should be consumed as part of a CRLF pair.
+    pub prev_cr: bool,
+
+    /// Total scratch bytes consumed (`line_buf` + `data_buf`).
+    pub scratch_bytes: usize,
+}
+
+// -----------------------------------------------------------------------------
+// SseScanResult
+// -----------------------------------------------------------------------------
+
+/// Outcome of [`scan_sse_chunk`].
+///
+/// Always returns completed payloads, even when the scratch limit is
+/// exceeded partway through a chunk. The caller should process the
+/// payloads first, then check `overflowed` to decide whether to
+/// continue or disable capture.
+pub(crate) struct SseScanResult {
+    /// Completed `data:` payloads dispatched during this chunk.
+    pub payloads: Vec<Vec<u8>>,
+
+    /// Whether the scratch limit was exceeded. When `true`, the
+    /// caller should store routes from `payloads`, then clear
+    /// capture state and stop scanning further chunks.
+    pub overflowed: bool,
+}
+
+// -----------------------------------------------------------------------------
+// Scanning
+// -----------------------------------------------------------------------------
+
+/// Process one SSE chunk, returning completed `data:` payloads and
+/// an overflow flag.
+#[allow(clippy::too_many_lines, reason = "linear byte-processing loop")]
+pub(crate) fn scan_sse_chunk(state: &mut SseScanState, chunk: &[u8], max_scratch_bytes: usize) -> SseScanResult {
+    let mut payloads = Vec::new();
+    let mut i = 0;
+
+    // If previous chunk ended with CR and this starts with LF, consume it
+    // as the second half of a CRLF pair (not a new line boundary).
+    if state.prev_cr && chunk.first() == Some(&b'\n') {
+        i = 1;
+    }
+    state.prev_cr = false;
+
+    while let Some(&b) = chunk.get(i) {
+        if b == b'\n' || b == b'\r' {
+            process_line(&state.line_buf, &mut state.data_buf, &mut state.has_data, &mut payloads);
+            state.line_buf.clear();
+
+            // CRLF within the same chunk: skip the LF.
+            if b == b'\r' {
+                if let Some(&next) = chunk.get(i + 1) {
+                    if next == b'\n' {
+                        i += 1;
+                    }
+                } else {
+                    state.prev_cr = true;
+                }
+            }
+        } else {
+            state.line_buf.push(b);
+        }
+
+        state.scratch_bytes = state.line_buf.len() + state.data_buf.len();
+        if state.scratch_bytes > max_scratch_bytes {
+            return SseScanResult {
+                payloads,
+                overflowed: true,
+            };
+        }
+
+        i += 1;
+    }
+
+    state.scratch_bytes = state.line_buf.len() + state.data_buf.len();
+    SseScanResult {
+        payloads,
+        overflowed: false,
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Private Utilities
+// -----------------------------------------------------------------------------
+
+/// Only `data:` fields are captured; other SSE fields (`event:`, `id:`,
+/// `retry:`) and comment lines are intentionally ignored because A2A
+/// task payloads are always in `data:`.
+fn process_line(line: &[u8], data_buf: &mut Vec<u8>, has_data: &mut bool, payloads: &mut Vec<Vec<u8>>) {
+    if line.is_empty() {
+        if *has_data {
+            payloads.push(data_buf.clone());
+            data_buf.clear();
+            *has_data = false;
+        }
+        return;
+    }
+
+    if line.first() == Some(&b':') {
+        return;
+    }
+
+    let Some(colon_pos) = line.iter().position(|&b| b == b':') else {
+        return;
+    };
+
+    if line.get(..colon_pos) != Some(b"data".as_slice()) {
+        return;
+    }
+
+    // Skip one optional space after the colon per SSE spec.
+    let value_start = if line.get(colon_pos + 1) == Some(&b' ') {
+        colon_pos + 2
+    } else {
+        colon_pos + 1
+    };
+    let value = line.get(value_start..).unwrap_or_default();
+
+    if *has_data {
+        data_buf.push(b'\n');
+    }
+    *has_data = true;
+    data_buf.extend_from_slice(value);
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    reason = "tests"
+)]
+mod tests {
+    use super::*;
+
+    const MAX_SCRATCH: usize = 65_536;
+
+    // -------------------------------------------------------------------------
+    // Single Complete Frame
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn single_data_frame_yields_payload() {
+        let mut state = SseScanState::default();
+        let chunk = b"data: {\"id\":\"task-1\"}\n\n";
+
+        let SseScanResult { payloads, .. } = scan_sse_chunk(&mut state, chunk, MAX_SCRATCH);
+
+        assert_eq!(payloads.len(), 1, "one event should yield one payload");
+        assert_eq!(payloads[0], b"{\"id\":\"task-1\"}");
+    }
+
+    #[test]
+    fn multiple_frames_in_one_chunk() {
+        let mut state = SseScanState::default();
+        let chunk = b"data: first\n\ndata: second\n\n";
+
+        let SseScanResult { payloads, .. } = scan_sse_chunk(&mut state, chunk, MAX_SCRATCH);
+
+        assert_eq!(payloads.len(), 2, "two events should yield two payloads");
+        assert_eq!(payloads[0], b"first");
+        assert_eq!(payloads[1], b"second");
+    }
+
+    // -------------------------------------------------------------------------
+    // Chunk Splitting
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn frame_split_across_two_chunks() {
+        let mut state = SseScanState::default();
+
+        let r = scan_sse_chunk(&mut state, b"data: {\"id\":", MAX_SCRATCH);
+        assert!(r.payloads.is_empty(), "incomplete frame yields no payload");
+
+        let r = scan_sse_chunk(&mut state, b"\"task-1\"}\n\n", MAX_SCRATCH);
+        assert_eq!(r.payloads.len(), 1, "completed frame yields payload");
+        assert_eq!(r.payloads[0], b"{\"id\":\"task-1\"}");
+    }
+
+    #[test]
+    fn line_split_across_chunks() {
+        let mut state = SseScanState::default();
+
+        let r = scan_sse_chunk(&mut state, b"da", MAX_SCRATCH);
+        assert!(r.payloads.is_empty(), "partial field name yields no payload");
+
+        let r = scan_sse_chunk(&mut state, b"ta: hello\n\n", MAX_SCRATCH);
+        assert_eq!(r.payloads.len(), 1, "completed line yields payload");
+        assert_eq!(r.payloads[0], b"hello");
+    }
+
+    #[test]
+    fn blank_line_split_across_chunks() {
+        let mut state = SseScanState::default();
+
+        let r = scan_sse_chunk(&mut state, b"data: hello\n", MAX_SCRATCH);
+        assert!(r.payloads.is_empty(), "first newline is end-of-line, not dispatch");
+
+        let r = scan_sse_chunk(&mut state, b"\n", MAX_SCRATCH);
+        assert_eq!(r.payloads.len(), 1, "second newline dispatches event");
+        assert_eq!(r.payloads[0], b"hello");
+    }
+
+    // -------------------------------------------------------------------------
+    // Multi-line Data
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn multiline_data_joined_with_newline() {
+        let mut state = SseScanState::default();
+        let chunk = b"data: line1\ndata: line2\ndata: line3\n\n";
+
+        let SseScanResult { payloads, .. } = scan_sse_chunk(&mut state, chunk, MAX_SCRATCH);
+
+        assert_eq!(payloads.len(), 1, "one event with multi-line data");
+        assert_eq!(payloads[0], b"line1\nline2\nline3");
+    }
+
+    #[test]
+    fn multiline_data_split_across_chunks() {
+        let mut state = SseScanState::default();
+
+        let r = scan_sse_chunk(&mut state, b"data: line1\n", MAX_SCRATCH);
+        assert!(r.payloads.is_empty(), "not dispatched yet");
+
+        let r = scan_sse_chunk(&mut state, b"data: line2\n\n", MAX_SCRATCH);
+        assert_eq!(r.payloads.len(), 1, "dispatched on blank line");
+        assert_eq!(r.payloads[0], b"line1\nline2");
+    }
+
+    // -------------------------------------------------------------------------
+    // CRLF
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn crlf_line_endings() {
+        let mut state = SseScanState::default();
+        let chunk = b"data: hello\r\n\r\n";
+
+        let SseScanResult { payloads, .. } = scan_sse_chunk(&mut state, chunk, MAX_SCRATCH);
+
+        assert_eq!(payloads.len(), 1, "CRLF should work as line endings");
+        assert_eq!(payloads[0], b"hello");
+    }
+
+    #[test]
+    fn crlf_split_across_chunks() {
+        let mut state = SseScanState::default();
+
+        let r = scan_sse_chunk(&mut state, b"data: hello\r", MAX_SCRATCH);
+        assert!(r.payloads.is_empty(), "CR at end of chunk, waiting for potential LF");
+
+        let r = scan_sse_chunk(&mut state, b"\n\r\n", MAX_SCRATCH);
+        assert_eq!(r.payloads.len(), 1, "CRLF spanning chunks should dispatch");
+        assert_eq!(r.payloads[0], b"hello");
+    }
+
+    #[test]
+    fn bare_cr_line_ending() {
+        let mut state = SseScanState::default();
+        let chunk = b"data: hello\r\r";
+
+        let SseScanResult { payloads, .. } = scan_sse_chunk(&mut state, chunk, MAX_SCRATCH);
+
+        assert_eq!(payloads.len(), 1, "bare CR should be a valid line terminator");
+        assert_eq!(payloads[0], b"hello");
+    }
+
+    // -------------------------------------------------------------------------
+    // Comments and Unknown Fields
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn comments_ignored() {
+        let mut state = SseScanState::default();
+        let chunk = b": this is a comment\ndata: hello\n\n";
+
+        let SseScanResult { payloads, .. } = scan_sse_chunk(&mut state, chunk, MAX_SCRATCH);
+
+        assert_eq!(payloads.len(), 1, "comment should be ignored");
+        assert_eq!(payloads[0], b"hello");
+    }
+
+    #[test]
+    fn unknown_fields_ignored() {
+        let mut state = SseScanState::default();
+        let chunk = b"event: message\nid: 42\ndata: hello\nretry: 1000\n\n";
+
+        let SseScanResult { payloads, .. } = scan_sse_chunk(&mut state, chunk, MAX_SCRATCH);
+
+        assert_eq!(payloads.len(), 1, "unknown fields should be ignored");
+        assert_eq!(payloads[0], b"hello");
+    }
+
+    #[test]
+    fn empty_frames_ignored() {
+        let mut state = SseScanState::default();
+        let chunk = b"\n\ndata: hello\n\n";
+
+        let SseScanResult { payloads, .. } = scan_sse_chunk(&mut state, chunk, MAX_SCRATCH);
+
+        assert_eq!(
+            payloads.len(),
+            1,
+            "empty frames (consecutive blank lines) should be ignored"
+        );
+        assert_eq!(payloads[0], b"hello");
+    }
+
+    #[test]
+    fn line_without_colon_ignored() {
+        let mut state = SseScanState::default();
+        let chunk = b"justtext\ndata: hello\n\n";
+
+        let SseScanResult { payloads, .. } = scan_sse_chunk(&mut state, chunk, MAX_SCRATCH);
+
+        assert_eq!(payloads.len(), 1, "line without colon should be ignored per SSE spec");
+        assert_eq!(payloads[0], b"hello");
+    }
+
+    // -------------------------------------------------------------------------
+    // Data Without Leading Space
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn data_without_space_after_colon() {
+        let mut state = SseScanState::default();
+        let chunk = b"data:nospace\n\n";
+
+        let SseScanResult { payloads, .. } = scan_sse_chunk(&mut state, chunk, MAX_SCRATCH);
+
+        assert_eq!(payloads.len(), 1, "data without space after colon should work");
+        assert_eq!(payloads[0], b"nospace");
+    }
+
+    #[test]
+    fn data_with_empty_value() {
+        let mut state = SseScanState::default();
+        let chunk = b"data:\n\n";
+
+        let SseScanResult { payloads, .. } = scan_sse_chunk(&mut state, chunk, MAX_SCRATCH);
+
+        assert_eq!(payloads.len(), 1, "data with empty value should yield empty payload");
+        assert!(payloads[0].is_empty(), "payload should be empty");
+    }
+
+    // -------------------------------------------------------------------------
+    // Scratch Overflow
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn scratch_overflow_sets_overflowed_flag() {
+        let mut state = SseScanState::default();
+        let chunk = b"data: a]very long line that exceeds the limit\n";
+
+        let result = scan_sse_chunk(&mut state, chunk, 10);
+
+        assert!(result.overflowed, "exceeding scratch limit should set overflowed");
+        assert!(result.payloads.is_empty(), "no completed events before overflow");
+    }
+
+    #[test]
+    fn completed_payload_returned_before_later_overflow() {
+        let mut state = SseScanState::default();
+        // First event completes (short), then a second event overflows (long).
+        let chunk = b"data: ok\n\ndata: this-is-way-too-long-for-the-limit\n\n";
+
+        let result = scan_sse_chunk(&mut state, chunk, 15);
+
+        assert!(result.overflowed, "should overflow on the second event");
+        assert_eq!(
+            result.payloads.len(),
+            1,
+            "first completed event should still be returned"
+        );
+        assert_eq!(result.payloads[0], b"ok");
+    }
+
+    #[test]
+    fn scratch_resets_after_dispatch() {
+        let mut state = SseScanState::default();
+
+        let r = scan_sse_chunk(&mut state, b"data: ab\n\n", 20);
+        assert_eq!(r.payloads.len(), 1, "first event dispatched");
+
+        assert_eq!(
+            state.scratch_bytes, 0,
+            "scratch should reset after data_buf is cleared by dispatch"
+        );
+
+        let r = scan_sse_chunk(&mut state, b"data: cd\n\n", 20);
+        assert_eq!(r.payloads.len(), 1, "second event should also succeed after reset");
+    }
+
+    // -------------------------------------------------------------------------
+    // No Event Name Required
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn data_without_event_name_yields_payload() {
+        let mut state = SseScanState::default();
+        let chunk = b"data: {\"task\":{\"id\":\"t1\"}}\n\n";
+
+        let SseScanResult { payloads, .. } = scan_sse_chunk(&mut state, chunk, MAX_SCRATCH);
+
+        assert_eq!(payloads.len(), 1, "data without event: name should still yield payload");
+    }
+
+    // -------------------------------------------------------------------------
+    // Mixed Content
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn json_rpc_response_in_sse_data() {
+        let mut state = SseScanState::default();
+        let chunk = b"data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"task\":{\"id\":\"task-42\",\"status\":{\"state\":\"TASK_STATE_WORKING\"}}}}\n\n";
+
+        let SseScanResult { payloads, .. } = scan_sse_chunk(&mut state, chunk, MAX_SCRATCH);
+
+        assert_eq!(payloads.len(), 1, "JSON-RPC response in SSE data");
+        let parsed: serde_json::Value = serde_json::from_slice(&payloads[0]).expect("should be valid JSON");
+        assert_eq!(
+            parsed["result"]["task"]["id"].as_str(),
+            Some("task-42"),
+            "task ID should be extractable from parsed payload"
+        );
+    }
+}

--- a/filter/src/builtins/http/ai/agentic/a2a/task_routing.rs
+++ b/filter/src/builtins/http/ai/agentic/a2a/task_routing.rs
@@ -142,11 +142,15 @@ impl LocalTaskRouteStore {
 
 /// Extract task route information from a parsed JSON-RPC response.
 ///
-/// Supports two shapes:
-/// - `result.task.id` (task nested under result)
-/// - `result.id` with `result.status` (direct task object in result)
+/// Supports these [A2A core object] response/stream shapes:
+/// - `result.task.id` — full `Task` nested under result
+/// - `result.id` with `result.status` — direct `Task` object in result
+/// - `result.statusUpdate.taskId` — `TaskStatusUpdateEvent` (carries terminal state)
+/// - `result.artifactUpdate.taskId` — `TaskArtifactUpdateEvent` (never terminal)
 ///
 /// Returns `None` for message-only responses or malformed JSON.
+///
+/// [A2A core object]: https://a2a-protocol.org/latest/specification/#5-core-objects
 pub(crate) fn extract_task_route(value: &Value) -> Option<ExtractedTaskRoute> {
     let result = value.get("result")?;
 
@@ -156,6 +160,14 @@ pub(crate) fn extract_task_route(value: &Value) -> Option<ExtractedTaskRoute> {
 
     if result.get("id").is_some() && result.get("status").is_some() {
         return extract_from_task_object(result);
+    }
+
+    if let Some(status_update) = result.get("statusUpdate") {
+        return extract_from_status_update(status_update);
+    }
+
+    if let Some(artifact_update) = result.get("artifactUpdate") {
+        return extract_from_artifact_update(artifact_update);
     }
 
     None
@@ -178,6 +190,42 @@ fn extract_from_task_object(task: &Value) -> Option<ExtractedTaskRoute> {
     Some(ExtractedTaskRoute {
         task_id: task_id.to_owned(),
         terminal,
+    })
+}
+
+/// Extract route info from a `TaskStatusUpdateEvent` (`result.statusUpdate`).
+fn extract_from_status_update(update: &Value) -> Option<ExtractedTaskRoute> {
+    let task_id = update.get("taskId")?.as_str()?;
+
+    if !validate_id(task_id) {
+        return None;
+    }
+
+    let terminal = update
+        .get("status")
+        .and_then(|s| s.get("state"))
+        .and_then(Value::as_str)
+        .is_some_and(is_terminal_state);
+
+    Some(ExtractedTaskRoute {
+        task_id: task_id.to_owned(),
+        terminal,
+    })
+}
+
+/// Extract route info from a `TaskArtifactUpdateEvent` (`result.artifactUpdate`).
+///
+/// Artifact updates carry no status, so they are never terminal.
+fn extract_from_artifact_update(update: &Value) -> Option<ExtractedTaskRoute> {
+    let task_id = update.get("taskId")?.as_str()?;
+
+    if !validate_id(task_id) {
+        return None;
+    }
+
+    Some(ExtractedTaskRoute {
+        task_id: task_id.to_owned(),
+        terminal: false,
     })
 }
 
@@ -424,6 +472,106 @@ mod tests {
 
         let route = extract_task_route(&json).expect("should extract route");
         assert!(!route.terminal, "TASK_STATE_INPUT_REQUIRED should not be terminal");
+    }
+
+    // ---- Streaming Event Extraction Tests ----
+
+    #[test]
+    fn extract_from_status_update_event() {
+        let json = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "statusUpdate": {
+                    "taskId": "task-su-1",
+                    "contextId": "ctx-1",
+                    "status": {"state": "TASK_STATE_WORKING"}
+                }
+            }
+        });
+
+        let route = extract_task_route(&json).expect("should extract from statusUpdate");
+        assert_eq!(route.task_id, "task-su-1");
+        assert!(!route.terminal, "TASK_STATE_WORKING is not terminal");
+    }
+
+    #[test]
+    fn extract_terminal_status_update_event() {
+        let json = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "statusUpdate": {
+                    "taskId": "task-su-2",
+                    "status": {"state": "TASK_STATE_COMPLETED"}
+                }
+            }
+        });
+
+        let route = extract_task_route(&json).expect("should extract from terminal statusUpdate");
+        assert_eq!(route.task_id, "task-su-2");
+        assert!(
+            route.terminal,
+            "TASK_STATE_COMPLETED from statusUpdate should be terminal"
+        );
+    }
+
+    #[test]
+    fn extract_from_artifact_update_event() {
+        let json = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "artifactUpdate": {
+                    "taskId": "task-au-1",
+                    "contextId": "ctx-1",
+                    "artifact": {
+                        "artifactId": "art-1",
+                        "parts": [{"text": "chunk"}]
+                    }
+                }
+            }
+        });
+
+        let route = extract_task_route(&json).expect("should extract from artifactUpdate");
+        assert_eq!(route.task_id, "task-au-1");
+        assert!(!route.terminal, "artifactUpdate is never terminal");
+    }
+
+    #[test]
+    fn status_update_without_task_id_returns_none() {
+        let json = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "statusUpdate": {
+                    "status": {"state": "TASK_STATE_WORKING"}
+                }
+            }
+        });
+
+        assert!(
+            extract_task_route(&json).is_none(),
+            "statusUpdate without taskId should return None"
+        );
+    }
+
+    #[test]
+    fn artifact_update_without_task_id_returns_none() {
+        let json = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "artifactUpdate": {
+                    "artifact": {"parts": []}
+                }
+            }
+        });
+
+        assert!(
+            extract_task_route(&json).is_none(),
+            "artifactUpdate without taskId should return None"
+        );
     }
 
     #[test]

--- a/filter/src/builtins/http/ai/agentic/a2a/tests.rs
+++ b/filter/src/builtins/http/ai/agentic/a2a/tests.rs
@@ -1610,6 +1610,597 @@ fn list_task_push_notification_configs_extracts_task_id() {
 }
 
 // -----------------------------------------------------------------------------
+// SSE Streaming Capture Tests
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn sse_streaming_response_enables_capture_for_send_streaming_message() {
+    let filter = make_task_routing_filter();
+
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.cluster = Some(Arc::from("agent-a"));
+    ctx.filter_metadata
+        .insert("a2a.method".to_owned(), "SendStreamingMessage".to_owned());
+
+    let mut resp = crate::context::Response {
+        status: http::StatusCode::OK,
+        headers: HeaderMap::new(),
+    };
+    resp.headers
+        .insert("content-type", "text/event-stream".parse().unwrap());
+    ctx.response_header = Some(&mut resp);
+
+    drop(filter.on_response(&mut ctx).await.unwrap());
+    ctx.response_header = None;
+
+    assert_eq!(
+        ctx.get_metadata("a2a.response.sse_capture_enabled"),
+        Some("true"),
+        "SSE capture should be enabled for SendStreamingMessage"
+    );
+    assert_eq!(
+        ctx.get_metadata("a2a.response.cluster"),
+        Some("agent-a"),
+        "cluster should be recorded for SSE capture"
+    );
+    assert!(
+        ctx.get_metadata("a2a.response.capture_enabled").is_none(),
+        "non-streaming capture should NOT be enabled"
+    );
+}
+
+#[tokio::test]
+async fn sse_streaming_capture_single_frame() {
+    let filter = make_task_routing_filter();
+    let store = filter.task_route_store.as_ref().unwrap();
+
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    seed_sse_capture(&mut ctx);
+
+    let sse_data = b"data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"task\":{\"id\":\"task-sse-1\",\"status\":{\"state\":\"TASK_STATE_WORKING\"}}}}\n\n";
+    let mut body = Some(Bytes::from(sse_data.to_vec()));
+    drop(filter.on_response_body(&mut ctx, &mut body, false).unwrap());
+
+    assert_eq!(
+        store.get_by_task_id("task-sse-1").as_deref(),
+        Some("agent-a"),
+        "SSE frame should capture task route"
+    );
+}
+
+#[tokio::test]
+async fn sse_streaming_capture_split_across_chunks() {
+    let filter = make_task_routing_filter();
+    let store = filter.task_route_store.as_ref().unwrap();
+
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    seed_sse_capture(&mut ctx);
+
+    let full = b"data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"task\":{\"id\":\"task-split\",\"status\":{\"state\":\"TASK_STATE_WORKING\"}}}}\n\n";
+    let (chunk1, chunk2) = full.split_at(30);
+
+    let mut body1 = Some(Bytes::from(chunk1.to_vec()));
+    drop(filter.on_response_body(&mut ctx, &mut body1, false).unwrap());
+    assert!(
+        store.get_by_task_id("task-split").is_none(),
+        "incomplete SSE should not capture"
+    );
+
+    let mut body2 = Some(Bytes::from(chunk2.to_vec()));
+    drop(filter.on_response_body(&mut ctx, &mut body2, false).unwrap());
+    assert_eq!(
+        store.get_by_task_id("task-split").as_deref(),
+        Some("agent-a"),
+        "completed SSE frame should capture after second chunk"
+    );
+}
+
+#[tokio::test]
+async fn sse_streaming_capture_line_split_across_chunks() {
+    let filter = make_task_routing_filter();
+    let store = filter.task_route_store.as_ref().unwrap();
+
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    seed_sse_capture(&mut ctx);
+
+    // Split in the middle of "data:" field name
+    let mut body1 = Some(Bytes::from("da"));
+    drop(filter.on_response_body(&mut ctx, &mut body1, false).unwrap());
+
+    let mut body2 = Some(Bytes::from(
+        "ta: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"task\":{\"id\":\"task-line-split\",\"status\":{\"state\":\"TASK_STATE_WORKING\"}}}}\n\n",
+    ));
+    drop(filter.on_response_body(&mut ctx, &mut body2, false).unwrap());
+
+    assert_eq!(
+        store.get_by_task_id("task-line-split").as_deref(),
+        Some("agent-a"),
+        "line split across chunks should still capture"
+    );
+}
+
+#[tokio::test]
+async fn sse_streaming_capture_multiline_data() {
+    let filter = make_task_routing_filter();
+    let store = filter.task_route_store.as_ref().unwrap();
+
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    seed_sse_capture(&mut ctx);
+
+    // JSON split across multiple data: lines
+    let sse_data = b"data: {\"jsonrpc\":\"2.0\",\"id\":1,\n\
+                     data: \"result\":{\"task\":{\"id\":\"task-multi\",\n\
+                     data: \"status\":{\"state\":\"TASK_STATE_WORKING\"}}}}\n\n";
+    let mut body = Some(Bytes::from(sse_data.to_vec()));
+    drop(filter.on_response_body(&mut ctx, &mut body, false).unwrap());
+
+    assert_eq!(
+        store.get_by_task_id("task-multi").as_deref(),
+        Some("agent-a"),
+        "multi-line data should be joined and parsed for task route"
+    );
+}
+
+#[tokio::test]
+async fn sse_streaming_capture_crlf_line_endings() {
+    let filter = make_task_routing_filter();
+    let store = filter.task_route_store.as_ref().unwrap();
+
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    seed_sse_capture(&mut ctx);
+
+    let sse_data = b"data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"task\":{\"id\":\"task-crlf\",\"status\":{\"state\":\"TASK_STATE_WORKING\"}}}}\r\n\r\n";
+    let mut body = Some(Bytes::from(sse_data.to_vec()));
+    drop(filter.on_response_body(&mut ctx, &mut body, false).unwrap());
+
+    assert_eq!(
+        store.get_by_task_id("task-crlf").as_deref(),
+        Some("agent-a"),
+        "CRLF line endings should work for SSE capture"
+    );
+}
+
+#[tokio::test]
+async fn sse_streaming_capture_ignores_comments_and_unknown_fields() {
+    let filter = make_task_routing_filter();
+    let store = filter.task_route_store.as_ref().unwrap();
+
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    seed_sse_capture(&mut ctx);
+
+    let sse_data = b": this is a comment\nevent: task_update\nid: 42\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"task\":{\"id\":\"task-ignore\",\"status\":{\"state\":\"TASK_STATE_WORKING\"}}}}\nretry: 5000\n\n";
+    let mut body = Some(Bytes::from(sse_data.to_vec()));
+    drop(filter.on_response_body(&mut ctx, &mut body, false).unwrap());
+
+    assert_eq!(
+        store.get_by_task_id("task-ignore").as_deref(),
+        Some("agent-a"),
+        "comments and unknown fields should be ignored"
+    );
+}
+
+#[tokio::test]
+async fn sse_streaming_capture_invalid_json_does_not_fail() {
+    let filter = make_task_routing_filter();
+    let store = filter.task_route_store.as_ref().unwrap();
+
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    seed_sse_capture(&mut ctx);
+
+    let sse_data = b"data: not valid json at all\n\n";
+    let mut body = Some(Bytes::from(sse_data.to_vec()));
+    let action = filter.on_response_body(&mut ctx, &mut body, false).unwrap();
+
+    assert!(matches!(action, FilterAction::Continue), "invalid JSON should not fail");
+    assert!(
+        store.get_by_task_id("anything").is_none(),
+        "invalid JSON should not create mapping"
+    );
+    assert_eq!(
+        ctx.get_metadata("a2a.response.sse_capture_enabled"),
+        Some("true"),
+        "capture should remain enabled after invalid JSON"
+    );
+}
+
+#[tokio::test]
+async fn sse_streaming_capture_oversized_scratch_clears_state() {
+    let filter = make_task_routing_filter_with_config(
+        r#"{"on_invalid": "continue", "task_routing": {"enabled": true, "max_response_body_bytes": 32}}"#,
+    );
+    let store = filter.task_route_store.as_ref().unwrap();
+
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    seed_sse_capture(&mut ctx);
+
+    let sse_data = b"data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"task\":{\"id\":\"task-big\",\"status\":{\"state\":\"TASK_STATE_WORKING\"}}}}\n\n";
+    let mut body = Some(Bytes::from(sse_data.to_vec()));
+    drop(filter.on_response_body(&mut ctx, &mut body, false).unwrap());
+
+    assert!(
+        store.get_by_task_id("task-big").is_none(),
+        "oversized SSE scratch should skip capture"
+    );
+    assert_sse_capture_cleared(&ctx);
+}
+
+#[tokio::test]
+async fn sse_streaming_capture_terminal_state_uses_terminal_ttl() {
+    let filter = make_task_routing_filter_with_config(
+        r#"{"on_invalid": "continue", "task_routing": {"enabled": true, "terminal_ttl_seconds": 0}}"#,
+    );
+    let store = filter.task_route_store.as_ref().unwrap();
+
+    // First, capture a working task
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    seed_sse_capture(&mut ctx);
+
+    let working = b"data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"task\":{\"id\":\"task-term\",\"status\":{\"state\":\"TASK_STATE_WORKING\"}}}}\n\n";
+    let mut body = Some(Bytes::from(working.to_vec()));
+    drop(filter.on_response_body(&mut ctx, &mut body, false).unwrap());
+    assert!(
+        store.get_by_task_id("task-term").is_some(),
+        "working task should be stored"
+    );
+
+    // Then see a terminal state (terminal_ttl_seconds=0 means remove immediately)
+    let completed = b"data: {\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"task\":{\"id\":\"task-term\",\"status\":{\"state\":\"TASK_STATE_COMPLETED\"}}}}\n\n";
+    let mut body = Some(Bytes::from(completed.to_vec()));
+    drop(filter.on_response_body(&mut ctx, &mut body, false).unwrap());
+    assert!(
+        store.get_by_task_id("task-term").is_none(),
+        "terminal task with ttl=0 should be removed"
+    );
+}
+
+#[tokio::test]
+async fn sse_streaming_capture_clears_on_eos() {
+    let filter = make_task_routing_filter();
+
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    seed_sse_capture(&mut ctx);
+
+    let mut body: Option<Bytes> = None;
+    drop(filter.on_response_body(&mut ctx, &mut body, true).unwrap());
+
+    assert_sse_capture_cleared(&ctx);
+}
+
+#[tokio::test]
+async fn non_sse_response_does_not_enter_sse_capture_path() {
+    let filter = make_task_routing_filter();
+
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.cluster = Some(Arc::from("agent-a"));
+    ctx.filter_metadata
+        .insert("a2a.method".to_owned(), "SendStreamingMessage".to_owned());
+
+    let mut resp = crate::context::Response {
+        status: http::StatusCode::OK,
+        headers: HeaderMap::new(),
+    };
+    resp.headers.insert("content-type", "application/json".parse().unwrap());
+    ctx.response_header = Some(&mut resp);
+
+    drop(filter.on_response(&mut ctx).await.unwrap());
+    ctx.response_header = None;
+
+    assert!(
+        ctx.get_metadata("a2a.response.sse_capture_enabled").is_none(),
+        "non-SSE response for SendStreamingMessage should not enable SSE capture"
+    );
+}
+
+#[tokio::test]
+async fn wrong_method_does_not_enter_sse_capture() {
+    let filter = make_task_routing_filter();
+
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.cluster = Some(Arc::from("agent-a"));
+    ctx.filter_metadata
+        .insert("a2a.method".to_owned(), "GetTask".to_owned());
+
+    let mut resp = crate::context::Response {
+        status: http::StatusCode::OK,
+        headers: HeaderMap::new(),
+    };
+    resp.headers
+        .insert("content-type", "text/event-stream".parse().unwrap());
+    ctx.response_header = Some(&mut resp);
+
+    drop(filter.on_response(&mut ctx).await.unwrap());
+    ctx.response_header = None;
+
+    assert!(
+        ctx.get_metadata("a2a.response.sse_capture_enabled").is_none(),
+        "GetTask with SSE should not enable SSE capture"
+    );
+}
+
+#[tokio::test]
+async fn error_sse_response_does_not_enable_capture() {
+    for method in ["SendStreamingMessage", "SubscribeToTask"] {
+        let filter = make_task_routing_filter();
+
+        let req = make_a2a_request(&[]);
+        let mut ctx = crate::test_utils::make_filter_context(&req);
+        ctx.cluster = Some(Arc::from("agent-a"));
+        ctx.filter_metadata.insert("a2a.method".to_owned(), method.to_owned());
+
+        let mut resp = crate::context::Response {
+            status: http::StatusCode::INTERNAL_SERVER_ERROR,
+            headers: HeaderMap::new(),
+        };
+        resp.headers
+            .insert("content-type", "text/event-stream".parse().unwrap());
+        ctx.response_header = Some(&mut resp);
+
+        drop(filter.on_response(&mut ctx).await.unwrap());
+        ctx.response_header = None;
+
+        assert!(
+            ctx.get_metadata("a2a.response.sse_capture_enabled").is_none(),
+            "{method} with 500 + text/event-stream should not enable SSE capture"
+        );
+        assert!(
+            ctx.get_metadata("a2a.response.cluster").is_none(),
+            "{method} with 500 should not record cluster"
+        );
+    }
+}
+
+#[tokio::test]
+async fn sse_streaming_bytes_pass_through_unchanged() {
+    let filter = make_task_routing_filter();
+
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    seed_sse_capture(&mut ctx);
+
+    let original = b"data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"task\":{\"id\":\"task-pass\",\"status\":{\"state\":\"TASK_STATE_WORKING\"}}}}\n\n";
+    let mut body = Some(Bytes::from(original.to_vec()));
+    drop(filter.on_response_body(&mut ctx, &mut body, false).unwrap());
+
+    assert_eq!(
+        body.as_deref(),
+        Some(original.as_slice()),
+        "SSE response bytes must pass through unchanged"
+    );
+}
+
+#[tokio::test]
+async fn sse_streaming_capture_mixed_case_content_type() {
+    let filter = make_task_routing_filter();
+
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.cluster = Some(Arc::from("agent-a"));
+    ctx.filter_metadata
+        .insert("a2a.method".to_owned(), "SendStreamingMessage".to_owned());
+
+    let mut resp = crate::context::Response {
+        status: http::StatusCode::OK,
+        headers: HeaderMap::new(),
+    };
+    resp.headers
+        .insert("content-type", "Text/Event-Stream; charset=utf-8".parse().unwrap());
+    ctx.response_header = Some(&mut resp);
+
+    drop(filter.on_response(&mut ctx).await.unwrap());
+    ctx.response_header = None;
+
+    assert_eq!(
+        ctx.get_metadata("a2a.response.sse_capture_enabled"),
+        Some("true"),
+        "mixed-case text/event-stream should enable SSE capture"
+    );
+}
+
+#[tokio::test]
+async fn sse_streaming_capture_direct_result_shape() {
+    let filter = make_task_routing_filter();
+    let store = filter.task_route_store.as_ref().unwrap();
+
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    seed_sse_capture(&mut ctx);
+
+    let sse_data =
+        b"data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"id\":\"task-direct\",\"status\":{\"state\":\"TASK_STATE_WORKING\"}}}\n\n";
+    let mut body = Some(Bytes::from(sse_data.to_vec()));
+    drop(filter.on_response_body(&mut ctx, &mut body, false).unwrap());
+
+    assert_eq!(
+        store.get_by_task_id("task-direct").as_deref(),
+        Some("agent-a"),
+        "direct result shape (result.id + result.status) should also capture from SSE"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// SSE Stream Event Shape Tests
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn sse_streaming_capture_status_update_event() {
+    let filter = make_task_routing_filter();
+    let store = filter.task_route_store.as_ref().unwrap();
+
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    seed_sse_capture(&mut ctx);
+
+    let sse_data =
+        b"data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"statusUpdate\":{\"taskId\":\"task-su\",\"status\":{\"state\":\"TASK_STATE_WORKING\"}}}}\n\n";
+    let mut body = Some(Bytes::from(sse_data.to_vec()));
+    drop(filter.on_response_body(&mut ctx, &mut body, false).unwrap());
+
+    assert_eq!(
+        store.get_by_task_id("task-su").as_deref(),
+        Some("agent-a"),
+        "statusUpdate event should capture task route"
+    );
+}
+
+#[tokio::test]
+async fn sse_streaming_capture_terminal_status_update() {
+    let filter = make_task_routing_filter_with_config(
+        r#"{"on_invalid": "continue", "task_routing": {"enabled": true, "terminal_ttl_seconds": 0}}"#,
+    );
+    let store = filter.task_route_store.as_ref().unwrap();
+
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    seed_sse_capture(&mut ctx);
+
+    // First event creates the route.
+    let working =
+        b"data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"task\":{\"id\":\"task-su-term\",\"status\":{\"state\":\"TASK_STATE_WORKING\"}}}}\n\n";
+    let mut body = Some(Bytes::from(working.to_vec()));
+    drop(filter.on_response_body(&mut ctx, &mut body, false).unwrap());
+    assert!(
+        store.get_by_task_id("task-su-term").is_some(),
+        "working task should be stored"
+    );
+
+    // Terminal statusUpdate removes it (terminal_ttl_seconds=0).
+    let completed =
+        b"data: {\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"statusUpdate\":{\"taskId\":\"task-su-term\",\"status\":{\"state\":\"TASK_STATE_COMPLETED\"}}}}\n\n";
+    let mut body = Some(Bytes::from(completed.to_vec()));
+    drop(filter.on_response_body(&mut ctx, &mut body, false).unwrap());
+    assert!(
+        store.get_by_task_id("task-su-term").is_none(),
+        "terminal statusUpdate with ttl=0 should remove the route"
+    );
+}
+
+#[tokio::test]
+async fn sse_streaming_capture_artifact_update_event() {
+    let filter = make_task_routing_filter();
+    let store = filter.task_route_store.as_ref().unwrap();
+
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    seed_sse_capture(&mut ctx);
+
+    let sse_data =
+        b"data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"artifactUpdate\":{\"taskId\":\"task-au\",\"contextId\":\"ctx-1\",\"artifact\":{\"artifactId\":\"a1\",\"parts\":[{\"text\":\"chunk\"}]}}}}\n\n";
+    let mut body = Some(Bytes::from(sse_data.to_vec()));
+    drop(filter.on_response_body(&mut ctx, &mut body, false).unwrap());
+
+    assert_eq!(
+        store.get_by_task_id("task-au").as_deref(),
+        Some("agent-a"),
+        "artifactUpdate event should capture task route"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Overflow Payload Preservation Tests
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn valid_task_before_oversized_sse_frame_stores_route_and_clears_capture() {
+    let filter = make_task_routing_filter_with_config(
+        r#"{"on_invalid": "continue", "task_routing": {"enabled": true, "max_response_body_bytes": 128}}"#,
+    );
+    let store = filter.task_route_store.as_ref().unwrap();
+
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    seed_sse_capture(&mut ctx);
+
+    // First event (~110 bytes) fits within 128-byte limit.
+    // Second event (~200+ bytes) overflows.
+    let padding = "x".repeat(100);
+    let sse = format!(
+        "data: {{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{{\"task\":{{\"id\":\"task-pre-overflow\",\"status\":{{\"state\":\"TASK_STATE_WORKING\"}}}}}}}}\n\n\
+         data: {{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{{\"task\":{{\"id\":\"task-big\",\"status\":{{\"state\":\"TASK_STATE_WORKING\"}},\"padding\":\"{padding}\"}}}}}}\n\n"
+    );
+    let sse_data = sse.as_bytes();
+    let mut body = Some(Bytes::from(sse_data.to_vec()));
+    drop(filter.on_response_body(&mut ctx, &mut body, false).unwrap());
+
+    assert_eq!(
+        store.get_by_task_id("task-pre-overflow").as_deref(),
+        Some("agent-a"),
+        "completed event before overflow should still be captured"
+    );
+    assert_sse_capture_cleared(&ctx);
+}
+
+// -----------------------------------------------------------------------------
+// SubscribeToTask SSE Capture Tests
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn on_response_enables_capture_for_success_sse_subscribe_to_task() {
+    let filter = make_task_routing_filter();
+
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.cluster = Some(Arc::from("agent-a"));
+    ctx.filter_metadata
+        .insert("a2a.method".to_owned(), "SubscribeToTask".to_owned());
+
+    let mut resp = crate::context::Response {
+        status: http::StatusCode::OK,
+        headers: HeaderMap::new(),
+    };
+    resp.headers
+        .insert("content-type", "text/event-stream".parse().unwrap());
+    ctx.response_header = Some(&mut resp);
+
+    drop(filter.on_response(&mut ctx).await.unwrap());
+    ctx.response_header = None;
+
+    assert_eq!(
+        ctx.get_metadata("a2a.response.sse_capture_enabled"),
+        Some("true"),
+        "SSE capture should be enabled for SubscribeToTask"
+    );
+    assert_eq!(
+        ctx.get_metadata("a2a.response.cluster"),
+        Some("agent-a"),
+        "cluster should be recorded for SubscribeToTask SSE capture"
+    );
+}
+
+#[tokio::test]
+async fn subscribe_to_task_sse_status_update_stores_route() {
+    let filter = make_task_routing_filter();
+    let store = filter.task_route_store.as_ref().unwrap();
+
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    seed_sse_capture(&mut ctx);
+
+    let sse_data =
+        b"data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"statusUpdate\":{\"taskId\":\"task-sub-1\",\"status\":{\"state\":\"TASK_STATE_WORKING\"}}}}\n\n";
+    let mut body = Some(Bytes::from(sse_data.to_vec()));
+    drop(filter.on_response_body(&mut ctx, &mut body, false).unwrap());
+
+    assert_eq!(
+        store.get_by_task_id("task-sub-1").as_deref(),
+        Some("agent-a"),
+        "SubscribeToTask SSE statusUpdate should capture/refresh task route"
+    );
+}
+
+// -----------------------------------------------------------------------------
 // Test Utilities
 // -----------------------------------------------------------------------------
 
@@ -1716,4 +2307,42 @@ fn make_a2a_request(extra_headers: &[(&str, &str)]) -> crate::context::Request {
         );
     }
     req
+}
+
+fn seed_sse_capture(ctx: &mut crate::filter::HttpFilterContext<'_>) {
+    ctx.filter_metadata
+        .insert("a2a.response.sse_capture_enabled".to_owned(), "true".to_owned());
+    ctx.filter_metadata
+        .insert("a2a.response.cluster".to_owned(), "agent-a".to_owned());
+}
+
+fn assert_sse_capture_cleared(ctx: &crate::filter::HttpFilterContext<'_>) {
+    assert!(
+        !ctx.filter_metadata.contains_key("a2a.response.sse_capture_enabled"),
+        "sse_capture_enabled not cleared"
+    );
+    assert!(
+        !ctx.filter_metadata.contains_key("a2a.response.sse_line_buf_hex"),
+        "sse_line_buf_hex not cleared"
+    );
+    assert!(
+        !ctx.filter_metadata.contains_key("a2a.response.sse_data_hex"),
+        "sse_data_hex not cleared"
+    );
+    assert!(
+        !ctx.filter_metadata.contains_key("a2a.response.sse_has_data"),
+        "sse_has_data not cleared"
+    );
+    assert!(
+        !ctx.filter_metadata.contains_key("a2a.response.sse_prev_cr"),
+        "sse_prev_cr not cleared"
+    );
+    assert!(
+        !ctx.filter_metadata.contains_key("a2a.response.sse_scratch_bytes"),
+        "sse_scratch_bytes not cleared"
+    );
+    assert!(
+        !ctx.filter_metadata.contains_key("a2a.response.cluster"),
+        "cluster not cleared"
+    );
 }

--- a/tests/integration/tests/suite/a2a.rs
+++ b/tests/integration/tests/suite/a2a.rs
@@ -85,7 +85,7 @@ fn a2a_streaming_message_sse_response_passes_through_unchanged() {
     stream.flush().unwrap();
 
     let mut response = Vec::new();
-    let _bytes = stream.read_to_end(&mut response);
+    read_until_timeout(&mut stream, &mut response);
     let raw = String::from_utf8_lossy(&response);
 
     assert_eq!(parse_status(&raw), 200);
@@ -432,7 +432,7 @@ fn a2a_sse_response_unchanged_with_task_routing_enabled() {
     stream.flush().unwrap();
 
     let mut response = Vec::new();
-    let _bytes = stream.read_to_end(&mut response);
+    read_until_timeout(&mut stream, &mut response);
     let raw = String::from_utf8_lossy(&response);
 
     assert_eq!(parse_status(&raw), 200);
@@ -445,6 +445,270 @@ fn a2a_sse_response_unchanged_with_task_routing_enabled() {
     assert_eq!(
         response_body, sse_body,
         "SSE response body should pass through unchanged with task routing enabled"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// SSE Streaming Task Routing Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn a2a_streaming_task_route_capture_then_lookup() {
+    let sse_body = "data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"task\":{\"id\":\"task-stream-1\",\"status\":{\"state\":\"TASK_STATE_WORKING\"}}}}\n\n";
+    let sse_guard = Backend::fixed(sse_body)
+        .header("content-type", "text/event-stream")
+        .header("cache-control", "no-cache")
+        .start_with_shutdown();
+    let agent_b_guard = start_backend_with_shutdown("agent-b");
+    let proxy_port = free_port();
+
+    let yaml = a2a_streaming_task_routing_yaml(proxy_port, sse_guard.port(), agent_b_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let _proxy = start_proxy(&config);
+
+    let send_body = r#"{"jsonrpc":"2.0","id":1,"method":"SendStreamingMessage","params":{"message":"Hello"}}"#;
+    let request = json_post_with_a2a_headers("/a2a/", send_body, &[]);
+
+    let mut stream = std::net::TcpStream::connect(format!("127.0.0.1:{proxy_port}")).unwrap();
+    stream
+        .set_read_timeout(Some(std::time::Duration::from_secs(5)))
+        .unwrap();
+    stream.write_all(request.as_bytes()).unwrap();
+    stream.flush().unwrap();
+
+    let mut response = Vec::new();
+    read_until_timeout(&mut stream, &mut response);
+    let raw = String::from_utf8_lossy(&response);
+
+    assert_eq!(parse_status(&raw), 200, "SendStreamingMessage should succeed");
+    assert!(
+        raw.contains("text/event-stream"),
+        "SSE content-type should reach client"
+    );
+
+    let response_body = parse_body(&raw);
+    assert_eq!(
+        response_body, sse_body,
+        "SSE response body should pass through unchanged"
+    );
+
+    let get_body = r#"{"jsonrpc":"2.0","id":2,"method":"GetTask","params":{"id":"task-stream-1"}}"#;
+    let request = json_post_with_a2a_headers("/a2a/", get_body, &[]);
+    let raw = http_send(&format!("127.0.0.1:{proxy_port}"), &request);
+    assert_eq!(parse_status(&raw), 200);
+    assert_eq!(
+        parse_body(&raw),
+        sse_body,
+        "GetTask should route to agent-a (which created the streamed task), not fallback agent-b"
+    );
+}
+
+#[test]
+fn a2a_streaming_multi_event_sse_captures_task_route() {
+    let sse_body = "data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"task\":{\"id\":\"task-multi-evt\",\"status\":{\"state\":\"TASK_STATE_WORKING\"}}}}\n\n\
+                    data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"statusUpdate\":{\"taskId\":\"task-multi-evt\",\"status\":{\"state\":\"TASK_STATE_COMPLETED\"}}}}\n\n";
+    let sse_guard = Backend::fixed(sse_body)
+        .header("content-type", "text/event-stream")
+        .header("cache-control", "no-cache")
+        .start_with_shutdown();
+    let agent_b_guard = start_backend_with_shutdown("agent-b");
+    let proxy_port = free_port();
+
+    let yaml = a2a_streaming_task_routing_yaml(proxy_port, sse_guard.port(), agent_b_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let _proxy = start_proxy(&config);
+
+    let send_body = r#"{"jsonrpc":"2.0","id":1,"method":"SendStreamingMessage","params":{"message":"Hello"}}"#;
+    let request = json_post_with_a2a_headers("/a2a/", send_body, &[]);
+
+    let mut stream = std::net::TcpStream::connect(format!("127.0.0.1:{proxy_port}")).unwrap();
+    stream
+        .set_read_timeout(Some(std::time::Duration::from_secs(5)))
+        .unwrap();
+    stream.write_all(request.as_bytes()).unwrap();
+    stream.flush().unwrap();
+
+    let mut response = Vec::new();
+    read_until_timeout(&mut stream, &mut response);
+    let raw = String::from_utf8_lossy(&response);
+    assert_eq!(parse_status(&raw), 200, "multi-event SSE should succeed");
+
+    let response_body = parse_body(&raw);
+    assert_eq!(
+        response_body, sse_body,
+        "multi-event SSE body should pass through unchanged"
+    );
+
+    let get_body = r#"{"jsonrpc":"2.0","id":2,"method":"GetTask","params":{"id":"task-multi-evt"}}"#;
+    let request = json_post_with_a2a_headers("/a2a/", get_body, &[]);
+    let raw = http_send(&format!("127.0.0.1:{proxy_port}"), &request);
+    assert_eq!(parse_status(&raw), 200);
+    assert_eq!(
+        parse_body(&raw),
+        sse_body,
+        "GetTask should route to agent-a (which created the streamed task), not fallback agent-b"
+    );
+}
+
+#[test]
+fn a2a_streaming_malformed_sse_does_not_create_mapping() {
+    let sse_body = "data: not valid json\n\n";
+    let sse_guard = Backend::fixed(sse_body)
+        .header("content-type", "text/event-stream")
+        .start_with_shutdown();
+    let agent_b_guard = start_backend_with_shutdown("agent-b");
+    let proxy_port = free_port();
+
+    let yaml = a2a_streaming_task_routing_yaml(proxy_port, sse_guard.port(), agent_b_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let _proxy = start_proxy(&config);
+
+    let send_body = r#"{"jsonrpc":"2.0","id":1,"method":"SendStreamingMessage","params":{"message":"Hello"}}"#;
+    let request = json_post_with_a2a_headers("/a2a/", send_body, &[]);
+
+    let mut stream = std::net::TcpStream::connect(format!("127.0.0.1:{proxy_port}")).unwrap();
+    stream
+        .set_read_timeout(Some(std::time::Duration::from_secs(5)))
+        .unwrap();
+    stream.write_all(request.as_bytes()).unwrap();
+    stream.flush().unwrap();
+
+    let mut response = Vec::new();
+    read_until_timeout(&mut stream, &mut response);
+    let raw = String::from_utf8_lossy(&response);
+    assert_eq!(parse_status(&raw), 200, "malformed SSE should still pass through");
+
+    let response_body = parse_body(&raw);
+    assert_eq!(
+        response_body, sse_body,
+        "malformed SSE body should pass through unchanged"
+    );
+
+    let get_body = r#"{"jsonrpc":"2.0","id":2,"method":"GetTask","params":{"id":"nonexistent-task"}}"#;
+    let request = json_post_with_a2a_headers("/a2a/", get_body, &[]);
+    let raw = http_send(&format!("127.0.0.1:{proxy_port}"), &request);
+    assert_eq!(parse_status(&raw), 200);
+    assert_eq!(
+        parse_body(&raw),
+        "agent-b",
+        "no mapping should exist from malformed SSE, so GetTask follows fallback"
+    );
+}
+
+#[test]
+fn a2a_non_streaming_task_routing_unchanged_with_sse_capture() {
+    let json_body = r#"{"jsonrpc":"2.0","id":1,"result":{"task":{"id":"task-json-1","contextId":"ctx-1","status":{"state":"TASK_STATE_WORKING"}}}}"#;
+    let agent_a_guard = Backend::fixed(json_body)
+        .header("content-type", "application/json")
+        .start_with_shutdown();
+    let agent_b_guard = start_backend_with_shutdown("agent-b");
+    let proxy_port = free_port();
+
+    let yaml = a2a_streaming_task_routing_yaml(proxy_port, agent_a_guard.port(), agent_b_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let send_body = r#"{"jsonrpc":"2.0","id":1,"method":"SendMessage","params":{"message":"Hello"}}"#;
+    let request = json_post_with_a2a_headers("/a2a/", send_body, &[]);
+    let raw = http_send(proxy.addr(), &request);
+    assert_eq!(parse_status(&raw), 200, "SendMessage should succeed");
+
+    let get_body = r#"{"jsonrpc":"2.0","id":2,"method":"GetTask","params":{"id":"task-json-1"}}"#;
+    let request = json_post_with_a2a_headers("/a2a/", get_body, &[]);
+    let raw = http_send(proxy.addr(), &request);
+    assert_eq!(parse_status(&raw), 200);
+    assert_eq!(
+        parse_body(&raw),
+        json_body,
+        "non-streaming SendMessage task routing should still work unchanged"
+    );
+}
+
+#[test]
+fn a2a_streaming_status_update_only_captures_task_route() {
+    let sse_body = "data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"statusUpdate\":{\"taskId\":\"task-su-only\",\"contextId\":\"ctx-1\",\"status\":{\"state\":\"TASK_STATE_WORKING\"}}}}\n\n\
+                    data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"artifactUpdate\":{\"taskId\":\"task-su-only\",\"contextId\":\"ctx-1\",\"artifact\":{\"artifactId\":\"a1\",\"parts\":[{\"text\":\"output\"}]}}}}\n\n\
+                    data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"statusUpdate\":{\"taskId\":\"task-su-only\",\"contextId\":\"ctx-1\",\"status\":{\"state\":\"TASK_STATE_COMPLETED\"}}}}\n\n";
+    let sse_guard = Backend::fixed(sse_body)
+        .header("content-type", "text/event-stream")
+        .header("cache-control", "no-cache")
+        .start_with_shutdown();
+    let agent_b_guard = start_backend_with_shutdown("agent-b");
+    let proxy_port = free_port();
+
+    let yaml = a2a_streaming_task_routing_yaml(proxy_port, sse_guard.port(), agent_b_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let _proxy = start_proxy(&config);
+
+    let send_body = r#"{"jsonrpc":"2.0","id":1,"method":"SendStreamingMessage","params":{"message":"Hello"}}"#;
+    let request = json_post_with_a2a_headers("/a2a/", send_body, &[]);
+
+    let mut stream = std::net::TcpStream::connect(format!("127.0.0.1:{proxy_port}")).unwrap();
+    stream
+        .set_read_timeout(Some(std::time::Duration::from_secs(5)))
+        .unwrap();
+    stream.write_all(request.as_bytes()).unwrap();
+    stream.flush().unwrap();
+
+    let mut response = Vec::new();
+    read_until_timeout(&mut stream, &mut response);
+    let raw = String::from_utf8_lossy(&response);
+    assert_eq!(parse_status(&raw), 200, "statusUpdate-only SSE should succeed");
+
+    let response_body = parse_body(&raw);
+    assert_eq!(
+        response_body, sse_body,
+        "statusUpdate-only SSE body should pass through unchanged"
+    );
+
+    let get_body = r#"{"jsonrpc":"2.0","id":2,"method":"GetTask","params":{"id":"task-su-only"}}"#;
+    let request = json_post_with_a2a_headers("/a2a/", get_body, &[]);
+    let raw = http_send(&format!("127.0.0.1:{proxy_port}"), &request);
+    assert_eq!(parse_status(&raw), 200);
+    assert_eq!(
+        parse_body(&raw),
+        sse_body,
+        "GetTask should route to agent-a (statusUpdate-only events captured task route)"
+    );
+}
+
+#[test]
+fn a2a_subscribe_to_task_sse_captures_task_route() {
+    let sse_body = "data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"statusUpdate\":{\"taskId\":\"task-sub-e2e\",\"contextId\":\"ctx-1\",\"status\":{\"state\":\"TASK_STATE_WORKING\"}}}}\n\n";
+    let sse_guard = Backend::fixed(sse_body)
+        .header("content-type", "text/event-stream")
+        .header("cache-control", "no-cache")
+        .start_with_shutdown();
+    let agent_b_guard = start_backend_with_shutdown("agent-b");
+    let proxy_port = free_port();
+
+    let yaml = a2a_streaming_task_routing_yaml(proxy_port, sse_guard.port(), agent_b_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let _proxy = start_proxy(&config);
+
+    let send_body = r#"{"jsonrpc":"2.0","id":1,"method":"SubscribeToTask","params":{"id":"task-sub-e2e"}}"#;
+    let request = json_post_with_a2a_headers("/a2a/", send_body, &[]);
+
+    let mut stream = std::net::TcpStream::connect(format!("127.0.0.1:{proxy_port}")).unwrap();
+    stream
+        .set_read_timeout(Some(std::time::Duration::from_secs(5)))
+        .unwrap();
+    stream.write_all(request.as_bytes()).unwrap();
+    stream.flush().unwrap();
+
+    let mut response = Vec::new();
+    read_until_timeout(&mut stream, &mut response);
+    let raw = String::from_utf8_lossy(&response);
+    assert_eq!(parse_status(&raw), 200, "SubscribeToTask SSE should succeed");
+
+    let get_body = r#"{"jsonrpc":"2.0","id":2,"method":"GetTask","params":{"id":"task-sub-e2e"}}"#;
+    let request = json_post_with_a2a_headers("/a2a/", get_body, &[]);
+    let raw = http_send(&format!("127.0.0.1:{proxy_port}"), &request);
+    assert_eq!(parse_status(&raw), 200);
+    assert_eq!(
+        parse_body(&raw),
+        sse_body,
+        "GetTask should route to agent-a after SubscribeToTask SSE captured the task route"
     );
 }
 
@@ -467,6 +731,17 @@ fn json_post_with_a2a_headers(path: &str, body: &str, headers: &[(&str, &str)]) 
          {body}",
         body.len(),
     )
+}
+
+/// SSE backends close the connection after sending all data, but the
+/// proxy may keep it open until the read timeout fires. `WouldBlock`
+/// is expected; other I/O errors are real failures.
+fn read_until_timeout(stream: &mut std::net::TcpStream, buf: &mut Vec<u8>) {
+    match stream.read_to_end(buf) {
+        Ok(_) => {},
+        Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {},
+        Err(e) => panic!("unexpected read error: {e}"),
+    }
 }
 
 fn a2a_routing_yaml(proxy_port: u16, agent_port: u16, default_port: u16) -> String {
@@ -722,6 +997,58 @@ filter_chains:
           - name: "default"
             endpoints:
               - "127.0.0.1:{default_port}"
+"#,
+    )
+}
+
+fn a2a_streaming_task_routing_yaml(proxy_port: u16, agent_a_port: u16, agent_b_port: u16) -> String {
+    format!(
+        r#"
+listeners:
+  - name: default
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: a2a
+        max_body_bytes: 65536
+        on_invalid: continue
+        headers:
+          method: x-praxis-a2a-method
+          task_id: x-praxis-a2a-task-id
+          streaming: x-praxis-a2a-streaming
+        task_routing:
+          enabled: true
+          route_cluster_header: x-praxis-a2a-route-cluster
+      - filter: router
+        routes:
+          - path_prefix: "/a2a/"
+            headers:
+              x-praxis-a2a-route-cluster: "agent-a"
+            cluster: "agent-a"
+          - path_prefix: "/a2a/"
+            headers:
+              x-praxis-a2a-route-cluster: "agent-b"
+            cluster: "agent-b"
+          - path_prefix: "/a2a/"
+            headers:
+              x-praxis-a2a-method: "SendMessage"
+            cluster: "agent-a"
+          - path_prefix: "/a2a/"
+            headers:
+              x-praxis-a2a-streaming: "true"
+            cluster: "agent-a"
+          - path_prefix: "/a2a/"
+            cluster: "agent-b"
+      - filter: load_balancer
+        clusters:
+          - name: "agent-a"
+            endpoints:
+              - "127.0.0.1:{agent_a_port}"
+          - name: "agent-b"
+            endpoints:
+              - "127.0.0.1:{agent_b_port}"
 "#,
     )
 }


### PR DESCRIPTION
## Summary

  Adds local A2A task-route capture for `SendStreamingMessage` SSE responses.

This extends the existing A2A task-routing flow so Praxis can learn which backend owns a task from streaming responses, not only non-streaming JSON `SendMessage` responses. Streaming bytes still pass through unchanged; the filter only inspects completed SSE `data:` frames and stores task ownership in the existing local route store.

The flow is: 

  1. Client sends SendStreamingMessage.
  2. Praxis routes it to agent-a.
  3. agent-a streams back a task ID like task-123.
  4. Praxis stores: task-123 -> agent-a.
  5. Later, the client sends GetTask(task-123).
  6. Praxis uses the stored route and sends that request back to agent-a, instead of the default backend.

  This PR adds:

  - bounded incremental SSE parsing for `text/event-stream` response bodies
  - capture for A2A v1.0 stream result shapes:
    - `task`
    - `message` pass-through with no route capture
    - `statusUpdate`
    - `artifactUpdate`
  - task route storage from streaming task/status/artifact events
  - terminal-status handling using existing terminal TTL behavior
  - byte-preserving pass-through for SSE responses
  - graceful pass-through for malformed, unrelated, or oversized SSE data
  - end-to-end routing coverage for streaming task creation followed by `GetTask`

  ## Scope

  This keeps task routing local and in-process. It does not add Redis/Valkey state or multi-replica task routing.

  Legacy `kind` discriminator stream events are intentionally not implemented because this PR targets A2A v1.0 stream response shapes.

  ## Validation

  - `cargo test -p praxis-proxy-filter a2a`
  - `cargo test -p praxis-tests-integration --test suite a2a`
  - `cargo clippy --workspace --all-targets -- -D warnings`
  - `cargo +nightly fmt --all --check`

  Live validation was also run with two real local A2A backends. `SendStreamingMessage` streamed A2A v1.0 `task`, `message`, `statusUpdate`, and `artifactUpdate` events from `agent-a`; a later `GetTask` for the captured task routed back to `agent-a` while unknown tasks fell through to `agent-b`.

  Full end to end conformance demo with the `a2a-sdk` library: https://github.com/nerdalert/praxis-research-spikes/tree/main/demo/a2a-streaming-task-capture

  ## References

  Refs praxis-proxy/ai#148
  Refs praxis-proxy/ai#158
  Follows praxis-proxy/praxis#480