### PR TITLE
feat(store): add openai_response_store HttpFilter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2541,6 +2541,7 @@ dependencies = [
  "prost-wkt-types",
  "rand 0.9.4",
  "regex",
+ "secrecy",
  "serde",
  "serde_json",
  "sqlx",
@@ -3284,6 +3285,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "serde",
+ "zeroize",
+]
 
 [[package]]
 name = "security-framework"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2669,6 +2669,7 @@ dependencies = [
  "rustls-pemfile",
  "serde",
  "serde_json",
+ "sqlx",
  "tempfile",
  "tokio",
  "tokio-rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ praxis-filter = { version = "0.3.1", path = "filter", package = "praxis-proxy-fi
 praxis-protocol = { version = "0.3.1", path = "protocol", package = "praxis-proxy-protocol" }
 praxis-tls = { version = "0.3.1", path = "tls", package = "praxis-proxy-tls" }
 praxis-test-utils = { path = "tests/utils" }
+secrecy = { version = "0.10.3", features = ["serde"] }
 serde = { version = "1.0.228", features = ["derive", "rc"] }
 serde_json = "1.0.150"
 rcgen = "0.14.8"

--- a/core/src/config/validate/listener/timeouts.rs
+++ b/core/src/config/validate/listener/timeouts.rs
@@ -5,12 +5,11 @@
 
 use tracing::debug;
 
+use super::super::cluster::MAX_TIMEOUT_MS;
 use crate::{
     config::{Listener, ProtocolKind},
     errors::ProxyError,
 };
-
-use super::super::cluster::MAX_TIMEOUT_MS;
 
 // -----------------------------------------------------------------------------
 // Timeout Constants

--- a/examples/README.md
+++ b/examples/README.md
@@ -133,6 +133,7 @@ page.
 | [format-routing.yaml](configs/ai/openai/responses/format-routing.yaml) | Route by AI API format (Responses vs Chat Completions) |
 | [responses-routing.yaml](configs/ai/openai/responses/responses-routing.yaml) | Route Responses API by mode (stateless vs stateful) |
 | [request-validate.yaml](configs/ai/openai/responses/request-validate.yaml) | Validate Responses API requests and reject invalid parameter combinations |
+| [response-store.yaml](configs/ai/openai/responses/response-store.yaml) | Persist non-streaming Responses API responses to SQLite |
 
 ### Branching
 

--- a/examples/configs/ai/openai/responses/full-flow.yaml
+++ b/examples/configs/ai/openai/responses/full-flow.yaml
@@ -66,11 +66,13 @@ filter_chains:
           mode: x-praxis-responses-mode
 
       - filter: openai_responses_validate
-        # Future #354 orchestration filters would follow here
-        # for stateful requests (gated by filter conditions on the
-        # x-praxis-responses-mode header or responses.* metadata)
-        # before all valid requests route to the inference backend:
-        #   - filter: response_store
+
+      - filter: openai_response_store
+        backend: sqlite
+        database_url: "sqlite::memory:"
+        responses_table: openai_responses
+        conversations_table: openai_conversations
+        # Future #354 orchestration filters would follow here:
         #   - filter: rehydrate
         #   - filter: compact
         #   - filter: tool_parse

--- a/examples/configs/ai/openai/responses/full-flow.yaml
+++ b/examples/configs/ai/openai/responses/full-flow.yaml
@@ -69,7 +69,10 @@ filter_chains:
 
       - filter: openai_response_store
         backend: sqlite
-        database_url: "sqlite::memory:"
+        # In-memory:
+        #   database_url: "sqlite::memory:"
+        # File-backed:
+        database_url: "sqlite://responses.db?mode=rwc"
         responses_table: openai_responses
         conversations_table: openai_conversations
         # Future #354 orchestration filters would follow here:

--- a/examples/configs/ai/openai/responses/response-store.yaml
+++ b/examples/configs/ai/openai/responses/response-store.yaml
@@ -1,0 +1,44 @@
+# Response Store
+#
+# Persists non-streaming Responses API responses to a SQLite
+# database. The `openai_responses_format` filter must run first to
+# classify the request body — `openai_response_store` reads its
+# metadata to decide whether to persist.
+#
+# Streaming responses (`stream: true`) are skipped; streaming
+# persistence will be handled by a separate filter. Non-2xx
+# responses and non-JSON content types are also skipped.
+#
+# The store is lazily initialized on the first qualifying
+# request. If initialization fails (bad URL, permissions),
+# the failure is permanent and the filter becomes a no-op.
+
+listeners:
+  - name: ai-gateway
+    address: "127.0.0.1:8080"
+    filter_chains: [responses-pipeline]
+
+filter_chains:
+  - name: responses-pipeline
+    filters:
+      - filter: openai_responses_format
+
+      - filter: openai_response_store
+        backend: sqlite
+        # In-memory:
+        #   database_url: "sqlite::memory:"
+        # File-backed:
+        database_url: "sqlite://responses.db?mode=rwc"
+        responses_table: openai_responses
+        conversations_table: openai_conversations
+
+      - filter: router
+        routes:
+          - path: "/v1/responses"
+            cluster: "inference-backend"
+
+      - filter: load_balancer
+        clusters:
+          - name: "inference-backend"
+            endpoints:
+              - "127.0.0.1:8000"

--- a/filter/Cargo.toml
+++ b/filter/Cargo.toml
@@ -15,7 +15,7 @@ name = "praxis_filter"
 
 [features]
 default = ["ai-inference"]
-ai-inference = ["dep:sqlx"]
+ai-inference = ["dep:secrecy", "dep:sqlx", "dep:tokio"]
 ext-proc = ["dep:praxis-proto", "dep:tonic", "dep:prost-wkt-types"]
 
 [lints]
@@ -32,11 +32,13 @@ praxis-proto = { workspace = true, optional = true }
 rand = { workspace = true }
 prost-wkt-types = { workspace = true, optional = true }
 regex = { workspace = true }
+secrecy = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 sqlx = { workspace = true, optional = true }
 thiserror = { workspace = true }
+tokio = { workspace = true, optional = true }
 tonic = { workspace = true, optional = true }
 tracing = { workspace = true }
 zeroize = { workspace = true }

--- a/filter/src/builtins/http/ai/mod.rs
+++ b/filter/src/builtins/http/ai/mod.rs
@@ -14,7 +14,7 @@ mod prompt_enrich;
 #[cfg(feature = "ai-inference")]
 #[allow(
     dead_code,
-    reason = "store module is the foundation for upcoming response store filter"
+    reason = "store module provides foundation for response store filter and upcoming CRUD endpoints"
 )]
 pub(crate) mod store;
 #[cfg(feature = "ai-inference")]
@@ -25,6 +25,8 @@ pub use agentic::{A2aFilter, JsonRpcFilter, McpFilter};
 pub use inference::ModelToHeaderFilter;
 #[cfg(feature = "ai-inference")]
 pub use openai::OpenaiResponsesValidateFilter;
+#[cfg(feature = "ai-inference")]
+pub use openai::ResponseStoreFilter;
 #[cfg(feature = "ai-inference")]
 pub use openai::ResponsesFormatFilter;
 #[cfg(feature = "ai-inference")]

--- a/filter/src/builtins/http/ai/openai/mod.rs
+++ b/filter/src/builtins/http/ai/openai/mod.rs
@@ -7,4 +7,5 @@ pub(crate) mod responses;
 
 #[cfg(feature = "ai-inference")]
 pub use responses::OpenaiResponsesValidateFilter;
+pub use responses::ResponseStoreFilter;
 pub use responses::ResponsesFormatFilter;

--- a/filter/src/builtins/http/ai/openai/mod.rs
+++ b/filter/src/builtins/http/ai/openai/mod.rs
@@ -7,5 +7,4 @@ pub(crate) mod responses;
 
 #[cfg(feature = "ai-inference")]
 pub use responses::OpenaiResponsesValidateFilter;
-pub use responses::ResponseStoreFilter;
-pub use responses::ResponsesFormatFilter;
+pub use responses::{ResponseStoreFilter, ResponsesFormatFilter};

--- a/filter/src/builtins/http/ai/openai/responses/mod.rs
+++ b/filter/src/builtins/http/ai/openai/responses/mod.rs
@@ -25,6 +25,8 @@ mod config;
 )]
 pub(crate) mod store;
 
+pub use store::ResponseStoreFilter;
+
 #[cfg(test)]
 #[allow(
     clippy::unwrap_used,

--- a/filter/src/builtins/http/ai/openai/responses/store/config.rs
+++ b/filter/src/builtins/http/ai/openai/responses/store/config.rs
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Configuration types for the response store filter.
+
+use secrecy::{ExposeSecret, SecretString};
+use serde::Deserialize;
+
+use crate::{
+    FilterError,
+    builtins::http::{ai::store::validate_table_identifier, transformation::has_dot_dot_traversal},
+};
+
+// -----------------------------------------------------------------------------
+// StorageBackend
+// -----------------------------------------------------------------------------
+
+/// Supported storage backends.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum StorageBackend {
+    /// SQLite backend (file-backed or in-memory).
+    Sqlite,
+}
+
+// -----------------------------------------------------------------------------
+// ResponseStoreConfig
+// -----------------------------------------------------------------------------
+
+/// YAML configuration for the [`ResponseStoreFilter`].
+///
+/// [`ResponseStoreFilter`]: super::ResponseStoreFilter
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ResponseStoreConfig {
+    /// Storage backend to use.
+    pub backend: StorageBackend,
+
+    /// Database connection URL. Wrapped in [`SecretString`] to
+    /// prevent accidental logging of credentials.
+    pub database_url: SecretString,
+
+    /// Table name for response records.
+    pub responses_table: String,
+
+    /// Table name for conversation message records.
+    pub conversations_table: String,
+}
+
+// -----------------------------------------------------------------------------
+// Config Validation
+// -----------------------------------------------------------------------------
+
+/// Validate the parsed configuration.
+pub(crate) fn validate_config(cfg: &ResponseStoreConfig) -> Result<(), FilterError> {
+    let database_url = cfg.database_url.expose_secret();
+    if database_url.is_empty() {
+        return Err("openai_response_store: 'database_url' must not be empty".into());
+    }
+    validate_database_url(database_url)?;
+    validate_table_identifier(&cfg.responses_table)
+        .map_err(|e| format!("openai_response_store: invalid responses_table: {e}"))?;
+    validate_table_identifier(&cfg.conversations_table)
+        .map_err(|e| format!("openai_response_store: invalid conversations_table: {e}"))?;
+    if cfg.responses_table.eq_ignore_ascii_case(&cfg.conversations_table) {
+        return Err("openai_response_store: response and conversation table names must be distinct".into());
+    }
+    Ok(())
+}
+
+/// Reject `..` segments in the SQLite file path to prevent a
+/// crafted `database_url` from escaping the intended directory
+/// and creating or overwriting files elsewhere on the filesystem.
+fn validate_database_url(database_url: &str) -> Result<(), FilterError> {
+    if is_memory_database_url(database_url) {
+        return Ok(());
+    }
+
+    let path = sqlite_file_path(database_url).unwrap_or(database_url);
+    if has_dot_dot_traversal(path) {
+        return Err("openai_response_store: database_url must not contain '..' path traversal".into());
+    }
+    Ok(())
+}
+
+/// Return whether a SQLite URL targets an in-memory database.
+fn is_memory_database_url(database_url: &str) -> bool {
+    let url = database_url.trim();
+    if url == "sqlite::memory:" || url == "sqlite://:memory:" {
+        return true;
+    }
+    url.split_once('?')
+        .map_or("", |(_, query)| query)
+        .split('&')
+        .any(|param| param == "mode=memory")
+}
+
+/// Extract the file path component from a SQLite URL.
+fn sqlite_file_path(database_url: &str) -> Option<&str> {
+    database_url
+        .strip_prefix("sqlite://")
+        .or_else(|| database_url.strip_prefix("sqlite:"))
+        .map(|rest| rest.split_once('?').map_or(rest, |(path, _query)| path))
+}

--- a/filter/src/builtins/http/ai/openai/responses/store/filter.rs
+++ b/filter/src/builtins/http/ai/openai/responses/store/filter.rs
@@ -1,0 +1,424 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! [`ResponseStoreFilter`] persists non-streaming Responses API
+//! responses to the configured store backend.
+//!
+//! # Lifecycle design
+//!
+//! The filter spans three phases, each refining the "should we
+//! persist?" decision as new information becomes available:
+//!
+//! - **`on_request`**: reads classifier metadata to decide whether
+//!   the request is persistable (POST, responses format, store
+//!   enabled, non-streaming). Lazily initializes the store backend.
+//!   Sets `responses.skip_persist` metadata on store init failure.
+//!
+//! - **`on_response`**: re-checks skip conditions, then inspects
+//!   the response status and content-type. Non-2xx or non-JSON
+//!   responses set `responses.skip_persist` and bail early.
+//!
+//! - **`on_response_body`**: at end-of-stream, extracts the record
+//!   from the buffered response JSON and spawns an async persist
+//!   task. Non-persistable exchanges release chunks immediately
+//!   via [`FilterAction::Release`] to avoid holding pass-through
+//!   traffic in the `StreamBuffer`.
+//!
+//! The repeated `should_skip_persist()` calls at each phase are
+//! intentional. Each phase learns something new (request metadata,
+//! response headers, body bytes), and early exit avoids wasted
+//! work (store init, body buffering, JSON parsing). Cross-phase
+//! state is carried exclusively through string metadata in
+//! [`filter_metadata`], following the same pattern as the A2A
+//! filter.
+//!
+//! [`filter_metadata`]: crate::HttpFilterContext::filter_metadata
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use serde_json::Value;
+use tokio::sync::OnceCell;
+use tracing::{debug, trace, warn};
+
+use secrecy::ExposeSecret;
+
+use super::config::{ResponseStoreConfig, StorageBackend, validate_config};
+use crate::builtins::http::ai::store::{ResponseRecord, ResponseStore, SqliteResponseStore};
+use crate::{
+    FilterAction, FilterError,
+    body::{BodyAccess, BodyMode, limits::MAX_JSON_BODY_BYTES},
+    factory::parse_filter_config,
+    filter::{HttpFilter, HttpFilterContext},
+};
+
+// -----------------------------------------------------------------------------
+// ResponseStoreFilter
+// -----------------------------------------------------------------------------
+
+/// Default tenant identifier for single-tenant deployments.
+const DEFAULT_TENANT_ID: &str = "default";
+
+/// Metadata key for the per-request tenant identifier.
+const TENANT_METADATA_KEY: &str = "responses.tenant_id";
+
+/// Persists non-streaming Responses API responses to the
+/// configured response store backend.
+///
+/// # YAML
+///
+/// ```yaml
+/// filter: openai_response_store
+/// backend: sqlite
+/// database_url: sqlite://responses.db?mode=rwc
+/// responses_table: openai_responses
+/// conversations_table: openai_conversation_messages
+/// ```
+pub struct ResponseStoreFilter {
+    /// Parsed configuration.
+    pub(crate) config: ResponseStoreConfig,
+
+    /// Lazily initialized store backend. `Option` ensures init
+    /// failure stores `None` permanently, preventing retries on
+    /// bad config.
+    pub(crate) store: OnceCell<Option<Arc<dyn ResponseStore>>>,
+}
+
+impl ResponseStoreFilter {
+    /// Create a filter from parsed YAML config.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FilterError`] if the YAML config is invalid.
+    pub fn from_config(config: &serde_yaml::Value) -> Result<Box<dyn HttpFilter>, FilterError> {
+        let cfg: ResponseStoreConfig = parse_filter_config("openai_response_store", config)?;
+        validate_config(&cfg)?;
+        Ok(Box::new(Self::new(cfg)))
+    }
+
+    /// Create a filter from validated config.
+    pub(super) fn new(config: ResponseStoreConfig) -> Self {
+        Self {
+            config,
+            store: OnceCell::new(),
+        }
+    }
+
+    /// Initialize the store backend, returning `None` on failure.
+    #[allow(clippy::cognitive_complexity, reason = "tracing macros inflate complexity")]
+    async fn init_store(&self) -> Option<Arc<dyn ResponseStore>> {
+        match self.config.backend {
+            StorageBackend::Sqlite => {
+                let result = SqliteResponseStore::new(
+                    self.config.database_url.expose_secret(),
+                    &self.config.responses_table,
+                    &self.config.conversations_table,
+                )
+                .await;
+
+                match result {
+                    Ok(store) => {
+                        debug!(
+                            backend = ?self.config.backend,
+                            responses_table = %self.config.responses_table,
+                            conversations_table = %self.config.conversations_table,
+                            "response store initialized"
+                        );
+                        Some(Arc::new(store))
+                    },
+                    Err(e) => {
+                        warn!(
+                            backend = ?self.config.backend,
+                            error = %e,
+                            "response store initialization failed (permanent)"
+                        );
+                        None
+                    },
+                }
+            },
+        }
+    }
+
+    /// Return whether this exchange should release response body
+    /// chunks immediately instead of waiting for EOS.
+    fn should_release_skipped_response_body(&self, ctx: &HttpFilterContext<'_>) -> bool {
+        should_skip_persist(ctx) || self.store.get().and_then(Option::as_ref).is_none()
+    }
+
+    /// Return the initialized store and terminal response bytes.
+    fn terminal_store_and_body<'a>(
+        &self,
+        ctx: &HttpFilterContext<'_>,
+        body: &'a Option<Bytes>,
+    ) -> Option<(Arc<dyn ResponseStore>, &'a Bytes)> {
+        if should_skip_persist(ctx) {
+            return None;
+        }
+
+        let store = self.store.get().and_then(Option::clone)?;
+        let bytes = body.as_ref().filter(|b| !b.is_empty())?;
+
+        Some((store, bytes))
+    }
+}
+
+// -----------------------------------------------------------------------------
+// ResponseCapture
+// -----------------------------------------------------------------------------
+
+/// Fields extracted from the response JSON for the store record.
+struct ResponseCapture {
+    /// Echoed input items from the response.
+    input: Value,
+
+    /// Model output items.
+    messages: Value,
+}
+
+impl ResponseCapture {
+    /// Extract input and output from a Responses API response object.
+    fn from_response_json(json: &Value) -> Self {
+        Self {
+            input: json.get("input").cloned().unwrap_or_else(|| json.clone()),
+            messages: json.get("output").cloned().unwrap_or_else(|| json.clone()),
+        }
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Bypass Helpers
+// -----------------------------------------------------------------------------
+
+/// Check whether this request should skip persistence entirely.
+fn should_skip(ctx: &HttpFilterContext<'_>) -> bool {
+    is_non_post_request(ctx) || is_non_responses_format(ctx) || is_store_disabled(ctx) || is_streaming_request(ctx)
+}
+
+/// Return whether the request method is not persistable.
+fn is_non_post_request(ctx: &HttpFilterContext<'_>) -> bool {
+    let skip = ctx.request.method != http::Method::POST;
+    if skip {
+        trace!(method = %ctx.request.method, "skipping non-POST request");
+    }
+    skip
+}
+
+/// Return whether the request is not a Responses API request.
+fn is_non_responses_format(ctx: &HttpFilterContext<'_>) -> bool {
+    let format = ctx.get_metadata("openai_responses_format.format");
+    let skip = format != Some("openai_responses");
+    if skip {
+        trace!(format = ?format, "skipping non-responses format");
+    }
+    skip
+}
+
+/// Return whether the request explicitly disabled persistence.
+fn is_store_disabled(ctx: &HttpFilterContext<'_>) -> bool {
+    let skip = ctx.get_metadata("openai_responses_format.store") == Some("false");
+    if skip {
+        trace!("skipping persistence (store=false)");
+    }
+    skip
+}
+
+/// Return whether the request uses streaming responses.
+fn is_streaming_request(ctx: &HttpFilterContext<'_>) -> bool {
+    let skip = ctx.get_metadata("openai_responses_format.stream") == Some("true");
+    if skip {
+        trace!("skipping streaming request (deferred)");
+    }
+    skip
+}
+
+/// Check whether persistence was skipped during the response phase.
+fn should_skip_persist(ctx: &HttpFilterContext<'_>) -> bool {
+    should_skip(ctx) || ctx.get_metadata("responses.skip_persist") == Some("true")
+}
+
+/// Return whether a `Content-Type` header is JSON.
+fn is_json_content_type(content_type: &str) -> bool {
+    content_type
+        .split(';')
+        .next()
+        .unwrap_or_default()
+        .trim()
+        .eq_ignore_ascii_case("application/json")
+}
+
+/// Check response headers before enabling response body buffering.
+fn response_is_persistable(ctx: &mut HttpFilterContext<'_>) -> bool {
+    let Some(resp) = ctx.response_header.as_ref() else {
+        return true;
+    };
+
+    if !resp.status.is_success() {
+        trace!(status = %resp.status, "skipping persistence for non-2xx response");
+        ctx.set_metadata("responses.skip_persist", "true");
+        return false;
+    }
+
+    let is_json = resp
+        .headers
+        .get(http::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(is_json_content_type);
+    if !is_json {
+        trace!("skipping persistence for non-JSON content type");
+        ctx.set_metadata("responses.skip_persist", "true");
+        return false;
+    }
+
+    true
+}
+
+/// Parse a response body into a [`ResponseRecord`], returning
+/// `None` for invalid JSON or missing required fields.
+#[allow(clippy::cognitive_complexity, reason = "tracing macros inflate complexity")]
+fn parse_response_record(bytes: &[u8], tenant_id: &str) -> Option<ResponseRecord> {
+    let json: Value = match serde_json::from_slice(bytes) {
+        Ok(v) => v,
+        Err(e) => {
+            warn!(error = %e, "response store: invalid response JSON");
+            return None;
+        },
+    };
+
+    let id = json.get("id").and_then(Value::as_str);
+    let created_at = json.get("created_at").and_then(Value::as_i64);
+    let model = json.get("model").and_then(Value::as_str);
+
+    let (Some(id), Some(created_at), Some(model)) = (id, created_at, model) else {
+        warn!("response store: missing required field (id, created_at, or model)");
+        return None;
+    };
+
+    let capture = ResponseCapture::from_response_json(&json);
+
+    Some(ResponseRecord {
+        id: id.to_owned(),
+        tenant_id: tenant_id.to_owned(),
+        created_at,
+        model: model.to_owned(),
+        response_object: json,
+        input: capture.input,
+        messages: capture.messages,
+    })
+}
+
+/// Persist a response record asynchronously.
+fn spawn_persist_response(store: Arc<dyn ResponseStore>, record: ResponseRecord) {
+    debug!(
+        id = %record.id,
+        model = %record.model,
+        "persisting response"
+    );
+
+    tokio::spawn(async move {
+        if let Err(e) = store.upsert_response(&record).await {
+            warn!(
+                id = %record.id,
+                error = %e,
+                "response store: upsert failed"
+            );
+        }
+    });
+}
+
+// -----------------------------------------------------------------------------
+// HttpFilter Implementation
+// -----------------------------------------------------------------------------
+
+#[async_trait]
+impl HttpFilter for ResponseStoreFilter {
+    fn name(&self) -> &'static str {
+        "openai_response_store"
+    }
+
+    fn response_body_access(&self) -> BodyAccess {
+        BodyAccess::ReadOnly
+    }
+
+    /// `StreamBuffer` so the protocol layer assembles the complete
+    /// response body before delivering it at end-of-stream.
+    ///
+    /// Non-streaming Responses API payloads are bounded by output
+    /// token limits (typically under 2 MiB). The 64 MiB ceiling is
+    /// 30x headroom; it will never fire in practice but guards
+    /// against a misbehaving backend. The client is already waiting
+    /// for the full model inference, so the hold-back latency from
+    /// `StreamBuffer` is negligible.
+    fn response_body_mode(&self) -> BodyMode {
+        BodyMode::StreamBuffer {
+            max_bytes: Some(MAX_JSON_BODY_BYTES),
+        }
+    }
+
+    async fn on_request(&self, ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
+        if should_skip(ctx) {
+            return Ok(FilterAction::Continue);
+        }
+
+        let store_opt = self.store.get_or_init(|| async { self.init_store().await }).await;
+        if store_opt.is_none() {
+            ctx.set_metadata("responses.skip_persist", "true");
+        }
+
+        Ok(FilterAction::Continue)
+    }
+
+    async fn on_response(&self, ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
+        if should_skip_persist(ctx) {
+            return Ok(FilterAction::Continue);
+        }
+
+        if !response_is_persistable(ctx) {
+            return Ok(FilterAction::Continue);
+        }
+
+        let store_opt = self.store.get_or_init(|| async { self.init_store().await }).await;
+        if store_opt.is_none() {
+            trace!("skipping persistence because response store is unavailable");
+            ctx.set_metadata("responses.skip_persist", "true");
+            return Ok(FilterAction::Continue);
+        }
+
+        trace!("response body persistence armed");
+
+        Ok(FilterAction::Continue)
+    }
+
+    fn on_response_body(
+        &self,
+        ctx: &mut HttpFilterContext<'_>,
+        body: &mut Option<Bytes>,
+        end_of_stream: bool,
+    ) -> Result<FilterAction, FilterError> {
+        if self.should_release_skipped_response_body(ctx) {
+            // This filter declares StreamBuffer globally. Response storage is
+            // only armed for non-streaming Responses API exchanges with a
+            // usable store and a JSON 2xx response; otherwise release chunks
+            // immediately instead of holding pass-through traffic until EOS.
+            return Ok(FilterAction::Release);
+        }
+
+        if !end_of_stream {
+            return Ok(FilterAction::Continue);
+        }
+
+        let Some((store, bytes)) = self.terminal_store_and_body(ctx, body) else {
+            return Ok(FilterAction::Continue);
+        };
+        let tenant_id = ctx
+            .get_metadata(TENANT_METADATA_KEY)
+            .unwrap_or(DEFAULT_TENANT_ID)
+            .to_owned();
+        let Some(record) = parse_response_record(bytes, &tenant_id) else {
+            return Ok(FilterAction::Continue);
+        };
+
+        spawn_persist_response(store, record);
+        Ok(FilterAction::Continue)
+    }
+}

--- a/filter/src/builtins/http/ai/openai/responses/store/filter.rs
+++ b/filter/src/builtins/http/ai/openai/responses/store/filter.rs
@@ -16,9 +16,13 @@
 //! - **`on_response`**: re-checks skip conditions, then inspects the response status and content-type. Non-2xx or
 //!   non-JSON responses set `responses.skip_persist` and bail early.
 //!
-//! - **`on_response_body`**: at end-of-stream, extracts the record from the buffered response JSON and spawns an async
-//!   persist task. Non-persistable exchanges release chunks immediately via [`FilterAction::Release`] to avoid holding
-//!   pass-through traffic in the `StreamBuffer`.
+//! - **`on_response_body`**: at end-of-stream, extracts the record from the buffered response JSON and persists it
+//!   synchronously via [`block_in_place`] before returning to Pingora. This guarantees the record is durable before the
+//!   client observes the completed response, preventing races with subsequent operations like `DELETE
+//!   /v1/responses/{id}`. Non-persistable exchanges release chunks immediately via [`FilterAction::Release`] to avoid
+//!   holding pass-through traffic in the `StreamBuffer`.
+//!
+//! [`block_in_place`]: tokio::task::block_in_place
 //!
 //! The repeated `should_skip_persist()` calls at each phase are
 //! intentional. Each phase learns something new (request metadata,
@@ -306,23 +310,26 @@ fn parse_response_record(bytes: &[u8], tenant_id: &str) -> Option<ResponseRecord
     })
 }
 
-/// Persist a response record asynchronously.
-fn spawn_persist_response(store: Arc<dyn ResponseStore>, record: ResponseRecord) {
+/// Persist a response record synchronously via [`block_in_place`].
+///
+/// Uses the current Tokio runtime handle to drive the async
+/// `upsert_response` call without yielding back to Pingora's
+/// synchronous `response_body_filter`. This guarantees the record
+/// is durable before the response reaches the client, preventing
+/// races where a subsequent `DELETE /v1/responses/{id}` arrives
+/// before the upsert completes.
+///
+/// [`block_in_place`]: tokio::task::block_in_place
+fn persist_response_blocking(store: &Arc<dyn ResponseStore>, record: &ResponseRecord) -> Result<(), FilterError> {
     debug!(
         id = %record.id,
         model = %record.model,
         "persisting response"
     );
 
-    tokio::spawn(async move {
-        if let Err(e) = store.upsert_response(&record).await {
-            warn!(
-                id = %record.id,
-                error = %e,
-                "response store: upsert failed"
-            );
-        }
-    });
+    let handle = tokio::runtime::Handle::current();
+    tokio::task::block_in_place(|| handle.block_on(store.upsert_response(record)))
+        .map_err(|e| -> FilterError { Box::new(e) })
 }
 
 // -----------------------------------------------------------------------------
@@ -417,7 +424,7 @@ impl HttpFilter for ResponseStoreFilter {
             return Ok(FilterAction::Continue);
         };
 
-        spawn_persist_response(store, record);
+        persist_response_blocking(&store, &record)?;
         Ok(FilterAction::Continue)
     }
 }

--- a/filter/src/builtins/http/ai/openai/responses/store/filter.rs
+++ b/filter/src/builtins/http/ai/openai/responses/store/filter.rs
@@ -9,20 +9,16 @@
 //! The filter spans three phases, each refining the "should we
 //! persist?" decision as new information becomes available:
 //!
-//! - **`on_request`**: reads classifier metadata to decide whether
-//!   the request is persistable (POST, responses format, store
-//!   enabled, non-streaming). Lazily initializes the store backend.
-//!   Sets `responses.skip_persist` metadata on store init failure.
+//! - **`on_request`**: reads classifier metadata to decide whether the request is persistable (POST, responses format,
+//!   store enabled, non-streaming). Lazily initializes the store backend. Sets `responses.skip_persist` metadata on
+//!   store init failure.
 //!
-//! - **`on_response`**: re-checks skip conditions, then inspects
-//!   the response status and content-type. Non-2xx or non-JSON
-//!   responses set `responses.skip_persist` and bail early.
+//! - **`on_response`**: re-checks skip conditions, then inspects the response status and content-type. Non-2xx or
+//!   non-JSON responses set `responses.skip_persist` and bail early.
 //!
-//! - **`on_response_body`**: at end-of-stream, extracts the record
-//!   from the buffered response JSON and spawns an async persist
-//!   task. Non-persistable exchanges release chunks immediately
-//!   via [`FilterAction::Release`] to avoid holding pass-through
-//!   traffic in the `StreamBuffer`.
+//! - **`on_response_body`**: at end-of-stream, extracts the record from the buffered response JSON and spawns an async
+//!   persist task. Non-persistable exchanges release chunks immediately via [`FilterAction::Release`] to avoid holding
+//!   pass-through traffic in the `StreamBuffer`.
 //!
 //! The repeated `should_skip_persist()` calls at each phase are
 //! intentional. Each phase learns something new (request metadata,
@@ -38,17 +34,16 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use bytes::Bytes;
+use secrecy::ExposeSecret;
 use serde_json::Value;
 use tokio::sync::OnceCell;
 use tracing::{debug, trace, warn};
 
-use secrecy::ExposeSecret;
-
 use super::config::{ResponseStoreConfig, StorageBackend, validate_config};
-use crate::builtins::http::ai::store::{ResponseRecord, ResponseStore, SqliteResponseStore};
 use crate::{
     FilterAction, FilterError,
     body::{BodyAccess, BodyMode, limits::MAX_JSON_BODY_BYTES},
+    builtins::http::ai::store::{ResponseRecord, ResponseStore, SqliteResponseStore},
     factory::parse_filter_config,
     filter::{HttpFilter, HttpFilterContext},
 };
@@ -106,7 +101,11 @@ impl ResponseStoreFilter {
     }
 
     /// Initialize the store backend, returning `None` on failure.
-    #[allow(clippy::cognitive_complexity, reason = "tracing macros inflate complexity")]
+    #[allow(
+        clippy::cognitive_complexity,
+        clippy::too_many_lines,
+        reason = "tracing macros inflate complexity"
+    )]
     async fn init_store(&self) -> Option<Arc<dyn ResponseStore>> {
         match self.config.backend {
             StorageBackend::Sqlite => {

--- a/filter/src/builtins/http/ai/openai/responses/store/filter.rs
+++ b/filter/src/builtins/http/ai/openai/responses/store/filter.rs
@@ -183,8 +183,8 @@ impl ResponseCapture {
     /// Extract input and output from a Responses API response object.
     fn from_response_json(json: &Value) -> Self {
         Self {
-            input: json.get("input").cloned().unwrap_or_else(|| json.clone()),
-            messages: json.get("output").cloned().unwrap_or_else(|| json.clone()),
+            input: json.get("input").cloned().unwrap_or(Value::Null),
+            messages: json.get("output").cloned().unwrap_or(Value::Null),
         }
     }
 }

--- a/filter/src/builtins/http/ai/openai/responses/store/mod.rs
+++ b/filter/src/builtins/http/ai/openai/responses/store/mod.rs
@@ -9,10 +9,25 @@
 //!
 //! [`ResponseStore`]: crate::builtins::http::ai::store::ResponseStore
 
+mod config;
+mod filter;
 mod input_items;
 
+pub use self::filter::ResponseStoreFilter;
 #[allow(
     unused_imports,
     reason = "re-exports for GET (#458) and DELETE (#459) response endpoints"
 )]
 pub use input_items::{InputItemPage, ListParams, Order, list_input_items};
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    clippy::too_many_lines,
+    clippy::cognitive_complexity,
+    reason = "tests"
+)]
+mod tests;

--- a/filter/src/builtins/http/ai/openai/responses/store/mod.rs
+++ b/filter/src/builtins/http/ai/openai/responses/store/mod.rs
@@ -13,12 +13,13 @@ mod config;
 mod filter;
 mod input_items;
 
-pub use self::filter::ResponseStoreFilter;
 #[allow(
     unused_imports,
     reason = "re-exports for GET (#458) and DELETE (#459) response endpoints"
 )]
 pub use input_items::{InputItemPage, ListParams, Order, list_input_items};
+
+pub use self::filter::ResponseStoreFilter;
 
 #[cfg(test)]
 #[allow(

--- a/filter/src/builtins/http/ai/openai/responses/store/tests.rs
+++ b/filter/src/builtins/http/ai/openai/responses/store/tests.rs
@@ -5,7 +5,7 @@
 
 use std::{
     path::PathBuf,
-    time::{Duration, SystemTime, UNIX_EPOCH},
+    time::{SystemTime, UNIX_EPOCH},
 };
 
 use bytes::Bytes;
@@ -230,7 +230,7 @@ fn response_body_mode_is_bounded_stream_buffer() {
 // on_request Bypass
 // -----------------------------------------------------------------------------
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn on_request_skips_when_format_metadata_absent() {
     let filter = make_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
@@ -247,7 +247,7 @@ async fn on_request_skips_when_format_metadata_absent() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn on_request_skips_when_format_is_openai_chat_completions() {
     let filter = make_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat/completions");
@@ -265,7 +265,7 @@ async fn on_request_skips_when_format_is_openai_chat_completions() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn on_request_skips_when_store_is_false() {
     let filter = make_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
@@ -284,7 +284,7 @@ async fn on_request_skips_when_store_is_false() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn on_request_skips_when_stream_is_true() {
     let filter = make_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
@@ -303,7 +303,7 @@ async fn on_request_skips_when_stream_is_true() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn on_request_skips_for_get_method() {
     let filter = make_filter();
     let req = crate::test_utils::make_request(http::Method::GET, "/v1/responses/resp_123");
@@ -318,7 +318,7 @@ async fn on_request_skips_for_get_method() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn on_request_skips_for_delete_method() {
     let filter = make_filter();
     let req = crate::test_utils::make_request(http::Method::DELETE, "/v1/responses/resp_123");
@@ -336,7 +336,7 @@ async fn on_request_skips_for_delete_method() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn on_request_initializes_store_for_openai_responses_format() {
     let filter = make_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
@@ -359,7 +359,7 @@ async fn on_request_initializes_store_for_openai_responses_format() {
 // on_response
 // -----------------------------------------------------------------------------
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn on_response_skips_when_format_metadata_absent() {
     let filter = make_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
@@ -377,7 +377,7 @@ async fn on_response_skips_when_format_metadata_absent() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn on_response_sets_skip_persist_for_non_2xx() {
     let filter = make_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
@@ -398,7 +398,7 @@ async fn on_response_sets_skip_persist_for_non_2xx() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn on_response_sets_skip_persist_for_non_json_content_type() {
     let filter = make_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
@@ -423,7 +423,7 @@ async fn on_response_sets_skip_persist_for_non_json_content_type() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn on_response_continues_for_json_200() {
     let filter = make_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
@@ -440,7 +440,7 @@ async fn on_response_continues_for_json_200() {
     assert!(matches!(action, FilterAction::Continue), "should continue for JSON 200");
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn on_response_accepts_mixed_case_json_content_type() {
     let filter = make_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
@@ -462,7 +462,7 @@ async fn on_response_accepts_mixed_case_json_content_type() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn on_response_does_not_buffer_when_store_unavailable() {
     let yaml: serde_yaml::Value = serde_yaml::from_str(
         r#"
@@ -522,7 +522,7 @@ fn on_response_body_releases_skipped_non_end_of_stream() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn on_response_body_releases_when_skip_persist_is_true() {
     let filter = make_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
@@ -539,7 +539,7 @@ async fn on_response_body_releases_when_skip_persist_is_true() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn on_response_body_releases_streaming_request_before_eos() {
     let filter = make_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
@@ -560,7 +560,7 @@ async fn on_response_body_releases_streaming_request_before_eos() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn on_response_body_buffers_persistable_non_end_of_stream() {
     let filter = make_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
@@ -576,7 +576,7 @@ async fn on_response_body_buffers_persistable_non_end_of_stream() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn on_response_body_skips_when_body_is_none() {
     let filter = make_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
@@ -592,7 +592,7 @@ async fn on_response_body_skips_when_body_is_none() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn on_response_body_continues_when_terminal_body_is_none() {
     let filter = make_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
@@ -615,7 +615,7 @@ async fn on_response_body_continues_when_terminal_body_is_none() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn on_response_body_skips_when_body_is_empty() {
     let filter = make_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
@@ -631,7 +631,7 @@ async fn on_response_body_skips_when_body_is_empty() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn on_response_body_skips_when_body_is_invalid_json() {
     let filter = make_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
@@ -647,7 +647,7 @@ async fn on_response_body_skips_when_body_is_invalid_json() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn on_response_body_skips_when_id_field_missing() {
     let filter = make_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
@@ -664,7 +664,7 @@ async fn on_response_body_skips_when_id_field_missing() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn on_response_body_skips_when_created_at_field_missing() {
     let filter = make_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
@@ -681,7 +681,7 @@ async fn on_response_body_skips_when_created_at_field_missing() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn on_response_body_skips_when_model_field_missing() {
     let filter = make_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
@@ -698,7 +698,7 @@ async fn on_response_body_skips_when_model_field_missing() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn on_response_body_persists_valid_response() {
     let filter = make_filter();
     let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
@@ -726,7 +726,6 @@ async fn on_response_body_persists_valid_response() {
         "should continue after spawning persist task"
     );
 
-    tokio::time::sleep(Duration::from_millis(100)).await;
 
     let store = store_opt.as_ref().unwrap();
     let record = store
@@ -753,7 +752,7 @@ async fn on_response_body_persists_valid_response() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn pipeline_persists_after_format_request_body_classification() {
     let (db_url, db_path) = temp_sqlite_url("pipeline_persists_after_format_request_body_classification");
 
@@ -827,7 +826,6 @@ async fn pipeline_persists_after_format_request_body_classification() {
         "response body phase should persist and continue"
     );
 
-    tokio::time::sleep(Duration::from_millis(100)).await;
 
     let store = SqliteResponseStore::new(&db_url, "test_responses", "test_conversations")
         .await
@@ -845,7 +843,7 @@ async fn pipeline_persists_after_format_request_body_classification() {
     cleanup_sqlite_file(&db_path);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn store_init_failure_is_permanent() {
     let yaml: serde_yaml::Value = serde_yaml::from_str(
         r#"

--- a/filter/src/builtins/http/ai/openai/responses/store/tests.rs
+++ b/filter/src/builtins/http/ai/openai/responses/store/tests.rs
@@ -11,8 +11,10 @@ use std::{
 use bytes::Bytes;
 use serde_json::json;
 
-use super::ResponseStoreFilter;
-use super::config::{ResponseStoreConfig, validate_config};
+use super::{
+    ResponseStoreFilter,
+    config::{ResponseStoreConfig, validate_config},
+};
 use crate::{
     FilterAction, FilterEntry, FilterPipeline, FilterRegistry,
     body::{BodyAccess, BodyMode},

--- a/filter/src/builtins/http/ai/openai/responses/store/tests.rs
+++ b/filter/src/builtins/http/ai/openai/responses/store/tests.rs
@@ -1,0 +1,925 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Unit tests for the `openai_response_store` filter.
+
+use std::{
+    path::PathBuf,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use bytes::Bytes;
+use serde_json::json;
+
+use super::ResponseStoreFilter;
+use super::config::{ResponseStoreConfig, validate_config};
+use crate::{
+    FilterAction, FilterEntry, FilterPipeline, FilterRegistry,
+    body::{BodyAccess, BodyMode},
+    builtins::http::ai::store::{ResponseStore, SqliteResponseStore},
+    factory::parse_filter_config,
+    filter::{HttpFilter, HttpFilterContext},
+};
+
+// -----------------------------------------------------------------------------
+// from_config
+// -----------------------------------------------------------------------------
+
+#[test]
+fn valid_config_parses() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+backend: sqlite
+database_url: "sqlite::memory:"
+responses_table: responses
+conversations_table: conversations
+"#,
+    )
+    .unwrap();
+    let filter = ResponseStoreFilter::from_config(&yaml).unwrap();
+    assert_eq!(
+        filter.name(),
+        "openai_response_store",
+        "filter should parse successfully"
+    );
+}
+
+#[test]
+fn empty_database_url_rejected() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+backend: sqlite
+database_url: ""
+responses_table: responses
+conversations_table: conversations
+"#,
+    )
+    .unwrap();
+    let result = ResponseStoreFilter::from_config(&yaml);
+    assert!(result.is_err(), "empty database_url should be rejected");
+}
+
+#[test]
+fn database_url_path_traversal_rejected() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+backend: sqlite
+database_url: "sqlite://../responses.db?mode=rwc"
+responses_table: responses
+conversations_table: conversations
+"#,
+    )
+    .unwrap();
+    let result = ResponseStoreFilter::from_config(&yaml);
+    assert!(result.is_err(), "database_url with .. traversal should be rejected");
+}
+
+#[test]
+fn database_url_encoded_path_traversal_rejected() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+backend: sqlite
+database_url: "sqlite://data/%2e%2e/responses.db?mode=rwc"
+responses_table: responses
+conversations_table: conversations
+"#,
+    )
+    .unwrap();
+    let result = ResponseStoreFilter::from_config(&yaml);
+    assert!(
+        result.is_err(),
+        "database_url with percent-encoded .. traversal should be rejected"
+    );
+}
+
+#[test]
+fn missing_backend_rejected() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+database_url: "sqlite::memory:"
+responses_table: responses
+conversations_table: conversations
+"#,
+    )
+    .unwrap();
+    let result = ResponseStoreFilter::from_config(&yaml);
+    assert!(result.is_err(), "missing backend should be rejected");
+}
+
+#[test]
+fn invalid_responses_table_rejected() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+backend: sqlite
+database_url: "sqlite::memory:"
+responses_table: bad-name
+conversations_table: conversations
+"#,
+    )
+    .unwrap();
+    let result = ResponseStoreFilter::from_config(&yaml);
+    assert!(result.is_err(), "invalid responses_table should be rejected");
+}
+
+#[test]
+fn invalid_conversations_table_rejected() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+backend: sqlite
+database_url: "sqlite::memory:"
+responses_table: responses
+conversations_table: bad-name
+"#,
+    )
+    .unwrap();
+    let result = ResponseStoreFilter::from_config(&yaml);
+    assert!(result.is_err(), "invalid conversations_table should be rejected");
+}
+
+#[test]
+fn duplicate_table_names_rejected() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+backend: sqlite
+database_url: "sqlite::memory:"
+responses_table: same_table
+conversations_table: same_table
+"#,
+    )
+    .unwrap();
+    let result = ResponseStoreFilter::from_config(&yaml);
+    assert!(result.is_err(), "duplicate table names should be rejected");
+}
+
+#[test]
+fn duplicate_table_names_rejected_case_insensitively() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+backend: sqlite
+database_url: "sqlite::memory:"
+responses_table: Responses
+conversations_table: responses
+"#,
+    )
+    .unwrap();
+    let result = ResponseStoreFilter::from_config(&yaml);
+    assert!(
+        result.is_err(),
+        "case-insensitive duplicate table names should be rejected"
+    );
+}
+
+#[test]
+fn unknown_field_rejected() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+backend: sqlite
+database_url: "sqlite::memory:"
+responses_table: responses
+conversations_table: conversations
+unknown_extra_field: true
+"#,
+    )
+    .unwrap();
+    let result = ResponseStoreFilter::from_config(&yaml);
+    assert!(
+        result.is_err(),
+        "unknown field should be rejected by deny_unknown_fields"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Filter Trait Declarations
+// -----------------------------------------------------------------------------
+
+#[test]
+fn name_returns_openai_response_store() {
+    let filter = make_filter();
+    assert_eq!(
+        filter.name(),
+        "openai_response_store",
+        "name should be openai_response_store"
+    );
+}
+
+#[test]
+fn response_body_access_is_read_only() {
+    let filter = make_filter();
+    assert_eq!(
+        filter.response_body_access(),
+        BodyAccess::ReadOnly,
+        "response body access should be ReadOnly"
+    );
+}
+
+#[test]
+fn response_body_mode_is_bounded_stream_buffer() {
+    let filter = make_filter();
+    assert_eq!(
+        filter.response_body_mode(),
+        BodyMode::StreamBuffer {
+            max_bytes: Some(67_108_864) // 64 MiB
+        },
+        "response body mode should be StreamBuffer capped at 64 MiB"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// on_request Bypass
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn on_request_skips_when_format_metadata_absent() {
+    let filter = make_filter();
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let action = filter.on_request(&mut ctx).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "should skip when format metadata is absent"
+    );
+    assert!(
+        filter.store.get().is_none(),
+        "store should not be initialized when skipped"
+    );
+}
+
+#[tokio::test]
+async fn on_request_skips_when_format_is_openai_chat_completions() {
+    let filter = make_filter();
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat/completions");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.set_metadata("openai_responses_format.format", "openai_chat_completions");
+
+    let action = filter.on_request(&mut ctx).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "should skip when format is openai_chat_completions"
+    );
+    assert!(
+        filter.store.get().is_none(),
+        "store should not be initialized for non-responses format"
+    );
+}
+
+#[tokio::test]
+async fn on_request_skips_when_store_is_false() {
+    let filter = make_filter();
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+    ctx.set_metadata("openai_responses_format.store", "false");
+
+    let action = filter.on_request(&mut ctx).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "should skip when store is false"
+    );
+    assert!(
+        filter.store.get().is_none(),
+        "store should not be initialized when store=false"
+    );
+}
+
+#[tokio::test]
+async fn on_request_skips_when_stream_is_true() {
+    let filter = make_filter();
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+    ctx.set_metadata("openai_responses_format.stream", "true");
+
+    let action = filter.on_request(&mut ctx).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "should skip when stream is true"
+    );
+    assert!(
+        filter.store.get().is_none(),
+        "store should not be initialized for streaming requests"
+    );
+}
+
+#[tokio::test]
+async fn on_request_skips_for_get_method() {
+    let filter = make_filter();
+    let req = crate::test_utils::make_request(http::Method::GET, "/v1/responses/resp_123");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+
+    let action = filter.on_request(&mut ctx).await.unwrap();
+    assert!(matches!(action, FilterAction::Continue), "should skip for GET method");
+    assert!(
+        filter.store.get().is_none(),
+        "store should not be initialized for non-POST requests"
+    );
+}
+
+#[tokio::test]
+async fn on_request_skips_for_delete_method() {
+    let filter = make_filter();
+    let req = crate::test_utils::make_request(http::Method::DELETE, "/v1/responses/resp_123");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+
+    let action = filter.on_request(&mut ctx).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "should skip for DELETE method"
+    );
+    assert!(
+        filter.store.get().is_none(),
+        "store should not be initialized for non-POST requests"
+    );
+}
+
+#[tokio::test]
+async fn on_request_initializes_store_for_openai_responses_format() {
+    let filter = make_filter();
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+
+    let action = filter.on_request(&mut ctx).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "should continue after initializing store"
+    );
+    let store_opt = filter.store.get().expect("store OnceCell should be initialized");
+    assert!(
+        store_opt.is_some(),
+        "store should be Some for valid sqlite::memory: config"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// on_response
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn on_response_skips_when_format_metadata_absent() {
+    let filter = make_filter();
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let action = filter.on_response(&mut ctx).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "should skip when format metadata is absent"
+    );
+    assert_eq!(
+        ctx.response_body_mode,
+        BodyMode::Stream,
+        "body mode should remain Stream when skipped"
+    );
+}
+
+#[tokio::test]
+async fn on_response_sets_skip_persist_for_non_2xx() {
+    let filter = make_filter();
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+    run_request_phase(&filter, &mut ctx).await;
+
+    let mut resp = crate::test_utils::make_response();
+    resp.status = http::StatusCode::INTERNAL_SERVER_ERROR;
+    ctx.response_header = Some(&mut resp);
+
+    let action = filter.on_response(&mut ctx).await.unwrap();
+    assert!(matches!(action, FilterAction::Continue), "should continue for non-2xx");
+    assert_eq!(
+        ctx.get_metadata("responses.skip_persist"),
+        Some("true"),
+        "should set skip_persist for non-2xx responses"
+    );
+}
+
+#[tokio::test]
+async fn on_response_sets_skip_persist_for_non_json_content_type() {
+    let filter = make_filter();
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+    run_request_phase(&filter, &mut ctx).await;
+
+    let mut resp = crate::test_utils::make_response();
+    resp.headers
+        .insert(http::header::CONTENT_TYPE, "text/plain".parse().unwrap());
+    ctx.response_header = Some(&mut resp);
+
+    let action = filter.on_response(&mut ctx).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "should continue for non-JSON content type"
+    );
+    assert_eq!(
+        ctx.get_metadata("responses.skip_persist"),
+        Some("true"),
+        "should set skip_persist for non-JSON responses"
+    );
+}
+
+#[tokio::test]
+async fn on_response_continues_for_json_200() {
+    let filter = make_filter();
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+    run_request_phase(&filter, &mut ctx).await;
+
+    let mut resp = crate::test_utils::make_response();
+    resp.headers
+        .insert(http::header::CONTENT_TYPE, "application/json".parse().unwrap());
+    ctx.response_header = Some(&mut resp);
+
+    let action = filter.on_response(&mut ctx).await.unwrap();
+    assert!(matches!(action, FilterAction::Continue), "should continue for JSON 200");
+}
+
+#[tokio::test]
+async fn on_response_accepts_mixed_case_json_content_type() {
+    let filter = make_filter();
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+    run_request_phase(&filter, &mut ctx).await;
+
+    let mut resp = crate::test_utils::make_response();
+    resp.headers.insert(
+        http::header::CONTENT_TYPE,
+        "Application/JSON; charset=utf-8".parse().unwrap(),
+    );
+    ctx.response_header = Some(&mut resp);
+
+    let action = filter.on_response(&mut ctx).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "should continue for mixed-case JSON content type"
+    );
+}
+
+#[tokio::test]
+async fn on_response_does_not_buffer_when_store_unavailable() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+backend: sqlite
+database_url: "sqlite:///nonexistent/path/that/will/fail.db"
+responses_table: responses
+conversations_table: conversations
+"#,
+    )
+    .unwrap();
+    let cfg: ResponseStoreConfig = parse_filter_config("openai_response_store", &yaml).unwrap();
+    validate_config(&cfg).unwrap();
+    let filter = ResponseStoreFilter::new(cfg);
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+    run_request_phase(&filter, &mut ctx).await;
+
+    let mut resp = crate::test_utils::make_response();
+    resp.headers
+        .insert(http::header::CONTENT_TYPE, "application/json".parse().unwrap());
+    ctx.response_header = Some(&mut resp);
+
+    let action = filter.on_response(&mut ctx).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "should continue when store init fails"
+    );
+    assert_eq!(
+        ctx.response_body_mode,
+        BodyMode::Stream,
+        "body mode should remain Stream when store is unavailable"
+    );
+    assert_eq!(
+        ctx.get_metadata("responses.skip_persist"),
+        Some("true"),
+        "should mark persistence skipped when store is unavailable"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// on_response_body
+// -----------------------------------------------------------------------------
+
+#[test]
+fn on_response_body_releases_skipped_non_end_of_stream() {
+    let filter = make_filter();
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+    let mut body = Some(Bytes::from_static(b"partial"));
+
+    let action = filter.on_response_body(&mut ctx, &mut body, false).unwrap();
+    assert!(
+        matches!(action, FilterAction::Release),
+        "should release non-persisted non-end-of-stream chunks"
+    );
+}
+
+#[tokio::test]
+async fn on_response_body_releases_when_skip_persist_is_true() {
+    let filter = make_filter();
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+    run_request_phase(&filter, &mut ctx).await;
+    ctx.set_metadata("responses.skip_persist", "true");
+    let mut body = Some(Bytes::from_static(b"{}"));
+
+    let action = filter.on_response_body(&mut ctx, &mut body, true).unwrap();
+    assert!(
+        matches!(action, FilterAction::Release),
+        "should release when skip_persist is true"
+    );
+}
+
+#[tokio::test]
+async fn on_response_body_releases_streaming_request_before_eos() {
+    let filter = make_filter();
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+    ctx.set_metadata("openai_responses_format.stream", "true");
+    let request_action = filter.on_request(&mut ctx).await.unwrap();
+    assert!(
+        matches!(request_action, FilterAction::Continue),
+        "streaming request should pass request phase"
+    );
+
+    let mut body = Some(Bytes::from_static(b"event: response.output_text.delta\n\n"));
+    let action = filter.on_response_body(&mut ctx, &mut body, false).unwrap();
+    assert!(
+        matches!(action, FilterAction::Release),
+        "streaming response chunks should release before EOS"
+    );
+}
+
+#[tokio::test]
+async fn on_response_body_buffers_persistable_non_end_of_stream() {
+    let filter = make_filter();
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+    run_request_phase(&filter, &mut ctx).await;
+
+    let mut body = Some(Bytes::from_static(b"{\"id\":\"resp_partial\""));
+    let action = filter.on_response_body(&mut ctx, &mut body, false).unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "persistable response should remain buffered before EOS"
+    );
+}
+
+#[tokio::test]
+async fn on_response_body_skips_when_body_is_none() {
+    let filter = make_filter();
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+    run_request_phase(&filter, &mut ctx).await;
+    let mut body: Option<Bytes> = None;
+
+    let action = filter.on_response_body(&mut ctx, &mut body, true).unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "should skip when body is None"
+    );
+}
+
+#[tokio::test]
+async fn on_response_body_continues_when_terminal_body_is_none() {
+    let filter = make_filter();
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+
+    drop(filter.on_request(&mut ctx).await.unwrap());
+
+    let mut resp = crate::test_utils::make_response();
+    resp.headers
+        .insert(http::header::CONTENT_TYPE, "application/json".parse().unwrap());
+    ctx.response_header = Some(&mut resp);
+    drop(filter.on_response(&mut ctx).await.unwrap());
+
+    let mut body: Option<Bytes> = None;
+    let action = filter.on_response_body(&mut ctx, &mut body, true).unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "should skip terminal response with no body"
+    );
+}
+
+#[tokio::test]
+async fn on_response_body_skips_when_body_is_empty() {
+    let filter = make_filter();
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+    run_request_phase(&filter, &mut ctx).await;
+    let mut body = Some(Bytes::new());
+
+    let action = filter.on_response_body(&mut ctx, &mut body, true).unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "should skip when body is empty"
+    );
+}
+
+#[tokio::test]
+async fn on_response_body_skips_when_body_is_invalid_json() {
+    let filter = make_filter();
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+    run_request_phase(&filter, &mut ctx).await;
+    let mut body = Some(Bytes::from_static(b"not json {{{"));
+
+    let action = filter.on_response_body(&mut ctx, &mut body, true).unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "should skip when body is invalid JSON"
+    );
+}
+
+#[tokio::test]
+async fn on_response_body_skips_when_id_field_missing() {
+    let filter = make_filter();
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+    run_request_phase(&filter, &mut ctx).await;
+    let body_json = json!({"created_at": 1000, "model": "gpt-4.1"});
+    let mut body = Some(Bytes::from(serde_json::to_vec(&body_json).unwrap()));
+
+    let action = filter.on_response_body(&mut ctx, &mut body, true).unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "should skip when id field is missing"
+    );
+}
+
+#[tokio::test]
+async fn on_response_body_skips_when_created_at_field_missing() {
+    let filter = make_filter();
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+    run_request_phase(&filter, &mut ctx).await;
+    let body_json = json!({"id": "resp_test", "model": "gpt-4.1"});
+    let mut body = Some(Bytes::from(serde_json::to_vec(&body_json).unwrap()));
+
+    let action = filter.on_response_body(&mut ctx, &mut body, true).unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "should skip when created_at field is missing"
+    );
+}
+
+#[tokio::test]
+async fn on_response_body_skips_when_model_field_missing() {
+    let filter = make_filter();
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+    run_request_phase(&filter, &mut ctx).await;
+    let body_json = json!({"id": "resp_test", "created_at": 1000});
+    let mut body = Some(Bytes::from(serde_json::to_vec(&body_json).unwrap()));
+
+    let action = filter.on_response_body(&mut ctx, &mut body, true).unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "should skip when model field is missing"
+    );
+}
+
+#[tokio::test]
+async fn on_response_body_persists_valid_response() {
+    let filter = make_filter();
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+
+    drop(filter.on_request(&mut ctx).await.unwrap());
+
+    let store_opt = filter.store.get().expect("store OnceCell should be initialized");
+    assert!(store_opt.is_some(), "store should be initialized");
+
+    let body_json = json!({
+        "id": "resp_test123",
+        "created_at": 1_719_900_000,
+        "model": "gpt-4.1",
+        "status": "completed",
+        "input": [{"role": "user", "content": "Hello"}],
+        "output": [{"type": "message", "content": "Hello"}]
+    });
+    let mut body = Some(Bytes::from(serde_json::to_vec(&body_json).unwrap()));
+
+    let action = filter.on_response_body(&mut ctx, &mut body, true).unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "should continue after spawning persist task"
+    );
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let store = store_opt.as_ref().unwrap();
+    let record = store
+        .get_response("default", "resp_test123")
+        .await
+        .expect("get_response should succeed")
+        .expect("record should exist after persist");
+
+    assert_eq!(record.id, "resp_test123", "persisted ID should match");
+    assert_eq!(record.created_at, 1_719_900_000, "persisted created_at should match");
+    assert_eq!(record.model, "gpt-4.1", "persisted model should match");
+    assert_eq!(record.tenant_id, "default", "persisted tenant_id should be default");
+    assert_eq!(
+        record.response_object, body_json,
+        "persisted response_object should match the full JSON"
+    );
+    assert_eq!(
+        record.input, body_json["input"],
+        "persisted input should be extracted from the response"
+    );
+    assert_eq!(
+        record.messages, body_json["output"],
+        "persisted messages should be extracted from the response output"
+    );
+}
+
+#[tokio::test]
+async fn pipeline_persists_after_format_request_body_classification() {
+    let (db_url, db_path) = temp_sqlite_url("pipeline_persists_after_format_request_body_classification");
+
+    let mut entries: Vec<FilterEntry> = serde_yaml::from_str(&format!(
+        r#"
+- filter: openai_responses_format
+- filter: openai_response_store
+  backend: sqlite
+  database_url: "{db_url}"
+  responses_table: test_responses
+  conversations_table: test_conversations
+"#
+    ))
+    .unwrap();
+    let registry = FilterRegistry::with_builtins();
+    let pipeline = FilterPipeline::build(&mut entries, &registry).unwrap();
+
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let request_json = json!({
+        "model": "gpt-4.1",
+        "input": [{"role": "user", "content": "Hello"}]
+    });
+    let mut request_body = Some(Bytes::from(serde_json::to_vec(&request_json).unwrap()));
+    let request_body_action = pipeline
+        .execute_http_request_body(&mut ctx, &mut request_body, true)
+        .await
+        .unwrap();
+    assert!(
+        matches!(request_body_action, FilterAction::Release),
+        "format classifier should release the buffered request body"
+    );
+    assert_eq!(
+        ctx.get_metadata("openai_responses_format.format"),
+        Some("openai_responses"),
+        "format classifier should write metadata before store filter runs"
+    );
+
+    let request_action = pipeline.execute_http_request(&mut ctx).await.unwrap();
+    assert!(
+        matches!(request_action, FilterAction::Continue),
+        "request phase should continue after initializing the store"
+    );
+
+    let mut resp = crate::test_utils::make_response();
+    resp.headers
+        .insert(http::header::CONTENT_TYPE, "application/json".parse().unwrap());
+    ctx.response_header = Some(&mut resp);
+    let response_action = pipeline.execute_http_response(&mut ctx).await.unwrap();
+    assert!(
+        matches!(response_action, FilterAction::Continue),
+        "response phase should continue and arm persistence buffering"
+    );
+    ctx.response_header = None;
+
+    let response_json = json!({
+        "id": "resp_pipeline",
+        "created_at": 1_719_900_000,
+        "model": "gpt-4.1",
+        "status": "completed",
+        "input": [{"role": "user", "content": "Hello"}],
+        "output": []
+    });
+    let mut response_body = Some(Bytes::from(serde_json::to_vec(&response_json).unwrap()));
+    let response_body_action = pipeline
+        .execute_http_response_body(&mut ctx, &mut response_body, true)
+        .unwrap();
+    assert!(
+        matches!(response_body_action, FilterAction::Continue),
+        "response body phase should persist and continue"
+    );
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let store = SqliteResponseStore::new(&db_url, "test_responses", "test_conversations")
+        .await
+        .unwrap();
+    let record = store
+        .get_response("default", "resp_pipeline")
+        .await
+        .unwrap()
+        .expect("pipeline should persist the response after body classification");
+    assert_eq!(record.response_object, response_json);
+    assert_eq!(record.input, response_json["input"]);
+
+    drop(store);
+    drop(pipeline);
+    cleanup_sqlite_file(&db_path);
+}
+
+#[tokio::test]
+async fn store_init_failure_is_permanent() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+backend: sqlite
+database_url: "sqlite:///nonexistent/path/that/will/fail.db"
+responses_table: responses
+conversations_table: conversations
+"#,
+    )
+    .unwrap();
+    let cfg: ResponseStoreConfig = parse_filter_config("openai_response_store", &yaml).unwrap();
+    validate_config(&cfg).unwrap();
+    let filter = ResponseStoreFilter::new(cfg);
+
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+
+    drop(filter.on_request(&mut ctx).await.unwrap());
+
+    let store_opt = filter
+        .store
+        .get()
+        .expect("store OnceCell should be initialized after first attempt");
+    assert!(store_opt.is_none(), "store should be None after failed init");
+
+    let mut ctx2 = crate::test_utils::make_filter_context(&req);
+    ctx2.set_metadata("openai_responses_format.format", "openai_responses");
+
+    drop(filter.on_request(&mut ctx2).await.unwrap());
+
+    let store_opt2 = filter.store.get().expect("store OnceCell should still be initialized");
+    assert!(
+        store_opt2.is_none(),
+        "store should remain None on second request (failure is permanent)"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Test Utilities
+// -----------------------------------------------------------------------------
+
+fn make_filter() -> ResponseStoreFilter {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+backend: sqlite
+database_url: "sqlite::memory:"
+responses_table: test_responses
+conversations_table: test_conversations
+"#,
+    )
+    .unwrap();
+    let cfg: ResponseStoreConfig = parse_filter_config("openai_response_store", &yaml).unwrap();
+    validate_config(&cfg).unwrap();
+    ResponseStoreFilter::new(cfg)
+}
+
+async fn run_request_phase(filter: &ResponseStoreFilter, ctx: &mut HttpFilterContext<'_>) {
+    let action = filter.on_request(ctx).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "request phase should continue"
+    );
+}
+
+fn temp_sqlite_url(test_name: &str) -> (String, PathBuf) {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after epoch")
+        .as_nanos();
+    let db_path = std::env::temp_dir().join(format!("praxis_{test_name}_{}_{}.db", std::process::id(), nanos));
+    (format!("sqlite://{}?mode=rwc", db_path.display()), db_path)
+}
+
+fn cleanup_sqlite_file(db_path: &PathBuf) {
+    drop(std::fs::remove_file(db_path));
+    drop(std::fs::remove_file(format!("{}-shm", db_path.display())));
+    drop(std::fs::remove_file(format!("{}-wal", db_path.display())));
+}

--- a/filter/src/builtins/http/ai/store/mod.rs
+++ b/filter/src/builtins/http/ai/store/mod.rs
@@ -33,6 +33,8 @@ pub use self::{
     trait_def::ResponseStore,
     types::{ConversationRecord, ResponseRecord, StoreError},
 };
+/// Validate a response-store table identifier.
+pub(crate) use schemas::validate_identifier as validate_table_identifier;
 
 // -----------------------------------------------------------------------------
 // ResponseStoreRegistry

--- a/filter/src/builtins/http/ai/store/mod.rs
+++ b/filter/src/builtins/http/ai/store/mod.rs
@@ -26,6 +26,8 @@ mod tests;
 use std::sync::Arc;
 
 use dashmap::{DashMap, mapref::entry::Entry};
+/// Validate a response-store table identifier.
+pub(crate) use schemas::validate_identifier as validate_table_identifier;
 
 #[allow(unused_imports, reason = "re-exports for upcoming store filter")]
 pub use self::{
@@ -33,8 +35,6 @@ pub use self::{
     trait_def::ResponseStore,
     types::{ConversationRecord, ResponseRecord, StoreError},
 };
-/// Validate a response-store table identifier.
-pub(crate) use schemas::validate_identifier as validate_table_identifier;
 
 // -----------------------------------------------------------------------------
 // ResponseStoreRegistry

--- a/filter/src/builtins/http/ai/store/schemas.rs
+++ b/filter/src/builtins/http/ai/store/schemas.rs
@@ -84,7 +84,7 @@ fn validate_table_names(tables: &TableNames) -> Result<(&str, &str), StoreError>
 const MAX_IDENTIFIER_LEN: usize = 128;
 
 /// Reject identifiers that could cause SQL injection or invalid DDL.
-fn validate_identifier(name: &str) -> Result<(), StoreError> {
+pub(crate) fn validate_identifier(name: &str) -> Result<(), StoreError> {
     if name.is_empty() {
         return Err(StoreError::Database("table name must not be empty".to_owned()));
     }

--- a/filter/src/builtins/http/mod.rs
+++ b/filter/src/builtins/http/mod.rs
@@ -18,6 +18,8 @@ pub use ai::OpenaiResponsesValidateFilter;
 #[cfg(feature = "ai-inference")]
 pub use ai::PromptEnrichFilter;
 #[cfg(feature = "ai-inference")]
+pub use ai::ResponseStoreFilter;
+#[cfg(feature = "ai-inference")]
 pub use ai::ResponseStoreRegistry;
 #[cfg(feature = "ai-inference")]
 pub use ai::ResponsesFormatFilter;

--- a/filter/src/builtins/mod.rs
+++ b/filter/src/builtins/mod.rs
@@ -13,6 +13,8 @@ pub use http::OpenaiResponsesValidateFilter;
 #[cfg(feature = "ai-inference")]
 pub use http::PromptEnrichFilter;
 #[cfg(feature = "ai-inference")]
+pub use http::ResponseStoreFilter;
+#[cfg(feature = "ai-inference")]
 pub use http::ResponseStoreRegistry;
 #[cfg(feature = "ai-inference")]
 pub use http::ResponsesFormatFilter;

--- a/filter/src/context.rs
+++ b/filter/src/context.rs
@@ -20,6 +20,10 @@ use crate::{body::BodyMode, pipeline::body::merge_body_mode, results::FilterResu
 ///
 /// Created by the protocol layer for each incoming request. Filters read
 /// and mutate it to select clusters, choose upstreams, and inject headers.
+#[allow(
+    clippy::struct_excessive_bools,
+    reason = "transport context tracks independent lifecycle flags across phases"
+)]
 pub struct HttpFilterContext<'a> {
     /// Per-filter body-done tracking. When `true` at index `i`,
     /// filter `i` is skipped for remaining body chunks.

--- a/filter/src/lib.rs
+++ b/filter/src/lib.rs
@@ -263,6 +263,10 @@ pub(crate) mod test_utils {
         }
     }
 
+    #[allow(
+        clippy::too_many_lines,
+        reason = "test context constructor mirrors all context fields"
+    )]
     pub(crate) fn make_filter_context(req: &Request) -> HttpFilterContext<'_> {
         HttpFilterContext {
             body_done_indices: Vec::new(),

--- a/filter/src/registry.rs
+++ b/filter/src/registry.rs
@@ -167,6 +167,12 @@ fn register_http_builtins(factories: &mut HashMap<String, FilterFactory>) {
         "openai_responses_validate",
         crate::builtins::OpenaiResponsesValidateFilter::from_config,
     );
+    #[cfg(feature = "ai-inference")]
+    register_http(
+        factories,
+        "openai_response_store",
+        crate::builtins::ResponseStoreFilter::from_config,
+    );
 }
 
 /// Register a single HTTP filter factory by name.
@@ -291,6 +297,11 @@ mod tests {
         assert!(
             names.contains(&"openai_responses_validate"),
             "validate should be registered"
+        );
+        #[cfg(feature = "ai-inference")]
+        assert!(
+            names.contains(&"openai_response_store"),
+            "response_store should be registered"
         );
     }
 

--- a/tests/fuzz/Cargo.lock
+++ b/tests/fuzz/Cargo.lock
@@ -1549,6 +1549,7 @@ dependencies = [
  "dashmap",
  "pingora-core",
  "praxis-proxy-tls",
+ "rand 0.9.4",
  "regex",
  "serde",
  "thiserror 2.0.18",
@@ -1569,10 +1570,12 @@ dependencies = [
  "praxis-proxy-core",
  "rand 0.9.4",
  "regex",
+ "secrecy",
  "serde",
  "serde_json",
  "sqlx",
  "thiserror 2.0.18",
+ "tokio",
  "tracing",
  "yaml_serde",
  "zeroize",
@@ -1842,6 +1845,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "serde",
+ "zeroize",
+]
 
 [[package]]
 name = "security-framework"

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -30,6 +30,7 @@ rustls-pemfile = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
+sqlx = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "io-util"] }
 tokio-rustls = { workspace = true }

--- a/tests/integration/tests/suite/examples/mod.rs
+++ b/tests/integration/tests/suite/examples/mod.rs
@@ -33,6 +33,8 @@ mod max_connections;
 mod model_to_header;
 mod multi_listener;
 #[cfg(feature = "ai-inference")]
+mod openai_response_store;
+#[cfg(feature = "ai-inference")]
 mod openai_responses_format;
 #[cfg(feature = "ai-inference")]
 mod openai_responses_validate;

--- a/tests/integration/tests/suite/examples/openai_response_store.rs
+++ b/tests/integration/tests/suite/examples/openai_response_store.rs
@@ -3,7 +3,7 @@
 
 //! Functional tests for the `openai_response_store` example config.
 
-use std::{collections::HashMap, time::Duration};
+use std::collections::HashMap;
 
 use praxis_test_utils::{
     Backend, example_config_path, free_port, http_send, json_post, parse_body, parse_status, patch_yaml, start_proxy,
@@ -54,8 +54,6 @@ async fn response_store_persists_response_to_sqlite() {
         RESPONSE_JSON,
         "response body should match the backend's JSON"
     );
-
-    tokio::time::sleep(Duration::from_millis(200)).await;
 
     let pool = sqlx::SqlitePool::connect(&db_url)
         .await

--- a/tests/integration/tests/suite/examples/openai_response_store.rs
+++ b/tests/integration/tests/suite/examples/openai_response_store.rs
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Functional tests for the `openai_response_store` example config.
+
+use std::collections::HashMap;
+
+use praxis_test_utils::{
+    Backend, example_config_path, free_port, http_send, json_post, parse_body, parse_status, patch_yaml, start_proxy,
+};
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn response_store_forwards_responses_api_request_to_backend() {
+    let response_json = r#"{"id":"resp_abc","created_at":1000,"model":"gpt-4.1","object":"response","output":[]}"#;
+    let backend_guard = Backend::fixed(response_json)
+        .header("content-type", "application/json")
+        .start_with_shutdown();
+    let proxy_port = free_port();
+
+    let yaml = std::fs::read_to_string(example_config_path("ai/openai/responses/response-store.yaml"))
+        .expect("example config should exist");
+    let patched = patch_yaml(
+        &yaml.replace("sqlite://responses.db?mode=rwc", "sqlite::memory:"),
+        proxy_port,
+        &HashMap::from([("127.0.0.1:3001", backend_guard.port())]),
+    );
+    let config = praxis_core::config::Config::from_yaml(&patched).expect("patched config should parse");
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        &json_post("/v1/responses", r#"{"model":"gpt-4.1","input":"Hello"}"#),
+    );
+
+    assert_eq!(parse_status(&raw), 200, "Responses API POST should return 200");
+    assert_eq!(
+        parse_body(&raw),
+        response_json,
+        "response body should match the backend's JSON"
+    );
+}
+
+#[test]
+fn response_store_passes_through_non_responses_traffic() {
+    let backend_guard = Backend::fixed("fallback")
+        .header("content-type", "text/plain")
+        .start_with_shutdown();
+    let proxy_port = free_port();
+
+    let yaml = std::fs::read_to_string(example_config_path("ai/openai/responses/response-store.yaml"))
+        .expect("example config should exist");
+    let patched = patch_yaml(
+        &yaml.replace("sqlite://responses.db?mode=rwc", "sqlite::memory:"),
+        proxy_port,
+        &HashMap::from([("127.0.0.1:3001", backend_guard.port())]),
+    );
+    let config = praxis_core::config::Config::from_yaml(&patched).expect("patched config should parse");
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        &json_post(
+            "/v1/responses",
+            r#"{"model":"gpt-4","messages":[{"role":"user","content":"Hi"}]}"#,
+        ),
+    );
+
+    assert_eq!(
+        parse_status(&raw),
+        200,
+        "Chat Completions body should still route through"
+    );
+}

--- a/tests/integration/tests/suite/examples/openai_response_store.rs
+++ b/tests/integration/tests/suite/examples/openai_response_store.rs
@@ -3,30 +3,42 @@
 
 //! Functional tests for the `openai_response_store` example config.
 
-use std::collections::HashMap;
+use std::{collections::HashMap, time::Duration};
 
 use praxis_test_utils::{
     Backend, example_config_path, free_port, http_send, json_post, parse_body, parse_status, patch_yaml, start_proxy,
 };
+use sqlx::Row;
+
+// -----------------------------------------------------------------------------
+// Constants
+// -----------------------------------------------------------------------------
+
+/// Backend response matching a real Responses API shape with `input`
+/// and `output` fields the store extracts for persistence.
+const RESPONSE_JSON: &str = r#"{"id":"resp_abc","created_at":1000,"model":"gpt-4.1","object":"response","input":"Hello","output":[{"type":"message","content":[{"type":"output_text","text":"Hi there"}]}]}"#;
+
+/// Table name from the example config.
+const RESPONSES_TABLE: &str = "openai_responses";
 
 // -----------------------------------------------------------------------------
 // Tests
 // -----------------------------------------------------------------------------
 
-#[test]
-fn response_store_forwards_responses_api_request_to_backend() {
-    let response_json = r#"{"id":"resp_abc","created_at":1000,"model":"gpt-4.1","object":"response","output":[]}"#;
-    let backend_guard = Backend::fixed(response_json)
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn response_store_persists_response_to_sqlite() {
+    let backend_guard = Backend::fixed(RESPONSE_JSON)
         .header("content-type", "application/json")
         .start_with_shutdown();
     let proxy_port = free_port();
 
+    let (db_url, db_path) = temp_sqlite_url("persist");
     let yaml = std::fs::read_to_string(example_config_path("ai/openai/responses/response-store.yaml"))
         .expect("example config should exist");
     let patched = patch_yaml(
-        &yaml.replace("sqlite://responses.db?mode=rwc", "sqlite::memory:"),
+        &yaml.replace("sqlite://responses.db?mode=rwc", &db_url),
         proxy_port,
-        &HashMap::from([("127.0.0.1:3001", backend_guard.port())]),
+        &HashMap::from([("127.0.0.1:8000", backend_guard.port())]),
     );
     let config = praxis_core::config::Config::from_yaml(&patched).expect("patched config should parse");
     let proxy = start_proxy(&config);
@@ -39,9 +51,49 @@ fn response_store_forwards_responses_api_request_to_backend() {
     assert_eq!(parse_status(&raw), 200, "Responses API POST should return 200");
     assert_eq!(
         parse_body(&raw),
-        response_json,
+        RESPONSE_JSON,
         "response body should match the backend's JSON"
     );
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let pool = sqlx::SqlitePool::connect(&db_url)
+        .await
+        .expect("should connect to test database");
+    let sql = format!("SELECT id, tenant_id, created_at, model, input, messages FROM {RESPONSES_TABLE} WHERE id = ?");
+    let row: sqlx::sqlite::SqliteRow = sqlx::query(&sql)
+        .bind("resp_abc")
+        .fetch_one(&pool)
+        .await
+        .expect("persisted record should exist in database");
+    pool.close().await;
+
+    let id: String = row.get("id");
+    let tenant_id: String = row.get("tenant_id");
+    let created_at: i64 = row.get("created_at");
+    let model: String = row.get("model");
+
+    assert_eq!(id, "resp_abc", "persisted id should match response");
+    assert_eq!(tenant_id, "default", "default tenant should be used");
+    assert_eq!(created_at, 1000, "persisted created_at should match response");
+    assert_eq!(model, "gpt-4.1", "persisted model should match response");
+
+    let input_raw: String = row.get("input");
+    let input: serde_json::Value = serde_json::from_str(&input_raw).expect("input column should be valid JSON");
+    assert_eq!(
+        input,
+        serde_json::json!("Hello"),
+        "input should match the response's input field"
+    );
+
+    let messages_raw: String = row.get("messages");
+    let messages: serde_json::Value =
+        serde_json::from_str(&messages_raw).expect("messages column should be valid JSON");
+    let items = messages.as_array().expect("messages should be an array");
+    assert_eq!(items.len(), 1, "messages should have one output item");
+
+    drop(proxy);
+    cleanup_sqlite_files(&db_path);
 }
 
 #[test]
@@ -56,7 +108,7 @@ fn response_store_passes_through_non_responses_traffic() {
     let patched = patch_yaml(
         &yaml.replace("sqlite://responses.db?mode=rwc", "sqlite::memory:"),
         proxy_port,
-        &HashMap::from([("127.0.0.1:3001", backend_guard.port())]),
+        &HashMap::from([("127.0.0.1:8000", backend_guard.port())]),
     );
     let config = praxis_core::config::Config::from_yaml(&patched).expect("patched config should parse");
     let proxy = start_proxy(&config);
@@ -74,4 +126,26 @@ fn response_store_passes_through_non_responses_traffic() {
         200,
         "Chat Completions body should still route through"
     );
+}
+
+// -----------------------------------------------------------------------------
+// Test Utilities
+// -----------------------------------------------------------------------------
+
+/// Generate a unique file-backed SQLite URL for test isolation.
+fn temp_sqlite_url(test_name: &str) -> (String, std::path::PathBuf) {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after epoch")
+        .as_nanos();
+    let db_path = std::env::temp_dir().join(format!("praxis_integ_{test_name}_{}_{nanos}.db", std::process::id()));
+    (format!("sqlite://{}?mode=rwc", db_path.display()), db_path)
+}
+
+/// Remove a SQLite database file and its WAL/SHM companions.
+fn cleanup_sqlite_files(db_path: &std::path::Path) {
+    drop(std::fs::remove_file(db_path));
+    drop(std::fs::remove_file(format!("{}-shm", db_path.display())));
+    drop(std::fs::remove_file(format!("{}-wal", db_path.display())));
 }


### PR DESCRIPTION
## Summary

- Adds the `openai_response_store` filter that persists non-streaming Responses API POST responses to SQLite via bounded StreamBuffer (64 MiB)
- Three-phase lifecycle (`on_request` / `on_response` / `on_response_body`) progressively refines the persist decision using classifier metadata, response headers, and body content
- Lazily initializes the SQLite backend on first qualifying request; permanent no-op on init failure
- Integration test verifies end-to-end DB persistence by querying the SQLite file after the async persist completes
- 103 unit tests covering all bypass paths, error handling, and pipeline integration

Closes praxis-proxy/ai#5

## Test plan

- [x] `make lint` passes (clippy + fmt + xtask lint-deps)
- [x] `make build` passes
- [x] `cargo test -p praxis-tests-integration --features ai-inference -- openai_response_store` (2 tests: persistence verification + passthrough)
- [x] Unit tests: `cargo test -p praxis-proxy-filter -- response_store` (103 tests)
- [x] Example config `response-store.yaml` included and covered by integration test