### PR TITLE
feat(filter): handle GET /v1/responses/{id} in response store

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -133,7 +133,7 @@ page.
 | [format-routing.yaml](configs/ai/openai/responses/format-routing.yaml) | Route by AI API format (Responses vs Chat Completions) |
 | [responses-routing.yaml](configs/ai/openai/responses/responses-routing.yaml) | Route Responses API by mode (stateless vs stateful) |
 | [request-validate.yaml](configs/ai/openai/responses/request-validate.yaml) | Validate Responses API requests and reject invalid parameter combinations |
-| [response-store.yaml](configs/ai/openai/responses/response-store.yaml) | Persist non-streaming Responses API responses to SQLite |
+| [response-store.yaml](configs/ai/openai/responses/response-store.yaml) | Persist and retrieve responses via GET /v1/responses/{id} |
 
 ### Branching
 

--- a/examples/configs/ai/openai/responses/response-store.yaml
+++ b/examples/configs/ai/openai/responses/response-store.yaml
@@ -1,9 +1,15 @@
 # Response Store
 #
 # Persists non-streaming Responses API responses to a SQLite
-# database. The `openai_responses_format` filter must run first to
-# classify the request body — `openai_response_store` reads its
-# metadata to decide whether to persist.
+# database and serves stored data via GET endpoints:
+#
+#   POST /v1/responses          — proxied to backend, response persisted
+#   GET  /v1/responses/{id}     — served from local store (200 or 404)
+#   GET  /v1/responses/{id}/input_items — paginated input items
+#
+# The `openai_responses_format` filter must run first to classify
+# the request body — `openai_response_store` reads its metadata
+# to decide whether to persist POST responses.
 #
 # Streaming responses (`stream: true`) are skipped; streaming
 # persistence will be handled by a separate filter. Non-2xx

--- a/filter/src/builtins/http/ai/openai/responses/store/filter.rs
+++ b/filter/src/builtins/http/ai/openai/responses/store/filter.rs
@@ -43,9 +43,13 @@ use serde_json::Value;
 use tokio::sync::OnceCell;
 use tracing::{debug, trace, warn};
 
-use super::config::{ResponseStoreConfig, StorageBackend, validate_config};
+use super::{
+    ListParams, Order,
+    config::{ResponseStoreConfig, StorageBackend, validate_config},
+    list_input_items,
+};
 use crate::{
-    FilterAction, FilterError,
+    FilterAction, FilterError, Rejection,
     body::{BodyAccess, BodyMode, limits::MAX_JSON_BODY_BYTES},
     builtins::http::ai::store::{ResponseRecord, ResponseStore, SqliteResponseStore},
     factory::parse_filter_config,
@@ -53,7 +57,7 @@ use crate::{
 };
 
 // -----------------------------------------------------------------------------
-// ResponseStoreFilter
+// Constants
 // -----------------------------------------------------------------------------
 
 /// Default tenant identifier for single-tenant deployments.
@@ -110,7 +114,7 @@ impl ResponseStoreFilter {
         clippy::too_many_lines,
         reason = "tracing macros inflate complexity"
     )]
-    async fn init_store(&self) -> Option<Arc<dyn ResponseStore>> {
+    pub(super) async fn init_store(&self) -> Option<Arc<dyn ResponseStore>> {
         match self.config.backend {
             StorageBackend::Sqlite => {
                 let result = SqliteResponseStore::new(
@@ -362,6 +366,13 @@ impl HttpFilter for ResponseStoreFilter {
     }
 
     async fn on_request(&self, ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
+        if ctx.request.method == http::Method::GET {
+            if let Some(action) = self.try_get_retrieval(ctx).await? {
+                return Ok(action);
+            }
+            return Ok(FilterAction::Continue);
+        }
+
         if should_skip(ctx) {
             return Ok(FilterAction::Continue);
         }
@@ -427,4 +438,190 @@ impl HttpFilter for ResponseStoreFilter {
         persist_response_blocking(&store, &record)?;
         Ok(FilterAction::Continue)
     }
+}
+
+// -----------------------------------------------------------------------------
+// GET Retrieval
+// -----------------------------------------------------------------------------
+
+impl ResponseStoreFilter {
+    /// Attempt to handle a GET request for a stored response or its
+    /// input items. Returns `Some(action)` when the path matches a
+    /// retrieval endpoint, or `None` for unrelated paths.
+    async fn try_get_retrieval(&self, ctx: &HttpFilterContext<'_>) -> Result<Option<FilterAction>, FilterError> {
+        let path = ctx.request.uri.path();
+        let path = path.strip_suffix('/').filter(|p| !p.is_empty()).unwrap_or(path);
+        let segments: Vec<&str> = path.split('/').collect();
+
+        match segments.as_slice() {
+            ["", "v1", "responses", id] if !id.is_empty() => Ok(Some(self.handle_get_response(ctx, id).await)),
+            ["", "v1", "responses", id, "input_items"] if !id.is_empty() => {
+                Ok(Some(self.handle_get_input_items(ctx, id).await))
+            },
+            _ => Ok(None),
+        }
+    }
+
+    /// Lazily initialize the store and return a clone of the `Arc`.
+    async fn ensure_store(&self) -> Option<Arc<dyn ResponseStore>> {
+        self.store
+            .get_or_init(|| async { self.init_store().await })
+            .await
+            .clone()
+    }
+
+    /// Serve `GET /v1/responses/{id}`.
+    async fn handle_get_response(&self, ctx: &HttpFilterContext<'_>, id: &str) -> FilterAction {
+        let Some(store) = self.ensure_store().await else {
+            return FilterAction::Reject(reject_store_error());
+        };
+
+        let tenant_id = ctx.get_metadata(TENANT_METADATA_KEY).unwrap_or(DEFAULT_TENANT_ID);
+        debug!(response_id = id, tenant_id, "retrieving stored response");
+
+        match store.get_response(tenant_id, id).await {
+            Ok(Some(record)) => {
+                let body = serde_json::to_vec(&record.response_object).unwrap_or_default();
+                FilterAction::Reject(
+                    Rejection::status(200)
+                        .with_header("content-type", "application/json")
+                        .with_body(body),
+                )
+            },
+            Ok(None) => {
+                debug!(response_id = id, "response not found");
+                FilterAction::Reject(reject_not_found(id))
+            },
+            Err(e) => {
+                warn!(response_id = id, error = %e, "store lookup failed");
+                FilterAction::Reject(reject_store_error())
+            },
+        }
+    }
+
+    /// Serve `GET /v1/responses/{id}/input_items`.
+    async fn handle_get_input_items(&self, ctx: &HttpFilterContext<'_>, id: &str) -> FilterAction {
+        let Some(store) = self.ensure_store().await else {
+            return FilterAction::Reject(reject_store_error());
+        };
+
+        let tenant_id = ctx.get_metadata(TENANT_METADATA_KEY).unwrap_or(DEFAULT_TENANT_ID);
+        debug!(response_id = id, tenant_id, "retrieving input items");
+
+        let record = match store.get_response(tenant_id, id).await {
+            Ok(Some(r)) => r,
+            Ok(None) => {
+                debug!(response_id = id, "response not found for input_items");
+                return FilterAction::Reject(reject_not_found(id));
+            },
+            Err(e) => {
+                warn!(response_id = id, error = %e, "store lookup failed");
+                return FilterAction::Reject(reject_store_error());
+            },
+        };
+
+        let params = parse_query_params(ctx.request.uri.query());
+        build_input_items_response(id, &record, &params)
+    }
+}
+
+// -----------------------------------------------------------------------------
+// GET Helpers
+// -----------------------------------------------------------------------------
+
+/// Build a paginated input items response from a stored record.
+fn build_input_items_response(id: &str, record: &ResponseRecord, params: &ListParams) -> FilterAction {
+    match list_input_items(record, params) {
+        Ok(page) => {
+            let first_id = page.data.first().and_then(|v| v.get("id")).and_then(|v| v.as_str());
+            let last_id = page.data.last().and_then(|v| v.get("id")).and_then(|v| v.as_str());
+
+            let body = serde_json::json!({
+                "object": "list",
+                "data": page.data,
+                "has_more": page.has_more,
+                "first_id": first_id,
+                "last_id": last_id,
+            });
+            debug!(
+                response_id = id,
+                count = page.data.len(),
+                has_more = page.has_more,
+                "serving input items"
+            );
+            let bytes = serde_json::to_vec(&body).unwrap_or_default();
+            FilterAction::Reject(
+                Rejection::status(200)
+                    .with_header("content-type", "application/json")
+                    .with_body(bytes),
+            )
+        },
+        Err(e) => {
+            warn!(response_id = id, error = %e, "input_items pagination failed");
+            FilterAction::Reject(reject_store_error())
+        },
+    }
+}
+
+/// Parse cursor-based pagination parameters from a query string.
+pub(super) fn parse_query_params(query: Option<&str>) -> ListParams {
+    let Some(qs) = query else {
+        return ListParams::default();
+    };
+
+    let mut params = ListParams::default();
+
+    for pair in qs.split('&') {
+        let Some((key, value)) = pair.split_once('=') else {
+            continue;
+        };
+        match key {
+            "after" => {
+                params.cursor = Some(
+                    percent_encoding::percent_decode_str(value)
+                        .decode_utf8_lossy()
+                        .into_owned(),
+                );
+            },
+            "limit" => {
+                if let Ok(n) = value.parse::<u32>() {
+                    params.limit = n;
+                }
+            },
+            "order" => match value {
+                "asc" => params.order = Order::Ascending,
+                "desc" => params.order = Order::Descending,
+                _ => {},
+            },
+            _ => {},
+        }
+    }
+
+    params
+}
+
+/// Build a 404 rejection with an `OpenAI`-style error body.
+fn reject_not_found(id: &str) -> Rejection {
+    let body = serde_json::json!({
+        "error": {
+            "message": format!("No response found with id '{id}'."),
+            "type": "invalid_request_error",
+        }
+    });
+    Rejection::status(404)
+        .with_header("content-type", "application/json")
+        .with_body(serde_json::to_vec(&body).unwrap_or_default())
+}
+
+/// Build a 500 rejection for internal store failures.
+fn reject_store_error() -> Rejection {
+    let body = serde_json::json!({
+        "error": {
+            "message": "Internal server error.",
+            "type": "server_error",
+        }
+    });
+    Rejection::status(500)
+        .with_header("content-type", "application/json")
+        .with_body(serde_json::to_vec(&body).unwrap_or_default())
 }

--- a/filter/src/builtins/http/ai/openai/responses/store/input_items.rs
+++ b/filter/src/builtins/http/ai/openai/responses/store/input_items.rs
@@ -89,9 +89,8 @@ pub struct InputItemPage {
 /// Extract and paginate input items from a [`ResponseRecord`].
 ///
 /// Items are extracted from the stored `input` JSON column and
-/// paginated in memory using an offset-based cursor. This is
-/// specific to the `OpenAI` Responses API `/v1/responses/{id}/input_items`
-/// endpoint.
+/// paginated in memory using item ID cursors when available. Numeric
+/// offset cursors remain supported for stored inputs without item IDs.
 ///
 /// # Errors
 ///
@@ -111,9 +110,8 @@ pub fn list_input_items(record: &ResponseRecord, params: &ListParams) -> Result<
     let offset = params
         .cursor
         .as_deref()
-        .map(str::parse::<usize>)
-        .transpose()
-        .map_err(|e| StoreError::Database(format!("invalid input_items cursor: {e}")))?
+        .map(|cursor| cursor_offset(&items, cursor))
+        .transpose()?
         .unwrap_or(0);
 
     let limit = usize::try_from(params.effective_limit()).map_err(|e| StoreError::Database(e.to_string()))?;
@@ -123,13 +121,52 @@ pub fn list_input_items(record: &ResponseRecord, params: &ListParams) -> Result<
         .min(items.len());
     let has_more = end < items.len();
 
-    let data: Vec<serde_json::Value> = items.into_iter().skip(offset).take(limit).collect();
+    let data: Vec<serde_json::Value> = items.iter().skip(offset).take(limit).cloned().collect();
 
-    let next_cursor = if has_more { Some(end.to_string()) } else { None };
+    let next_cursor = page_next_cursor(&data, end, has_more);
 
     Ok(InputItemPage {
         data,
         next_cursor,
         has_more,
     })
+}
+
+/// Resolve an `after` cursor to the offset where the next page starts.
+/// ID-based lookup takes precedence: if an item's `id` field matches
+/// the cursor string, the offset is the position after that item.
+/// Numeric parsing is a fallback for inputs without item IDs.
+fn cursor_offset(items: &[serde_json::Value], cursor: &str) -> Result<usize, StoreError> {
+    if let Some(offset) = cursor_id_offset(items, cursor) {
+        return Ok(offset);
+    }
+
+    cursor
+        .parse::<usize>()
+        .map_err(|e| StoreError::Database(format!("invalid input_items cursor: {e}")))
+}
+
+/// Return the offset after the item whose `id` matches the cursor.
+fn cursor_id_offset(items: &[serde_json::Value], cursor: &str) -> Option<usize> {
+    items
+        .iter()
+        .position(|item| item_id(item) == Some(cursor))
+        .map(|index| index + 1)
+}
+
+/// Return the public item ID when the input item has one.
+fn item_id(item: &serde_json::Value) -> Option<&str> {
+    item.get("id").and_then(serde_json::Value::as_str)
+}
+
+/// Return the cursor clients should use to fetch the next page.
+fn page_next_cursor(data: &[serde_json::Value], end: usize, has_more: bool) -> Option<String> {
+    if !has_more {
+        return None;
+    }
+
+    data.last()
+        .and_then(item_id)
+        .map(str::to_owned)
+        .or_else(|| Some(end.to_string()))
 }

--- a/filter/src/builtins/http/ai/openai/responses/store/mod.rs
+++ b/filter/src/builtins/http/ai/openai/responses/store/mod.rs
@@ -13,11 +13,9 @@ mod config;
 mod filter;
 mod input_items;
 
-#[allow(
-    unused_imports,
-    reason = "re-exports for GET (#458) and DELETE (#459) response endpoints"
-)]
-pub use input_items::{InputItemPage, ListParams, Order, list_input_items};
+#[allow(unused_imports, reason = "re-export for DELETE (#459) response endpoint")]
+pub use input_items::InputItemPage;
+pub use input_items::{ListParams, Order, list_input_items};
 
 pub use self::filter::ResponseStoreFilter;
 

--- a/filter/src/builtins/http/ai/openai/responses/store/tests.rs
+++ b/filter/src/builtins/http/ai/openai/responses/store/tests.rs
@@ -304,17 +304,20 @@ async fn on_request_skips_when_stream_is_true() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn on_request_skips_for_get_method() {
+async fn on_request_skips_for_get_to_unrelated_path() {
     let filter = make_filter();
-    let req = crate::test_utils::make_request(http::Method::GET, "/v1/responses/resp_123");
+    let req = crate::test_utils::make_request(http::Method::GET, "/v1/models");
     let mut ctx = crate::test_utils::make_filter_context(&req);
     ctx.set_metadata("openai_responses_format.format", "openai_responses");
 
     let action = filter.on_request(&mut ctx).await.unwrap();
-    assert!(matches!(action, FilterAction::Continue), "should skip for GET method");
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "should skip for GET to unrelated path"
+    );
     assert!(
         filter.store.get().is_none(),
-        "store should not be initialized for non-POST requests"
+        "store should not be initialized for non-responses GET paths"
     );
 }
 
@@ -883,6 +886,278 @@ conversations_table: conversations
 }
 
 // -----------------------------------------------------------------------------
+// GET /v1/responses/{id}
+// -----------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn get_response_returns_200_when_found() {
+    let filter = make_filter();
+    init_store_and_seed(
+        &filter,
+        "resp_found",
+        "default",
+        json!([{"id": "item_1", "type": "message"}]),
+    )
+    .await;
+
+    let req = crate::test_utils::make_request(http::Method::GET, "/v1/responses/resp_found");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let action = filter.on_request(&mut ctx).await.unwrap();
+    let rejection = expect_reject(action);
+    assert_eq!(rejection.status, 200, "should return 200 for found response");
+    assert_has_json_content_type(&rejection);
+
+    let body: serde_json::Value = serde_json::from_slice(rejection.body.as_deref().unwrap()).unwrap();
+    assert_eq!(
+        body["status"], "completed",
+        "body should contain the stored response_object"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn get_response_returns_404_when_not_found() {
+    let filter = make_filter();
+    init_store(&filter).await;
+
+    let req = crate::test_utils::make_request(http::Method::GET, "/v1/responses/resp_nonexistent");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let action = filter.on_request(&mut ctx).await.unwrap();
+    let rejection = expect_reject(action);
+    assert_eq!(rejection.status, 404, "should return 404 for missing response");
+    assert_has_json_content_type(&rejection);
+
+    let body: serde_json::Value = serde_json::from_slice(rejection.body.as_deref().unwrap()).unwrap();
+    assert_eq!(
+        body["error"]["type"], "invalid_request_error",
+        "error type should be invalid_request_error"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn get_response_tenant_isolation() {
+    let filter = make_filter();
+    init_store_and_seed(&filter, "resp_tenant", "tenant_a", json!([])).await;
+
+    let req = crate::test_utils::make_request(http::Method::GET, "/v1/responses/resp_tenant");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let action = filter.on_request(&mut ctx).await.unwrap();
+    let rejection = expect_reject(action);
+    assert_eq!(
+        rejection.status, 404,
+        "should return 404 when response belongs to a different tenant"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn get_response_trailing_slash_handled() {
+    let filter = make_filter();
+    init_store_and_seed(&filter, "resp_slash", "default", json!([])).await;
+
+    let req = crate::test_utils::make_request(http::Method::GET, "/v1/responses/resp_slash/");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let action = filter.on_request(&mut ctx).await.unwrap();
+    let rejection = expect_reject(action);
+    assert_eq!(
+        rejection.status, 200,
+        "trailing slash should be stripped and response found"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn get_unrelated_path_continues() {
+    let filter = make_filter();
+
+    let req = crate::test_utils::make_request(http::Method::GET, "/v1/chat/completions");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let action = filter.on_request(&mut ctx).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "GET to unrelated path should continue"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// GET /v1/responses/{id}/input_items
+// -----------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn get_input_items_returns_200_when_found() {
+    let filter = make_filter();
+    init_store_and_seed(
+        &filter,
+        "resp_items",
+        "default",
+        json!([
+            {"id": "item_1", "type": "message", "content": "hello"},
+            {"id": "item_2", "type": "message", "content": "world"}
+        ]),
+    )
+    .await;
+
+    let req = crate::test_utils::make_request(http::Method::GET, "/v1/responses/resp_items/input_items");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let action = filter.on_request(&mut ctx).await.unwrap();
+    let rejection = expect_reject(action);
+    assert_eq!(rejection.status, 200, "should return 200 for input items");
+    assert_has_json_content_type(&rejection);
+
+    let body: serde_json::Value = serde_json::from_slice(rejection.body.as_deref().unwrap()).unwrap();
+    assert_eq!(body["object"], "list", "should have list object type");
+    assert_eq!(body["data"].as_array().unwrap().len(), 2, "should have 2 items");
+    assert_eq!(body["has_more"], false, "should have no more items");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn get_input_items_returns_404_when_not_found() {
+    let filter = make_filter();
+    init_store(&filter).await;
+
+    let req = crate::test_utils::make_request(http::Method::GET, "/v1/responses/resp_missing/input_items");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let action = filter.on_request(&mut ctx).await.unwrap();
+    let rejection = expect_reject(action);
+    assert_eq!(
+        rejection.status, 404,
+        "should return 404 when response not found for input_items"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn get_input_items_with_limit_and_order() {
+    let filter = make_filter();
+    init_store_and_seed(
+        &filter,
+        "resp_page",
+        "default",
+        json!([
+            {"id": "item_1", "type": "message"},
+            {"id": "item_2", "type": "message"},
+            {"id": "item_3", "type": "message"},
+            {"id": "item_4", "type": "message"}
+        ]),
+    )
+    .await;
+
+    let req = crate::test_utils::make_request(
+        http::Method::GET,
+        "/v1/responses/resp_page/input_items?limit=2&order=asc",
+    );
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let action = filter.on_request(&mut ctx).await.unwrap();
+    let rejection = expect_reject(action);
+    assert_eq!(rejection.status, 200, "should return 200 for paginated input items");
+
+    let body: serde_json::Value = serde_json::from_slice(rejection.body.as_deref().unwrap()).unwrap();
+    assert_eq!(body["data"].as_array().unwrap().len(), 2, "should limit to 2 items");
+    assert_eq!(body["has_more"], true, "should indicate more items exist");
+    assert_eq!(
+        body["first_id"], "item_1",
+        "first_id should be item_1 in ascending order"
+    );
+    assert_eq!(body["last_id"], "item_2", "last_id should be item_2 in ascending order");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn get_input_items_with_cursor() {
+    let filter = make_filter();
+    init_store_and_seed(
+        &filter,
+        "resp_cursor",
+        "default",
+        json!([
+            {"id": "item_1", "type": "message"},
+            {"id": "item_2", "type": "message"},
+            {"id": "item_3", "type": "message"},
+            {"id": "item_4", "type": "message"}
+        ]),
+    )
+    .await;
+
+    let req = crate::test_utils::make_request(
+        http::Method::GET,
+        "/v1/responses/resp_cursor/input_items?after=item_2&limit=2&order=asc",
+    );
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let action = filter.on_request(&mut ctx).await.unwrap();
+    let rejection = expect_reject(action);
+    assert_eq!(rejection.status, 200, "should return 200 for cursor-based pagination");
+
+    let body: serde_json::Value = serde_json::from_slice(rejection.body.as_deref().unwrap()).unwrap();
+    let data = body["data"].as_array().unwrap();
+    assert_eq!(data.len(), 2, "should return 2 items after cursor");
+    assert_eq!(data[0]["id"], "item_3", "first item should be item_3 after item_2");
+    assert_eq!(data[1]["id"], "item_4", "second item should be item_4");
+    assert_eq!(body["has_more"], false, "should indicate no more items after this page");
+}
+
+// -----------------------------------------------------------------------------
+// parse_query_params
+// -----------------------------------------------------------------------------
+
+#[test]
+fn parse_query_params_empty() {
+    let params = super::filter::parse_query_params(None);
+    assert!(params.cursor.is_none(), "cursor should be None for empty query");
+    assert_eq!(params.limit, 20, "limit should default to 20");
+    assert_eq!(
+        params.order,
+        super::Order::Descending,
+        "order should default to Descending"
+    );
+}
+
+#[test]
+fn parse_query_params_all_fields() {
+    let params = super::filter::parse_query_params(Some("after=5&limit=10&order=asc"));
+    assert_eq!(
+        params.cursor.as_deref(),
+        Some("5"),
+        "cursor should be parsed from after param"
+    );
+    assert_eq!(params.limit, 10, "limit should be parsed from query");
+    assert_eq!(
+        params.order,
+        super::Order::Ascending,
+        "order should be parsed as Ascending"
+    );
+}
+
+#[test]
+fn parse_query_params_invalid_limit_ignored() {
+    let params = super::filter::parse_query_params(Some("limit=abc"));
+    assert_eq!(params.limit, 20, "invalid limit should keep default");
+}
+
+#[test]
+fn parse_query_params_decodes_percent_encoded_cursor() {
+    let params = super::filter::parse_query_params(Some("after=item%5F1"));
+    assert_eq!(
+        params.cursor.as_deref(),
+        Some("item_1"),
+        "percent-encoded cursor should be decoded"
+    );
+}
+
+#[test]
+fn parse_query_params_unknown_order_ignored() {
+    let params = super::filter::parse_query_params(Some("order=random"));
+    assert_eq!(
+        params.order,
+        super::Order::Descending,
+        "unknown order value should keep default"
+    );
+}
+
+// -----------------------------------------------------------------------------
 // Test Utilities
 // -----------------------------------------------------------------------------
 
@@ -922,4 +1197,41 @@ fn cleanup_sqlite_file(db_path: &PathBuf) {
     drop(std::fs::remove_file(db_path));
     drop(std::fs::remove_file(format!("{}-shm", db_path.display())));
     drop(std::fs::remove_file(format!("{}-wal", db_path.display())));
+}
+
+async fn init_store(filter: &ResponseStoreFilter) {
+    filter.store.get_or_init(|| async { filter.init_store().await }).await;
+}
+
+async fn init_store_and_seed(filter: &ResponseStoreFilter, id: &str, tenant_id: &str, input: serde_json::Value) {
+    let store_opt = filter.store.get_or_init(|| async { filter.init_store().await }).await;
+    let store = store_opt.as_ref().expect("store should be initialized");
+    let record = crate::builtins::http::ai::store::ResponseRecord {
+        id: id.to_owned(),
+        tenant_id: tenant_id.to_owned(),
+        created_at: 1000,
+        model: "gpt-4.1".to_owned(),
+        response_object: json!({"status": "completed"}),
+        input,
+        messages: json!([{"role": "user", "content": "hello"}]),
+    };
+    store
+        .upsert_response(&record)
+        .await
+        .expect("seed response should succeed");
+}
+
+fn expect_reject(action: FilterAction) -> crate::Rejection {
+    match action {
+        FilterAction::Reject(r) => r,
+        other => panic!("expected Reject, got {other:?}"),
+    }
+}
+
+fn assert_has_json_content_type(rejection: &crate::Rejection) {
+    let has_ct = rejection
+        .headers
+        .iter()
+        .any(|(k, v)| k == "content-type" && v == "application/json");
+    assert!(has_ct, "rejection should have application/json content-type");
 }

--- a/filter/src/builtins/http/ai/store/tests.rs
+++ b/filter/src/builtins/http/ai/store/tests.rs
@@ -265,6 +265,48 @@ fn input_items_from_array_input() {
 }
 
 #[test]
+fn input_items_uses_item_id_cursor() {
+    let record = ResponseRecord {
+        input: json!([
+            {"id": "item_1", "type": "message", "role": "user", "content": "Hello"},
+            {"id": "item_2", "type": "message", "role": "user", "content": "World"},
+            {"id": "item_3", "type": "message", "role": "user", "content": "!"}
+        ]),
+        ..make_response_record("resp_1", "tenant_a", 1000)
+    };
+
+    let page = list_input_items(
+        &record,
+        &ListParams {
+            limit: 2,
+            order: Order::Ascending,
+            ..ListParams::default()
+        },
+    )
+    .expect("list should succeed");
+
+    assert_eq!(
+        page.next_cursor.as_deref(),
+        Some("item_2"),
+        "cursor should use the last item ID"
+    );
+
+    let page2 = list_input_items(
+        &record,
+        &ListParams {
+            cursor: page.next_cursor,
+            limit: 2,
+            order: Order::Ascending,
+        },
+    )
+    .expect("list should succeed");
+
+    assert_eq!(page2.data.len(), 1, "second page should return remaining item");
+    assert_eq!(page2.data[0]["id"], "item_3", "second page should start after item_2");
+    assert!(!page2.has_more, "second page should complete pagination");
+}
+
+#[test]
 fn input_items_from_string_input() {
     let record = ResponseRecord {
         input: json!("Hello, world!"),

--- a/tests/integration/tests/suite/examples/openai_response_store.rs
+++ b/tests/integration/tests/suite/examples/openai_response_store.rs
@@ -6,7 +6,8 @@
 use std::collections::HashMap;
 
 use praxis_test_utils::{
-    Backend, example_config_path, free_port, http_send, json_post, parse_body, parse_status, patch_yaml, start_proxy,
+    Backend, example_config_path, free_port, http_get, http_send, json_post, parse_body, parse_status, patch_yaml,
+    start_proxy,
 };
 use sqlx::Row;
 
@@ -123,6 +124,60 @@ fn response_store_passes_through_non_responses_traffic() {
         parse_status(&raw),
         200,
         "Chat Completions body should still route through"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// GET Retrieval
+// -----------------------------------------------------------------------------
+
+#[test]
+fn get_missing_response_returns_404() {
+    let proxy_port = free_port();
+
+    let yaml = std::fs::read_to_string(example_config_path("ai/openai/responses/response-store.yaml"))
+        .expect("example config should exist");
+    let patched = patch_yaml(
+        &yaml.replace("sqlite://responses.db?mode=rwc", "sqlite::memory:"),
+        proxy_port,
+        &HashMap::new(),
+    );
+    let config = praxis_core::config::Config::from_yaml(&patched).expect("patched config should parse");
+    let proxy = start_proxy(&config);
+    let (status, body) = http_get(proxy.addr(), "/v1/responses/resp_nonexistent", None);
+
+    assert_eq!(status, 404, "GET for missing response should return 404");
+    let parsed: serde_json::Value = serde_json::from_str(&body).expect("body should be valid JSON");
+    assert_eq!(
+        parsed["error"]["type"].as_str(),
+        Some("invalid_request_error"),
+        "404 body should use invalid_request_error type"
+    );
+}
+
+#[test]
+fn get_missing_input_items_returns_404() {
+    let proxy_port = free_port();
+
+    let yaml = std::fs::read_to_string(example_config_path("ai/openai/responses/response-store.yaml"))
+        .expect("example config should exist");
+    let patched = patch_yaml(
+        &yaml.replace("sqlite://responses.db?mode=rwc", "sqlite::memory:"),
+        proxy_port,
+        &HashMap::new(),
+    );
+    let config = praxis_core::config::Config::from_yaml(&patched).expect("patched config should parse");
+    let proxy = start_proxy(&config);
+    let (status, body) = http_get(proxy.addr(), "/v1/responses/resp_nonexistent/input_items", None);
+
+    assert_eq!(status, 404, "input_items for missing response should return 404");
+    let parsed: serde_json::Value = serde_json::from_str(&body).expect("body should be valid JSON");
+    assert!(
+        parsed["error"]["message"]
+            .as_str()
+            .expect("error message should be a string")
+            .contains("resp_nonexistent"),
+        "error message should include the missing ID"
     );
 }
 


### PR DESCRIPTION
## Summary

- Intercept `GET /v1/responses/{id}` and `GET /v1/responses/{id}/input_items` in the `openai_response_store` filter's `on_request` phase, serving stored data directly from the local `ResponseStore` and short-circuiting the proxy path
- Returns 200 with the stored `response_object` or 404 with an OpenAI-style error body
- Input items endpoint supports cursor-based pagination with `after`, `limit`, and `order` query parameters using item ID cursors
- Enables backends like vLLM that don't persist responses server-side

Depends on praxis-proxy/praxis#582.

Closes praxis-proxy/ai#14

## Test plan

- [x] 14 new unit tests covering GET response (200, 404, tenant isolation, trailing slash), GET input_items (200, 404, limit+order, cursor), query param parsing
- [x] 2 new integration tests verifying 404 responses for missing IDs via the example config
- [x] `make lint` clean (clippy + fmt + lint-deps + lint-example-tests)
- [x] `make build` clean
- [x] All 117 store-related tests pass

Signed-off-by: Sébastien Han <seb@redhat.com>