### PR TITLE
feat(store): handle DELETE /v1/responses/{id} in filter pipeline

### DIFF
--- a/examples/configs/ai/openai/responses/response-store.yaml
+++ b/examples/configs/ai/openai/responses/response-store.yaml
@@ -1,19 +1,32 @@
 # Response Store
 #
 # Persists non-streaming Responses API responses to a SQLite
-# database and serves stored data via GET endpoints:
+# database and serves stored data via GET endpoints and handles
+# DELETE /v1/responses/{id} locally:
 #
 #   POST /v1/responses          — proxied to backend, response persisted
 #   GET  /v1/responses/{id}     — served from local store (200 or 404)
 #   GET  /v1/responses/{id}/input_items — paginated input items
+#   DELETE /v1/responses/{id}   — deleted from local store (200 or 404)
 #
 # The `openai_responses_format` filter must run first to classify
 # the request body — `openai_response_store` reads its metadata
 # to decide whether to persist POST responses.
 #
-# Streaming responses (`stream: true`) are skipped; streaming
-# persistence will be handled by a separate filter. Non-2xx
-# responses and non-JSON content types are also skipped.
+# POST persistence:
+#   The `openai_responses_format` filter must run first to
+#   classify the request body — `openai_response_store` reads its
+#   metadata to decide whether to persist. Streaming responses
+#   (`stream: true`) are skipped; streaming persistence will be
+#   handled by a separate filter. Non-2xx responses and non-JSON
+#   content types are also skipped.
+#
+# DELETE handling:
+#   DELETE /v1/responses/{id} is intercepted during `on_request`
+#   and short-circuited with a 200 (deleted) or 404 (not found)
+#   JSON response. The request never reaches the backend.
+#
+#   curl -X DELETE http://127.0.0.1:8080/v1/responses/resp_abc
 #
 # The store is lazily initialized on the first qualifying
 # request. If initialization fails (bad URL, permissions),

--- a/filter/src/builtins/http/ai/openai/responses/store/filter.rs
+++ b/filter/src/builtins/http/ai/openai/responses/store/filter.rs
@@ -2,7 +2,8 @@
 // Copyright (c) 2026 Praxis Contributors
 
 //! [`ResponseStoreFilter`] persists non-streaming Responses API
-//! responses to the configured store backend.
+//! responses to the configured store backend and handles
+//! `DELETE /v1/responses/{id}` locally.
 //!
 //! # Lifecycle design
 //!
@@ -147,6 +148,40 @@ impl ResponseStoreFilter {
         }
     }
 
+    /// Handle `DELETE /v1/responses/{id}` by deleting from the store.
+    async fn handle_delete(&self, tenant_id: &str, id: &str) -> Result<FilterAction, FilterError> {
+        let store = self.store.get_or_init(|| async { self.init_store().await }).await;
+
+        let Some(store) = store else {
+            return Ok(FilterAction::Continue);
+        };
+
+        let deleted = store
+            .delete_response(tenant_id, id)
+            .await
+            .map_err(|e| FilterError::from(format!("openai_response_store: delete failed: {e}")))?;
+
+        if deleted {
+            debug!(id, tenant_id, "response deleted");
+            Ok(FilterAction::Reject(
+                Rejection::status(200)
+                    .with_header("content-type", "application/json")
+                    .with_body(Bytes::from(format!(
+                        r#"{{"id":"{id}","object":"response.deleted","deleted":true}}"#
+                    ))),
+            ))
+        } else {
+            debug!(id, tenant_id, "response not found for delete");
+            Ok(FilterAction::Reject(
+                Rejection::status(404)
+                    .with_header("content-type", "application/json")
+                    .with_body(Bytes::from(format!(
+                        r#"{{"error":{{"message":"No response found with id: '{id}'.","type":"invalid_request_error"}}}}"#
+                    ))),
+            ))
+        }
+    }
+
     /// Return whether this exchange should release response body
     /// chunks immediately instead of waiting for EOS.
     fn should_release_skipped_response_body(&self, ctx: &HttpFilterContext<'_>) -> bool {
@@ -190,6 +225,23 @@ impl ResponseCapture {
             input: json.get("input").cloned().unwrap_or(Value::Null),
             messages: json.get("output").cloned().unwrap_or(Value::Null),
         }
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Path Extraction
+// -----------------------------------------------------------------------------
+
+/// Extract the response ID from a `/v1/responses/{id}` path.
+///
+/// Returns `None` if the path does not match the expected pattern.
+pub(super) fn extract_response_id(path: &str) -> Option<&str> {
+    let path = path.strip_suffix('/').filter(|p| !p.is_empty()).unwrap_or(path);
+    let segments: Vec<&str> = path.split('/').collect();
+
+    match segments.as_slice() {
+        ["", "v1", "responses", id] if !id.is_empty() => Some(id),
+        _ => None,
     }
 }
 
@@ -369,6 +421,14 @@ impl HttpFilter for ResponseStoreFilter {
         if ctx.request.method == http::Method::GET {
             if let Some(action) = self.try_get_retrieval(ctx).await? {
                 return Ok(action);
+            }
+            return Ok(FilterAction::Continue);
+        }
+
+        if ctx.request.method == http::Method::DELETE {
+            if let Some(id) = extract_response_id(ctx.request.uri.path()) {
+                let tenant_id = ctx.get_metadata(TENANT_METADATA_KEY).unwrap_or(DEFAULT_TENANT_ID);
+                return self.handle_delete(tenant_id, id).await;
             }
             return Ok(FilterAction::Continue);
         }

--- a/filter/src/builtins/http/ai/openai/responses/store/filter.rs
+++ b/filter/src/builtins/http/ai/openai/responses/store/filter.rs
@@ -163,22 +163,10 @@ impl ResponseStoreFilter {
 
         if deleted {
             debug!(id, tenant_id, "response deleted");
-            Ok(FilterAction::Reject(
-                Rejection::status(200)
-                    .with_header("content-type", "application/json")
-                    .with_body(Bytes::from(format!(
-                        r#"{{"id":"{id}","object":"response.deleted","deleted":true}}"#
-                    ))),
-            ))
+            Ok(FilterAction::Reject(delete_success_rejection(id)?))
         } else {
             debug!(id, tenant_id, "response not found for delete");
-            Ok(FilterAction::Reject(
-                Rejection::status(404)
-                    .with_header("content-type", "application/json")
-                    .with_body(Bytes::from(format!(
-                        r#"{{"error":{{"message":"No response found with id: '{id}'.","type":"invalid_request_error"}}}}"#
-                    ))),
-            ))
+            Ok(FilterAction::Reject(delete_not_found_rejection(id)?))
         }
     }
 
@@ -243,6 +231,39 @@ pub(super) fn extract_response_id(path: &str) -> Option<&str> {
         ["", "v1", "responses", id] if !id.is_empty() => Some(id),
         _ => None,
     }
+}
+
+// -----------------------------------------------------------------------------
+// Delete Response Helpers
+// -----------------------------------------------------------------------------
+
+/// Build the 200 rejection for a successful delete.
+fn delete_success_rejection(id: &str) -> Result<Rejection, FilterError> {
+    let body = serde_json::to_string(&serde_json::json!({
+        "id": id,
+        "object": "response.deleted",
+        "deleted": true,
+    }))
+    .map_err(|e| FilterError::from(format!("openai_response_store: serialize failed: {e}")))?;
+
+    Ok(Rejection::status(200)
+        .with_header("content-type", "application/json")
+        .with_body(Bytes::from(body)))
+}
+
+/// Build the 404 rejection for a missing response.
+fn delete_not_found_rejection(id: &str) -> Result<Rejection, FilterError> {
+    let body = serde_json::to_string(&serde_json::json!({
+        "error": {
+            "message": format!("No response found with id: '{id}'."),
+            "type": "invalid_request_error",
+        }
+    }))
+    .map_err(|e| FilterError::from(format!("openai_response_store: serialize failed: {e}")))?;
+
+    Ok(Rejection::status(404)
+        .with_header("content-type", "application/json")
+        .with_body(Bytes::from(body)))
 }
 
 // -----------------------------------------------------------------------------

--- a/filter/src/builtins/http/ai/openai/responses/store/filter.rs
+++ b/filter/src/builtins/http/ai/openai/responses/store/filter.rs
@@ -224,7 +224,7 @@ impl ResponseCapture {
 ///
 /// Returns `None` if the path does not match the expected pattern.
 pub(super) fn extract_response_id(path: &str) -> Option<&str> {
-    let path = path.strip_suffix('/').filter(|p| !p.is_empty()).unwrap_or(path);
+    let path = path.strip_suffix('/').unwrap_or(path);
     let segments: Vec<&str> = path.split('/').collect();
 
     match segments.as_slice() {

--- a/filter/src/builtins/http/ai/openai/responses/store/tests.rs
+++ b/filter/src/builtins/http/ai/openai/responses/store/tests.rs
@@ -1100,6 +1100,203 @@ async fn get_input_items_with_cursor() {
 }
 
 // -----------------------------------------------------------------------------
+// DELETE
+// -----------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn delete_existing_response_returns_200() {
+    let filter = make_filter();
+    init_store_and_seed(&filter, "resp_del1", "default", json!([])).await;
+
+    let req = crate::test_utils::make_request(http::Method::DELETE, "/v1/responses/resp_del1");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let action = filter.on_request(&mut ctx).await.unwrap();
+    let rejection = expect_reject(action);
+    assert_eq!(rejection.status, 200, "existing response should return 200");
+    assert_has_json_content_type(&rejection);
+
+    let body: serde_json::Value =
+        serde_json::from_slice(rejection.body.as_deref().expect("body should be present"))
+            .expect("body should be valid JSON");
+    assert_eq!(body["id"], "resp_del1", "body should contain the response id");
+    assert_eq!(
+        body["object"], "response.deleted",
+        "body should have object=response.deleted"
+    );
+    assert_eq!(body["deleted"], true, "body should have deleted=true");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn delete_nonexistent_response_returns_404() {
+    let filter = make_filter();
+    init_store_and_seed(&filter, "resp_exists", "default", json!([])).await;
+
+    let req = crate::test_utils::make_request(http::Method::DELETE, "/v1/responses/resp_missing");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let action = filter.on_request(&mut ctx).await.unwrap();
+    let rejection = expect_reject(action);
+    assert_eq!(rejection.status, 404, "nonexistent response should return 404");
+    assert_has_json_content_type(&rejection);
+
+    let body: serde_json::Value =
+        serde_json::from_slice(rejection.body.as_deref().expect("body should be present"))
+            .expect("body should be valid JSON");
+    assert_eq!(
+        body["error"]["type"], "invalid_request_error",
+        "error type should be invalid_request_error"
+    );
+    assert!(
+        body["error"]["message"].as_str().is_some_and(|m| m.contains("resp_missing")),
+        "error message should reference the missing id"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn delete_is_idempotent() {
+    let filter = make_filter();
+    init_store_and_seed(&filter, "resp_idem", "default", json!([])).await;
+
+    let req = crate::test_utils::make_request(http::Method::DELETE, "/v1/responses/resp_idem");
+    let mut ctx1 = crate::test_utils::make_filter_context(&req);
+    let action1 = filter.on_request(&mut ctx1).await.unwrap();
+    let r1 = expect_reject(action1);
+    assert_eq!(r1.status, 200, "first delete should return 200");
+
+    let mut ctx2 = crate::test_utils::make_filter_context(&req);
+    let action2 = filter.on_request(&mut ctx2).await.unwrap();
+    let r2 = expect_reject(action2);
+    assert_eq!(r2.status, 404, "second delete should return 404");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn delete_cross_tenant_returns_404() {
+    let filter = make_filter();
+    init_store_and_seed(&filter, "resp_tenant", "tenant_a", json!([])).await;
+
+    let req = crate::test_utils::make_request(http::Method::DELETE, "/v1/responses/resp_tenant");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let action = filter.on_request(&mut ctx).await.unwrap();
+    let rejection = expect_reject(action);
+    assert_eq!(rejection.status, 404, "delete from wrong tenant should return 404");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn delete_uses_tenant_metadata() {
+    let filter = make_filter();
+    init_store_and_seed(&filter, "resp_tmeta", "tenant_x", json!([])).await;
+
+    let req = crate::test_utils::make_request(http::Method::DELETE, "/v1/responses/resp_tmeta");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.set_metadata("responses.tenant_id", "tenant_x");
+
+    let action = filter.on_request(&mut ctx).await.unwrap();
+    let rejection = expect_reject(action);
+    assert_eq!(
+        rejection.status, 200,
+        "delete with matching tenant metadata should return 200"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn delete_continues_when_store_unavailable() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+backend: sqlite
+database_url: "sqlite:///nonexistent/path/that/will/fail.db"
+responses_table: responses
+conversations_table: conversations
+"#,
+    )
+    .unwrap();
+    let cfg: ResponseStoreConfig = parse_filter_config("openai_response_store", &yaml).unwrap();
+    validate_config(&cfg).unwrap();
+    let filter = ResponseStoreFilter::new(cfg);
+
+    let req = crate::test_utils::make_request(http::Method::DELETE, "/v1/responses/resp_gone");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let action = filter.on_request(&mut ctx).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "DELETE should continue when store is unavailable"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn delete_response_has_json_content_type() {
+    let filter = make_filter();
+    init_store_and_seed(&filter, "resp_ct", "default", json!([])).await;
+
+    let req = crate::test_utils::make_request(http::Method::DELETE, "/v1/responses/resp_ct");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let action = filter.on_request(&mut ctx).await.unwrap();
+    let rejection = expect_reject(action);
+    assert_has_json_content_type(&rejection);
+}
+
+// -----------------------------------------------------------------------------
+// extract_response_id
+// -----------------------------------------------------------------------------
+
+#[test]
+fn extract_response_id_valid() {
+    assert_eq!(
+        super::filter::extract_response_id("/v1/responses/resp_abc"),
+        Some("resp_abc"),
+        "should extract ID from valid path"
+    );
+}
+
+#[test]
+fn extract_response_id_trailing_slash() {
+    assert_eq!(
+        super::filter::extract_response_id("/v1/responses/resp_abc/"),
+        Some("resp_abc"),
+        "should extract ID with trailing slash"
+    );
+}
+
+#[test]
+fn extract_response_id_no_id() {
+    assert_eq!(
+        super::filter::extract_response_id("/v1/responses"),
+        None,
+        "should return None without ID segment"
+    );
+}
+
+#[test]
+fn extract_response_id_sub_resource() {
+    assert_eq!(
+        super::filter::extract_response_id("/v1/responses/resp_abc/input_items"),
+        None,
+        "should return None for sub-resource path"
+    );
+}
+
+#[test]
+fn extract_response_id_unrelated_path() {
+    assert_eq!(
+        super::filter::extract_response_id("/v1/chat/completions"),
+        None,
+        "should return None for unrelated path"
+    );
+}
+
+#[test]
+fn extract_response_id_empty_id_segment() {
+    assert_eq!(
+        super::filter::extract_response_id("/v1/responses/"),
+        None,
+        "should return None for empty ID segment"
+    );
+}
+
+// -----------------------------------------------------------------------------
 // parse_query_params
 // -----------------------------------------------------------------------------
 

--- a/filter/src/builtins/http/ai/openai/responses/store/tests.rs
+++ b/filter/src/builtins/http/ai/openai/responses/store/tests.rs
@@ -322,20 +322,19 @@ async fn on_request_skips_for_get_to_unrelated_path() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn on_request_skips_for_delete_method() {
+async fn on_request_skips_delete_on_unrelated_path() {
     let filter = make_filter();
-    let req = crate::test_utils::make_request(http::Method::DELETE, "/v1/responses/resp_123");
+    let req = crate::test_utils::make_request(http::Method::DELETE, "/v1/chat/completions");
     let mut ctx = crate::test_utils::make_filter_context(&req);
-    ctx.set_metadata("openai_responses_format.format", "openai_responses");
 
     let action = filter.on_request(&mut ctx).await.unwrap();
     assert!(
         matches!(action, FilterAction::Continue),
-        "should skip for DELETE method"
+        "DELETE to unrelated path should continue"
     );
     assert!(
         filter.store.get().is_none(),
-        "store should not be initialized for non-POST requests"
+        "store should not be initialized for unrelated DELETE"
     );
 }
 
@@ -1116,9 +1115,8 @@ async fn delete_existing_response_returns_200() {
     assert_eq!(rejection.status, 200, "existing response should return 200");
     assert_has_json_content_type(&rejection);
 
-    let body: serde_json::Value =
-        serde_json::from_slice(rejection.body.as_deref().expect("body should be present"))
-            .expect("body should be valid JSON");
+    let body: serde_json::Value = serde_json::from_slice(rejection.body.as_deref().expect("body should be present"))
+        .expect("body should be valid JSON");
     assert_eq!(body["id"], "resp_del1", "body should contain the response id");
     assert_eq!(
         body["object"], "response.deleted",
@@ -1140,15 +1138,16 @@ async fn delete_nonexistent_response_returns_404() {
     assert_eq!(rejection.status, 404, "nonexistent response should return 404");
     assert_has_json_content_type(&rejection);
 
-    let body: serde_json::Value =
-        serde_json::from_slice(rejection.body.as_deref().expect("body should be present"))
-            .expect("body should be valid JSON");
+    let body: serde_json::Value = serde_json::from_slice(rejection.body.as_deref().expect("body should be present"))
+        .expect("body should be valid JSON");
     assert_eq!(
         body["error"]["type"], "invalid_request_error",
         "error type should be invalid_request_error"
     );
     assert!(
-        body["error"]["message"].as_str().is_some_and(|m| m.contains("resp_missing")),
+        body["error"]["message"]
+            .as_str()
+            .is_some_and(|m| m.contains("resp_missing")),
         "error message should reference the missing id"
     );
 }

--- a/tests/integration/tests/suite/examples/openai_response_store.rs
+++ b/tests/integration/tests/suite/examples/openai_response_store.rs
@@ -127,6 +127,107 @@ fn response_store_passes_through_non_responses_traffic() {
     );
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn response_store_delete_returns_200_after_post() {
+    let backend_guard = Backend::fixed(RESPONSE_JSON)
+        .header("content-type", "application/json")
+        .start_with_shutdown();
+    let proxy_port = free_port();
+
+    let (db_url, db_path) = temp_sqlite_url("delete_200");
+    let yaml = std::fs::read_to_string(example_config_path("ai/openai/responses/response-store.yaml"))
+        .expect("example config should exist");
+    let patched = patch_yaml(
+        &yaml.replace("sqlite://responses.db?mode=rwc", &db_url),
+        proxy_port,
+        &HashMap::from([("127.0.0.1:8000", backend_guard.port())]),
+    );
+    let config = praxis_core::config::Config::from_yaml(&patched).expect("patched config should parse");
+    let proxy = start_proxy(&config);
+
+    let post_raw = http_send(
+        proxy.addr(),
+        &json_post("/v1/responses", r#"{"model":"gpt-4.1","input":"Hello"}"#),
+    );
+    assert_eq!(parse_status(&post_raw), 200, "POST should succeed");
+
+    let delete_raw = http_send(
+        proxy.addr(),
+        "DELETE /v1/responses/resp_abc HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+    );
+    assert_eq!(
+        parse_status(&delete_raw),
+        200,
+        "DELETE of existing response should return 200"
+    );
+
+    let body = parse_body(&delete_raw);
+    let json: serde_json::Value = serde_json::from_str(&body).expect("body should be valid JSON");
+    assert_eq!(json["id"], "resp_abc", "response id should match");
+    assert_eq!(json["deleted"], true, "deleted flag should be true");
+
+    drop(proxy);
+    cleanup_sqlite_files(&db_path);
+}
+
+#[test]
+fn response_store_delete_nonexistent_returns_404() {
+    let backend_guard = Backend::fixed("unused")
+        .header("content-type", "text/plain")
+        .start_with_shutdown();
+    let proxy_port = free_port();
+
+    let yaml = std::fs::read_to_string(example_config_path("ai/openai/responses/response-store.yaml"))
+        .expect("example config should exist");
+    let patched = patch_yaml(
+        &yaml.replace("sqlite://responses.db?mode=rwc", "sqlite::memory:"),
+        proxy_port,
+        &HashMap::from([("127.0.0.1:8000", backend_guard.port())]),
+    );
+    let config = praxis_core::config::Config::from_yaml(&patched).expect("patched config should parse");
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        "DELETE /v1/responses/resp_nonexistent HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+    );
+    assert_eq!(
+        parse_status(&raw),
+        404,
+        "DELETE of nonexistent response should return 404"
+    );
+}
+
+#[test]
+fn response_store_delete_has_json_content_type() {
+    let backend_guard = Backend::fixed("unused")
+        .header("content-type", "text/plain")
+        .start_with_shutdown();
+    let proxy_port = free_port();
+
+    let yaml = std::fs::read_to_string(example_config_path("ai/openai/responses/response-store.yaml"))
+        .expect("example config should exist");
+    let patched = patch_yaml(
+        &yaml.replace("sqlite://responses.db?mode=rwc", "sqlite::memory:"),
+        proxy_port,
+        &HashMap::from([("127.0.0.1:8000", backend_guard.port())]),
+    );
+    let config = praxis_core::config::Config::from_yaml(&patched).expect("patched config should parse");
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        "DELETE /v1/responses/resp_any HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+    );
+
+    let ct = praxis_test_utils::parse_header(&raw, "content-type");
+    assert_eq!(
+        ct.as_deref(),
+        Some("application/json"),
+        "DELETE response should have JSON content type"
+    );
+}
+
 // -----------------------------------------------------------------------------
 // GET Retrieval
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes praxis-proxy/ai#13. Adds DELETE handling to the `openai_response_store` filter, intercepting `DELETE /v1/responses/{id}` during `on_request` and short-circuiting with a JSON 200 (deleted) or 404 (not found) response before the request reaches the backend. Tenant isolation uses the same `responses.tenant_id` metadata key as POST persistence, falling back to `"default"` for single-tenant deployments.

This PR builds on praxis-proxy/praxis#582, which adds the `openai_response_store` filter with POST persistence and synchronous fail-closed writes.

## Changes

- Add `handle_delete` method and `extract_response_id` path helper to `ResponseStoreFilter`
- Modify `on_request` to intercept DELETE before the POST persistence skip logic
- Add 8 unit tests (200/404/idempotent/cross-tenant/tenant-metadata/content-type) and 6 path extraction tests
- Add 3 integration tests (POST-then-DELETE 200, nonexistent 404, JSON content-type)
- Update example config comments with DELETE documentation and curl example

## Test plan

- [x] `make fmt` — no formatting changes
- [x] `make lint` — clippy clean
- [x] `make test-schema` — 159 tests pass
- [x] Unit tests — 79 store tests pass (14 new)
- [x] Integration tests — 5 tests pass (3 new DELETE tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)