### PR TITLE
feat(xtask): auto-generate examples/README.md from config headers

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -164,8 +164,21 @@ New capabilities require:
 3. Example config in `examples/configs/`
 4. Functional integration test for the example config
    in `tests/integration/tests/suite/examples/`
-5. Update `examples/README.md` to list any new or
-   renamed example configs
+5. Run `cargo xtask sync-example-readme --fix` to
+   regenerate `examples/README.md`
+
+Example configs must use this header comment format
+so the README generator can extract descriptions:
+
+```yaml
+# Title
+#
+# One-line or multi-line description used in the
+# README table (first sentence is taken).
+#
+# Usage:
+#   cargo run -p praxis -- -c examples/configs/...
+```
 
 Example config tests must exercise the actual
 functionality end-to-end (e.g. a WebSocket config
@@ -193,7 +206,7 @@ See `docs/filters/extensions.md` for the full guide.
 5. Add example config in `examples/configs/<category>/`
 6. Add functional integration test in
    `tests/integration/tests/suite/examples/`
-7. Update `examples/README.md`
+7. Run `cargo xtask sync-example-readme --fix`
 
 ## Adding a Protocol
 

--- a/Makefile
+++ b/Makefile
@@ -212,6 +212,7 @@ lint:
 	cargo +$(NIGHTLY_VERSION) fmt --all -- --check
 	cargo xtask lint-deps
 	cargo xtask lint-example-tests
+	cargo xtask sync-example-readme
 
 fmt:
 	cargo +$(NIGHTLY_VERSION) fmt --all

--- a/examples/README.md
+++ b/examples/README.md
@@ -65,7 +65,7 @@ page.
 | [container-default.yaml](configs/operations/container-default.yaml) | Default config for containerized deployments |
 | [hot-reload.yaml](configs/operations/hot-reload.yaml) | Filter pipelines are swapped atomically at runtime when the config file changes |
 | [log-overrides.yaml](configs/operations/log-overrides.yaml) | Use `runtime.log_overrides` to raise or lower log verbosity for specific modules without flooding output from every subsystem |
-| [max-connections.yaml](configs/operations/max-connections.yaml) | HTTP listeners return 503 with Retry-After: 1 |
+| [max-connections.yaml](configs/operations/max-connections.yaml) | HTTP listeners return 503 with Retry-After: 1. TCP listeners close the socket immediately |
 | [multi-listener.yaml](configs/operations/multi-listener.yaml) | Demonstrates multiple HTTP listeners, each with its own filter pipeline |
 | [production-gateway.yaml](configs/operations/production-gateway.yaml) | Combines TLS, logging, timeouts, security headers, path routing, and load balancing |
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,144 +18,144 @@ page.
 
 ## Configs
 
-### Traffic Management
+### AI / Inference
 
 | File | Description |
 | ------ | ------------- |
-| [basic-reverse-proxy.yaml](configs/traffic-management/basic-reverse-proxy.yaml) | Minimal single-listener, single-cluster proxy |
-| [path-based-routing.yaml](configs/traffic-management/path-based-routing.yaml) | Route by URL path prefix to separate clusters |
-| [hosts.yaml](configs/traffic-management/hosts.yaml) | Route by Host header; one listener, multiple domains |
-| [canary-routing.yaml](configs/traffic-management/canary-routing.yaml) | Weighted traffic split for canary deployments |
-| [circuit-breaker.yaml](configs/traffic-management/circuit-breaker.yaml) | Per-cluster circuit breaker with closed/open/half-open states |
-| [round-robin.yaml](configs/traffic-management/round-robin.yaml) | Default strategy: even distribution across backends |
-| [weighted-load-balancing.yaml](configs/traffic-management/weighted-load-balancing.yaml) | Proportional traffic split via per-endpoint weights |
-| [least-connections.yaml](configs/traffic-management/least-connections.yaml) | Route to backend with fewest in-flight requests |
-| [p2c.yaml](configs/traffic-management/p2c.yaml) | Power-of-two-choices: O(1) load-aware selection |
-| [session-affinity.yaml](configs/traffic-management/session-affinity.yaml) | consistent_hash to pin a user to one backend |
-| [health-checks.yaml](configs/traffic-management/health-checks.yaml) | Active HTTP and TCP health check probes per cluster |
-| [timeout.yaml](configs/traffic-management/timeout.yaml) | 504 when upstream exceeds a latency SLA |
-| [rate-limiting.yaml](configs/traffic-management/rate-limiting.yaml) | Token bucket rate limiter with per-IP and global modes |
-| [static-response.yaml](configs/traffic-management/static-response.yaml) | Fixed response without upstream |
-| [redirect.yaml](configs/traffic-management/redirect.yaml) | 3xx redirects with path/query template substitution |
-| [hostname-upstream.yaml](configs/traffic-management/hostname-upstream.yaml) | Resolve hostname upstream endpoints such as `localhost:9000` |
-| [grpc-detection.yaml](configs/traffic-management/grpc-detection.yaml) | Detect gRPC content-type and branch-route by variant |
+| [a2a-classifier-routing.yaml](configs/ai/a2a-classifier-routing.yaml) | Routes A2A requests by body-derived method, family, task ID, and streaming detection |
+| [a2a-task-routing.yaml](configs/ai/a2a-task-routing.yaml) | Captures task ownership from non-streaming JSON SendMessage responses and routes follow-up task operations back to the backend cluster that created the task |
+| [ai-inference-body-based-routing.yaml](configs/ai/ai-inference-body-based-routing.yaml) | Routes LLM API requests to different backends based on the `model` field in the JSON request body |
+| [credential-injection.yaml](configs/ai/credential-injection.yaml) | Injects per-cluster API credentials into upstream requests and strips client-provided credentials to prevent forwarding |
+| [json-rpc-routing.yaml](configs/ai/json-rpc-routing.yaml) | Routes JSON-RPC 2.0 requests to different backends based on the "method" field in the JSON request body |
+| [mcp-classifier-routing.yaml](configs/ai/mcp-classifier-routing.yaml) | Routes MCP requests by body-derived method and tool name |
+| [model-to-header-routing.yaml](configs/ai/model-to-header-routing.yaml) | Routes LLM API requests to different backends based on the "model" field in the JSON request body |
+| [format-routing.yaml](configs/ai/openai/responses/format-routing.yaml) | Routes AI API traffic by detected body format |
+| [full-flow.yaml](configs/ai/openai/responses/full-flow.yaml) | Combines format classification, request validation, and backend routing into a single pipeline |
+| [request-validate.yaml](configs/ai/openai/responses/request-validate.yaml) | Validates Responses API requests and rejects invalid parameter combinations |
+| [response-store.yaml](configs/ai/openai/responses/response-store.yaml) | Persists non-streaming Responses API responses to a SQLite database and serves stored data via GET endpoints and handles DELETE /v1/responses/{id} locally |
+| [responses-routing.yaml](configs/ai/openai/responses/responses-routing.yaml) | Routes Responses API traffic by detected mode |
+| [prompt-enrichment.yaml](configs/ai/prompt-enrichment.yaml) | Injects system messages into OpenAI-compatible chat completion requests before forwarding to the upstream provider |
 
-### Payload Processing
+### Branching
 
 | File | Description |
 | ------ | ------------- |
-| [mcp-static-catalog.yaml](configs/payload-processing/mcp-static-catalog.yaml) | MCP static catalog and broker; tools/call routing in a follow-up PR |
-| [stream-buffer.yaml](configs/payload-processing/stream-buffer.yaml) | Stream-buffered body inspection before forwarding |
-| [compression.yaml](configs/payload-processing/compression.yaml) | Gzip, brotli, and zstd response compression |
-| [multi-field-extraction.yaml](configs/payload-processing/multi-field-extraction.yaml) | Extract multiple JSON fields into headers in one pass |
-| [conditional-field-extraction.yaml](configs/payload-processing/conditional-field-extraction.yaml) | Apply json_body_field only on matching request paths |
-| [field-extraction-access-control.yaml](configs/payload-processing/field-extraction-access-control.yaml) | Extract tenant_id from body for header-based routing |
-| [body-size-limit-with-extraction.yaml](configs/payload-processing/body-size-limit-with-extraction.yaml) | Global body size ceiling with json_body_field extraction |
-| [multi-listener-body-pipeline.yaml](configs/payload-processing/multi-listener-body-pipeline.yaml) | Three listeners with different body processing strategies |
-
-### Security
-
-| File | Description |
-| ------ | ------------- |
-| [csrf.yaml](configs/security/csrf.yaml) | CSRF protection via origin validation |
-| [forwarded-headers.yaml](configs/security/forwarded-headers.yaml) | X-Forwarded-For/Proto/Host with trusted proxies |
-| [guardrails.yaml](configs/security/guardrails.yaml) | Reject requests matching header or body string/regex rules |
-| [ip-acl.yaml](configs/security/ip-acl.yaml) | Allow or deny by source IP/CIDR |
-| [downstream-read-timeout.yaml](configs/security/downstream-read-timeout.yaml) | Protect against slow client attacks with read timeouts |
-| [cors.yaml](configs/security/cors.yaml) | CORS preflight handling with origin validation |
+| [conditional-skip-to.yaml](configs/branching/conditional-skip-to.yaml) | Skips browser-facing middleware for clean requests |
+| [conditional-terminal.yaml](configs/branching/conditional-terminal.yaml) | Short-circuits the pipeline when guardrails detects a dangerous request header |
+| [cross-chain-flat.yaml](configs/branching/cross-chain-flat.yaml) | A listener references two chains: preprocessing and routing |
+| [multiple-branches.yaml](configs/branching/multiple-branches.yaml) | Multiple branches on a single filter, evaluated in order |
+| [named-chain-ref.yaml](configs/branching/named-chain-ref.yaml) | A branch references a top-level chain by name instead of defining filters inline |
+| [nested-branches.yaml](configs/branching/nested-branches.yaml) | Branch filters that themselves contain branches, forming a multi-level decision tree |
+| [reentrance.yaml](configs/branching/reentrance.yaml) | Loops back to a named filter up to N times |
+| [unconditional-branch.yaml](configs/branching/unconditional-branch.yaml) | Always runs a utility chain before continuing the main pipeline |
 
 ### Observability
 
 | File | Description |
 | ------ | ------------- |
-| [access-logging.yaml](configs/observability/access-logging.yaml) | Access log with sampling |
-| [logging.yaml](configs/observability/logging.yaml) | request_id + access_log: correlation IDs and structured logs |
-| [tcp-access-log.yaml](configs/observability/tcp-access-log.yaml) | Structured JSON TCP connection logging |
+| [access-logging.yaml](configs/observability/access-logging.yaml) | Structured JSON logging with sampling; logs ~10% of requests. request_id ensures each log line has a correlation ID. access_log emits method, path, status, and timing |
+| [logging.yaml](configs/observability/logging.yaml) | request_id — ensures every request has a correlation ID |
+| [tcp-access-log.yaml](configs/observability/tcp-access-log.yaml) | Structured JSON logging of TCP connection events (connect and disconnect) |
 
-### Transformation
-
-| File | Description |
-| ------ | ------------- |
-| [header-manipulation.yaml](configs/transformation/header-manipulation.yaml) | Add, overwrite, and remove request/response headers |
-| [path-rewriting.yaml](configs/transformation/path-rewriting.yaml) | Strip prefix, add prefix, or regex replace on request paths |
-| [url-rewriting.yaml](configs/transformation/url-rewriting.yaml) | Regex path transformation and query string manipulation |
-
-### Protocols
+### Operations
 
 | File | Description |
 | ------ | ------------- |
-| [tcp-proxy.yaml](configs/protocols/tcp-proxy.yaml) | L4 bidirectional TCP forwarding |
-| [tcp-timeouts.yaml](configs/protocols/tcp-timeouts.yaml) | TCP proxy with idle and max duration timeouts |
-| [tcp-consistent-hash.yaml](configs/protocols/tcp-consistent-hash.yaml) | TCP load balancing with consistent-hash client IP affinity |
-| [tcp-least-connections.yaml](configs/protocols/tcp-least-connections.yaml) | TCP load balancing via least-connections strategy |
-| [tcp-round-robin.yaml](configs/protocols/tcp-round-robin.yaml) | TCP round-robin load balancing across replicas |
-| [mixed-protocol.yaml](configs/protocols/mixed-protocol.yaml) | HTTP + TCP listeners on one server |
-| [tls-termination.yaml](configs/protocols/tls-termination.yaml) | HTTPS listener; plain HTTP to backends |
-| [tls-cipher-suites.yaml](configs/protocols/tls-cipher-suites.yaml) | Restrict accepted TLS cipher suites per listener |
-| [tls-sni-routing.yaml](configs/protocols/tls-sni-routing.yaml) | Route TLS connections by SNI hostname without termination |
-| [tcp-tls-mtls.yaml](configs/protocols/tcp-tls-mtls.yaml) | TCP proxy with mutual TLS |
-| [tcp-tls-termination.yaml](configs/protocols/tcp-tls-termination.yaml) | TCP proxy with TLS termination |
-| [tls-http-reencrypt.yaml](configs/protocols/tls-http-reencrypt.yaml) | TLS termination with re-encryption to upstream |
-| [tls-mtls-both.yaml](configs/protocols/tls-mtls-both.yaml) | mTLS on both listener and upstream |
-| [tls-mtls-listener.yaml](configs/protocols/tls-mtls-listener.yaml) | mTLS on listener (require client cert) |
-| [tls-mtls-listener-request.yaml](configs/protocols/tls-mtls-listener-request.yaml) | mTLS on listener (request client cert) |
-| [tls-mtls-upstream.yaml](configs/protocols/tls-mtls-upstream.yaml) | mTLS to upstream (client cert) |
-| [tls-multi-cert.yaml](configs/protocols/tls-multi-cert.yaml) | SNI-based multi-certificate selection |
-| [tls-verify-disabled.yaml](configs/protocols/tls-verify-disabled.yaml) | Upstream TLS with verification disabled |
-| [tls-version-constraint.yaml](configs/protocols/tls-version-constraint.yaml) | Minimum TLS version constraint |
-| [upstream-ca-file.yaml](configs/protocols/upstream-ca-file.yaml) | Global upstream CA file reference |
-| [upstream-tls.yaml](configs/protocols/upstream-tls.yaml) | Plain HTTP listener; TLS to upstream with SNI |
-| [websocket.yaml](configs/protocols/websocket.yaml) | Transparent WebSocket upgrade proxying over HTTP |
+| [admin-interface.yaml](configs/operations/admin-interface.yaml) | Exposes an admin endpoint for operational health checks, readiness probes, and Prometheus metrics |
+| [container-default.yaml](configs/operations/container-default.yaml) | Default config for containerized deployments |
+| [hot-reload.yaml](configs/operations/hot-reload.yaml) | Filter pipelines are swapped atomically at runtime when the config file changes |
+| [log-overrides.yaml](configs/operations/log-overrides.yaml) | Use `runtime.log_overrides` to raise or lower log verbosity for specific modules without flooding output from every subsystem |
+| [max-connections.yaml](configs/operations/max-connections.yaml) | HTTP listeners return 503 with Retry-After: 1 |
+| [multi-listener.yaml](configs/operations/multi-listener.yaml) | Demonstrates multiple HTTP listeners, each with its own filter pipeline |
+| [production-gateway.yaml](configs/operations/production-gateway.yaml) | Combines TLS, logging, timeouts, security headers, path routing, and load balancing |
+
+### Payload Processing
+
+| File | Description |
+| ------ | ------------- |
+| [body-size-limit-with-extraction.yaml](configs/payload-processing/body-size-limit-with-extraction.yaml) | Combines body_limits.max_request_bytes with json_body_field to enforce a global body ceiling while still performing body-based routing |
+| [compression.yaml](configs/payload-processing/compression.yaml) | Enables transparent response compression using Pingora's built-in compression module |
+| [conditional-field-extraction.yaml](configs/payload-processing/conditional-field-extraction.yaml) | Uses the condition system to apply json_body_field only on specific request paths |
+| [field-extraction-access-control.yaml](configs/payload-processing/field-extraction-access-control.yaml) | Extracts the "tenant_id" field from the JSON request body and promotes it to an X-Tenant-Id header |
+| [mcp-static-catalog.yaml](configs/payload-processing/mcp-static-catalog.yaml) | Provides a static MCP catalog and broker for initialize, tools/list, ping, and notifications/initialized requests |
+| [multi-field-extraction.yaml](configs/payload-processing/multi-field-extraction.yaml) | A single json_body_field filter extracts multiple top-level JSON fields into separate request headers in one pass |
+| [multi-listener-body-pipeline.yaml](configs/payload-processing/multi-listener-body-pipeline.yaml) | Three listeners, each with a different body processing strategy |
+| [stream-buffer.yaml](configs/payload-processing/stream-buffer.yaml) | json_body_field inspects request body chunks as they arrive and defers upstream forwarding until the field is extracted (or end-of-stream) |
 
 ### Pipeline
 
 | File | Description |
 | ------ | ------------- |
 | [default.yaml](../core/src/config/default.yaml) | Built-in default config (static JSON on /) |
-| [composed-chains.yaml](configs/pipeline/composed-chains.yaml) | Multiple named chains composed per listener |
-| [conditional-filters.yaml](configs/pipeline/conditional-filters.yaml) | when/unless conditions on request and response phase |
-| [branch-chains.yaml](configs/pipeline/branch-chains.yaml) | All branch chain scenarios in one config (six patterns) |
-| [failure-mode.yaml](configs/pipeline/failure-mode.yaml) | Failure mode behavior (open continues, closed rejects on error) |
+| [branch-chains.yaml](configs/pipeline/branch-chains.yaml) | Filters write structured results to FilterResultSet |
+| [composed-chains.yaml](configs/pipeline/composed-chains.yaml) | Multiple named chains are composed per listener |
+| [conditional-filters.yaml](configs/pipeline/conditional-filters.yaml) | Filters support `conditions` (request phase) and `response_conditions` (response phase) to gate execution |
+| [failure-mode.yaml](configs/pipeline/failure-mode.yaml) | Demonstrates open and closed failure handling for filters |
 
-### AI / Inference
-
-| File | Description |
-| ------ | ------------- |
-| [a2a-classifier-routing.yaml](configs/ai/a2a-classifier-routing.yaml) | Route A2A requests by method, family, task ID, and streaming detection |
-| [a2a-task-routing.yaml](configs/ai/a2a-task-routing.yaml) | Local A2A task ownership routing from JSON responses |
-| [ai-inference-body-based-routing.yaml](configs/ai/ai-inference-body-based-routing.yaml) | Route LLM requests by model field in JSON body |
-| [credential-injection.yaml](configs/ai/credential-injection.yaml) | Inject per-cluster API credentials and strip client tokens |
-| [json-rpc-routing.yaml](configs/ai/json-rpc-routing.yaml) | Route JSON-RPC 2.0 requests by method for MCP and A2A protocols |
-| [mcp-classifier-routing.yaml](configs/ai/mcp-classifier-routing.yaml) | Route MCP requests by body-derived method and tool name |
-| [model-to-header-routing.yaml](configs/ai/model-to-header-routing.yaml) | Route by model field in JSON body via X-Model header |
-| [prompt-enrichment.yaml](configs/ai/prompt-enrichment.yaml) | Inject system messages into chat completion requests |
-| [full-flow.yaml](configs/ai/openai/responses/full-flow.yaml) | Full Responses API gateway flow |
-| [format-routing.yaml](configs/ai/openai/responses/format-routing.yaml) | Route by AI API format (Responses vs Chat Completions) |
-| [responses-routing.yaml](configs/ai/openai/responses/responses-routing.yaml) | Route Responses API by mode (stateless vs stateful) |
-| [request-validate.yaml](configs/ai/openai/responses/request-validate.yaml) | Validate Responses API requests and reject invalid parameter combinations |
-| [response-store.yaml](configs/ai/openai/responses/response-store.yaml) | Persist and retrieve responses via GET /v1/responses/{id} |
-
-### Branching
+### Protocols
 
 | File | Description |
 | ------ | ------------- |
-| [unconditional-branch.yaml](configs/branching/unconditional-branch.yaml) | Always-fire branch for injecting side-effect chains |
-| [conditional-terminal.yaml](configs/branching/conditional-terminal.yaml) | Short-circuit the pipeline with a static response on result match |
-| [conditional-skip-to.yaml](configs/branching/conditional-skip-to.yaml) | Skip filters by jumping to a named rejoin point on result match |
-| [multiple-branches.yaml](configs/branching/multiple-branches.yaml) | Multiple branches on one filter with first-match-wins evaluation |
-| [named-chain-ref.yaml](configs/branching/named-chain-ref.yaml) | Reference a top-level chain by name instead of inline definition |
-| [nested-branches.yaml](configs/branching/nested-branches.yaml) | Multi-level decision tree with branches inside branches |
-| [reentrance.yaml](configs/branching/reentrance.yaml) | Loop back to a named filter with max_iterations cap |
-| [cross-chain-flat.yaml](configs/branching/cross-chain-flat.yaml) | Branch across concatenated chains via flat pipeline name index |
+| [mixed-protocol.yaml](configs/protocols/mixed-protocol.yaml) | HTTP and TCP listeners run on a single server instance |
+| [tcp-consistent-hash.yaml](configs/protocols/tcp-consistent-hash.yaml) | TCP consistent-hash load balancing (client IP affinity) |
+| [tcp-least-connections.yaml](configs/protocols/tcp-least-connections.yaml) | TCP least-connections load balancing |
+| [tcp-proxy.yaml](configs/protocols/tcp-proxy.yaml) | Bidirectional TCP forwarding |
+| [tcp-round-robin.yaml](configs/protocols/tcp-round-robin.yaml) | TCP round-robin load balancing across database replicas |
+| [tcp-timeouts.yaml](configs/protocols/tcp-timeouts.yaml) | TCP proxy with session and max duration timeouts. `tcp_session_timeout_ms` wraps the entire TCP forwarding session in a hard deadline, terminating connections after the threshold regardless of activity. `tcp_max_duration_secs` caps the total session duration in seconds |
+| [tcp-tls-mtls.yaml](configs/protocols/tcp-tls-mtls.yaml) | The proxy requires TCP clients to present a valid TLS certificate signed by the trusted CA |
+| [tcp-tls-termination.yaml](configs/protocols/tcp-tls-termination.yaml) | TLS on the listener; plain TCP to the upstream backend |
+| [tls-cipher-suites.yaml](configs/protocols/tls-cipher-suites.yaml) | Restrict accepted cipher suites per listener |
+| [tls-http-reencrypt.yaml](configs/protocols/tls-http-reencrypt.yaml) | HTTPS on the listener; TLS to the upstream backend |
+| [tls-mtls-both.yaml](configs/protocols/tls-mtls-both.yaml) | Client mTLS to the proxy (client cert required), and proxy mTLS to the upstream backend (proxy presents its own client certificate) |
+| [tls-mtls-listener-request.yaml](configs/protocols/tls-mtls-listener-request.yaml) | The proxy requests a client certificate but does not require one |
+| [tls-mtls-listener.yaml](configs/protocols/tls-mtls-listener.yaml) | The proxy requires clients to present a valid TLS certificate signed by the trusted CA |
+| [tls-mtls-upstream.yaml](configs/protocols/tls-mtls-upstream.yaml) | Plain HTTP from clients; the proxy presents a client certificate to the upstream backend, which requires mutual TLS authentication |
+| [tls-multi-cert.yaml](configs/protocols/tls-multi-cert.yaml) | Multiple certificates on one listener; Praxis selects the certificate matching the client's SNI hostname |
+| [tls-sni-routing.yaml](configs/protocols/tls-sni-routing.yaml) | Routes TLS connections to different upstreams based on the Server Name Indication (SNI) hostname in the ClientHello |
+| [tls-termination.yaml](configs/protocols/tls-termination.yaml) | HTTPS on the listener; plain HTTP to the backend |
+| [tls-verify-disabled.yaml](configs/protocols/tls-verify-disabled.yaml) | Plain HTTP listener; TLS to the upstream with certificate verification disabled |
+| [tls-version-constraint.yaml](configs/protocols/tls-version-constraint.yaml) | Restrict accepted TLS versions via `min_version` |
+| [upstream-ca-file.yaml](configs/protocols/upstream-ca-file.yaml) | Sets a trusted CA bundle for all upstream TLS connections via `runtime.upstream_ca_file` |
+| [upstream-tls.yaml](configs/protocols/upstream-tls.yaml) | Plain HTTP on the listener; TLS to the upstream |
+| [websocket.yaml](configs/protocols/websocket.yaml) | HTTP listener that transparently proxies WebSocket upgrade requests |
 
-### Operations
+### Security
 
 | File | Description |
 | ------ | ------------- |
-| [production-gateway.yaml](configs/operations/production-gateway.yaml) | Full production setup with composed chains |
-| [multi-listener.yaml](configs/operations/multi-listener.yaml) | Multiple listeners sharing a filter chain |
-| [hot-reload.yaml](configs/operations/hot-reload.yaml) | Dynamic config reload without restart |
-| [admin-interface.yaml](configs/operations/admin-interface.yaml) | Admin interface with health endpoints |
-| [container-default.yaml](configs/operations/container-default.yaml) | Default containerized deployment with public binding |
-| [max-connections.yaml](configs/operations/max-connections.yaml) | Per-listener connection limit with 503 rejection |
-| [log-overrides.yaml](configs/operations/log-overrides.yaml) | Per-module log level tuning via runtime config |
+| [cors.yaml](configs/security/cors.yaml) | Spec-compliant CORS filter with preflight handling, origin validation, and credential support |
+| [csrf.yaml](configs/security/csrf.yaml) | Cross-site request forgery protection via origin validation |
+| [downstream-read-timeout.yaml](configs/security/downstream-read-timeout.yaml) | Protects against slow client attacks by limiting how long the proxy waits for data from downstream clients |
+| [forwarded-headers.yaml](configs/security/forwarded-headers.yaml) | Injects X-Forwarded-For, X-Forwarded-Proto, and X-Forwarded-Host into upstream requests |
+| [guardrails.yaml](configs/security/guardrails.yaml) | Reject requests that match header or body inspection rules |
+| [ip-acl.yaml](configs/security/ip-acl.yaml) | Allow or deny requests by source IP/CIDR |
+
+### Traffic Management
+
+| File | Description |
+| ------ | ------------- |
+| [basic-reverse-proxy.yaml](configs/traffic-management/basic-reverse-proxy.yaml) | Minimal config: one listener, one upstream, default filter chain |
+| [canary-routing.yaml](configs/traffic-management/canary-routing.yaml) | Sends ~10% of traffic to a canary backend while the stable backend handles the remaining ~90% |
+| [circuit-breaker.yaml](configs/traffic-management/circuit-breaker.yaml) | Prevents cascading failures by tracking consecutive upstream errors per cluster |
+| [grpc-detection.yaml](configs/traffic-management/grpc-detection.yaml) | Detects gRPC requests from the content-type header and promotes the variant to filter metadata and results |
+| [health-checks.yaml](configs/traffic-management/health-checks.yaml) | Per-cluster health checks probe endpoints on a timer and remove unhealthy backends from the load balancer rotation |
+| [hostname-upstream.yaml](configs/traffic-management/hostname-upstream.yaml) | Demonstrates using DNS hostnames instead of IP addresses for upstream endpoints |
+| [hosts.yaml](configs/traffic-management/hosts.yaml) | One listener serves multiple domains |
+| [least-connections.yaml](configs/traffic-management/least-connections.yaml) | Routes each request to the backend with the fewest in-flight requests |
+| [p2c.yaml](configs/traffic-management/p2c.yaml) | Samples two random endpoints and picks the one with fewer in-flight requests |
+| [path-based-routing.yaml](configs/traffic-management/path-based-routing.yaml) | Routes by URL path prefix |
+| [rate-limiting.yaml](configs/traffic-management/rate-limiting.yaml) | Token bucket rate limiter with per-IP or global modes |
+| [redirect.yaml](configs/traffic-management/redirect.yaml) | Returns a 3xx redirect without contacting any upstream |
+| [round-robin.yaml](configs/traffic-management/round-robin.yaml) | Default strategy |
+| [session-affinity.yaml](configs/traffic-management/session-affinity.yaml) | Hashes a request header to pin a user's requests to one backend |
+| [static-response.yaml](configs/traffic-management/static-response.yaml) | Returns a fixed response without contacting any upstream |
+| [timeout.yaml](configs/traffic-management/timeout.yaml) | Returns 504 if the upstream takes longer than timeout_ms to respond |
+| [weighted-load-balancing.yaml](configs/traffic-management/weighted-load-balancing.yaml) | Traffic split proportional to per-endpoint weights |
+
+### Transformation
+
+| File | Description |
+| ------ | ------------- |
+| [header-manipulation.yaml](configs/transformation/header-manipulation.yaml) | Add, overwrite, and remove headers on requests and responses |
+| [path-rewriting.yaml](configs/transformation/path-rewriting.yaml) | Rewrite request paths before forwarding to upstream |
+| [url-rewriting.yaml](configs/transformation/url-rewriting.yaml) | Regex-based path transformation and query string manipulation |

--- a/examples/configs/ai/openai/responses/request-validate.yaml
+++ b/examples/configs/ai/openai/responses/request-validate.yaml
@@ -1,5 +1,8 @@
 # Responses API Request Validation
 #
+# Validates Responses API requests and rejects invalid parameter
+# combinations.
+#
 # Requires the ai-inference feature:
 #   cargo build -p praxis --features ai-inference
 #

--- a/examples/configs/payload-processing/mcp-static-catalog.yaml
+++ b/examples/configs/payload-processing/mcp-static-catalog.yaml
@@ -1,4 +1,7 @@
-# Praxis MCP static catalog and broker; tools/call routing follows in a later PR
+# MCP Static Catalog
+#
+# Provides a static MCP catalog and broker for initialize,
+# tools/list, ping, and notifications/initialized requests.
 #
 # Pipeline: mcp -> load_balancer (no router).
 # Praxis short-circuits initialize, tools/list, ping,

--- a/examples/configs/pipeline/failure-mode.yaml
+++ b/examples/configs/pipeline/failure-mode.yaml
@@ -1,5 +1,7 @@
 # Per-Filter Failure Mode
 #
+# Demonstrates open and closed failure handling for filters.
+#
 # Each filter can specify `failure_mode` to control what happens when
 # the filter returns an error:
 #

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -20,6 +20,7 @@ mod echo;
 mod lint_deps;
 mod lint_example_tests;
 mod port;
+mod sync_example_readme;
 
 use clap::{Parser, Subcommand};
 
@@ -57,6 +58,10 @@ enum Command {
     /// Check that every example config has a corresponding
     /// integration test.
     LintExampleTests(lint_example_tests::Args),
+
+    /// Verify or regenerate the `examples/README.md` table
+    /// from YAML config header comments.
+    SyncExampleReadme(sync_example_readme::Args),
 }
 
 // -----------------------------------------------------------------------------
@@ -72,6 +77,7 @@ fn main() {
         Command::Benchmark(args) => benchmark::run(*args),
         Command::LintDeps(args) => lint_deps::run(args),
         Command::LintExampleTests(args) => lint_example_tests::run(args),
+        Command::SyncExampleReadme(args) => sync_example_readme::run(&args),
     }
 }
 

--- a/xtask/src/sync_example_readme.rs
+++ b/xtask/src/sync_example_readme.rs
@@ -1,0 +1,546 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! `cargo xtask sync-example-readme` generates the table section of
+//! `examples/README.md` from YAML config header comments.
+
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+};
+
+use clap::Parser;
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Title overrides for category directories whose display name cannot be
+/// derived by simple title-casing. All other directories are converted
+/// automatically (e.g. `"traffic-management"` → `"Traffic Management"`).
+const TITLE_OVERRIDES: &[(&str, &str)] = &[("ai", "AI / Inference")];
+
+/// Comment-line prefixes that begin a non-description block. Paragraphs
+/// whose first line starts with any of these are skipped during description
+/// extraction.
+const SKIP_PREFIXES: &[&str] = &[
+    "Backend endpoints ",
+    "Example:",
+    "Flow:",
+    "Pipeline:",
+    "Requires ",
+    "Test:",
+    "Try it:",
+    "Usage:",
+    "What reloads ",
+    "What requires ",
+];
+
+/// Entries that live outside `examples/configs/` but belong in the README.
+/// `(category, filename, link_path, description)`.
+const SPECIAL_ENTRIES: &[(&str, &str, &str, &str)] = &[(
+    "pipeline",
+    "default.yaml",
+    "../core/src/config/default.yaml",
+    "Built-in default config (static JSON on /)",
+)];
+
+/// Marker line that separates the hand-maintained header from the
+/// auto-generated tables.
+const CONFIGS_MARKER: &str = "## Configs\n";
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+/// CLI arguments for `cargo xtask sync-example-readme`.
+#[derive(Parser)]
+pub(crate) struct Args {
+    /// Write the generated tables instead of checking for drift.
+    #[arg(long)]
+    fix: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Entry Point
+// ---------------------------------------------------------------------------
+
+/// Verify or regenerate the table section of `examples/README.md`.
+pub(crate) fn run(args: &Args) {
+    let root = workspace_root();
+    let readme_path = root.join("examples/README.md");
+    let configs_dir = root.join("examples/configs");
+
+    let categories = discover_categories(&configs_dir);
+    let entries = collect_entries(&configs_dir);
+    let new_tables = generate_tables(&categories, &entries);
+
+    let current = std::fs::read_to_string(&readme_path).unwrap_or_default();
+    let (header, current_tables) = split_at_marker(&current);
+
+    if args.fix {
+        let output = format!("{header}{new_tables}");
+        std::fs::write(&readme_path, &output).unwrap();
+        println!("wrote {}", readme_path.display());
+        return;
+    }
+
+    if current_tables == new_tables {
+        println!("examples/README.md tables are up to date");
+    } else {
+        eprintln!("examples/README.md tables are out of date");
+        eprintln!("run `cargo xtask sync-example-readme --fix` to regenerate");
+        std::process::exit(1);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Private Types
+// ---------------------------------------------------------------------------
+
+/// A parsed example config entry for the README table.
+struct ExampleEntry {
+    /// One-line description extracted from the header comment.
+    description: String,
+    /// Filename only (e.g. `full-flow.yaml`).
+    filename: String,
+    /// Relative link path from `examples/` (e.g. `configs/ai/full-flow.yaml`).
+    link_path: String,
+}
+
+// ---------------------------------------------------------------------------
+// Collection
+// ---------------------------------------------------------------------------
+
+/// Discover category directories under `configs_dir` and derive display
+/// titles. Returns `(dir_name, title)` pairs sorted alphabetically.
+fn discover_categories(configs_dir: &Path) -> Vec<(String, String)> {
+    let Ok(entries) = std::fs::read_dir(configs_dir) else {
+        return Vec::new();
+    };
+    let mut categories: Vec<(String, String)> = entries
+        .flatten()
+        .filter(|e| e.path().is_dir())
+        .map(|e| {
+            let name = e.file_name().to_string_lossy().into_owned();
+            let title = category_title(&name);
+            (name, title)
+        })
+        .collect();
+    categories.sort();
+    categories
+}
+
+/// Derive a display title from a directory name. Checks [`TITLE_OVERRIDES`]
+/// first, then falls back to title-casing each hyphen-separated word.
+fn category_title(dir_name: &str) -> String {
+    if let Some((_, title)) = TITLE_OVERRIDES.iter().find(|(d, _)| *d == dir_name) {
+        return (*title).to_owned();
+    }
+    dir_name
+        .split('-')
+        .map(|word| {
+            let mut chars = word.chars();
+            match chars.next() {
+                Some(c) => {
+                    let upper: String = c.to_uppercase().collect();
+                    format!("{upper}{rest}", rest = chars.as_str())
+                },
+                None => String::new(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Collect all example config entries grouped by category directory.
+fn collect_entries(configs_dir: &Path) -> BTreeMap<String, Vec<ExampleEntry>> {
+    let mut by_category: BTreeMap<String, Vec<ExampleEntry>> = BTreeMap::new();
+
+    let mut paths = Vec::new();
+    walk_yaml(configs_dir, &mut paths);
+    paths.sort();
+
+    for path in &paths {
+        let rel = path.strip_prefix(configs_dir).unwrap();
+        let category = rel
+            .components()
+            .next()
+            .unwrap()
+            .as_os_str()
+            .to_string_lossy()
+            .into_owned();
+
+        let filename = path.file_name().unwrap().to_string_lossy().into_owned();
+        let link_path = format!("configs/{}", rel.to_string_lossy());
+        let description = extract_description(path);
+
+        by_category.entry(category).or_default().push(ExampleEntry {
+            description,
+            filename,
+            link_path,
+        });
+    }
+
+    by_category
+}
+
+/// Recursively find all `.yaml` files under `dir`.
+fn walk_yaml(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            walk_yaml(&path, out);
+        } else if path.extension().is_some_and(|e| e == "yaml") {
+            out.push(path);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Generation
+// ---------------------------------------------------------------------------
+
+/// Render the table section (everything after `## Configs`).
+fn generate_tables(categories: &[(String, String)], entries: &BTreeMap<String, Vec<ExampleEntry>>) -> String {
+    let mut out = String::new();
+
+    for (dir_name, section_title) in categories {
+        let Some(items) = entries.get(dir_name.as_str()) else {
+            continue;
+        };
+
+        out.push_str(&format!("\n### {section_title}\n\n"));
+        out.push_str("| File | Description |\n");
+        out.push_str("| ------ | ------------- |\n");
+
+        for (cat, fname, path, desc) in SPECIAL_ENTRIES {
+            if *cat == dir_name.as_str() {
+                out.push_str(&format!("| [{fname}]({path}) | {desc} |\n"));
+            }
+        }
+
+        for e in items {
+            out.push_str(&format!("| [{}]({}) | {} |\n", e.filename, e.link_path, e.description));
+        }
+    }
+
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Description Extraction
+// ---------------------------------------------------------------------------
+
+/// Extract a one-line description from a YAML file's header comments.
+fn extract_description(path: &Path) -> String {
+    let content = std::fs::read_to_string(path).unwrap();
+    description_from_header(&content)
+}
+
+/// Core extraction logic, separated for testability.
+///
+/// Parses the leading comment block into paragraphs, skips the title and
+/// any `Requires`/`Usage`/etc. blocks, and returns the first sentence of
+/// the first remaining paragraph. Falls back to the title when no
+/// description paragraph exists.
+fn description_from_header(content: &str) -> String {
+    let paragraphs = parse_comment_paragraphs(content);
+
+    let desc = paragraphs.iter().skip(1).find(|p| !is_skip_paragraph(p));
+
+    let text = match desc {
+        Some(para) => para.join(" "),
+        None => match paragraphs.first() {
+            Some(title) => title.join(" "),
+            None => return String::new(),
+        },
+    };
+
+    normalize_description(&first_sentence(&text))
+}
+
+/// Parse the leading comment block into paragraphs separated by blank
+/// comment lines (`#` with no text).
+fn parse_comment_paragraphs(content: &str) -> Vec<Vec<String>> {
+    let mut paragraphs: Vec<Vec<String>> = Vec::new();
+    let mut current: Vec<String> = Vec::new();
+
+    for line in content.lines() {
+        if let Some(rest) = line.strip_prefix('#') {
+            let text = rest.strip_prefix(' ').unwrap_or(rest);
+            if text.is_empty() {
+                if !current.is_empty() {
+                    paragraphs.push(std::mem::take(&mut current));
+                }
+            } else if !text.starts_with("  ") {
+                current.push(text.to_owned());
+            }
+        } else {
+            break;
+        }
+    }
+
+    if !current.is_empty() {
+        paragraphs.push(current);
+    }
+
+    paragraphs
+}
+
+/// Return `true` if the paragraph starts with a non-description prefix.
+fn is_skip_paragraph(para: &[String]) -> bool {
+    para.first()
+        .is_some_and(|first| SKIP_PREFIXES.iter().any(|prefix| first.starts_with(prefix)) || first.ends_with(':'))
+}
+
+/// Extract the first sentence from `s`. A sentence boundary is a period
+/// followed by a space and an uppercase letter, or a period at end of string.
+fn first_sentence(s: &str) -> String {
+    let s = s.trim();
+    let bytes = s.as_bytes();
+
+    for (i, &b) in bytes.iter().enumerate() {
+        if b != b'.' {
+            continue;
+        }
+        if i + 1 == bytes.len() {
+            return s[..i].to_owned();
+        }
+        if bytes.get(i + 1) == Some(&b' ') && bytes.get(i + 2).is_some_and(u8::is_ascii_uppercase) {
+            return s[..i].to_owned();
+        }
+    }
+
+    s.to_owned()
+}
+
+/// Normalize a generated table description.
+fn normalize_description(s: &str) -> String {
+    s.trim().trim_end_matches(['.', ':']).trim_end().to_owned()
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Split README content at the `## Configs` marker, returning the header
+/// (including the marker line) and the table section.
+fn split_at_marker(content: &str) -> (&str, &str) {
+    if let Some(pos) = content.find(CONFIGS_MARKER) {
+        let split = pos + CONFIGS_MARKER.len();
+        (&content[..split], &content[split..])
+    } else {
+        (content, "")
+    }
+}
+
+/// Locate the workspace root directory.
+fn workspace_root() -> PathBuf {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_owned());
+    Path::new(&manifest_dir)
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .to_owned()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::indexing_slicing, reason = "tests assert lengths before indexing")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn standard_header_parsed() {
+        let input = "\
+# Title Here
+#
+# Description line one
+# and line two.
+#
+# Usage:
+#   cargo run
+listeners:
+";
+        let paras = parse_comment_paragraphs(input);
+        assert_eq!(paras.len(), 3, "expected title + desc + usage paragraphs");
+        assert_eq!(paras[0], vec!["Title Here"]);
+        assert_eq!(paras[1], vec!["Description line one", "and line two."]);
+    }
+
+    #[test]
+    fn single_line_header_parsed() {
+        let input = "\
+# One-liner description.
+listeners:
+";
+        let paras = parse_comment_paragraphs(input);
+        assert_eq!(paras.len(), 1, "expected single paragraph");
+        assert_eq!(paras[0], vec!["One-liner description."]);
+    }
+
+    #[test]
+    fn requires_block_skipped() {
+        let input = "\
+# Title
+#
+# Requires the ai-inference feature:
+#   cargo build --features ai-inference
+#
+# Real description here.
+";
+        let desc = description_from_header(input);
+        assert_eq!(desc, "Real description here");
+    }
+
+    #[test]
+    fn placeholder_block_skipped() {
+        let input = "\
+# Static Catalog
+#
+# Pipeline: mcp -> load_balancer.
+#
+# Backend endpoints are placeholders for a future flow.
+";
+        let desc = description_from_header(input);
+        assert_eq!(desc, "Static Catalog");
+    }
+
+    #[test]
+    fn colon_intro_block_skipped() {
+        let input = "\
+# Failure Mode
+#
+# Each filter can specify `failure_mode` to control what happens:
+#
+# Demonstrates open and closed behavior.
+";
+        let desc = description_from_header(input);
+        assert_eq!(desc, "Demonstrates open and closed behavior");
+    }
+
+    #[test]
+    fn fallback_to_title() {
+        let input = "\
+# TCP round-robin load balancing across replicas.
+listeners:
+";
+        let desc = description_from_header(input);
+        assert_eq!(desc, "TCP round-robin load balancing across replicas");
+    }
+
+    #[test]
+    fn multi_sentence_takes_first() {
+        let input = "\
+# Title
+#
+# First sentence. Second sentence.
+";
+        let desc = description_from_header(input);
+        assert_eq!(desc, "First sentence");
+    }
+
+    #[test]
+    fn first_sentence_strips_trailing_period() {
+        assert_eq!(first_sentence("Hello world."), "Hello world");
+    }
+
+    #[test]
+    fn normalize_description_strips_trailing_colon() {
+        assert_eq!(normalize_description("Hello world:"), "Hello world");
+    }
+
+    #[test]
+    fn first_sentence_multi_sentences() {
+        assert_eq!(first_sentence("First sentence. Second sentence."), "First sentence");
+    }
+
+    #[test]
+    fn first_sentence_no_period() {
+        assert_eq!(first_sentence("No period here"), "No period here");
+    }
+
+    #[test]
+    fn first_sentence_preserves_version_numbers() {
+        assert_eq!(
+            first_sentence("Supports version 1.0 and 2.0 formats."),
+            "Supports version 1.0 and 2.0 formats"
+        );
+    }
+
+    #[test]
+    fn first_sentence_preserves_abbreviations() {
+        assert_eq!(first_sentence("e.g. this is an example."), "e.g. this is an example");
+    }
+
+    #[test]
+    fn skip_prefixes_are_sorted() {
+        let mut sorted = SKIP_PREFIXES.to_vec();
+        sorted.sort_unstable();
+        assert_eq!(SKIP_PREFIXES, sorted.as_slice(), "SKIP_PREFIXES must be sorted");
+    }
+
+    #[test]
+    fn title_from_hyphenated_dir() {
+        assert_eq!(category_title("traffic-management"), "Traffic Management");
+        assert_eq!(category_title("payload-processing"), "Payload Processing");
+    }
+
+    #[test]
+    fn title_from_single_word_dir() {
+        assert_eq!(category_title("security"), "Security");
+        assert_eq!(category_title("protocols"), "Protocols");
+    }
+
+    #[test]
+    fn title_override_applied() {
+        assert_eq!(category_title("ai"), "AI / Inference");
+    }
+
+    #[test]
+    fn split_at_marker_found() {
+        let content = "# Header\n\n## Configs\nsome tables\n";
+        let (header, tables) = split_at_marker(content);
+        assert_eq!(header, "# Header\n\n## Configs\n");
+        assert_eq!(tables, "some tables\n");
+    }
+
+    #[test]
+    fn split_at_marker_not_found() {
+        let content = "# No configs section\n";
+        let (header, tables) = split_at_marker(content);
+        assert_eq!(header, "# No configs section\n");
+        assert_eq!(tables, "");
+    }
+
+    #[test]
+    fn discover_finds_real_categories() {
+        let root = workspace_root();
+        let categories = discover_categories(&root.join("examples/configs"));
+        assert!(
+            categories.len() > 5,
+            "expected 5+ categories, found {}",
+            categories.len()
+        );
+        assert!(
+            categories.iter().any(|(d, _)| d == "ai"),
+            "ai category should be discovered"
+        );
+    }
+
+    #[test]
+    fn collect_finds_real_configs() {
+        let root = workspace_root();
+        let entries = collect_entries(&root.join("examples/configs"));
+        assert!(
+            entries.values().map(Vec::len).sum::<usize>() > 50,
+            "expected 50+ configs"
+        );
+    }
+}

--- a/xtask/src/sync_example_readme.rs
+++ b/xtask/src/sync_example_readme.rs
@@ -264,7 +264,8 @@ fn description_from_header(content: &str) -> String {
 }
 
 /// Parse the leading comment block into paragraphs separated by blank
-/// comment lines (`#` with no text).
+/// comment lines (`#` with no text). Lines indented by two or more spaces
+/// (after `# `) are skipped to exclude embedded code examples.
 fn parse_comment_paragraphs(content: &str) -> Vec<Vec<String>> {
     let mut paragraphs: Vec<Vec<String>> = Vec::new();
     let mut current: Vec<String> = Vec::new();
@@ -299,12 +300,17 @@ fn is_skip_paragraph(para: &[String]) -> bool {
 
 /// Extract the first sentence from `s`. A sentence boundary is a period
 /// followed by a space and an uppercase letter, or a period at end of string.
+/// Periods immediately preceded by a digit are not treated as sentence
+/// endings to avoid splitting on decimals (e.g. `"Retry-After: 1. TCP …"`).
 fn first_sentence(s: &str) -> String {
     let s = s.trim();
     let bytes = s.as_bytes();
 
     for (i, &b) in bytes.iter().enumerate() {
         if b != b'.' {
+            continue;
+        }
+        if bytes.get(i.wrapping_sub(1)).is_some_and(u8::is_ascii_digit) {
             continue;
         }
         if i + 1 == bytes.len() {
@@ -340,7 +346,7 @@ fn split_at_marker(content: &str) -> (&str, &str) {
 
 /// Locate the workspace root directory.
 fn workspace_root() -> PathBuf {
-    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_owned());
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set — run via `cargo xtask`");
     Path::new(&manifest_dir)
         .parent()
         .unwrap_or_else(|| Path::new("."))
@@ -477,6 +483,14 @@ listeners:
     #[test]
     fn first_sentence_preserves_abbreviations() {
         assert_eq!(first_sentence("e.g. this is an example."), "e.g. this is an example");
+    }
+
+    #[test]
+    fn first_sentence_skips_decimal_boundary() {
+        assert_eq!(
+            first_sentence("Returns 503 with Retry-After: 1. TCP listeners close immediately."),
+            "Returns 503 with Retry-After: 1. TCP listeners close immediately"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add `cargo xtask sync-example-readme` that scans `examples/configs/`, discovers category directories dynamically, extracts descriptions from YAML header comments, and generates the README table section. Only `"ai" → "AI / Inference"` needs a title override; all other categories are title-cased automatically from directory names.
- Wire the check into `make lint` (and transitively into the pre-commit hook) so missing or stale README entries fail CI. Run `--fix` to regenerate.
- Improve header comments in three example configs (`request-validate`, `mcp-static-catalog`, `failure-mode`) that had poor or missing description blocks.
- Update CLAUDE.md to document the expected YAML header format and replace manual README update steps with the xtask command.

## Test plan

- [x] `cargo test -p xtask` — 49 tests pass (18 for sync_example_readme)
- [x] `cargo xtask sync-example-readme` — check mode passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo +nightly fmt --all -- --check` — clean