### PR TITLE
feat(filter): add ResponsesState for cross-phase Responses API state

### DIFF
--- a/filter/src/builtins/http/ai/openai/responses/mod.rs
+++ b/filter/src/builtins/http/ai/openai/responses/mod.rs
@@ -21,8 +21,9 @@ mod config;
 #[expect(clippy::allow_attributes, reason = "dead_code expect unfulfilled on modules")]
 #[allow(
     dead_code,
-    reason = "store utilities for GET (#458) and DELETE (#459) response endpoints"
+    reason = "state infrastructure for upcoming Responses API filter consumers (#354)"
 )]
+pub(crate) mod state;
 pub(crate) mod store;
 
 pub use store::ResponseStoreFilter;

--- a/filter/src/builtins/http/ai/openai/responses/state.rs
+++ b/filter/src/builtins/http/ai/openai/responses/state.rs
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Request-scoped state for the Responses API filter set.
+//!
+//! [`ResponsesState`] is stored in [`RequestExtensions`] and shared
+//! across filter phases. It holds the heavy data needed by the
+//! validate → rehydrate → `tool_parse` → `responses_proxy` →
+//! `stream_events` → `tool_dispatch` pipeline.
+//!
+//! [`RequestExtensions`]: crate::extensions::RequestExtensions
+
+/// Request-scoped state shared across Responses API filters.
+///
+/// Stored in [`RequestExtensions`] by the validate filter and read
+/// or mutated by subsequent filters. Uses [`serde_json::Value`] for
+/// flexibility while the Responses API types stabilize; can be
+/// refactored to typed structs later without affecting external
+/// callers.
+///
+/// [`RequestExtensions`]: crate::extensions::RequestExtensions
+pub(crate) struct ResponsesState {
+    /// Current agentic loop iteration (0-indexed). Incremented by
+    /// `tool_dispatch` at the start of each new inference round.
+    pub iteration: u32,
+
+    /// Full accumulated conversation history across all turns.
+    ///
+    /// When `previous_response_id` is set, `rehydrate` fetches the
+    /// stored history and writes the complete message sequence here.
+    /// When no previous response exists, contains only the current
+    /// request's input. `responses_proxy` reads this as the
+    /// authoritative conversation to send to the backend.
+    pub messages: Vec<serde_json::Value>,
+
+    /// Output items accumulated across the current response.
+    pub output_items: Vec<serde_json::Value>,
+
+    /// Parsed request body as received from the client.
+    pub request_body: serde_json::Value,
+
+    /// The constructed response object for the current iteration.
+    pub response_object: serde_json::Value,
+
+    /// Tool calls from the current inference response only.
+    ///
+    /// Cleared by `tool_dispatch` at the start of each iteration
+    /// before `stream_events` writes new ones. Without explicit
+    /// clearing, stale tool calls from a previous iteration cause
+    /// duplicate dispatch.
+    pub tool_calls: Vec<serde_json::Value>,
+
+    /// Tool choice setting. Reset to `"auto"` by `tool_dispatch`
+    /// after the first iteration; the original value from the
+    /// request only applies to the first inference call.
+    pub tool_choice: serde_json::Value,
+
+    /// Processed tool definitions from the request.
+    pub tools: Vec<serde_json::Value>,
+
+    /// Token usage accumulated across all iterations within the
+    /// request. `stream_events` merges per-iteration usage into
+    /// the running total.
+    pub usage: serde_json::Value,
+}
+
+impl ResponsesState {
+    /// Create initial state from a parsed request body.
+    pub(crate) fn from_request_body(body: serde_json::Value) -> Self {
+        let messages = normalize_input(&body);
+        let tools = extract_array_field(&body, "tools");
+        let tool_choice = body
+            .get("tool_choice")
+            .cloned()
+            .unwrap_or_else(|| serde_json::Value::String("auto".to_owned()));
+
+        Self {
+            iteration: 0,
+            messages,
+            output_items: Vec::new(),
+            request_body: body,
+            response_object: serde_json::Value::Null,
+            tool_calls: Vec::new(),
+            tool_choice,
+            tools,
+            usage: serde_json::Value::Null,
+        }
+    }
+}
+
+/// Normalize the `input` field into a message array.
+///
+/// The Responses API `input` can be a string (single user message)
+/// or an array of message objects. Normalizes both forms to a
+/// `Vec<Value>`.
+fn normalize_input(body: &serde_json::Value) -> Vec<serde_json::Value> {
+    match body.get("input") {
+        Some(serde_json::Value::Array(arr)) => arr.clone(),
+        Some(serde_json::Value::String(s)) => {
+            vec![serde_json::json!({
+                "type": "message",
+                "role": "user",
+                "content": s,
+            })]
+        },
+        _ => Vec::new(),
+    }
+}
+
+/// Extract a JSON array field by name, defaulting to empty.
+fn extract_array_field(body: &serde_json::Value, field: &str) -> Vec<serde_json::Value> {
+    body.get(field)
+        .and_then(serde_json::Value::as_array)
+        .cloned()
+        .unwrap_or_default()
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    reason = "tests"
+)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn from_request_body_extracts_string_input() {
+        let body = json!({
+            "model": "gpt-4o",
+            "input": "Hello, world!"
+        });
+        let state = ResponsesState::from_request_body(body);
+        assert_eq!(state.messages.len(), 1, "string input should produce one message");
+        assert_eq!(
+            state.messages[0]["role"], "user",
+            "string input should default to user role"
+        );
+        assert_eq!(
+            state.messages[0]["type"], "message",
+            "string input should produce a Responses message item"
+        );
+        assert_eq!(state.messages[0]["content"], "Hello, world!");
+    }
+
+    #[test]
+    fn from_request_body_extracts_array_input() {
+        let body = json!({
+            "model": "gpt-4o",
+            "input": [
+                {"role": "user", "content": "first"},
+                {"role": "assistant", "content": "second"}
+            ]
+        });
+        let state = ResponsesState::from_request_body(body);
+        assert_eq!(state.messages.len(), 2, "array input should preserve all messages");
+    }
+
+    #[test]
+    fn from_request_body_empty_input() {
+        let body = json!({"model": "gpt-4o"});
+        let state = ResponsesState::from_request_body(body);
+        assert!(state.messages.is_empty(), "missing input should produce empty messages");
+    }
+
+    #[test]
+    fn from_request_body_extracts_tools() {
+        let body = json!({
+            "model": "gpt-4o",
+            "input": "test",
+            "tools": [{"type": "function", "name": "get_weather"}]
+        });
+        let state = ResponsesState::from_request_body(body);
+        assert_eq!(state.tools.len(), 1, "should extract one tool");
+    }
+
+    #[test]
+    fn from_request_body_default_tool_choice() {
+        let body = json!({"model": "gpt-4o", "input": "test"});
+        let state = ResponsesState::from_request_body(body);
+        assert_eq!(state.tool_choice, json!("auto"), "default tool_choice should be auto");
+    }
+
+    #[test]
+    fn from_request_body_explicit_tool_choice() {
+        let body = json!({
+            "model": "gpt-4o",
+            "input": "test",
+            "tool_choice": "required"
+        });
+        let state = ResponsesState::from_request_body(body);
+        assert_eq!(
+            state.tool_choice,
+            json!("required"),
+            "should preserve explicit tool_choice"
+        );
+    }
+
+    #[test]
+    fn initial_state_has_zero_iteration() {
+        let body = json!({"model": "gpt-4o", "input": "test"});
+        let state = ResponsesState::from_request_body(body);
+        assert_eq!(state.iteration, 0, "initial iteration should be 0");
+    }
+
+    #[test]
+    fn initial_state_has_empty_tool_calls() {
+        let body = json!({"model": "gpt-4o", "input": "test"});
+        let state = ResponsesState::from_request_body(body);
+        assert!(state.tool_calls.is_empty(), "initial tool_calls should be empty");
+    }
+
+    #[test]
+    fn initial_state_has_null_usage() {
+        let body = json!({"model": "gpt-4o", "input": "test"});
+        let state = ResponsesState::from_request_body(body);
+        assert!(state.usage.is_null(), "initial usage should be null");
+    }
+
+    #[test]
+    fn request_body_is_preserved() {
+        let body = json!({"model": "gpt-4o", "input": "hello", "temperature": 0.7});
+        let state = ResponsesState::from_request_body(body.clone());
+        assert_eq!(state.request_body, body, "original request body should be preserved");
+    }
+}

--- a/filter/src/builtins/http/ai/openai/responses/state.rs
+++ b/filter/src/builtins/http/ai/openai/responses/state.rs
@@ -20,17 +20,24 @@
 ///
 /// [`RequestExtensions`]: crate::extensions::RequestExtensions
 pub(crate) struct ResponsesState {
+    /// The current request's input items, immutable after construction.
+    ///
+    /// Preserved as-is so downstream filters can inspect what the
+    /// client actually sent, independent of conversation history
+    /// resolved by `rehydrate`.
+    pub input: Vec<serde_json::Value>,
+
     /// Current agentic loop iteration (0-indexed). Incremented by
     /// `tool_dispatch` at the start of each new inference round.
     pub iteration: u32,
 
-    /// Full accumulated conversation history across all turns.
+    /// Resolved conversation history sent to the backend.
     ///
-    /// When `previous_response_id` is set, `rehydrate` fetches the
-    /// stored history and writes the complete message sequence here.
-    /// When no previous response exists, contains only the current
-    /// request's input. `responses_proxy` reads this as the
-    /// authoritative conversation to send to the backend.
+    /// Initialized from the current request's input. When
+    /// `previous_response_id` is set, `rehydrate` prepends stored
+    /// history. `tool_dispatch` appends tool results during agentic
+    /// loops. `responses_proxy` reads this as the authoritative
+    /// conversation to send to the backend.
     pub messages: Vec<serde_json::Value>,
 
     /// Output items accumulated across the current response.
@@ -75,6 +82,7 @@ impl ResponsesState {
             .unwrap_or_else(|| serde_json::Value::String("auto".to_owned()));
 
         Self {
+            input: messages.clone(),
             iteration: 0,
             messages,
             output_items: Vec::new(),
@@ -139,16 +147,16 @@ mod tests {
             "input": "Hello, world!"
         });
         let state = ResponsesState::from_request_body(body);
-        assert_eq!(state.messages.len(), 1, "string input should produce one message");
+        assert_eq!(state.input.len(), 1, "string input should produce one item");
         assert_eq!(
-            state.messages[0]["role"], "user",
+            state.input[0]["role"], "user",
             "string input should default to user role"
         );
         assert_eq!(
-            state.messages[0]["type"], "message",
+            state.input[0]["type"], "message",
             "string input should produce a Responses message item"
         );
-        assert_eq!(state.messages[0]["content"], "Hello, world!");
+        assert_eq!(state.input[0]["content"], "Hello, world!");
     }
 
     #[test]
@@ -161,14 +169,30 @@ mod tests {
             ]
         });
         let state = ResponsesState::from_request_body(body);
-        assert_eq!(state.messages.len(), 2, "array input should preserve all messages");
+        assert_eq!(state.input.len(), 2, "array input should preserve all items");
     }
 
     #[test]
     fn from_request_body_empty_input() {
         let body = json!({"model": "gpt-4o"});
         let state = ResponsesState::from_request_body(body);
-        assert!(state.messages.is_empty(), "missing input should produce empty messages");
+        assert!(state.input.is_empty(), "missing input should produce empty input");
+    }
+
+    #[test]
+    fn input_and_messages_start_identical() {
+        let body = json!({
+            "model": "gpt-4o",
+            "input": [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "hi"}
+            ]
+        });
+        let state = ResponsesState::from_request_body(body);
+        assert_eq!(
+            state.input, state.messages,
+            "input and messages should be identical at construction"
+        );
     }
 
     #[test]

--- a/filter/src/builtins/http/ai/openai/responses/state.rs
+++ b/filter/src/builtins/http/ai/openai/responses/state.rs
@@ -20,6 +20,25 @@
 ///
 /// [`RequestExtensions`]: crate::extensions::RequestExtensions
 pub(crate) struct ResponsesState {
+    /// Truncation strategy for managing context window limits.
+    ///
+    /// Preserves the full object from the request so filters can
+    /// inspect both the strategy type and any parameters.
+    pub context_management: Option<serde_json::Value>,
+
+    /// Conversation scope for multi-turn state.
+    ///
+    /// Can be a string ID or an object with `id`. Controls which
+    /// stored conversation this request belongs to.
+    pub conversation: Option<serde_json::Value>,
+
+    /// Additional fields to include in the response.
+    ///
+    /// E.g. `["usage"]`, `["file_search_results"]`. Filters that
+    /// construct the response object check this to decide which
+    /// optional sections to populate.
+    pub include: Vec<String>,
+
     /// The current request's input items, immutable after construction.
     ///
     /// Preserved as-is so downstream filters can inspect what the
@@ -30,6 +49,12 @@ pub(crate) struct ResponsesState {
     /// Current agentic loop iteration (0-indexed). Incremented by
     /// `tool_dispatch` at the start of each new inference round.
     pub iteration: u32,
+
+    /// Maximum number of tool-call rounds in the agentic loop.
+    ///
+    /// `tool_dispatch` checks this to cap iterations. `None` means
+    /// no explicit limit was set by the client.
+    pub max_tool_calls: Option<u32>,
 
     /// Resolved conversation history sent to the backend.
     ///
@@ -42,6 +67,16 @@ pub(crate) struct ResponsesState {
 
     /// Output items accumulated across the current response.
     pub output_items: Vec<serde_json::Value>,
+
+    /// Whether tool calls may execute concurrently within an
+    /// iteration. Defaults to `true` per the API spec.
+    pub parallel_tool_calls: bool,
+
+    /// ID of a previous response to continue from.
+    ///
+    /// When set, `rehydrate` fetches the stored conversation
+    /// history for this response and prepends it to `messages`.
+    pub previous_response_id: Option<String>,
 
     /// Parsed request body as received from the client.
     pub request_body: serde_json::Value,
@@ -75,23 +110,28 @@ impl ResponsesState {
     /// Create initial state from a parsed request body.
     pub(crate) fn from_request_body(body: serde_json::Value) -> Self {
         let messages = normalize_input(&body);
-        let tools = extract_array_field(&body, "tools");
         let tool_choice = body
             .get("tool_choice")
             .cloned()
             .unwrap_or_else(|| serde_json::Value::String("auto".to_owned()));
 
         Self {
+            context_management: body.get("context_management").cloned(),
+            conversation: body.get("conversation").cloned(),
+            include: extract_string_array(&body, "include"),
             input: messages.clone(),
             iteration: 0,
+            max_tool_calls: extract_u32(&body, "max_tool_calls"),
             messages,
             output_items: Vec::new(),
-            request_body: body,
+            parallel_tool_calls: extract_bool_or(&body, "parallel_tool_calls", true),
+            previous_response_id: extract_string(&body, "previous_response_id"),
             response_object: serde_json::Value::Null,
             tool_calls: Vec::new(),
             tool_choice,
-            tools,
+            tools: extract_array_field(&body, "tools"),
             usage: serde_json::Value::Null,
+            request_body: body,
         }
     }
 }
@@ -121,6 +161,38 @@ fn extract_array_field(body: &serde_json::Value, field: &str) -> Vec<serde_json:
         .and_then(serde_json::Value::as_array)
         .cloned()
         .unwrap_or_default()
+}
+
+/// Extract a string field by name.
+fn extract_string(body: &serde_json::Value, field: &str) -> Option<String> {
+    body.get(field)
+        .and_then(serde_json::Value::as_str)
+        .map(ToOwned::to_owned)
+}
+
+/// Extract an array of strings by name, defaulting to empty.
+fn extract_string_array(body: &serde_json::Value, field: &str) -> Vec<String> {
+    body.get(field)
+        .and_then(serde_json::Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(serde_json::Value::as_str)
+                .map(ToOwned::to_owned)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Extract a `u32` field by name.
+fn extract_u32(body: &serde_json::Value, field: &str) -> Option<u32> {
+    body.get(field)
+        .and_then(serde_json::Value::as_u64)
+        .and_then(|v| u32::try_from(v).ok())
+}
+
+/// Extract a bool field by name, returning a default if absent.
+fn extract_bool_or(body: &serde_json::Value, field: &str, default: bool) -> bool {
+    body.get(field).and_then(serde_json::Value::as_bool).unwrap_or(default)
 }
 
 // -----------------------------------------------------------------------------
@@ -254,5 +326,89 @@ mod tests {
         let body = json!({"model": "gpt-4o", "input": "hello", "temperature": 0.7});
         let state = ResponsesState::from_request_body(body.clone());
         assert_eq!(state.request_body, body, "original request body should be preserved");
+    }
+
+    #[test]
+    fn extracts_previous_response_id() {
+        let body = json!({"model": "gpt-4o", "input": "test", "previous_response_id": "resp_abc123"});
+        let state = ResponsesState::from_request_body(body);
+        assert_eq!(state.previous_response_id.as_deref(), Some("resp_abc123"));
+    }
+
+    #[test]
+    fn previous_response_id_defaults_to_none() {
+        let body = json!({"model": "gpt-4o", "input": "test"});
+        let state = ResponsesState::from_request_body(body);
+        assert!(state.previous_response_id.is_none());
+    }
+
+    #[test]
+    fn extracts_conversation_string() {
+        let body = json!({"model": "gpt-4o", "input": "test", "conversation": "conv_xyz"});
+        let state = ResponsesState::from_request_body(body);
+        assert_eq!(state.conversation, Some(json!("conv_xyz")));
+    }
+
+    #[test]
+    fn extracts_conversation_object() {
+        let body = json!({"model": "gpt-4o", "input": "test", "conversation": {"id": "conv_xyz"}});
+        let state = ResponsesState::from_request_body(body);
+        assert_eq!(state.conversation, Some(json!({"id": "conv_xyz"})));
+    }
+
+    #[test]
+    fn extracts_context_management() {
+        let body = json!({
+            "model": "gpt-4o",
+            "input": "test",
+            "context_management": {"type": "truncation", "max_tokens": 4096}
+        });
+        let state = ResponsesState::from_request_body(body);
+        assert_eq!(
+            state.context_management,
+            Some(json!({"type": "truncation", "max_tokens": 4096}))
+        );
+    }
+
+    #[test]
+    fn extracts_include() {
+        let body = json!({"model": "gpt-4o", "input": "test", "include": ["usage", "file_search_results"]});
+        let state = ResponsesState::from_request_body(body);
+        assert_eq!(state.include, vec!["usage", "file_search_results"]);
+    }
+
+    #[test]
+    fn include_defaults_to_empty() {
+        let body = json!({"model": "gpt-4o", "input": "test"});
+        let state = ResponsesState::from_request_body(body);
+        assert!(state.include.is_empty());
+    }
+
+    #[test]
+    fn extracts_max_tool_calls() {
+        let body = json!({"model": "gpt-4o", "input": "test", "max_tool_calls": 5});
+        let state = ResponsesState::from_request_body(body);
+        assert_eq!(state.max_tool_calls, Some(5));
+    }
+
+    #[test]
+    fn max_tool_calls_defaults_to_none() {
+        let body = json!({"model": "gpt-4o", "input": "test"});
+        let state = ResponsesState::from_request_body(body);
+        assert!(state.max_tool_calls.is_none());
+    }
+
+    #[test]
+    fn parallel_tool_calls_defaults_to_true() {
+        let body = json!({"model": "gpt-4o", "input": "test"});
+        let state = ResponsesState::from_request_body(body);
+        assert!(state.parallel_tool_calls);
+    }
+
+    #[test]
+    fn parallel_tool_calls_explicit_false() {
+        let body = json!({"model": "gpt-4o", "input": "test", "parallel_tool_calls": false});
+        let state = ResponsesState::from_request_body(body);
+        assert!(!state.parallel_tool_calls);
     }
 }


### PR DESCRIPTION
## Summary

- Adds `ResponsesState` struct stored in `RequestExtensions` to carry parsed request data across the Responses API filter pipeline (validate → rehydrate → tool_parse → responses_proxy → stream_events → tool_dispatch)
- Extracts input messages (string or array), tools, and tool_choice from the request body; tracks tool calls, output items, usage, and agentic loop iteration across inference rounds
- Builds on praxis-proxy/praxis#621 which introduced the generic `RequestExtensions` type-map infrastructure

## Test plan

- [x] `make lint` passes (clippy, fmt, machete, lint-deps, lint-example-tests)
- [x] 10 unit tests covering all `ResponsesState` factory methods and initial state invariants
- [ ] CI green

Signed-off-by: Sébastien Han <seb@redhat.com>