### PR TITLE
refactor(store): No need to clone the `Arc`, deref store right away

### DIFF
--- a/filter/src/builtins/http/ai/openai/responses/store/filter.rs
+++ b/filter/src/builtins/http/ai/openai/responses/store/filter.rs
@@ -243,12 +243,12 @@ impl ResponseStoreFilter {
         &self,
         ctx: &HttpFilterContext<'_>,
         body: &'a Option<Bytes>,
-    ) -> Option<(Arc<dyn ResponseStore>, &'a Bytes)> {
+    ) -> Option<(&dyn ResponseStore, &'a Bytes)> {
         if should_skip_persist(ctx) {
             return None;
         }
 
-        let store = self.store.get().and_then(Option::clone)?;
+        let store = self.store.get().and_then(Option::as_deref)?;
         let bytes = body.as_ref().filter(|b| !b.is_empty())?;
 
         Some((store, bytes))
@@ -458,7 +458,7 @@ fn parse_response_record(bytes: &[u8], tenant_id: &str) -> Option<ResponseRecord
 /// before the upsert completes.
 ///
 /// [`block_in_place`]: tokio::task::block_in_place
-fn persist_response_blocking(store: &Arc<dyn ResponseStore>, record: &ResponseRecord) -> Result<(), FilterError> {
+fn persist_response_blocking(store: &dyn ResponseStore, record: &ResponseRecord) -> Result<(), FilterError> {
     debug!(
         id = %record.id,
         model = %record.model,
@@ -576,7 +576,7 @@ impl HttpFilter for ResponseStoreFilter {
             return Ok(FilterAction::Continue);
         };
 
-        persist_response_blocking(&store, &record)?;
+        persist_response_blocking(store, &record)?;
         Ok(FilterAction::Continue)
     }
 }


### PR DESCRIPTION
Real minor change, but there is no need to `Arc::clone` the `ResponseStore`, `deref`ing and using the reference right away is sufficient as we do all this while `ResponseStoreFilter` being deref'ed itself, or am I missing some (possibly future?) intent here?

/cc @leseb 