### PR TITLE
fix(filter): handle bare-string conversation IDs in Responses API

### DIFF
--- a/filter/src/builtins/http/ai/openai/responses/validate/mod.rs
+++ b/filter/src/builtins/http/ai/openai/responses/validate/mod.rs
@@ -192,11 +192,14 @@ fn reject_invalid(message: &str) -> FilterAction {
 }
 
 /// Extract conversation ID from the request body.
+///
+/// Handles both `"conversation": "conv_id"` and `"conversation": {"id": "conv_id"}`.
 fn extract_conversation_id(body: &serde_json::Value) -> Option<String> {
-    body.get("conversation")
-        .and_then(|c| c.get("id"))
-        .and_then(serde_json::Value::as_str)
-        .map(str::to_owned)
+    body.get("conversation").and_then(|c| {
+        c.as_str()
+            .or_else(|| c.get("id").and_then(serde_json::Value::as_str))
+            .map(str::to_owned)
+    })
 }
 
 /// Enrich filter context with validated metadata for downstream filters.
@@ -339,6 +342,17 @@ mod tests {
             ctx.filter_metadata.get("responses.conversation_id").map(String::as_str),
             Some("conv_existing_123"),
             "conversation_id should be extracted from request body"
+        );
+    }
+
+    #[tokio::test]
+    async fn valid_request_with_bare_string_conversation_id() {
+        let ctx = run_filter(r#"{"input": "Hi", "conversation": "conv_existing_123"}"#, &[]).await;
+
+        assert_eq!(
+            ctx.filter_metadata.get("responses.conversation_id").map(String::as_str),
+            Some("conv_existing_123"),
+            "bare-string conversation ID should be extracted from request body"
         );
     }
 


### PR DESCRIPTION
## Summary

- `extract_conversation_id` only handled the object form `{"conversation": {"id": "..."}}`, ignoring the bare-string form `{"conversation": "conv_existing"}` defined in the OpenAI Responses API spec (`ConversationParam` is `oneOf: [string, {id: string}]`).
- This caused the classifier to correctly mark a request as stateful, but the validator to generate a fresh `conv_*` ID downstream, breaking conversation continuity.
- Also regenerates stale filter docs from earlier refactors on main.

## Test plan

- [x] New unit test `valid_request_with_bare_string_conversation_id` verifies bare-string extraction
- [x] Existing `valid_request_with_conversation_id` confirms object form still works
- [x] `valid_request_generates_conversation_id` confirms fallback generation still works
- [x] `make lint` passes