### PR TITLE
fix(classifier): use prompt.id instead of prompt.prompt_id

### DIFF
--- a/docs/filters/http/ai/openai_responses_format.md
+++ b/docs/filters/http/ai/openai_responses_format.md
@@ -11,7 +11,7 @@ Requires Cargo feature: `ai-inference`.
 
 Classification formats: `openai_responses`, `openai_chat_completions`, `unknown_json`, `invalid_json`, `non_json`.
 
-Routing mode for Responses API: `stateful` when the request contains `previous_response_id`, non-empty `tools`, `store=true` (default when omitted), `background=true`, `conversation`, or `prompt_id`; `stateless` when `store=false` with no other stateful markers.
+Routing mode for Responses API: `stateful` when the request contains `previous_response_id`, non-empty `tools`, `store=true` (default when omitted), `background=true`, `conversation`, or `prompt.id`; `stateless` when `store=false` with no other stateful markers.
 
 Use with branch chains to route stateful and stateless requests to different clusters.
 

--- a/examples/configs/ai/openai/responses/full-flow.yaml
+++ b/examples/configs/ai/openai/responses/full-flow.yaml
@@ -27,7 +27,7 @@
 #   - store is true (the OpenAI spec default when omitted)
 #   - background is true
 #   - conversation is set
-#   - prompt_id is set
+#   - prompt.id is set
 #
 # Example requests:
 #

--- a/examples/configs/ai/openai/responses/responses-routing.yaml
+++ b/examples/configs/ai/openai/responses/responses-routing.yaml
@@ -15,7 +15,7 @@
 # - store is true (the OpenAI spec default when omitted)
 # - background is true
 # - conversation is set
-# - prompt_id is set
+# - prompt.id is set
 #
 # Stateless requires store=false and no other stateful markers.
 

--- a/filter/src/builtins/http/ai/classifier/mod.rs
+++ b/filter/src/builtins/http/ai/classifier/mod.rs
@@ -57,7 +57,7 @@ pub(crate) struct ClassifiedRequest {
     pub has_conversation: bool,
     /// Whether `previous_response_id` is present and non-null.
     pub has_previous_response_id: bool,
-    /// Whether `prompt.prompt_id` is present and non-null.
+    /// Whether `prompt.id` is present and non-null.
     pub has_prompt_id: bool,
     /// Whether `tools` is a non-empty array.
     pub has_tools: bool,
@@ -139,7 +139,7 @@ pub(crate) fn classify_request_body(body: &[u8]) -> ClassifiedRequest {
         has_prompt_id: obj
             .get("prompt")
             .and_then(serde_json::Value::as_object)
-            .and_then(|prompt| prompt.get("prompt_id"))
+            .and_then(|prompt| prompt.get("id"))
             .is_some_and(|v| !v.is_null()),
         has_tools: obj
             .get("tools")
@@ -579,10 +579,10 @@ mod tests {
 
     #[test]
     fn prompt_id_nested_detected() {
-        let body = br#"{"model":"gpt-4.1","input":"test","prompt":{"prompt_id":"pmpt_123"}}"#;
+        let body = br#"{"model":"gpt-4.1","input":"test","prompt":{"id":"pmpt_123"}}"#;
         let result = classify_request_body(body);
 
-        assert!(result.has_prompt_id, "nested prompt.prompt_id should be detected");
+        assert!(result.has_prompt_id, "nested prompt.id should be detected");
     }
 
     #[test]
@@ -595,10 +595,10 @@ mod tests {
 
     #[test]
     fn prompt_id_null_not_detected() {
-        let body = br#"{"model":"gpt-4.1","input":"test","prompt":{"prompt_id":null}}"#;
+        let body = br#"{"model":"gpt-4.1","input":"test","prompt":{"id":null}}"#;
         let result = classify_request_body(body);
 
-        assert!(!result.has_prompt_id, "null prompt_id should not be detected");
+        assert!(!result.has_prompt_id, "null prompt.id should not be detected");
     }
 
     #[test]
@@ -614,12 +614,12 @@ mod tests {
 
     #[test]
     fn prompt_object_prompt_id_field_detected() {
-        let body = br#"{"model":"gpt-4.1","input":"test","prompt":{"prompt_id":"pmpt_123"}}"#;
+        let body = br#"{"model":"gpt-4.1","input":"test","prompt":{"id":"pmpt_123"}}"#;
         let result = classify_request_body(body);
 
         assert!(
             result.has_prompt_id,
-            "prompt.prompt_id should be detected as the prompt identifier"
+            "prompt.id should be detected as the prompt identifier"
         );
     }
 
@@ -636,7 +636,7 @@ mod tests {
 
     #[test]
     fn prompt_object_classifies_as_responses() {
-        let body = br#"{"model":"gpt-4.1","prompt":{"prompt_id":"pmpt_123","variables":{"city":"SF"}}}"#;
+        let body = br#"{"model":"gpt-4.1","prompt":{"id":"pmpt_123","variables":{"city":"SF"}}}"#;
         let result = classify_request_body(body);
 
         assert_eq!(
@@ -644,7 +644,7 @@ mod tests {
             AiRequestFormat::Responses,
             "prompt object should classify as responses even without input"
         );
-        assert!(result.has_prompt_id, "prompt_id should be detected");
+        assert!(result.has_prompt_id, "prompt.id should be detected");
     }
 
     #[test]

--- a/filter/src/builtins/http/ai/openai/responses/classifier/mod.rs
+++ b/filter/src/builtins/http/ai/openai/responses/classifier/mod.rs
@@ -129,7 +129,7 @@ pub(crate) fn classify_request_body(body: &[u8]) -> ClassifiedRequest {
         has_prompt_id: obj
             .get("prompt")
             .and_then(serde_json::Value::as_object)
-            .and_then(|prompt| prompt.get("prompt_id"))
+            .and_then(|prompt| prompt.get("id"))
             .is_some_and(|v| !v.is_null()),
         has_tools: obj
             .get("tools")
@@ -448,10 +448,10 @@ mod tests {
 
     #[test]
     fn prompt_id_nested_detected() {
-        let body = br#"{"model":"gpt-4.1","input":"test","prompt":{"prompt_id":"pmpt_123"}}"#;
+        let body = br#"{"model":"gpt-4.1","input":"test","prompt":{"id":"pmpt_123"}}"#;
         let result = classify_request_body(body);
 
-        assert!(result.has_prompt_id, "nested prompt.prompt_id should be detected");
+        assert!(result.has_prompt_id, "nested prompt.id should be detected");
     }
 
     #[test]
@@ -464,10 +464,10 @@ mod tests {
 
     #[test]
     fn prompt_id_null_not_detected() {
-        let body = br#"{"model":"gpt-4.1","input":"test","prompt":{"prompt_id":null}}"#;
+        let body = br#"{"model":"gpt-4.1","input":"test","prompt":{"id":null}}"#;
         let result = classify_request_body(body);
 
-        assert!(!result.has_prompt_id, "null prompt_id should not be detected");
+        assert!(!result.has_prompt_id, "null prompt.id should not be detected");
     }
 
     #[test]
@@ -483,12 +483,12 @@ mod tests {
 
     #[test]
     fn prompt_object_prompt_id_field_detected() {
-        let body = br#"{"model":"gpt-4.1","input":"test","prompt":{"prompt_id":"pmpt_123"}}"#;
+        let body = br#"{"model":"gpt-4.1","input":"test","prompt":{"id":"pmpt_123"}}"#;
         let result = classify_request_body(body);
 
         assert!(
             result.has_prompt_id,
-            "prompt.prompt_id should be detected as the prompt identifier"
+            "prompt.id should be detected as the prompt identifier"
         );
     }
 
@@ -505,7 +505,7 @@ mod tests {
 
     #[test]
     fn prompt_object_classifies_as_responses() {
-        let body = br#"{"model":"gpt-4.1","prompt":{"prompt_id":"pmpt_123","variables":{"city":"SF"}}}"#;
+        let body = br#"{"model":"gpt-4.1","prompt":{"id":"pmpt_123","variables":{"city":"SF"}}}"#;
         let result = classify_request_body(body);
 
         assert_eq!(
@@ -513,7 +513,7 @@ mod tests {
             AiRequestFormat::Responses,
             "prompt object should classify as responses even without input"
         );
-        assert!(result.has_prompt_id, "prompt_id should be detected");
+        assert!(result.has_prompt_id, "prompt.id should be detected");
     }
 
     #[test]

--- a/filter/src/builtins/http/ai/openai/responses/mod.rs
+++ b/filter/src/builtins/http/ai/openai/responses/mod.rs
@@ -90,7 +90,7 @@ pub(crate) const DEFAULT_TENANT_ID: &str = "default";
 ///
 /// Routing mode for Responses API: `stateful` when the request contains
 /// `previous_response_id`, non-empty `tools`, `store=true` (default when
-/// omitted), `background=true`, `conversation`, or `prompt_id`;
+/// omitted), `background=true`, `conversation`, or `prompt.id`;
 /// `stateless` when `store=false` with no other stateful markers.
 ///
 /// Use with branch chains to route stateful and stateless requests to

--- a/filter/src/builtins/http/ai/openai/responses/tests.rs
+++ b/filter/src/builtins/http/ai/openai/responses/tests.rs
@@ -773,11 +773,7 @@ async fn mode_stateful_when_conversation_present() {
 
 #[tokio::test]
 async fn mode_stateful_when_prompt_id_present() {
-    let ctx = run_filter(
-        "{}",
-        r#"{"input":"test","store":false,"prompt":{"prompt_id":"pmpt_123"}}"#,
-    )
-    .await;
+    let ctx = run_filter("{}", r#"{"input":"test","store":false,"prompt":{"id":"pmpt_123"}}"#).await;
     let results = ctx.filter_results.get("openai_responses_format").unwrap();
 
     assert_eq!(results.get("mode"), Some("stateful"));
@@ -852,7 +848,7 @@ async fn mode_header_suppressed_when_null() {
 // -----------------------------------------------------------------------------
 
 /// Full Responses body with all optional fields for promotion tests.
-const FULL_RESPONSES_BODY: &str = r#"{"model":"gpt-4.1","input":"test","stream":true,"store":false,"background":true,"previous_response_id":"resp_abc","conversation":{"id":"conv_1"},"tools":[{"type":"function"}],"prompt":{"prompt_id":"pmpt_123"}}"#;
+const FULL_RESPONSES_BODY: &str = r#"{"model":"gpt-4.1","input":"test","stream":true,"store":false,"background":true,"previous_response_id":"resp_abc","conversation":{"id":"conv_1"},"tools":[{"type":"function"}],"prompt":{"id":"pmpt_123"}}"#;
 
 /// Run the filter's `on_request_body` and return the resulting context.
 async fn run_filter(config_yaml: &str, body_str: &str) -> HttpFilterContext<'static> {

--- a/tests/integration/tests/suite/responses_routing.rs
+++ b/tests/integration/tests/suite/responses_routing.rs
@@ -38,8 +38,8 @@ fn mode_branch_routes_stateful_conditions_to_stateful_path() {
             r#"{"model":"gpt-4.1","input":"Hello","store":false,"conversation":{"id":"conv_123"}}"#,
         ),
         (
-            "prompt_id present",
-            r#"{"model":"gpt-4.1","input":"Hello","store":false,"prompt":{"prompt_id":"pmpt_123"}}"#,
+            "prompt.id present",
+            r#"{"model":"gpt-4.1","input":"Hello","store":false,"prompt":{"id":"pmpt_123"}}"#,
         ),
     ];
 


### PR DESCRIPTION
## Summary

- Fix AI classifier to look up `prompt.id` instead of `prompt.prompt_id` per the OpenAI Responses API spec — requests with `{"prompt":{"id":"pmpt_123"}}` were silently ignored, causing stateful requests to be misrouted as stateless
- Fix filter-docs xtask to parse category-root `.rs` files as shared types so enums like `OnInvalidBehavior` render as variant names (`continue | reject | error`) instead of the raw Rust type name in generated docs
- Update all affected tests, example configs, integration tests, and doc comments

## Test plan

- [x] `cargo test -p praxis-proxy-filter -- prompt_id` — all 8 tests pass
- [x] `make lint` — clean (clippy, fmt, filter-docs, example-readme)
- [x] `make build` — workspace + benches compile
- [ ] CI passes