### PR TITLE
Share Responses body size limits

### DIFF
--- a/filter/src/body/limits.rs
+++ b/filter/src/body/limits.rs
@@ -12,3 +12,9 @@ pub(crate) const DEFAULT_JSON_BODY_MAX_BYTES: usize = 10_485_760; // 10 MiB
 
 /// Hard ceiling for JSON body inspection buffers (64 MiB).
 pub(crate) const MAX_JSON_BODY_BYTES: usize = 67_108_864; // 64 MiB
+
+/// Default maximum body size for OpenAI Responses request inspection and transformation (64 MiB).
+///
+/// OpenAI Responses requests can carry large inline payloads, including
+/// `file_data` up to 32 MiB and `image_url` data URLs up to 20 MiB.
+pub(crate) const OPENAI_RESPONSES_BODY_MAX_BYTES: usize = MAX_JSON_BODY_BYTES;

--- a/filter/src/body/limits.rs
+++ b/filter/src/body/limits.rs
@@ -12,9 +12,3 @@ pub(crate) const DEFAULT_JSON_BODY_MAX_BYTES: usize = 10_485_760; // 10 MiB
 
 /// Hard ceiling for JSON body inspection buffers (64 MiB).
 pub(crate) const MAX_JSON_BODY_BYTES: usize = 67_108_864; // 64 MiB
-
-/// Default maximum body size for OpenAI Responses request inspection and transformation (64 MiB).
-///
-/// OpenAI Responses requests can carry large inline payloads, including
-/// `file_data` up to 32 MiB and `image_url` data URLs up to 20 MiB.
-pub(crate) const OPENAI_RESPONSES_BODY_MAX_BYTES: usize = MAX_JSON_BODY_BYTES;

--- a/filter/src/body/mod.rs
+++ b/filter/src/body/mod.rs
@@ -12,5 +12,5 @@ mod mode;
 pub use access::BodyAccess;
 pub use buffer::{BodyBuffer, BodyBufferOverflow};
 pub use builder::BodyCapabilities;
-pub(crate) use limits::DEFAULT_JSON_BODY_MAX_BYTES;
+pub(crate) use limits::{DEFAULT_JSON_BODY_MAX_BYTES, OPENAI_RESPONSES_BODY_MAX_BYTES};
 pub use mode::BodyMode;

--- a/filter/src/body/mod.rs
+++ b/filter/src/body/mod.rs
@@ -6,11 +6,11 @@
 mod access;
 mod buffer;
 mod builder;
-pub(crate) mod limits;
+mod limits;
 mod mode;
 
 pub use access::BodyAccess;
 pub use buffer::{BodyBuffer, BodyBufferOverflow};
 pub use builder::BodyCapabilities;
-pub(crate) use limits::{DEFAULT_JSON_BODY_MAX_BYTES, OPENAI_RESPONSES_BODY_MAX_BYTES};
+pub(crate) use limits::{DEFAULT_JSON_BODY_MAX_BYTES, MAX_JSON_BODY_BYTES};
 pub use mode::BodyMode;

--- a/filter/src/builtins/http/ai/config_validation.rs
+++ b/filter/src/builtins/http/ai/config_validation.rs
@@ -3,7 +3,7 @@
 
 //! Shared config validation helpers for AI classifier filters.
 
-use crate::{FilterError, body::limits::MAX_JSON_BODY_BYTES};
+use crate::{FilterError, body::MAX_JSON_BODY_BYTES};
 
 // ---------------------------------------------------------------------------
 // Header Name Validation

--- a/filter/src/builtins/http/ai/openai/responses/config.rs
+++ b/filter/src/builtins/http/ai/openai/responses/config.rs
@@ -7,22 +7,12 @@ use serde::Deserialize;
 
 use crate::{
     FilterError,
+    body::DEFAULT_JSON_BODY_MAX_BYTES,
     builtins::http::ai::{
         OnInvalidBehavior,
         config_validation::{validate_header_name, validate_max_body_bytes},
     },
 };
-
-// -----------------------------------------------------------------------------
-// Constants
-// -----------------------------------------------------------------------------
-
-/// Default maximum request body size for `StreamBuffer` mode (10 MiB).
-///
-/// Matches the shared default for JSON body inspection filters.
-/// Operators needing larger payloads (e.g. inline file data URLs) can
-/// override via `max_body_bytes` in config.
-const DEFAULT_MAX_BODY_BYTES: usize = 10_485_760; // 10 MiB
 
 // -----------------------------------------------------------------------------
 // Behavior Enums
@@ -126,7 +116,7 @@ pub(crate) struct ResponsesFormatConfig {
 
 /// Default max body bytes.
 fn default_max_body_bytes() -> usize {
-    DEFAULT_MAX_BODY_BYTES
+    DEFAULT_JSON_BODY_MAX_BYTES
 }
 
 // -----------------------------------------------------------------------------

--- a/filter/src/builtins/http/ai/openai/responses/store/filter.rs
+++ b/filter/src/builtins/http/ai/openai/responses/store/filter.rs
@@ -57,7 +57,7 @@ use super::{
 };
 use crate::{
     FilterAction, FilterError, Rejection,
-    body::{BodyAccess, BodyMode, limits::MAX_JSON_BODY_BYTES},
+    body::{BodyAccess, BodyMode, MAX_JSON_BODY_BYTES},
     builtins::http::ai::store::{
         PostgresResponseStore, ResponseRecord, ResponseStore, SqliteResponseStore, StoreError,
     },

--- a/filter/src/builtins/http/ai/openai/responses/validate/mod.rs
+++ b/filter/src/builtins/http/ai/openai/responses/validate/mod.rs
@@ -29,16 +29,9 @@ use tracing::{debug, trace};
 use self::rules::validate_request;
 use crate::{
     FilterAction, FilterError, Rejection,
-    body::{BodyAccess, BodyMode},
+    body::{BodyAccess, BodyMode, OPENAI_RESPONSES_BODY_MAX_BYTES},
     filter::{HttpFilter, HttpFilterContext},
 };
-
-// -----------------------------------------------------------------------------
-// Constants
-// -----------------------------------------------------------------------------
-
-/// Maximum request body size for `StreamBuffer` mode (64 MiB).
-const MAX_BODY_BYTES: usize = 67_108_864; // 64 MiB
 
 // -----------------------------------------------------------------------------
 // OpenaiResponsesValidateFilter
@@ -97,7 +90,7 @@ impl HttpFilter for OpenaiResponsesValidateFilter {
 
     fn request_body_mode(&self) -> BodyMode {
         BodyMode::StreamBuffer {
-            max_bytes: Some(MAX_BODY_BYTES),
+            max_bytes: Some(OPENAI_RESPONSES_BODY_MAX_BYTES),
         }
     }
 

--- a/filter/src/builtins/http/ai/openai/responses/validate/mod.rs
+++ b/filter/src/builtins/http/ai/openai/responses/validate/mod.rs
@@ -29,7 +29,7 @@ use tracing::{debug, trace};
 use self::rules::validate_request;
 use crate::{
     FilterAction, FilterError, Rejection,
-    body::{BodyAccess, BodyMode, OPENAI_RESPONSES_BODY_MAX_BYTES},
+    body::{BodyAccess, BodyMode, MAX_JSON_BODY_BYTES},
     filter::{HttpFilter, HttpFilterContext},
 };
 
@@ -90,7 +90,7 @@ impl HttpFilter for OpenaiResponsesValidateFilter {
 
     fn request_body_mode(&self) -> BodyMode {
         BodyMode::StreamBuffer {
-            max_bytes: Some(OPENAI_RESPONSES_BODY_MAX_BYTES),
+            max_bytes: Some(MAX_JSON_BODY_BYTES),
         }
     }
 


### PR DESCRIPTION
Part of praxis-proxy/ai#85.

## Summary
- add a shared Responses body-size alias for filters that inspect or transform Responses request bodies
- switch Responses validation to the shared 64 MiB Responses limit
- keep the format classifier on the generic JSON inspection default

## Stack
- base of praxis-proxy/praxis#702
- followed by praxis-proxy/praxis#703, praxis-proxy/praxis#696, and praxis-proxy/praxis#677

## Validation
- cargo test -p praxis-proxy-filter --lib --features ai-inference openai::responses
- cargo test -p praxis-tests-integration openai_responses_to_chat_completions
- make lint