### PR TITLE
feat(filter): support wildcard Responses model aliases

### DIFF
--- a/docs/filters/http/ai/openai_responses_model_rewrite.md
+++ b/docs/filters/http/ai/openai_responses_model_rewrite.md
@@ -7,6 +7,10 @@ Rewrites the `model` field in Responses API request bodies.
 
 Requires Cargo feature: `ai-inference`.
 
+## Configuration Notes
+
+Quote wildcard alias keys in YAML, such as `"gpt-4.1-*"`, so `*` is parsed as a literal character rather than YAML alias syntax. The examples quote all alias keys for consistency.
+
 ## Configuration
 
 | Field | Type | Required | Description |
@@ -16,7 +20,7 @@ Requires Cargo feature: `ai-inference`.
 | `headers.effective_model` | string | no | Header name for the effective (post-rewrite) model value. |
 | `headers.original_model` | string | no | Header name for the original (pre-rewrite) model value. |
 | `max_body_bytes` | usize | no | Maximum request body size to buffer before parsing. |
-| `model_aliases` | object<string, string> | no | Map from client-facing model names or single-wildcard patterns to backend model names. Exact aliases win before wildcard aliases; wildcard aliases are matched by literal specificity. |
+| `model_aliases` | object<string, string> | no | Map from client-facing model names or single-wildcard patterns to backend model names. Quote wildcard keys in YAML. Exact aliases win before wildcard aliases; wildcard aliases are matched by literal specificity. |
 | `on_invalid` | `continue` \| `reject` | no | Behavior when the body is not valid JSON. |
 
 ## Examples
@@ -27,9 +31,9 @@ Requires Cargo feature: `ai-inference`.
 filter: openai_responses_model_rewrite
 default_model: "llama-3.3-70b"
 model_aliases:
-  codex-mini-latest: "llama-3.3-70b"
+  "codex-mini-latest": "llama-3.3-70b"
   "gpt-4.1-*": "qwen-2.5-72b"
-  gpt-4.1-mini: "qwen-2.5-72b"
+  "gpt-4.1-mini": "qwen-2.5-72b"
 ```
 
 ### Example 2
@@ -38,7 +42,7 @@ model_aliases:
 filter: openai_responses_model_rewrite
 default_model: "llama-3.3-70b"
 model_aliases:
-  codex-mini-latest: "llama-3.3-70b"
+  "codex-mini-latest": "llama-3.3-70b"
   "gpt-4.1-*": "qwen-2.5-72b"
 max_body_bytes: 10485760
 on_invalid: continue

--- a/docs/filters/http/ai/openai_responses_model_rewrite.md
+++ b/docs/filters/http/ai/openai_responses_model_rewrite.md
@@ -16,7 +16,7 @@ Requires Cargo feature: `ai-inference`.
 | `headers.effective_model` | string | no | Header name for the effective (post-rewrite) model value. |
 | `headers.original_model` | string | no | Header name for the original (pre-rewrite) model value. |
 | `max_body_bytes` | usize | no | Maximum request body size to buffer before parsing. |
-| `model_aliases` | object<string, string> | no | Map from client-facing model names to backend model names. |
+| `model_aliases` | object<string, string> | no | Map from client-facing model names or single-wildcard patterns to backend model names. Exact aliases win before wildcard aliases; wildcard aliases are matched by literal specificity. |
 | `on_invalid` | `continue` \| `reject` | no | Behavior when the body is not valid JSON. |
 
 ## Examples
@@ -28,6 +28,7 @@ filter: openai_responses_model_rewrite
 default_model: "llama-3.3-70b"
 model_aliases:
   codex-mini-latest: "llama-3.3-70b"
+  "gpt-4.1-*": "qwen-2.5-72b"
   gpt-4.1-mini: "qwen-2.5-72b"
 ```
 
@@ -38,6 +39,7 @@ filter: openai_responses_model_rewrite
 default_model: "llama-3.3-70b"
 model_aliases:
   codex-mini-latest: "llama-3.3-70b"
+  "gpt-4.1-*": "qwen-2.5-72b"
 max_body_bytes: 10485760
 on_invalid: continue
 headers:

--- a/examples/configs/ai/openai/responses/model-rewrite.yaml
+++ b/examples/configs/ai/openai/responses/model-rewrite.yaml
@@ -10,7 +10,7 @@
 # not the original client-facing name.
 #
 # Use case: Codex or other Responses API clients send
-# `model: "codex-mini-latest"` and the proxy transparently
+# `model: "codex-mini-2026-06-24"` and the proxy transparently
 # rewrites it to a locally-hosted model before forwarding.
 #
 # Requires the ai-inference feature:
@@ -33,7 +33,7 @@ filter_chains:
       - filter: openai_responses_model_rewrite
         default_model: "llama-3.3-70b"
         model_aliases:
-          codex-mini-latest: "llama-3.3-70b"
+          "codex-*": "llama-3.3-70b"
           gpt-4.1-mini: "qwen-2.5-72b"
         headers:
           effective_model: x-praxis-ai-effective-model

--- a/examples/configs/ai/openai/responses/model-rewrite.yaml
+++ b/examples/configs/ai/openai/responses/model-rewrite.yaml
@@ -34,7 +34,7 @@ filter_chains:
         default_model: "llama-3.3-70b"
         model_aliases:
           "codex-*": "llama-3.3-70b"
-          gpt-4.1-mini: "qwen-2.5-72b"
+          "gpt-4.1-mini": "qwen-2.5-72b"
         headers:
           effective_model: x-praxis-ai-effective-model
           original_model: x-praxis-ai-original-model

--- a/filter/src/builtins/http/ai/openai/responses/model_rewrite/config.rs
+++ b/filter/src/builtins/http/ai/openai/responses/model_rewrite/config.rs
@@ -22,6 +22,7 @@ use crate::{
 /// default_model: "llama-3.3-70b"
 /// model_aliases:
 ///   codex-mini-latest: "llama-3.3-70b"
+///   "gpt-4.1-*": "qwen-2.5-72b"
 ///   gpt-4.1-mini: "qwen-2.5-72b"
 /// max_body_bytes: 10485760
 /// on_invalid: continue
@@ -45,7 +46,9 @@ pub(super) struct ModelRewriteConfig {
     #[serde(default = "default_max_body_bytes")]
     pub max_body_bytes: usize,
 
-    /// Map from client-facing model names to backend model names.
+    /// Map from client-facing model names or single-wildcard patterns
+    /// to backend model names. Exact aliases win before wildcard aliases;
+    /// wildcard aliases are matched by literal specificity.
     #[serde(default)]
     pub model_aliases: HashMap<String, String>,
 
@@ -157,6 +160,12 @@ fn validate_aliases(aliases: &HashMap<String, String>) -> Result<(), FilterError
     for (source, target) in aliases {
         if source.is_empty() {
             return Err("openai_responses_model_rewrite: alias source name must not be empty".into());
+        }
+        if source.chars().filter(|&c| c == '*').count() > 1 {
+            return Err(format!(
+                "openai_responses_model_rewrite: alias source pattern '{source}' must contain at most one '*'",
+            )
+            .into());
         }
         if target.is_empty() {
             return Err(

--- a/filter/src/builtins/http/ai/openai/responses/model_rewrite/config.rs
+++ b/filter/src/builtins/http/ai/openai/responses/model_rewrite/config.rs
@@ -21,15 +21,19 @@ use crate::{
 /// filter: openai_responses_model_rewrite
 /// default_model: "llama-3.3-70b"
 /// model_aliases:
-///   codex-mini-latest: "llama-3.3-70b"
+///   "codex-mini-latest": "llama-3.3-70b"
 ///   "gpt-4.1-*": "qwen-2.5-72b"
-///   gpt-4.1-mini: "qwen-2.5-72b"
+///   "gpt-4.1-mini": "qwen-2.5-72b"
 /// max_body_bytes: 10485760
 /// on_invalid: continue
 /// headers:
 ///   effective_model: x-praxis-ai-effective-model
 ///   original_model: x-praxis-ai-original-model
 /// ```
+///
+/// Quote wildcard alias keys in YAML, such as `"gpt-4.1-*"`, so `*` is
+/// parsed as a literal character rather than YAML alias syntax. The examples
+/// quote all alias keys for consistency.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(super) struct ModelRewriteConfig {
@@ -47,8 +51,8 @@ pub(super) struct ModelRewriteConfig {
     pub max_body_bytes: usize,
 
     /// Map from client-facing model names or single-wildcard patterns
-    /// to backend model names. Exact aliases win before wildcard aliases;
-    /// wildcard aliases are matched by literal specificity.
+    /// to backend model names. Quote wildcard keys in YAML. Exact aliases win
+    /// before wildcard aliases; wildcard aliases are matched by literal specificity.
     #[serde(default)]
     pub model_aliases: HashMap<String, String>,
 

--- a/filter/src/builtins/http/ai/openai/responses/model_rewrite/mod.rs
+++ b/filter/src/builtins/http/ai/openai/responses/model_rewrite/mod.rs
@@ -4,12 +4,17 @@
 //! Model rewrite filter for `OpenAI` Responses API requests.
 //!
 //! Rewrites the top-level `model` field in `POST /v1/responses`
-//! request bodies using a configured alias map. When the `model`
-//! field is missing or null and a `default_model` is configured,
-//! injects the default. Preserves every other field semantically,
-//! including `input`, `instructions`, `tools`, and unknown fields.
-//! Rewritten requests are re-serialized as JSON, so original
-//! whitespace and byte-level object key order are not preserved.
+//! request bodies using a configured alias map. Alias sources may
+//! be exact model names or single-wildcard patterns such as
+//! `codex-*`; exact aliases win before wildcard aliases, then the
+//! wildcard with the most literal characters wins. Equal-specificity
+//! wildcard ties use lexical source-pattern ordering so `HashMap`
+//! iteration order cannot affect the rewrite. When the `model` field
+//! is missing or null and a `default_model` is configured, injects the
+//! default. Preserves every other field semantically, including
+//! `input`, `instructions`, `tools`, and unknown fields. Rewritten
+//! requests are re-serialized as JSON, so original whitespace and
+//! byte-level object key order are not preserved.
 //!
 //! Gates on the request path (`POST /v1/responses` exactly), not
 //! on classifier metadata. This ensures `on_invalid: reject` fires
@@ -67,6 +72,7 @@ const MAX_PROMOTED_VALUE_LEN: usize = 256;
 /// default_model: "llama-3.3-70b"
 /// model_aliases:
 ///   codex-mini-latest: "llama-3.3-70b"
+///   "gpt-4.1-*": "qwen-2.5-72b"
 ///   gpt-4.1-mini: "qwen-2.5-72b"
 /// ```
 ///
@@ -77,6 +83,7 @@ const MAX_PROMOTED_VALUE_LEN: usize = 256;
 /// default_model: "llama-3.3-70b"
 /// model_aliases:
 ///   codex-mini-latest: "llama-3.3-70b"
+///   "gpt-4.1-*": "qwen-2.5-72b"
 /// max_body_bytes: 10485760
 /// on_invalid: continue
 /// headers:
@@ -93,7 +100,8 @@ pub struct ModelRewriteFilter {
     /// Maximum request body size for `StreamBuffer` mode.
     max_body_bytes: usize,
 
-    /// Map from client-facing model names to backend model names.
+    /// Map from client-facing model names or single-wildcard patterns
+    /// to backend model names.
     model_aliases: HashMap<String, String>,
 
     /// Behavior when the body is not valid JSON.
@@ -241,8 +249,8 @@ fn apply_alias(
     aliases: &HashMap<String, String>,
     model: String,
 ) -> RewriteResult {
-    if let Some(target) = aliases.get(&model) {
-        let effective = target.clone();
+    if let Some(target) = resolve_alias(aliases, &model) {
+        let effective = target.to_owned();
         obj.insert("model".to_owned(), serde_json::Value::String(effective.clone()));
         RewriteResult {
             default_injected: false,
@@ -259,6 +267,53 @@ fn apply_alias(
             original_model: Some(model),
             rewritten: false,
         }
+    }
+}
+
+/// Resolve exact aliases first, then the most specific single-wildcard alias.
+///
+/// Equal-specificity wildcard ties use lexical pattern ordering so
+/// `HashMap` iteration order cannot affect the result.
+fn resolve_alias<'a>(aliases: &'a HashMap<String, String>, model: &str) -> Option<&'a str> {
+    if let Some(target) = aliases.get(model) {
+        return Some(target);
+    }
+
+    let mut best: Option<(&str, &str, u32)> = None;
+    for (pattern, target) in aliases {
+        if !pattern.contains('*') || !pattern_matches(pattern, model) {
+            continue;
+        }
+
+        let specificity = pattern_specificity(pattern);
+        let should_replace = best.is_none_or(|(best_pattern, _, best_specificity)| {
+            specificity > best_specificity || (specificity == best_specificity && pattern.as_str() < best_pattern)
+        });
+        if should_replace {
+            best = Some((pattern, target, specificity));
+        }
+    }
+    best.map(|(_, target, _)| target)
+}
+
+/// Match an exact or single-wildcard alias pattern against a model name.
+fn pattern_matches(pattern: &str, value: &str) -> bool {
+    if let Some(pos) = pattern.find('*') {
+        let (prefix, rest) = pattern.split_at(pos);
+        let suffix = rest.get(1..).unwrap_or_default();
+        value.starts_with(prefix) && value.ends_with(suffix) && value.len() >= prefix.len() + suffix.len()
+    } else {
+        pattern == value
+    }
+}
+
+/// Exact patterns sort above wildcards; wildcard specificity is literal length.
+fn pattern_specificity(pattern: &str) -> u32 {
+    if pattern.contains('*') {
+        let literal_len = pattern.len().saturating_sub(1);
+        u32::try_from(literal_len).unwrap_or(u32::MAX - 1)
+    } else {
+        u32::MAX
     }
 }
 

--- a/filter/src/builtins/http/ai/openai/responses/model_rewrite/mod.rs
+++ b/filter/src/builtins/http/ai/openai/responses/model_rewrite/mod.rs
@@ -71,9 +71,9 @@ const MAX_PROMOTED_VALUE_LEN: usize = 256;
 /// filter: openai_responses_model_rewrite
 /// default_model: "llama-3.3-70b"
 /// model_aliases:
-///   codex-mini-latest: "llama-3.3-70b"
+///   "codex-mini-latest": "llama-3.3-70b"
 ///   "gpt-4.1-*": "qwen-2.5-72b"
-///   gpt-4.1-mini: "qwen-2.5-72b"
+///   "gpt-4.1-mini": "qwen-2.5-72b"
 /// ```
 ///
 /// # Full YAML
@@ -82,7 +82,7 @@ const MAX_PROMOTED_VALUE_LEN: usize = 256;
 /// filter: openai_responses_model_rewrite
 /// default_model: "llama-3.3-70b"
 /// model_aliases:
-///   codex-mini-latest: "llama-3.3-70b"
+///   "codex-mini-latest": "llama-3.3-70b"
 ///   "gpt-4.1-*": "qwen-2.5-72b"
 /// max_body_bytes: 10485760
 /// on_invalid: continue
@@ -101,7 +101,7 @@ pub struct ModelRewriteFilter {
     max_body_bytes: usize,
 
     /// Map from client-facing model names or single-wildcard patterns
-    /// to backend model names.
+    /// to backend model names. Quote wildcard keys in YAML.
     model_aliases: HashMap<String, String>,
 
     /// Behavior when the body is not valid JSON.

--- a/filter/src/builtins/http/ai/openai/responses/model_rewrite/tests.rs
+++ b/filter/src/builtins/http/ai/openai/responses/model_rewrite/tests.rs
@@ -27,6 +27,23 @@ model_aliases:
 }
 
 #[test]
+fn from_config_accepts_wildcard_alias() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+model_aliases:
+  "codex-*": "llama-3.3-70b"
+"#,
+    )
+    .unwrap();
+    let filter = ModelRewriteFilter::from_config(&yaml).unwrap();
+    assert_eq!(
+        filter.name(),
+        "openai_responses_model_rewrite",
+        "single-wildcard alias should parse"
+    );
+}
+
+#[test]
 fn from_config_minimal_default_only() {
     let yaml: serde_yaml::Value = serde_yaml::from_str(r#"default_model: "llama-3.3-70b""#).unwrap();
     let filter = ModelRewriteFilter::from_config(&yaml).unwrap();
@@ -113,6 +130,22 @@ model_aliases:
     .unwrap();
     let result = ModelRewriteFilter::from_config(&yaml);
     assert!(result.is_err(), "empty alias target should be rejected");
+}
+
+#[test]
+fn from_config_rejects_alias_source_with_multiple_wildcards() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+model_aliases:
+  "gpt-*-mini-*": "qwen-2.5-72b"
+"#,
+    )
+    .unwrap();
+    let result = ModelRewriteFilter::from_config(&yaml);
+    assert!(
+        result.is_err(),
+        "alias source with more than one wildcard should be rejected"
+    );
 }
 
 #[test]
@@ -477,6 +510,102 @@ async fn known_alias_rewrites_model() {
             .map(String::as_str),
         Some("true"),
         "rewritten flag"
+    );
+}
+
+#[tokio::test]
+async fn wildcard_alias_rewrites_model() {
+    let (ctx, body) = run_filter_with_body(
+        WILDCARD_ALIAS_CONFIG,
+        r#"{"model":"codex-mini-2026-06-24","input":"test"}"#,
+    )
+    .await;
+
+    let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(
+        parsed["model"].as_str(),
+        Some("llama-3.3-70b"),
+        "wildcard alias should rewrite matching model"
+    );
+    assert_eq!(
+        ctx.filter_metadata
+            .get("openai_responses_model_rewrite.original_model")
+            .map(String::as_str),
+        Some("codex-mini-2026-06-24"),
+        "original model metadata should preserve wildcard-matched client model"
+    );
+    assert_eq!(
+        ctx.filter_metadata
+            .get("openai_responses_model_rewrite.rewritten")
+            .map(String::as_str),
+        Some("true"),
+        "wildcard rewrite should set rewritten flag"
+    );
+}
+
+#[tokio::test]
+async fn exact_alias_beats_wildcard_alias() {
+    let (ctx, body) =
+        run_filter_with_body(WILDCARD_ALIAS_CONFIG, r#"{"model":"codex-mini-latest","input":"test"}"#).await;
+
+    let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(
+        parsed["model"].as_str(),
+        Some("llama-exact"),
+        "exact alias should take precedence over wildcard alias"
+    );
+    assert_eq!(
+        ctx.filter_metadata
+            .get("openai_responses_model_rewrite.effective_model")
+            .map(String::as_str),
+        Some("llama-exact"),
+        "effective model metadata should use exact alias target"
+    );
+}
+
+#[tokio::test]
+async fn more_specific_wildcard_alias_beats_less_specific_alias() {
+    let (_ctx, body) = run_filter_with_body(
+        WILDCARD_ALIAS_CONFIG,
+        r#"{"model":"gpt-4.1-2026-06-24","input":"test"}"#,
+    )
+    .await;
+
+    let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(
+        parsed["model"].as_str(),
+        Some("qwen-2.5-72b"),
+        "more specific wildcard should beat broader wildcard"
+    );
+}
+
+#[tokio::test]
+async fn wildcard_alias_tie_uses_lexical_pattern_order() {
+    let (_ctx, body) = run_filter_with_body(WILDCARD_ALIAS_CONFIG, r#"{"model":"foo-bar","input":"test"}"#).await;
+
+    let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(
+        parsed["model"].as_str(),
+        Some("bar-family"),
+        "equal-specificity wildcard ties should be deterministic"
+    );
+}
+
+#[tokio::test]
+async fn wildcard_alias_miss_passes_model_unchanged() {
+    let (ctx, body) =
+        run_filter_with_body(WILDCARD_ALIAS_CONFIG, r#"{"model":"anthropic-sonnet","input":"test"}"#).await;
+
+    let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(
+        parsed["model"].as_str(),
+        Some("anthropic-sonnet"),
+        "non-matching wildcard aliases should pass through unchanged"
+    );
+    assert!(
+        !ctx.filter_metadata
+            .contains_key("openai_responses_model_rewrite.rewritten"),
+        "wildcard miss should not set rewritten flag"
     );
 }
 
@@ -895,6 +1024,17 @@ const ALIAS_CONFIG: &str = r#"
 model_aliases:
   codex-mini-latest: "llama-3.3-70b"
   gpt-4.1-mini: "qwen-2.5-72b"
+"#;
+
+/// Config with exact and wildcard alias mappings.
+const WILDCARD_ALIAS_CONFIG: &str = r#"
+model_aliases:
+  codex-mini-latest: "llama-exact"
+  "codex-*": "llama-3.3-70b"
+  "gpt-*": "generic-gpt"
+  "gpt-4.1-*": "qwen-2.5-72b"
+  "foo-*": "foo-family"
+  "*-bar": "bar-family"
 "#;
 
 /// Config with only default model.

--- a/tests/integration/tests/suite/examples/openai_responses_model_rewrite.rs
+++ b/tests/integration/tests/suite/examples/openai_responses_model_rewrite.rs
@@ -15,7 +15,7 @@ use praxis_test_utils::{
 // -----------------------------------------------------------------------------
 
 #[test]
-fn example_config_alias_routes_to_llama_backend() {
+fn example_config_wildcard_alias_routes_to_llama_backend() {
     let llama_guard = start_backend_with_shutdown("llama-backend");
     let qwen_guard = start_backend_with_shutdown("qwen-backend");
     let default_guard = start_backend_with_shutdown("default-backend");
@@ -32,14 +32,14 @@ fn example_config_alias_routes_to_llama_backend() {
     );
     let proxy = start_proxy(&config);
 
-    let body = r#"{"model":"codex-mini-latest","input":"Hello from example test"}"#;
+    let body = r#"{"model":"codex-mini-2026-06-24","input":"Hello from example test"}"#;
     let raw = http_send(proxy.addr(), &json_post("/v1/responses", body));
 
     assert_eq!(parse_status(&raw), 200, "example config should route successfully");
     assert_eq!(
         parse_body(&raw),
         "llama-backend",
-        "codex-mini-latest should route to llama-backend via effective model header"
+        "codex-* should route to llama-backend via effective model header"
     );
 }
 

--- a/tests/integration/tests/suite/openai_responses_model_rewrite.rs
+++ b/tests/integration/tests/suite/openai_responses_model_rewrite.rs
@@ -31,6 +31,26 @@ fn responses_model_alias_reaches_upstream() {
     );
 }
 
+#[test]
+fn responses_wildcard_model_alias_reaches_upstream() {
+    let echo_guard = start_echo_backend();
+    let proxy_port = free_port();
+
+    let config = Config::from_yaml(&rewrite_yaml(proxy_port, echo_guard.port())).unwrap();
+    let proxy = start_proxy(&config);
+
+    let body = r#"{"model":"codex-mini-2026-06-24","input":"Hello, wildcard!"}"#;
+    let raw = http_send(proxy.addr(), &json_post("/v1/responses", body));
+
+    assert_eq!(parse_status(&raw), 200, "proxy should return 200");
+    let echoed: serde_json::Value = serde_json::from_str(&parse_body(&raw)).unwrap();
+    assert_eq!(
+        echoed["model"].as_str(),
+        Some("llama-3.3-70b"),
+        "wildcard model alias should be rewritten to alias target"
+    );
+}
+
 // -----------------------------------------------------------------------------
 // Default Model Injection
 // -----------------------------------------------------------------------------
@@ -243,13 +263,13 @@ fn effective_model_header_routes_to_expected_backend() {
     .unwrap();
     let proxy = start_proxy(&config);
 
-    let body = r#"{"model":"codex-mini-latest","input":"route to llama"}"#;
+    let body = r#"{"model":"codex-mini-2026-06-24","input":"route to llama"}"#;
     let raw = http_send(proxy.addr(), &json_post("/v1/responses", body));
     assert_eq!(parse_status(&raw), 200, "llama route should return 200");
     assert_eq!(
         parse_body(&raw),
         "llama-backend",
-        "codex-mini-latest should route to llama-backend via effective model header"
+        "wildcard codex model should route to llama-backend via effective model header"
     );
 
     let body = r#"{"model":"gpt-4.1-mini","input":"route to qwen"}"#;
@@ -390,6 +410,7 @@ filter_chains:
         default_model: "llama-3.3-70b"
         model_aliases:
           codex-mini-latest: "llama-3.3-70b"
+          "codex-*": "llama-3.3-70b"
           gpt-4.1-mini: "qwen-2.5-72b"
       - filter: router
         routes:
@@ -448,6 +469,7 @@ filter_chains:
       - filter: openai_responses_model_rewrite
         model_aliases:
           codex-mini-latest: "llama-3.3-70b"
+          "codex-*": "llama-3.3-70b"
           gpt-4.1-mini: "qwen-2.5-72b"
       - filter: router
         routes:


### PR DESCRIPTION
## Summary

Follow-up to the merged `/v1/responses` passthrough work. This lets openai_responses_model_rewrite alias sources use a single wildcard, so operators can map a model family like `codex-*` to a backend deployment without updating config every time the client-facing model name changes.

The filter now:

- Keeps exact model aliases working as before.
- Allows single-wildcard alias keys such as `codex-*` or `gpt-4.1-*`
- Resolves exact aliases before wildcard aliases.
- Resolves wildcard aliases by literal specificity, with deterministic lexical tie-breaking.
- Rejects alias source patterns with more than one wildcard.

## Why

The original filter used exact HashMap keys only. That works for stable names, but it is fragile for client-controlled or provider-controlled model names. For example, if Codex sends `codex-mini-2026-06-24` instead of `codex-mini-latest`, an exact alias would miss and the request would reach the backend with an unknown model name.

With this change, operators can configure:

```yaml
model_aliases:
  "codex-*": "llama-3.3-70b"
```

That keeps the rewrite policy stable across client model-name churn while preserving exact aliases for cases that need a narrower override.

## Validation

- cargo test -p praxis-proxy-filter --features ai-inference model_rewrite::tests
- cargo test -p praxis-tests-integration openai_responses_model_rewrite
- make lint
