### PR TITLE
fix(filter): return 400 for malformed input_items cursors

### DIFF
--- a/filter/src/builtins/http/ai/openai/responses/store/filter.rs
+++ b/filter/src/builtins/http/ai/openai/responses/store/filter.rs
@@ -51,7 +51,7 @@ use tracing::{debug, trace, warn};
 
 use super::{
     super::{DEFAULT_STORE_NAME, DEFAULT_TENANT_ID, TENANT_METADATA_KEY, state::ResponsesState},
-    ListParams, Order,
+    InputItemPage, ListParams, Order,
     config::{ResponseStoreConfig, StorageBackend, revalidate_postgres_host, validate_config},
     list_input_items,
 };
@@ -828,35 +828,42 @@ impl ResponseStoreFilter {
 /// Build a paginated input items response from a stored record.
 fn build_input_items_response(id: &str, record: &ResponseRecord, params: &ListParams) -> FilterAction {
     match list_input_items(record, params) {
-        Ok(page) => {
-            let first_id = page.data.first().and_then(|v| v.get("id")).and_then(|v| v.as_str());
-            let last_id = page.data.last().and_then(|v| v.get("id")).and_then(|v| v.as_str());
-
-            let body = serde_json::json!({
-                "object": "list",
-                "data": page.data,
-                "has_more": page.has_more,
-                "first_id": first_id,
-                "last_id": last_id,
-            });
-            debug!(
-                response_id = id,
-                count = page.data.len(),
-                has_more = page.has_more,
-                "serving input items"
-            );
-            let bytes = serde_json::to_vec(&body).unwrap_or_default();
-            FilterAction::Reject(
-                Rejection::status(200)
-                    .with_header("content-type", "application/json")
-                    .with_body(bytes),
-            )
+        Ok(page) => build_input_items_ok(id, &page),
+        Err(StoreError::InvalidInput(msg)) => {
+            debug!(response_id = id, error = %msg, "invalid input_items pagination parameter");
+            FilterAction::Reject(reject_invalid_input(&msg))
         },
         Err(e) => {
             warn!(response_id = id, error = %e, "input_items pagination failed");
             FilterAction::Reject(reject_store_error())
         },
     }
+}
+
+/// Serialize a successful input items page into a 200 JSON response.
+fn build_input_items_ok(id: &str, page: &InputItemPage) -> FilterAction {
+    let first_id = page.data.first().and_then(|v| v.get("id")).and_then(|v| v.as_str());
+    let last_id = page.data.last().and_then(|v| v.get("id")).and_then(|v| v.as_str());
+
+    let body = serde_json::json!({
+        "object": "list",
+        "data": page.data,
+        "has_more": page.has_more,
+        "first_id": first_id,
+        "last_id": last_id,
+    });
+    debug!(
+        response_id = id,
+        count = page.data.len(),
+        has_more = page.has_more,
+        "serving input items"
+    );
+    let bytes = serde_json::to_vec(&body).unwrap_or_default();
+    FilterAction::Reject(
+        Rejection::status(200)
+            .with_header("content-type", "application/json")
+            .with_body(bytes),
+    )
 }
 
 /// Parse cursor-based pagination parameters from a query string.
@@ -905,6 +912,19 @@ fn reject_not_found(id: &str) -> Rejection {
         }
     });
     Rejection::status(404)
+        .with_header("content-type", "application/json")
+        .with_body(serde_json::to_vec(&body).unwrap_or_default())
+}
+
+/// Build a 400 rejection for invalid client-supplied parameters.
+fn reject_invalid_input(message: &str) -> Rejection {
+    let body = serde_json::json!({
+        "error": {
+            "message": message,
+            "type": "invalid_request_error",
+        }
+    });
+    Rejection::status(400)
         .with_header("content-type", "application/json")
         .with_body(serde_json::to_vec(&body).unwrap_or_default())
 }

--- a/filter/src/builtins/http/ai/openai/responses/store/input_items.rs
+++ b/filter/src/builtins/http/ai/openai/responses/store/input_items.rs
@@ -96,10 +96,8 @@ pub struct InputItemPage {
 ///
 /// # Errors
 ///
-/// Returns [`StoreError::Database`] if the cursor is malformed
-/// or overflows while calculating the page window. Uses the
-/// `Database` variant as a pragmatic fit until a dedicated
-/// input-validation variant is added to [`StoreError`].
+/// Returns [`StoreError::InvalidInput`] if the cursor is malformed
+/// or overflows while calculating the page window.
 pub fn list_input_items(record: &ResponseRecord, params: &ListParams) -> Result<InputItemPage, StoreError> {
     let mut items = match &record.input {
         serde_json::Value::Array(arr) => arr.clone(),
@@ -116,10 +114,10 @@ pub fn list_input_items(record: &ResponseRecord, params: &ListParams) -> Result<
         .transpose()?
         .unwrap_or(0);
 
-    let limit = usize::try_from(params.effective_limit()).map_err(|e| StoreError::Database(e.to_string()))?;
+    let limit = usize::try_from(params.effective_limit()).map_err(|e| StoreError::InvalidInput(e.to_string()))?;
     let end = offset
         .checked_add(limit)
-        .ok_or_else(|| StoreError::Database("input_items cursor offset overflow".to_owned()))?
+        .ok_or_else(|| StoreError::InvalidInput("input_items cursor offset overflow".to_owned()))?
         .min(items.len());
     let has_more = end < items.len();
 
@@ -145,7 +143,7 @@ fn cursor_offset(items: &[serde_json::Value], cursor: &str) -> Result<usize, Sto
 
     cursor
         .parse::<usize>()
-        .map_err(|e| StoreError::Database(format!("invalid input_items cursor: {e}")))
+        .map_err(|e| StoreError::InvalidInput(format!("invalid input_items cursor: {e}")))
 }
 
 /// Return the offset after the item whose `id` matches the cursor.

--- a/filter/src/builtins/http/ai/openai/responses/store/mod.rs
+++ b/filter/src/builtins/http/ai/openai/responses/store/mod.rs
@@ -13,9 +13,7 @@ mod config;
 mod filter;
 mod input_items;
 
-#[expect(unused_imports, reason = "re-export for DELETE (#459) response endpoint")]
-pub use input_items::InputItemPage;
-pub use input_items::{ListParams, Order, list_input_items};
+pub use input_items::{InputItemPage, ListParams, Order, list_input_items};
 
 pub use self::filter::ResponseStoreFilter;
 

--- a/filter/src/builtins/http/ai/openai/responses/store/tests.rs
+++ b/filter/src/builtins/http/ai/openai/responses/store/tests.rs
@@ -2527,6 +2527,44 @@ async fn get_input_items_with_cursor() {
     assert_eq!(body["has_more"], false, "should indicate no more items after this page");
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn get_input_items_with_malformed_cursor_returns_400() {
+    let filter = make_filter();
+    init_store_and_seed(
+        &filter,
+        "resp_bad_cursor",
+        "default",
+        json!([
+            {"id": "item_1", "type": "message"},
+            {"id": "item_2", "type": "message"}
+        ]),
+    )
+    .await;
+
+    let req = crate::test_utils::make_request(
+        http::Method::GET,
+        "/v1/responses/resp_bad_cursor/input_items?after=not-a-cursor",
+    );
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let action = filter.on_request(&mut ctx).await.unwrap();
+    let rejection = expect_reject(action);
+    assert_eq!(rejection.status, 400, "malformed cursor should return 400");
+    assert_has_json_content_type(&rejection);
+
+    let body: serde_json::Value = serde_json::from_slice(rejection.body.as_deref().unwrap()).unwrap();
+    assert_eq!(
+        body["error"]["type"], "invalid_request_error",
+        "malformed cursor should return an invalid request error"
+    );
+    assert!(
+        body["error"]["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("invalid input_items cursor")),
+        "error message should explain the invalid input_items cursor"
+    );
+}
+
 // -----------------------------------------------------------------------------
 // DELETE
 // -----------------------------------------------------------------------------

--- a/filter/src/builtins/http/ai/store/types.rs
+++ b/filter/src/builtins/http/ai/store/types.rs
@@ -112,6 +112,9 @@ pub enum StoreError {
     /// Database connection or query failure.
     Database(String),
 
+    /// Client-supplied input is invalid (e.g. malformed cursor).
+    InvalidInput(String),
+
     /// JSON serialization or deserialization failure.
     Serialization(String),
 
@@ -123,6 +126,7 @@ impl fmt::Display for StoreError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Database(msg) => write!(f, "database error: {msg}"),
+            Self::InvalidInput(msg) => write!(f, "invalid input: {msg}"),
             Self::Serialization(msg) => write!(f, "serialization error: {msg}"),
             Self::Unavailable(msg) => write!(f, "store unavailable: {msg}"),
         }


### PR DESCRIPTION
## Summary

Malformed or overflowing `after` cursors on `GET /v1/responses/{id}/input_items` were wrapped as `StoreError::Database` and surfaced as HTTP 500 `server_error`. Invalid pagination input is a client error, not an internal outage — this misleads clients, monitoring dashboards, and can trigger inappropriate retries.

- Add `StoreError::InvalidInput` variant for client-supplied validation failures
- Use `InvalidInput` in cursor parsing (`cursor_offset`, limit conversion, overflow check)
- Return HTTP 400 `invalid_request_error` (matching the OpenAI error format) for `InvalidInput` errors; other `StoreError` variants still produce 500
- Add integration test `get_input_items_with_malformed_cursor_returns_400` verifying the 400 status, error type, and error message

## Test plan

- [x] `cargo test -p praxis-proxy-filter -- input_items` — all 16 tests pass (including new malformed cursor test)
- [x] `make lint` — clean
- [x] `make fmt` — clean