### PR TITLE
fix(store): move conversation lifecycle to ConversationItemStore

### DIFF
--- a/filter/src/builtins/http/ai/openai/responses/rehydrate/tests.rs
+++ b/filter/src/builtins/http/ai/openai/responses/rehydrate/tests.rs
@@ -554,20 +554,12 @@ impl ResponseStore for MockStore {
         Ok(false)
     }
 
-    async fn upsert_conversation(&self, _record: &ConversationRecord) -> Result<(), StoreError> {
-        Ok(())
-    }
-
     async fn get_conversation(
         &self,
         _tenant_id: &str,
         _conversation_id: &str,
     ) -> Result<Option<ConversationRecord>, StoreError> {
         Ok(None)
-    }
-
-    async fn delete_conversation(&self, _tenant_id: &str, _conversation_id: &str) -> Result<bool, StoreError> {
-        Ok(false)
     }
 }
 

--- a/filter/src/builtins/http/ai/store/postgres.rs
+++ b/filter/src/builtins/http/ai/store/postgres.rs
@@ -140,6 +140,89 @@ impl PostgresResponseStore {
         );
         Ok(Self { pool, tables })
     }
+
+    /// Insert or update a conversation row shared by both store traits.
+    async fn upsert_conversation_record(&self, record: &ConversationRecord) -> Result<(), StoreError> {
+        let messages = serde_json::to_string(&record.messages).map_err(|e| StoreError::Serialization(e.to_string()))?;
+        let metadata = serde_json::to_string(&record.metadata).map_err(|e| StoreError::Serialization(e.to_string()))?;
+
+        let sql = format!(
+            "INSERT INTO {} \
+             (conversation_id, tenant_id, created_at, metadata, messages) \
+             VALUES ($1, $2, $3, $4, $5) \
+             ON CONFLICT (conversation_id, tenant_id) DO UPDATE SET \
+             messages = EXCLUDED.messages",
+            self.tables.conversations
+        );
+
+        sqlx::query(AssertSqlSafe(sql.as_str()))
+            .bind(&record.conversation_id)
+            .bind(&record.tenant_id)
+            .bind(record.created_at)
+            .bind(&metadata)
+            .bind(&messages)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| StoreError::Database(e.to_string()))?;
+
+        Ok(())
+    }
+
+    /// Retrieve a conversation row shared by both store traits.
+    async fn get_conversation_record(
+        &self,
+        tenant_id: &str,
+        conversation_id: &str,
+    ) -> Result<Option<ConversationRecord>, StoreError> {
+        let sql = format!(
+            "SELECT conversation_id, tenant_id, created_at, \
+                    metadata, messages \
+             FROM {} \
+             WHERE conversation_id = $1 AND tenant_id = $2",
+            self.tables.conversations
+        );
+
+        let row = sqlx::query(AssertSqlSafe(sql.as_str()))
+            .bind(conversation_id)
+            .bind(tenant_id)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|e| StoreError::Database(e.to_string()))?;
+
+        row.map(|r| row_to_conversation_record(&r)).transpose()
+    }
+
+    /// Delete a conversation row and any configured item rows.
+    async fn delete_conversation_record(&self, tenant_id: &str, conversation_id: &str) -> Result<bool, StoreError> {
+        let mut tx = Box::pin(self.pool.begin())
+            .await
+            .map_err(|e| StoreError::Database(e.to_string()))?;
+
+        if let Some(items_table) = &self.tables.items {
+            let items_sql = format!("DELETE FROM {items_table} WHERE tenant_id = $1 AND conversation_id = $2");
+            sqlx::query(AssertSqlSafe(items_sql.as_str()))
+                .bind(tenant_id)
+                .bind(conversation_id)
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| StoreError::Database(e.to_string()))?;
+        }
+
+        let sql = format!(
+            "DELETE FROM {} WHERE conversation_id = $1 AND tenant_id = $2",
+            self.tables.conversations
+        );
+
+        let result = sqlx::query(AssertSqlSafe(sql.as_str()))
+            .bind(conversation_id)
+            .bind(tenant_id)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| StoreError::Database(e.to_string()))?;
+
+        tx.commit().await.map_err(|e| StoreError::Database(e.to_string()))?;
+        Ok(result.rows_affected() > 0)
+    }
 }
 
 /// Build `PostgreSQL` connection options from URL and optional TLS overrides.
@@ -231,84 +314,12 @@ impl ResponseStore for PostgresResponseStore {
         Ok(result.rows_affected() > 0)
     }
 
-    async fn upsert_conversation(&self, record: &ConversationRecord) -> Result<(), StoreError> {
-        let messages = serde_json::to_string(&record.messages).map_err(|e| StoreError::Serialization(e.to_string()))?;
-        let metadata = serde_json::to_string(&record.metadata).map_err(|e| StoreError::Serialization(e.to_string()))?;
-
-        let sql = format!(
-            "INSERT INTO {} \
-             (conversation_id, tenant_id, created_at, metadata, messages) \
-             VALUES ($1, $2, $3, $4, $5) \
-             ON CONFLICT (conversation_id, tenant_id) DO UPDATE SET \
-             messages = EXCLUDED.messages",
-            self.tables.conversations
-        );
-
-        sqlx::query(AssertSqlSafe(sql.as_str()))
-            .bind(&record.conversation_id)
-            .bind(&record.tenant_id)
-            .bind(record.created_at)
-            .bind(&metadata)
-            .bind(&messages)
-            .execute(&self.pool)
-            .await
-            .map_err(|e| StoreError::Database(e.to_string()))?;
-
-        Ok(())
-    }
-
     async fn get_conversation(
         &self,
         tenant_id: &str,
         conversation_id: &str,
     ) -> Result<Option<ConversationRecord>, StoreError> {
-        let sql = format!(
-            "SELECT conversation_id, tenant_id, created_at, \
-                    metadata, messages \
-             FROM {} \
-             WHERE conversation_id = $1 AND tenant_id = $2",
-            self.tables.conversations
-        );
-
-        let row = sqlx::query(AssertSqlSafe(sql.as_str()))
-            .bind(conversation_id)
-            .bind(tenant_id)
-            .fetch_optional(&self.pool)
-            .await
-            .map_err(|e| StoreError::Database(e.to_string()))?;
-
-        row.map(|r| row_to_conversation_record(&r)).transpose()
-    }
-
-    async fn delete_conversation(&self, tenant_id: &str, conversation_id: &str) -> Result<bool, StoreError> {
-        let mut tx = Box::pin(self.pool.begin())
-            .await
-            .map_err(|e| StoreError::Database(e.to_string()))?;
-
-        if let Some(items_table) = &self.tables.items {
-            let items_sql = format!("DELETE FROM {items_table} WHERE tenant_id = $1 AND conversation_id = $2");
-            sqlx::query(AssertSqlSafe(items_sql.as_str()))
-                .bind(tenant_id)
-                .bind(conversation_id)
-                .execute(&mut *tx)
-                .await
-                .map_err(|e| StoreError::Database(e.to_string()))?;
-        }
-
-        let sql = format!(
-            "DELETE FROM {} WHERE conversation_id = $1 AND tenant_id = $2",
-            self.tables.conversations
-        );
-
-        let result = sqlx::query(AssertSqlSafe(sql.as_str()))
-            .bind(conversation_id)
-            .bind(tenant_id)
-            .execute(&mut *tx)
-            .await
-            .map_err(|e| StoreError::Database(e.to_string()))?;
-
-        tx.commit().await.map_err(|e| StoreError::Database(e.to_string()))?;
-        Ok(result.rows_affected() > 0)
+        self.get_conversation_record(tenant_id, conversation_id).await
     }
 }
 
@@ -318,6 +329,22 @@ impl ResponseStore for PostgresResponseStore {
 )]
 #[async_trait]
 impl ConversationItemStore for PostgresResponseStore {
+    async fn upsert_conversation(&self, record: &ConversationRecord) -> Result<(), StoreError> {
+        self.upsert_conversation_record(record).await
+    }
+
+    async fn get_conversation(
+        &self,
+        tenant_id: &str,
+        conversation_id: &str,
+    ) -> Result<Option<ConversationRecord>, StoreError> {
+        self.get_conversation_record(tenant_id, conversation_id).await
+    }
+
+    async fn delete_conversation(&self, tenant_id: &str, conversation_id: &str) -> Result<bool, StoreError> {
+        self.delete_conversation_record(tenant_id, conversation_id).await
+    }
+
     async fn create_conversation_items(&self, items: &[ConversationItemRecord]) -> Result<(), StoreError> {
         let table = self
             .tables
@@ -333,8 +360,7 @@ impl ConversationItemStore for PostgresResponseStore {
             "INSERT INTO {table} \
              (item_id, tenant_id, conversation_id, item_data, created_at, position) \
              VALUES ($1, $2, $3, $4, $5, $6) \
-             ON CONFLICT(item_id, tenant_id) DO UPDATE SET \
-             conversation_id = EXCLUDED.conversation_id, \
+             ON CONFLICT(item_id, tenant_id, conversation_id) DO UPDATE SET \
              item_data = EXCLUDED.item_data, \
              created_at = EXCLUDED.created_at, \
              position = EXCLUDED.position"

--- a/filter/src/builtins/http/ai/store/schemas.rs
+++ b/filter/src/builtins/http/ai/store/schemas.rs
@@ -133,12 +133,12 @@ fn append_items_ddl(stmts: &mut Vec<String>, i: &str) {
             item_data         TEXT NOT NULL,
             created_at        BIGINT NOT NULL,
             position          BIGINT NOT NULL,
-            PRIMARY KEY (item_id, tenant_id)
+            PRIMARY KEY (item_id, tenant_id, conversation_id)
         )"
     ));
     stmts.push(format!(
         "CREATE INDEX IF NOT EXISTS idx_{i}_conversation \
-         ON {i}(conversation_id, tenant_id, position)"
+         ON {i}(conversation_id, tenant_id, position, item_id)"
     ));
 }
 

--- a/filter/src/builtins/http/ai/store/sqlite.rs
+++ b/filter/src/builtins/http/ai/store/sqlite.rs
@@ -83,6 +83,90 @@ impl SqliteResponseStore {
         );
         Ok(Self { pool, tables })
     }
+
+    /// Insert or update a conversation row shared by both store traits.
+    async fn upsert_conversation_record(&self, record: &ConversationRecord) -> Result<(), StoreError> {
+        let messages = serde_json::to_string(&record.messages).map_err(|e| StoreError::Serialization(e.to_string()))?;
+        let metadata = serde_json::to_string(&record.metadata).map_err(|e| StoreError::Serialization(e.to_string()))?;
+
+        let sql = format!(
+            "INSERT INTO {} \
+             (conversation_id, tenant_id, created_at, metadata, messages) \
+             VALUES (?, ?, ?, ?, ?) \
+             ON CONFLICT(conversation_id, tenant_id) \
+             DO UPDATE SET messages = excluded.messages",
+            self.tables.conversations
+        );
+
+        sqlx::query(AssertSqlSafe(sql.as_str()))
+            .bind(&record.conversation_id)
+            .bind(&record.tenant_id)
+            .bind(record.created_at)
+            .bind(&metadata)
+            .bind(&messages)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| StoreError::Database(e.to_string()))?;
+
+        Ok(())
+    }
+
+    /// Retrieve a conversation row shared by both store traits.
+    async fn get_conversation_record(
+        &self,
+        tenant_id: &str,
+        conversation_id: &str,
+    ) -> Result<Option<ConversationRecord>, StoreError> {
+        let sql = format!(
+            "SELECT conversation_id, tenant_id, created_at, metadata, messages \
+             FROM {} \
+             WHERE conversation_id = ? AND tenant_id = ?",
+            self.tables.conversations
+        );
+
+        let row = sqlx::query(AssertSqlSafe(sql.as_str()))
+            .bind(conversation_id)
+            .bind(tenant_id)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|e| StoreError::Database(e.to_string()))?;
+
+        row.map(|r| row_to_conversation_record(&r)).transpose()
+    }
+
+    /// Delete a conversation row and any configured item rows.
+    async fn delete_conversation_record(&self, tenant_id: &str, conversation_id: &str) -> Result<bool, StoreError> {
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(|e| StoreError::Database(e.to_string()))?;
+
+        if let Some(items_table) = &self.tables.items {
+            let items_sql = format!("DELETE FROM {items_table} WHERE tenant_id = ? AND conversation_id = ?");
+            sqlx::query(AssertSqlSafe(items_sql.as_str()))
+                .bind(tenant_id)
+                .bind(conversation_id)
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| StoreError::Database(e.to_string()))?;
+        }
+
+        let sql = format!(
+            "DELETE FROM {} WHERE conversation_id = ? AND tenant_id = ?",
+            self.tables.conversations
+        );
+
+        let result = sqlx::query(AssertSqlSafe(sql.as_str()))
+            .bind(conversation_id)
+            .bind(tenant_id)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| StoreError::Database(e.to_string()))?;
+
+        tx.commit().await.map_err(|e| StoreError::Database(e.to_string()))?;
+        Ok(result.rows_affected() > 0)
+    }
 }
 
 /// Build pool options for the requested `SQLite` database URL.
@@ -172,85 +256,12 @@ impl ResponseStore for SqliteResponseStore {
         Ok(result.rows_affected() > 0)
     }
 
-    async fn upsert_conversation(&self, record: &ConversationRecord) -> Result<(), StoreError> {
-        let messages = serde_json::to_string(&record.messages).map_err(|e| StoreError::Serialization(e.to_string()))?;
-        let metadata = serde_json::to_string(&record.metadata).map_err(|e| StoreError::Serialization(e.to_string()))?;
-
-        let sql = format!(
-            "INSERT INTO {} \
-             (conversation_id, tenant_id, created_at, metadata, messages) \
-             VALUES (?, ?, ?, ?, ?) \
-             ON CONFLICT(conversation_id, tenant_id) \
-             DO UPDATE SET messages = excluded.messages",
-            self.tables.conversations
-        );
-
-        sqlx::query(AssertSqlSafe(sql.as_str()))
-            .bind(&record.conversation_id)
-            .bind(&record.tenant_id)
-            .bind(record.created_at)
-            .bind(&metadata)
-            .bind(&messages)
-            .execute(&self.pool)
-            .await
-            .map_err(|e| StoreError::Database(e.to_string()))?;
-
-        Ok(())
-    }
-
     async fn get_conversation(
         &self,
         tenant_id: &str,
         conversation_id: &str,
     ) -> Result<Option<ConversationRecord>, StoreError> {
-        let sql = format!(
-            "SELECT conversation_id, tenant_id, created_at, metadata, messages \
-             FROM {} \
-             WHERE conversation_id = ? AND tenant_id = ?",
-            self.tables.conversations
-        );
-
-        let row = sqlx::query(AssertSqlSafe(sql.as_str()))
-            .bind(conversation_id)
-            .bind(tenant_id)
-            .fetch_optional(&self.pool)
-            .await
-            .map_err(|e| StoreError::Database(e.to_string()))?;
-
-        row.map(|r| row_to_conversation_record(&r)).transpose()
-    }
-
-    async fn delete_conversation(&self, tenant_id: &str, conversation_id: &str) -> Result<bool, StoreError> {
-        let mut tx = self
-            .pool
-            .begin()
-            .await
-            .map_err(|e| StoreError::Database(e.to_string()))?;
-
-        if let Some(items_table) = &self.tables.items {
-            let items_sql = format!("DELETE FROM {items_table} WHERE tenant_id = ? AND conversation_id = ?");
-            sqlx::query(AssertSqlSafe(items_sql.as_str()))
-                .bind(tenant_id)
-                .bind(conversation_id)
-                .execute(&mut *tx)
-                .await
-                .map_err(|e| StoreError::Database(e.to_string()))?;
-        }
-
-        let sql = format!(
-            "DELETE FROM {} WHERE conversation_id = ? AND tenant_id = ?",
-            self.tables.conversations
-        );
-
-        let result = sqlx::query(AssertSqlSafe(sql.as_str()))
-            .bind(conversation_id)
-            .bind(tenant_id)
-            .execute(&mut *tx)
-            .await
-            .map_err(|e| StoreError::Database(e.to_string()))?;
-
-        tx.commit().await.map_err(|e| StoreError::Database(e.to_string()))?;
-        Ok(result.rows_affected() > 0)
+        self.get_conversation_record(tenant_id, conversation_id).await
     }
 }
 
@@ -260,6 +271,22 @@ impl ResponseStore for SqliteResponseStore {
 )]
 #[async_trait]
 impl ConversationItemStore for SqliteResponseStore {
+    async fn upsert_conversation(&self, record: &ConversationRecord) -> Result<(), StoreError> {
+        self.upsert_conversation_record(record).await
+    }
+
+    async fn get_conversation(
+        &self,
+        tenant_id: &str,
+        conversation_id: &str,
+    ) -> Result<Option<ConversationRecord>, StoreError> {
+        self.get_conversation_record(tenant_id, conversation_id).await
+    }
+
+    async fn delete_conversation(&self, tenant_id: &str, conversation_id: &str) -> Result<bool, StoreError> {
+        self.delete_conversation_record(tenant_id, conversation_id).await
+    }
+
     async fn create_conversation_items(&self, items: &[ConversationItemRecord]) -> Result<(), StoreError> {
         let table = self
             .tables
@@ -277,8 +304,7 @@ impl ConversationItemStore for SqliteResponseStore {
             "INSERT INTO {table} \
              (item_id, tenant_id, conversation_id, item_data, created_at, position) \
              VALUES (?, ?, ?, ?, ?, ?) \
-             ON CONFLICT(item_id, tenant_id) DO UPDATE SET \
-             conversation_id = excluded.conversation_id, \
+             ON CONFLICT(item_id, tenant_id, conversation_id) DO UPDATE SET \
              item_data = excluded.item_data, \
              created_at = excluded.created_at, \
              position = excluded.position"

--- a/filter/src/builtins/http/ai/store/tests.rs
+++ b/filter/src/builtins/http/ai/store/tests.rs
@@ -10,7 +10,7 @@ use serde_json::json;
 use super::{
     ConversationItemRecord, ConversationRecord, PostgresResponseStore, ResponseRecord, ResponseStoreRegistry,
     SqliteResponseStore, SslMode, StoreError,
-    trait_def::{ConversationItemStore as _, ResponseStore},
+    trait_def::{ConversationItemStore, ResponseStore},
 };
 use crate::builtins::http::ai::openai::responses::store::{ListParams, Order, list_input_items};
 
@@ -444,8 +444,7 @@ async fn upsert_and_get_conversation() {
 
     store.upsert_conversation(&record).await.expect("upsert should succeed");
 
-    let fetched = store
-        .get_conversation("tenant_a", "conv_1")
+    let fetched = ResponseStore::get_conversation(&store, "tenant_a", "conv_1")
         .await
         .expect("get should succeed")
         .expect("record should exist");
@@ -479,8 +478,7 @@ async fn upsert_conversation_overwrites() {
         .await
         .expect("second upsert should succeed");
 
-    let fetched = store
-        .get_conversation("tenant_a", "conv_1")
+    let fetched = ConversationItemStore::get_conversation(&store, "tenant_a", "conv_1")
         .await
         .expect("get should succeed")
         .expect("record should exist");
@@ -496,8 +494,7 @@ async fn upsert_conversation_overwrites() {
 async fn get_missing_conversation_returns_none() {
     let store = make_store().await;
 
-    let result = store
-        .get_conversation("tenant_a", "nonexistent")
+    let result = ConversationItemStore::get_conversation(&store, "tenant_a", "nonexistent")
         .await
         .expect("get should succeed");
 
@@ -516,8 +513,7 @@ async fn conversation_tenant_isolation() {
     };
     store.upsert_conversation(&record).await.expect("upsert should succeed");
 
-    let result = store
-        .get_conversation("tenant_b", "conv_1")
+    let result = ConversationItemStore::get_conversation(&store, "tenant_b", "conv_1")
         .await
         .expect("get should succeed");
 
@@ -543,8 +539,7 @@ async fn delete_existing_conversation() {
 
     assert!(deleted, "delete should return true for existing conversation");
 
-    let fetched = store
-        .get_conversation("tenant_a", "conv_1")
+    let fetched = ConversationItemStore::get_conversation(&store, "tenant_a", "conv_1")
         .await
         .expect("get should succeed");
 
@@ -582,8 +577,7 @@ async fn delete_conversation_tenant_isolation() {
 
     assert!(!deleted, "tenant_b should not be able to delete tenant_a conversation");
 
-    let still_exists = store
-        .get_conversation("tenant_a", "conv_1")
+    let still_exists = ConversationItemStore::get_conversation(&store, "tenant_a", "conv_1")
         .await
         .expect("get should succeed");
 
@@ -801,6 +795,63 @@ async fn conversation_item_upsert_updates_existing() {
         json!({"type": "message", "role": "assistant", "content": "updated"}),
         "upsert should update item data"
     );
+}
+
+#[tokio::test]
+async fn conversation_item_upsert_allows_same_item_id_in_different_conversations() {
+    let store = make_store_with_items().await;
+    let item_conv1 = ConversationItemRecord {
+        item_data: json!({"conversation": "conv_1"}),
+        ..make_conversation_item("item_shared", "tenant_a", "conv_1", 1)
+    };
+    let item_conv2 = ConversationItemRecord {
+        item_data: json!({"conversation": "conv_2"}),
+        ..make_conversation_item("item_shared", "tenant_a", "conv_2", 1)
+    };
+
+    store
+        .create_conversation_items(&[item_conv1])
+        .await
+        .expect("initial item insert should succeed");
+    store
+        .create_conversation_items(&[item_conv2])
+        .await
+        .expect("same item_id in another conversation should insert");
+
+    let conv1_item = store
+        .get_conversation_item("tenant_a", "conv_1", "item_shared")
+        .await
+        .expect("conv_1 get should succeed")
+        .expect("conv_1 item should still exist");
+    let conv2_item = store
+        .get_conversation_item("tenant_a", "conv_2", "item_shared")
+        .await
+        .expect("conv_2 get should succeed")
+        .expect("conv_2 item should exist");
+
+    assert_eq!(conv1_item.conversation_id, "conv_1", "conv_1 row should remain scoped");
+    assert_eq!(conv2_item.conversation_id, "conv_2", "conv_2 row should be inserted");
+    assert_eq!(
+        conv1_item.item_data,
+        json!({"conversation": "conv_1"}),
+        "conv_1 item data should not be overwritten"
+    );
+    assert_eq!(
+        conv2_item.item_data,
+        json!({"conversation": "conv_2"}),
+        "conv_2 item data should be stored separately"
+    );
+
+    let conv1_items = store
+        .list_conversation_items("tenant_a", "conv_1", None, 100, true)
+        .await
+        .expect("conv_1 list should succeed");
+    let conv2_items = store
+        .list_conversation_items("tenant_a", "conv_2", None, 100, true)
+        .await
+        .expect("conv_2 list should succeed");
+    assert_item_ids(&conv1_items, &["item_shared"]);
+    assert_item_ids(&conv2_items, &["item_shared"]);
 }
 
 #[tokio::test]
@@ -1315,8 +1366,7 @@ async fn pg_upsert_and_get_conversation() {
 
     store.upsert_conversation(&record).await.expect("upsert should succeed");
 
-    let fetched = store
-        .get_conversation("tenant_a", "conv_1")
+    let fetched = ResponseStore::get_conversation(&store, "tenant_a", "conv_1")
         .await
         .expect("get should succeed")
         .expect("record should exist");
@@ -1352,8 +1402,7 @@ async fn pg_upsert_conversation_overwrites() {
         .await
         .expect("second upsert should succeed");
 
-    let fetched = store
-        .get_conversation("tenant_a", "conv_1")
+    let fetched = ConversationItemStore::get_conversation(&store, "tenant_a", "conv_1")
         .await
         .expect("get should succeed")
         .expect("record should exist");
@@ -1386,8 +1435,7 @@ async fn pg_delete_existing_conversation() {
 
     assert!(deleted, "delete should return true for existing conversation");
 
-    let fetched = store
-        .get_conversation("tenant_a", "conv_1")
+    let fetched = ConversationItemStore::get_conversation(&store, "tenant_a", "conv_1")
         .await
         .expect("get should succeed");
 
@@ -1408,8 +1456,7 @@ async fn pg_conversation_tenant_isolation() {
     };
     store.upsert_conversation(&record).await.expect("upsert should succeed");
 
-    let result = store
-        .get_conversation("tenant_b", "conv_1")
+    let result = ConversationItemStore::get_conversation(&store, "tenant_b", "conv_1")
         .await
         .expect("get should succeed");
 
@@ -1632,6 +1679,64 @@ async fn pg_conversation_item_upsert_updates_existing() {
         json!({"type": "message", "role": "assistant", "content": "updated"}),
         "upsert should update item data"
     );
+}
+
+#[tokio::test]
+#[ignore]
+async fn pg_conversation_item_upsert_allows_same_item_id_in_different_conversations() {
+    let store = make_pg_store_with_items().await;
+    let item_conv1 = ConversationItemRecord {
+        item_data: json!({"conversation": "conv_1"}),
+        ..make_conversation_item("item_shared", "tenant_a", "conv_1", 1)
+    };
+    let item_conv2 = ConversationItemRecord {
+        item_data: json!({"conversation": "conv_2"}),
+        ..make_conversation_item("item_shared", "tenant_a", "conv_2", 1)
+    };
+
+    store
+        .create_conversation_items(&[item_conv1])
+        .await
+        .expect("initial item insert should succeed");
+    store
+        .create_conversation_items(&[item_conv2])
+        .await
+        .expect("same item_id in another conversation should insert");
+
+    let conv1_item = store
+        .get_conversation_item("tenant_a", "conv_1", "item_shared")
+        .await
+        .expect("conv_1 get should succeed")
+        .expect("conv_1 item should still exist");
+    let conv2_item = store
+        .get_conversation_item("tenant_a", "conv_2", "item_shared")
+        .await
+        .expect("conv_2 get should succeed")
+        .expect("conv_2 item should exist");
+
+    assert_eq!(conv1_item.conversation_id, "conv_1", "conv_1 row should remain scoped");
+    assert_eq!(conv2_item.conversation_id, "conv_2", "conv_2 row should be inserted");
+    assert_eq!(
+        conv1_item.item_data,
+        json!({"conversation": "conv_1"}),
+        "conv_1 item data should not be overwritten"
+    );
+    assert_eq!(
+        conv2_item.item_data,
+        json!({"conversation": "conv_2"}),
+        "conv_2 item data should be stored separately"
+    );
+
+    let conv1_items = store
+        .list_conversation_items("tenant_a", "conv_1", None, 100, true)
+        .await
+        .expect("conv_1 list should succeed");
+    let conv2_items = store
+        .list_conversation_items("tenant_a", "conv_2", None, 100, true)
+        .await
+        .expect("conv_2 list should succeed");
+    assert_item_ids(&conv1_items, &["item_shared"]);
+    assert_item_ids(&conv2_items, &["item_shared"]);
 }
 
 #[tokio::test]

--- a/filter/src/builtins/http/ai/store/trait_def.rs
+++ b/filter/src/builtins/http/ai/store/trait_def.rs
@@ -2,7 +2,7 @@
 // Copyright (c) 2026 Praxis Contributors
 
 //! The [`ResponseStore`] and [`ConversationItemStore`] async traits
-//! for response and conversation item persistence.
+//! for response persistence and conversation lifecycle/item persistence.
 
 use async_trait::async_trait;
 
@@ -19,6 +19,10 @@ use super::types::{ConversationItemRecord, ConversationRecord, ResponseRecord, S
 ///
 /// `get_response` returns `None` for both "not found" and "wrong
 /// tenant" to avoid information leakage.
+///
+/// Conversation access is read-only here so response rehydration can
+/// load cached conversations without taking ownership of conversation
+/// lifecycle mutations.
 #[async_trait]
 pub trait ResponseStore: Send + Sync {
     /// Insert or update a response record.
@@ -53,6 +57,33 @@ pub trait ResponseStore: Send + Sync {
     /// Returns [`StoreError`] if the database operation fails.
     async fn delete_response(&self, tenant_id: &str, id: &str) -> Result<bool, StoreError>;
 
+    /// Retrieve conversation messages by conversation ID and tenant.
+    ///
+    /// Returns `None` if the conversation does not exist or belongs
+    /// to a different tenant.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError`] if the database operation fails.
+    async fn get_conversation(
+        &self,
+        tenant_id: &str,
+        conversation_id: &str,
+    ) -> Result<Option<ConversationRecord>, StoreError>;
+}
+
+// -----------------------------------------------------------------------------
+// ConversationItemStore Trait
+// -----------------------------------------------------------------------------
+
+/// Async persistence layer for conversation lifecycle and item records.
+///
+/// Provides full conversation lifecycle management plus CRUD
+/// operations for individual items within a conversation. Every query
+/// is tenant- and conversation-scoped.
+#[async_trait]
+#[cfg_attr(not(test), expect(dead_code, reason = "used by conversations filter in #623"))]
+pub trait ConversationItemStore: Send + Sync {
     /// Insert or update a conversation message cache.
     ///
     /// # Errors
@@ -83,25 +114,11 @@ pub trait ResponseStore: Send + Sync {
     ///
     /// Returns [`StoreError`] if the database operation fails.
     async fn delete_conversation(&self, tenant_id: &str, conversation_id: &str) -> Result<bool, StoreError>;
-}
 
-// -----------------------------------------------------------------------------
-// ConversationItemStore Trait
-// -----------------------------------------------------------------------------
-
-/// Async persistence layer for conversation item records.
-///
-/// Provides CRUD operations for individual items within a
-/// conversation. Every query is tenant- and conversation-scoped.
-/// Implementors must also implement [`ResponseStore`] since they
-/// share the same backing database and connection pool.
-#[async_trait]
-#[cfg_attr(not(test), expect(dead_code, reason = "used by conversations filter in #623"))]
-pub trait ConversationItemStore: Send + Sync {
     /// Insert one or more conversation items.
     ///
     /// Items are inserted individually. Duplicate `item_id` +
-    /// `tenant_id` pairs are upserted.
+    /// `tenant_id` + `conversation_id` triples are upserted.
     ///
     /// # Errors
     ///


### PR DESCRIPTION
## Summary

- Move `upsert_conversation` and `delete_conversation` from `ResponseStore` to `ConversationItemStore` so the conversations filter can manage conversations without depending on response persistence
- Keep `get_conversation` on both traits — `ResponseStore` needs read-only access, `ConversationItemStore` needs full lifecycle
- Change items table PK to `(item_id, tenant_id, conversation_id)` so the same `item_id` can exist in different conversations without silent migration on upsert conflict

Closes praxis-proxy/ai#63

## Test plan

- [x] Existing conversation CRUD tests pass with fully-qualified trait dispatch
- [x] New `conversation_item_upsert_allows_same_item_id_in_different_conversations` test (both backends)
- [x] Rehydrate mock updated to match trimmed `ResponseStore` trait
- [x] `make lint` clean