### PR TITLE
fix(filter): use Responses API error format for all response rejections

### DIFF
--- a/filter/src/builtins/http/ai/openai/responses/error.rs
+++ b/filter/src/builtins/http/ai/openai/responses/error.rs
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Responses API error formatting.
+//!
+//! Builds OpenAI-compatible error responses. Non-streaming errors use
+//! the HTTP API `{"error":{...}}` envelope; streaming errors use the
+//! Responses API SSE `error` event shape.
+
+use bytes::Bytes;
+
+use crate::Rejection;
+
+/// Build a non-streaming OpenAI API error JSON body.
+///
+/// Produces `{"error":{"message":"<msg>","type":"<code>","param":null,"code":"<code>"}}`.
+pub(crate) fn responses_error_body(code: &str, message: &str) -> Bytes {
+    Bytes::from(
+        serde_json::json!({
+            "error": {
+                "message": message,
+                "type": code,
+                "param": null,
+                "code": code,
+            },
+        })
+        .to_string(),
+    )
+}
+
+/// Build a Responses API error as an SSE event.
+///
+/// Produces `event: error\ndata: <ResponseErrorEvent json>\n\n`.
+pub(crate) fn responses_error_sse_body(code: &str, message: &str) -> Bytes {
+    let json = serde_json::json!({
+        "type": "error",
+        "sequence_number": 0,
+        "error": {
+            "type": code,
+            "code": code,
+            "message": message,
+            "param": null,
+        },
+    });
+    Bytes::from(format!("event: error\ndata: {json}\n\n"))
+}
+
+/// Build a [`Rejection`] with the appropriate OpenAI error format.
+///
+/// When `streaming` is true, produces `text/event-stream` with a
+/// Responses API SSE error event. Otherwise produces `application/json`
+/// with the HTTP API error envelope.
+pub(crate) fn responses_error_rejection(status: u16, code: &str, message: &str, streaming: bool) -> Rejection {
+    if streaming {
+        Rejection::status(status)
+            .with_header("content-type", "text/event-stream")
+            .with_body(responses_error_sse_body(code, message))
+    } else {
+        Rejection::status(status)
+            .with_header("content-type", "application/json")
+            .with_body(responses_error_body(code, message))
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[cfg(test)]
+#[expect(clippy::allow_attributes, reason = "blanket test suppressions")]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    reason = "tests"
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_body_has_correct_shape() {
+        let body = responses_error_body("invalid_request_error", "bad input");
+        let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(
+            parsed["error"]["type"], "invalid_request_error",
+            "error type should match"
+        );
+        assert_eq!(
+            parsed["error"]["code"], "invalid_request_error",
+            "error code should match"
+        );
+        assert_eq!(parsed["error"]["message"], "bad input", "message field should match");
+        assert!(parsed["error"]["param"].is_null(), "param should be null");
+    }
+
+    #[test]
+    fn error_body_escapes_special_characters() {
+        let body = responses_error_body("server_error", "line1\nline2\"quoted\"");
+        let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            parsed["error"]["message"].as_str(),
+            Some("line1\nline2\"quoted\""),
+            "special characters should survive JSON round-trip"
+        );
+    }
+
+    #[test]
+    fn sse_body_has_event_and_data_lines() {
+        let body = responses_error_sse_body("server_error", "oops");
+        let text = std::str::from_utf8(&body).unwrap();
+
+        assert!(text.starts_with("event: error\n"), "should start with event line");
+        assert!(text.contains("data: {"), "should have data line with JSON");
+        assert!(text.ends_with("\n\n"), "should end with double newline");
+    }
+
+    #[test]
+    fn sse_body_contains_valid_json() {
+        let body = responses_error_sse_body("invalid_request_error", "missing field");
+        let text = std::str::from_utf8(&body).unwrap();
+
+        let data_line = text
+            .lines()
+            .find(|l| l.starts_with("data: "))
+            .unwrap()
+            .strip_prefix("data: ")
+            .unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(data_line).unwrap();
+
+        assert_eq!(parsed["type"], "error", "SSE event type should be error");
+        assert_eq!(parsed["sequence_number"], 0, "SSE error should include sequence number");
+        assert_eq!(
+            parsed["error"]["type"], "invalid_request_error",
+            "SSE error type should match"
+        );
+        assert_eq!(
+            parsed["error"]["code"], "invalid_request_error",
+            "SSE error code should match"
+        );
+        assert_eq!(
+            parsed["error"]["message"], "missing field",
+            "SSE error message should match"
+        );
+        assert!(parsed["error"]["param"].is_null(), "SSE error param should be null");
+    }
+
+    #[test]
+    fn rejection_non_streaming_uses_json_content_type() {
+        let r = responses_error_rejection(400, "invalid_request_error", "bad", false);
+
+        assert_eq!(r.status, 400, "status should be preserved");
+        let ct = r.headers.iter().find(|(k, _)| k == "content-type");
+        assert_eq!(
+            ct.map(|(_, v)| v.as_str()),
+            Some("application/json"),
+            "non-streaming should use application/json"
+        );
+    }
+
+    #[test]
+    fn rejection_streaming_uses_sse_content_type() {
+        let r = responses_error_rejection(500, "server_error", "fail", true);
+
+        assert_eq!(r.status, 500, "status should be preserved");
+        let ct = r.headers.iter().find(|(k, _)| k == "content-type");
+        assert_eq!(
+            ct.map(|(_, v)| v.as_str()),
+            Some("text/event-stream"),
+            "streaming should use text/event-stream"
+        );
+    }
+
+    #[test]
+    fn rejection_non_streaming_body_is_plain_json() {
+        let r = responses_error_rejection(404, "invalid_request_error", "not found", false);
+        let body = r.body.unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            parsed["error"]["type"], "invalid_request_error",
+            "non-streaming error type should match"
+        );
+        assert_eq!(
+            parsed["error"]["message"], "not found",
+            "non-streaming error message should match"
+        );
+    }
+
+    #[test]
+    fn rejection_streaming_body_is_sse_event() {
+        let r = responses_error_rejection(400, "invalid_request_error", "bad", true);
+        let body = r.body.unwrap();
+        let text = std::str::from_utf8(&body).unwrap();
+        assert!(
+            text.starts_with("event: error\n"),
+            "streaming body should start with error event"
+        );
+    }
+}

--- a/filter/src/builtins/http/ai/openai/responses/mod.rs
+++ b/filter/src/builtins/http/ai/openai/responses/mod.rs
@@ -18,6 +18,7 @@
 //! to validate parameter combinations and extract additional fields.
 
 mod config;
+pub(crate) mod error;
 #[cfg(feature = "ai-inference")]
 pub(crate) mod model_rewrite;
 pub(crate) mod proxy;

--- a/filter/src/builtins/http/ai/openai/responses/mod.rs
+++ b/filter/src/builtins/http/ai/openai/responses/mod.rs
@@ -57,7 +57,7 @@ use tracing::{debug, trace};
 use self::config::{ResponsesFormatConfig, build_config};
 use super::super::OnInvalidBehavior;
 use crate::{
-    FilterAction, FilterError, Rejection,
+    FilterAction, FilterError,
     body::{BodyAccess, BodyMode},
     builtins::http::{
         ai::classifier::{AiRequestFormat, ClassifiedRequest, classify_request_body, empty_result, is_responses_path},
@@ -225,13 +225,12 @@ fn handle_invalid_format(format: AiRequestFormat, config: &ResponsesFormatConfig
             };
 
             trace!(reason = message, "rejecting unrecognized body");
-            Some(FilterAction::Reject(
-                Rejection::status(400)
-                    .with_header("content-type", "application/json")
-                    .with_body(Bytes::from(format!(
-                        r#"{{"error":{{"message":"{message}","type":"invalid_request_error"}}}}"#
-                    ))),
-            ))
+            Some(FilterAction::Reject(error::responses_error_rejection(
+                400,
+                "invalid_request_error",
+                message,
+                false,
+            )))
         },
     }
 }

--- a/filter/src/builtins/http/ai/openai/responses/model_rewrite/mod.rs
+++ b/filter/src/builtins/http/ai/openai/responses/model_rewrite/mod.rs
@@ -44,8 +44,9 @@ use bytes::Bytes;
 use tracing::{debug, trace, warn};
 
 use self::config::{ModelRewriteConfig, OnInvalidBehavior, validate_config};
+use super::error::responses_error_rejection;
 use crate::{
-    FilterAction, FilterError, Rejection,
+    FilterAction, FilterError,
     body::{BodyAccess, BodyMode},
     builtins::http::{ai::classifier::is_responses_create, value_safety::is_safe_promoted_value},
     factory::parse_filter_config,
@@ -137,13 +138,18 @@ impl ModelRewriteFilter {
         let Some(raw) = body.as_ref() else {
             return Ok(FilterAction::Continue);
         };
+
+        let streaming = ctx
+            .get_metadata("openai_responses_format.stream")
+            .is_some_and(|v| v == "true");
+
         let mut value: serde_json::Value = match serde_json::from_slice(raw) {
             Ok(v) => v,
-            Err(_) => return Ok(invalid_body_action(self.on_invalid)),
+            Err(_) => return Ok(invalid_body_action(self.on_invalid, streaming)),
         };
 
         let Some(obj) = value.as_object_mut() else {
-            return Ok(invalid_body_action(self.on_invalid));
+            return Ok(invalid_body_action(self.on_invalid, streaming));
         };
 
         let result = apply_rewrite(obj, &self.model_aliases, self.default_model.as_deref());
@@ -507,15 +513,14 @@ fn set_filter_result(
 }
 
 /// Map [`OnInvalidBehavior`] to the appropriate [`FilterAction`].
-fn invalid_body_action(behavior: OnInvalidBehavior) -> FilterAction {
+fn invalid_body_action(behavior: OnInvalidBehavior, streaming: bool) -> FilterAction {
     match behavior {
         OnInvalidBehavior::Continue => FilterAction::Continue,
-        OnInvalidBehavior::Reject => FilterAction::Reject(
-            Rejection::status(400)
-                .with_header("content-type", "application/json")
-                .with_body(Bytes::from(
-                    r#"{"error":{"message":"invalid JSON body","type":"invalid_request_error"}}"#,
-                )),
-        ),
+        OnInvalidBehavior::Reject => FilterAction::Reject(responses_error_rejection(
+            400,
+            "invalid_request_error",
+            "invalid JSON body",
+            streaming,
+        )),
     }
 }

--- a/filter/src/builtins/http/ai/openai/responses/proxy/mod.rs
+++ b/filter/src/builtins/http/ai/openai/responses/proxy/mod.rs
@@ -38,9 +38,9 @@ use bytes::Bytes;
 use tracing::{debug, trace};
 
 use self::config::{ResponsesProxyConfig, build_config};
-use super::state::ResponsesState;
+use super::{error::responses_error_rejection, state::ResponsesState};
 use crate::{
-    FilterAction, FilterError, Rejection,
+    FilterAction, FilterError,
     body::{BodyAccess, BodyMode},
     factory::parse_filter_config,
     filter::{HttpFilter, HttpFilterContext},
@@ -107,7 +107,11 @@ impl ResponsesProxyFilter {
     }
 
     /// Serialize the rebuilt body from conversation state.
-    fn serialize_body(&self, state: &ResponsesState) -> Result<Result<Vec<u8>, FilterAction>, FilterError> {
+    fn serialize_body(
+        &self,
+        state: &ResponsesState,
+        streaming: bool,
+    ) -> Result<Result<Vec<u8>, FilterAction>, FilterError> {
         let mut outbound = state.request_body.clone();
         if let Some(obj) = outbound.as_object_mut() {
             obj.insert("input".to_owned(), serde_json::Value::Array(state.messages.clone()));
@@ -124,7 +128,12 @@ impl ResponsesProxyFilter {
                 max_bytes = self.config.max_body_bytes,
                 "rebuilt request body exceeds maximum size"
             );
-            return Ok(Err(FilterAction::Reject(Rejection::status(413))));
+            return Ok(Err(FilterAction::Reject(responses_error_rejection(
+                413,
+                "invalid_request_error",
+                "request body exceeds maximum size",
+                streaming,
+            ))));
         }
 
         debug!(
@@ -173,7 +182,11 @@ impl HttpFilter for ResponsesProxyFilter {
             return Ok(FilterAction::Continue);
         };
 
-        let serialized = match self.serialize_body(state)? {
+        let streaming = ctx
+            .get_metadata("openai_responses_format.stream")
+            .is_some_and(|v| v == "true");
+
+        let serialized = match self.serialize_body(state, streaming)? {
             Ok(bytes) => bytes,
             Err(action) => return Ok(action),
         };

--- a/filter/src/builtins/http/ai/openai/responses/rehydrate/mod.rs
+++ b/filter/src/builtins/http/ai/openai/responses/rehydrate/mod.rs
@@ -16,9 +16,11 @@ use bytes::Bytes;
 use serde_json::Value;
 use tracing::{debug, warn};
 
-use super::{DEFAULT_STORE_NAME, DEFAULT_TENANT_ID, TENANT_METADATA_KEY, state::ResponsesState};
+use super::{
+    DEFAULT_STORE_NAME, DEFAULT_TENANT_ID, TENANT_METADATA_KEY, error::responses_error_rejection, state::ResponsesState,
+};
 use crate::{
-    FilterAction, FilterError, Rejection,
+    FilterAction, FilterError,
     body::{BodyAccess, BodyMode, MAX_JSON_BODY_BYTES},
     builtins::http::ai::store::{ResponseRecord, ResponseStoreRegistry},
     factory::parse_filter_config,
@@ -113,7 +115,11 @@ impl HttpFilter for RehydrateFilter {
             return Ok(FilterAction::Release);
         }
 
-        validate_previous_response(ctx, body).await
+        let streaming = ctx
+            .get_metadata("openai_responses_format.stream")
+            .is_some_and(|v| v == "true");
+
+        validate_previous_response(ctx, body, streaming).await
     }
 }
 
@@ -136,12 +142,13 @@ fn is_responses_cancel_path(path: &str) -> bool {
 async fn validate_previous_response(
     ctx: &mut HttpFilterContext<'_>,
     body: &Option<Bytes>,
+    streaming: bool,
 ) -> Result<FilterAction, FilterError> {
     let Some(bytes) = body.as_ref() else {
         return Ok(FilterAction::Release);
     };
 
-    let (parsed_body, prev_id) = match parse_body_and_extract_id(bytes) {
+    let (parsed_body, prev_id) = match parse_body_and_extract_id(bytes, streaming) {
         Ok((body, Some(id))) => (body, id),
         Ok((_, None)) => return Ok(FilterAction::Release),
         Err(action) => return Ok(action),
@@ -152,12 +159,12 @@ async fn validate_previous_response(
         .unwrap_or(DEFAULT_TENANT_ID)
         .to_owned();
 
-    let record = match fetch_previous_response(ctx, &tenant_id, &prev_id).await {
+    let record = match fetch_previous_response(ctx, &tenant_id, &prev_id, streaming).await {
         Ok(r) => r,
         Err(action) => return Ok(action),
     };
 
-    if let Err(action) = validate_response_status(&record) {
+    if let Err(action) = validate_response_status(&record, streaming) {
         return Ok(action);
     }
 
@@ -185,16 +192,16 @@ fn build_state(parsed_body: Value, messages: Value) -> ResponsesState {
 ///
 /// Returns the parsed body alongside the optional ID so callers
 /// can reuse it for [`ResponsesState`] construction.
-fn parse_body_and_extract_id(bytes: &[u8]) -> Result<(Value, Option<String>), FilterAction> {
+fn parse_body_and_extract_id(bytes: &[u8], streaming: bool) -> Result<(Value, Option<String>), FilterAction> {
     let parsed: Value = serde_json::from_slice(bytes).map_err(|e| {
         debug!(error = %e, "rehydrate: invalid request JSON");
-        reject_invalid(&format!("invalid request body: {e}"))
+        reject_invalid(&format!("invalid request body: {e}"), streaming)
     })?;
 
     let id = match parsed.get("previous_response_id") {
         None | Some(Value::Null) => None,
         Some(Value::String(s)) => Some(s.clone()),
-        Some(_) => return Err(reject_invalid("previous_response_id must be a string")),
+        Some(_) => return Err(reject_invalid("previous_response_id must be a string", streaming)),
     };
 
     Ok((parsed, id))
@@ -209,30 +216,31 @@ async fn fetch_previous_response(
     ctx: &HttpFilterContext<'_>,
     tenant_id: &str,
     prev_id: &str,
+    streaming: bool,
 ) -> Result<ResponseRecord, FilterAction> {
     let registry = ctx.extensions.get::<ResponseStoreRegistry>().ok_or_else(|| {
         warn!("rehydrate: response store registry not available");
-        reject_server_error("response store is not available")
+        reject_server_error("response store is not available", streaming)
     })?;
 
     let store = registry.get(DEFAULT_STORE_NAME).ok_or_else(|| {
         warn!("rehydrate: default response store not registered");
-        reject_server_error("response store is not available")
+        reject_server_error("response store is not available", streaming)
     })?;
 
     let record = store.get_response(tenant_id, prev_id).await.map_err(|e| {
         warn!(error = %e, "rehydrate: failed to fetch previous response");
-        reject_server_error("failed to fetch previous response")
+        reject_server_error("failed to fetch previous response", streaming)
     })?;
 
     record.ok_or_else(|| {
         debug!(id = %prev_id, "rehydrate: previous response not found");
-        reject_invalid(&format!("response '{prev_id}' not found"))
+        reject_invalid(&format!("response '{prev_id}' not found"), streaming)
     })
 }
 
 /// Validate that the stored response has status `"completed"`.
-fn validate_response_status(record: &ResponseRecord) -> Result<(), FilterAction> {
+fn validate_response_status(record: &ResponseRecord, streaming: bool) -> Result<(), FilterAction> {
     let status = record
         .response_object
         .get("status")
@@ -240,9 +248,10 @@ fn validate_response_status(record: &ResponseRecord) -> Result<(), FilterAction>
         .unwrap_or("unknown");
 
     if status != "completed" {
-        return Err(reject_invalid(&format!(
-            "cannot continue from response with status '{status}'"
-        )));
+        return Err(reject_invalid(
+            &format!("cannot continue from response with status '{status}'"),
+            streaming,
+        ));
     }
 
     Ok(())
@@ -252,38 +261,19 @@ fn validate_response_status(record: &ResponseRecord) -> Result<(), FilterAction>
 // Rejection Helpers
 // -----------------------------------------------------------------------------
 
-/// Build a 400 rejection with a JSON error body.
-fn reject_invalid(message: &str) -> FilterAction {
-    let body = serde_json::json!({
-        "error": {
-            "message": message,
-            "type": "invalid_request_error"
-        }
-    })
-    .to_string();
-
-    FilterAction::Reject(
-        Rejection::status(400)
-            .with_header("content-type", "application/json")
-            .with_body(Bytes::from(body)),
-    )
+/// Build a 400 rejection with a Responses API error body.
+fn reject_invalid(message: &str, streaming: bool) -> FilterAction {
+    FilterAction::Reject(responses_error_rejection(
+        400,
+        "invalid_request_error",
+        message,
+        streaming,
+    ))
 }
 
-/// Build a 500 rejection with a JSON error body.
-fn reject_server_error(message: &str) -> FilterAction {
-    let body = serde_json::json!({
-        "error": {
-            "message": message,
-            "type": "server_error"
-        }
-    })
-    .to_string();
-
-    FilterAction::Reject(
-        Rejection::status(500)
-            .with_header("content-type", "application/json")
-            .with_body(Bytes::from(body)),
-    )
+/// Build a 500 rejection with a Responses API error body.
+fn reject_server_error(message: &str, streaming: bool) -> FilterAction {
+    FilterAction::Reject(responses_error_rejection(500, "server_error", message, streaming))
 }
 
 // -----------------------------------------------------------------------------

--- a/filter/src/builtins/http/ai/openai/responses/store/filter.rs
+++ b/filter/src/builtins/http/ai/openai/responses/store/filter.rs
@@ -50,7 +50,10 @@ use tokio::sync::OnceCell;
 use tracing::{debug, trace, warn};
 
 use super::{
-    super::{DEFAULT_STORE_NAME, DEFAULT_TENANT_ID, TENANT_METADATA_KEY, state::ResponsesState},
+    super::{
+        DEFAULT_STORE_NAME, DEFAULT_TENANT_ID, TENANT_METADATA_KEY, error::responses_error_rejection,
+        state::ResponsesState,
+    },
     InputItemPage, ListParams, Order,
     config::{ResponseStoreConfig, StorageBackend, revalidate_postgres_host, validate_config},
     list_input_items,
@@ -219,7 +222,7 @@ impl ResponseStoreFilter {
             Ok(FilterAction::Reject(delete_success_rejection(id)?))
         } else {
             debug!(id, tenant_id, "response not found for delete");
-            Ok(FilterAction::Reject(delete_not_found_rejection(id)?))
+            Ok(FilterAction::Reject(delete_not_found_rejection(id)))
         }
     }
 
@@ -388,18 +391,13 @@ fn delete_success_rejection(id: &str) -> Result<Rejection, FilterError> {
 }
 
 /// Build the 404 rejection for a missing response.
-fn delete_not_found_rejection(id: &str) -> Result<Rejection, FilterError> {
-    let body = serde_json::to_string(&serde_json::json!({
-        "error": {
-            "message": format!("No response found with id: '{id}'."),
-            "type": "invalid_request_error",
-        }
-    }))
-    .map_err(|e| FilterError::from(format!("openai_response_store: serialize failed: {e}")))?;
-
-    Ok(Rejection::status(404)
-        .with_header("content-type", "application/json")
-        .with_body(Bytes::from(body)))
+fn delete_not_found_rejection(id: &str) -> Rejection {
+    responses_error_rejection(
+        404,
+        "invalid_request_error",
+        &format!("No response found with id: '{id}'."),
+        false,
+    )
 }
 
 // -----------------------------------------------------------------------------
@@ -894,41 +892,22 @@ pub(super) fn parse_query_params(query: Option<&str>) -> ListParams {
     params
 }
 
-/// Build a 404 rejection with an `OpenAI`-style error body.
+/// Build a 404 rejection with a Responses API error body.
 fn reject_not_found(id: &str) -> Rejection {
-    let body = serde_json::json!({
-        "error": {
-            "message": format!("No response found with id '{id}'."),
-            "type": "invalid_request_error",
-        }
-    });
-    Rejection::status(404)
-        .with_header("content-type", "application/json")
-        .with_body(serde_json::to_vec(&body).unwrap_or_default())
+    responses_error_rejection(
+        404,
+        "invalid_request_error",
+        &format!("No response found with id '{id}'."),
+        false,
+    )
 }
 
 /// Build a 400 rejection for invalid client-supplied parameters.
 fn reject_invalid_input(message: &str) -> Rejection {
-    let body = serde_json::json!({
-        "error": {
-            "message": message,
-            "type": "invalid_request_error",
-        }
-    });
-    Rejection::status(400)
-        .with_header("content-type", "application/json")
-        .with_body(serde_json::to_vec(&body).unwrap_or_default())
+    responses_error_rejection(400, "invalid_request_error", message, false)
 }
 
 /// Build a 500 rejection for internal store failures.
 fn reject_store_error() -> Rejection {
-    let body = serde_json::json!({
-        "error": {
-            "message": "Internal server error.",
-            "type": "server_error",
-        }
-    });
-    Rejection::status(500)
-        .with_header("content-type", "application/json")
-        .with_body(serde_json::to_vec(&body).unwrap_or_default())
+    responses_error_rejection(500, "server_error", "Internal server error.", false)
 }

--- a/filter/src/builtins/http/ai/openai/responses/validate/mod.rs
+++ b/filter/src/builtins/http/ai/openai/responses/validate/mod.rs
@@ -27,8 +27,9 @@ use bytes::Bytes;
 use tracing::{debug, trace};
 
 use self::rules::validate_request;
+use super::error::responses_error_rejection;
 use crate::{
-    FilterAction, FilterError, Rejection,
+    FilterAction, FilterError,
     body::{BodyAccess, BodyMode, MAX_JSON_BODY_BYTES},
     filter::{HttpFilter, HttpFilterContext},
 };
@@ -148,22 +149,25 @@ impl HttpFilter for OpenaiResponsesValidateFilter {
 
 /// Parse the request body and run validation checks.
 fn parse_and_validate(ctx: &HttpFilterContext<'_>, body: &Option<Bytes>) -> Result<serde_json::Value, FilterAction> {
+    let streaming = ctx
+        .get_metadata("openai_responses_format.stream")
+        .is_some_and(|v| v == "true");
     let Some(chunk) = body.as_deref() else {
         debug!("rejecting request with missing body");
-        return Err(reject_invalid("request body is required"));
+        return Err(reject_invalid("request body is required", streaming));
     };
 
     let parsed: serde_json::Value = match serde_json::from_slice(chunk) {
         Ok(v) => v,
         Err(e) => {
             debug!(error = %e, "failed to parse request body");
-            return Err(reject_invalid(&format!("invalid request body: {e}")));
+            return Err(reject_invalid(&format!("invalid request body: {e}"), streaming));
         },
     };
 
     if let Err(e) = validate_request(ctx) {
         debug!(error = %e, "request validation failed");
-        return Err(reject_invalid(&e.to_string()));
+        return Err(reject_invalid(&e.to_string(), streaming));
     }
 
     Ok(parsed)
@@ -183,21 +187,14 @@ fn is_bodyless_responses_request(method: &http::Method, path: &str) -> bool {
     }
 }
 
-/// Build a 400 rejection with a JSON error body.
-fn reject_invalid(message: &str) -> FilterAction {
-    let body = serde_json::json!({
-        "error": {
-            "message": message,
-            "type": "invalid_request_error"
-        }
-    })
-    .to_string();
-
-    FilterAction::Reject(
-        Rejection::status(400)
-            .with_header("content-type", "application/json")
-            .with_body(Bytes::from(body)),
-    )
+/// Build a 400 rejection with a Responses API error body.
+fn reject_invalid(message: &str, streaming: bool) -> FilterAction {
+    FilterAction::Reject(responses_error_rejection(
+        400,
+        "invalid_request_error",
+        message,
+        streaming,
+    ))
 }
 
 /// Extract conversation ID from the request body.
@@ -422,7 +419,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn rejection_has_json_content_type() {
+    async fn streaming_rejection_has_sse_content_type() {
         let action = run_filter_raw(
             r#"{"input": "test"}"#,
             &[
@@ -435,34 +432,65 @@ mod tests {
             let has_content_type = rejection
                 .headers
                 .iter()
-                .any(|(k, v)| k == "content-type" && v == "application/json");
-            assert!(has_content_type, "rejection should have application/json content-type");
+                .any(|(k, v)| k == "content-type" && v == "text/event-stream");
+            assert!(
+                has_content_type,
+                "streaming rejection should have text/event-stream content-type"
+            );
         } else {
             panic!("expected rejection");
         }
     }
 
     #[tokio::test]
-    async fn rejection_body_is_valid_json() {
+    async fn non_streaming_rejection_has_json_content_type() {
         let action = run_filter_raw(
             r#"{"input": "test"}"#,
             &[
-                ("openai_responses_format.stream", "true"),
                 ("openai_responses_format.background", "true"),
+                ("openai_responses_format.store", "false"),
+            ],
+        )
+        .await;
+        if let FilterAction::Reject(rejection) = action {
+            let has_content_type = rejection
+                .headers
+                .iter()
+                .any(|(k, v)| k == "content-type" && v == "application/json");
+            assert!(
+                has_content_type,
+                "non-streaming rejection should have application/json content-type"
+            );
+        } else {
+            panic!("expected rejection");
+        }
+    }
+
+    #[tokio::test]
+    async fn rejection_body_uses_responses_error_format() {
+        let action = run_filter_raw(
+            r#"{"input": "test"}"#,
+            &[
+                ("openai_responses_format.background", "true"),
+                ("openai_responses_format.store", "false"),
             ],
         )
         .await;
         if let FilterAction::Reject(rejection) = action {
             let body = rejection.body.unwrap();
             let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap();
-            assert!(
-                parsed["error"]["message"].is_string(),
-                "rejection body should contain error.message"
-            );
             assert_eq!(
                 parsed["error"]["type"].as_str(),
                 Some("invalid_request_error"),
-                "rejection body should have invalid_request_error type"
+                "rejection body should have error type=invalid_request_error"
+            );
+            assert!(
+                parsed["error"]["message"].is_string(),
+                "rejection body should contain error message"
+            );
+            assert!(
+                parsed["error"]["param"].is_null(),
+                "rejection body should have error param=null"
             );
         } else {
             panic!("expected rejection");
@@ -471,7 +499,7 @@ mod tests {
 
     #[test]
     fn reject_invalid_escapes_control_characters() {
-        let action = reject_invalid("line1\nline2");
+        let action = reject_invalid("line1\nline2", false);
         if let FilterAction::Reject(rejection) = action {
             let body = rejection.body.unwrap();
             let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap();

--- a/tests/integration/tests/suite/examples/openai_responses_validate.rs
+++ b/tests/integration/tests/suite/examples/openai_responses_validate.rs
@@ -6,8 +6,8 @@
 use std::collections::HashMap;
 
 use praxis_test_utils::{
-    free_port, http_send, json_post, load_example_config, parse_body, parse_status, start_backend_with_shutdown,
-    start_proxy,
+    free_port, http_send, json_post, load_example_config, parse_body, parse_header, parse_status,
+    start_backend_with_shutdown, start_proxy,
 };
 
 // -----------------------------------------------------------------------------
@@ -56,13 +56,35 @@ fn openai_responses_validate_example_rejects_stream_and_background() {
     );
 
     assert_eq!(parse_status(&raw), 400, "stream + background should be rejected");
-    let body = parse_body(&raw);
-    let parsed: serde_json::Value = serde_json::from_str(&body).expect("error body should be JSON");
     assert_eq!(
-        parsed["error"]["type"].as_str(),
-        Some("invalid_request_error"),
-        "error type should be invalid_request_error"
+        parse_header(&raw, "content-type").as_deref(),
+        Some("text/event-stream"),
+        "streaming rejection should use SSE content type"
     );
+    let body = parse_body(&raw);
+    let data_line = body
+        .lines()
+        .find(|l| l.starts_with("data: "))
+        .expect("SSE body should contain a data line");
+    let parsed: serde_json::Value =
+        serde_json::from_str(data_line.strip_prefix("data: ").unwrap()).expect("SSE data should be valid JSON");
+    assert_eq!(parsed["type"].as_str(), Some("error"), "SSE event type should be error");
+    assert_eq!(
+        parsed["sequence_number"].as_i64(),
+        Some(0),
+        "SSE error event should include sequence number"
+    );
+    assert_eq!(
+        parsed["error"]["code"].as_str(),
+        Some("invalid_request_error"),
+        "error code should be invalid_request_error"
+    );
+    assert_eq!(
+        parsed["error"]["message"].as_str(),
+        Some("stream and background cannot both be true"),
+        "error message should describe the validation failure"
+    );
+    assert!(parsed["error"]["param"].is_null(), "error param should be null");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Fixes Responses API filters to return errors in the correct Responses API format (`{"type":"error","code":"...","message":"...","param":null}`) instead of Chat Completions format (`{"error":{"message":"...","type":"..."}}`)
- Adds shared error builder module (`responses/error.rs`) and migrates all rejection points in validate, rehydrate, store, model_rewrite, and proxy filters
- For streaming requests, errors are now SSE-formatted with `text/event-stream` content-type

Part of praxis-proxy/ai#7.