### PR TITLE
feat(filter): extract MCP tools and usage from previous response

### DIFF
--- a/filter/src/builtins/http/ai/openai/responses/rehydrate/mod.rs
+++ b/filter/src/builtins/http/ai/openai/responses/rehydrate/mod.rs
@@ -27,6 +27,7 @@ use crate::{
     filter::{HttpFilter, HttpFilterContext},
 };
 
+// -----------------------------------------------------------------------------
 // Constants
 // -----------------------------------------------------------------------------
 
@@ -184,10 +185,7 @@ async fn validate_previous_response(
         return Ok(action);
     }
 
-    extract_mcp_tools(ctx, &record);
-    extract_previous_usage(ctx, &record);
-
-    ctx.extensions.insert(build_state(parsed_body, record.messages));
+    populate_state_and_metadata(ctx, parsed_body, &record);
 
     debug!(previous_response_id = %prev_id, "previous response validated, state populated");
     ctx.set_metadata("responses.previous_response_id", prev_id);
@@ -195,16 +193,87 @@ async fn validate_previous_response(
     Ok(FilterAction::Release)
 }
 
+/// Promote previous response metadata and insert request state.
+fn populate_state_and_metadata(ctx: &mut HttpFilterContext<'_>, parsed_body: Value, record: &ResponseRecord) {
+    let previous_tools = collect_mcp_tool_listings(record);
+    write_mcp_tools_metadata(ctx, &previous_tools);
+
+    let previous_usage = record.response_object.get("usage").filter(|usage| !usage.is_null());
+    write_previous_usage_metadata(ctx, previous_usage);
+
+    ctx.extensions.insert(build_state(
+        parsed_body,
+        record,
+        previous_tools,
+        previous_usage.cloned(),
+    ));
+}
+
 /// Build [`ResponsesState`] by prepending stored messages before the current input.
 // TODO(#697): enforce a max rehydrated history size.
-fn build_state(parsed_body: Value, messages: Value) -> ResponsesState {
+fn build_state(
+    parsed_body: Value,
+    record: &ResponseRecord,
+    previous_tools: Vec<Value>,
+    previous_usage: Option<Value>,
+) -> ResponsesState {
     let mut state = ResponsesState::from_request_body(parsed_body);
-    let stored = match messages {
-        Value::Array(arr) => arr,
-        _ => Vec::new(),
-    };
+    let stored = stored_messages_for_rehydrate(record);
     state.messages.splice(0..0, stored);
+    state.previous_tools = previous_tools;
+    state.previous_usage = previous_usage;
     state
+}
+
+/// Return stored history, reconstructing from public fields for
+/// records created before hidden messages were persisted.
+fn stored_messages_for_rehydrate(record: &ResponseRecord) -> Vec<Value> {
+    if let Some(messages) = record.messages.as_array().filter(|messages| !messages.is_empty()) {
+        return messages.clone();
+    }
+
+    reconstruct_messages_from_public_response(record)
+}
+
+/// Reconstruct previous input/output items from public stored fields.
+fn reconstruct_messages_from_public_response(record: &ResponseRecord) -> Vec<Value> {
+    let mut messages = Vec::new();
+
+    append_stored_input_items(&mut messages, record.input.clone());
+
+    if let Some(output) = record.response_object.get("output").filter(|output| !output.is_null()) {
+        append_stored_output_items(&mut messages, output.clone());
+    }
+
+    messages
+}
+
+/// Append stored response input as Responses API item params.
+fn append_stored_input_items(messages: &mut Vec<Value>, input: Value) {
+    match input {
+        Value::Null => {},
+        Value::String(text) => messages.push(user_message_item(&text)),
+        Value::Array(items) => messages.extend(items),
+        other => messages.push(other),
+    }
+}
+
+/// Append stored response output items.
+fn append_stored_output_items(messages: &mut Vec<Value>, output: Value) {
+    if let Value::Array(items) = output {
+        messages.extend(items);
+    } else {
+        messages.push(output);
+    }
+}
+
+/// Build a Responses API user message item from string input.
+fn user_message_item(text: &str) -> Value {
+    serde_json::json!({
+        "type": "message",
+        "role": "user",
+        "content": text,
+    })
 }
 
 /// Parse the request body and extract `previous_response_id`.
@@ -278,22 +347,16 @@ fn validate_response_status(record: &ResponseRecord) -> Result<(), FilterAction>
 // MCP Tool & Usage Extraction
 // -----------------------------------------------------------------------------
 
-/// Extract MCP tool listings from stored history or previous
-/// response output and set a compact metadata signal for downstream
-/// filters.
-///
-/// Scans stored message history and `record.response_object["output"]`
-/// for items with `"type": "mcp_list_tools"` and builds a compact
-/// JSON array of `{"server_label": "x", "tools": ["name1", "name2"]}`.
+/// Set a compact MCP tool metadata signal for downstream filters.
 ///
 /// If the serialized value exceeds [`MAX_METADATA_VALUE_BYTES`],
 /// a boolean `"true"` is set instead.
-fn extract_mcp_tools(ctx: &mut HttpFilterContext<'_>, record: &ResponseRecord) {
-    let summaries = collect_mcp_tool_summaries(record);
-    if summaries.is_empty() {
+fn write_mcp_tools_metadata(ctx: &mut HttpFilterContext<'_>, listings: &[Value]) {
+    if listings.is_empty() {
         return;
     }
 
+    let summaries = compact_mcp_tool_summaries(listings);
     let compact = Value::Array(summaries);
     match serde_json::to_string(&compact) {
         Ok(s) if s.len() <= MAX_METADATA_VALUE_BYTES => {
@@ -310,66 +373,83 @@ fn extract_mcp_tools(ctx: &mut HttpFilterContext<'_>, record: &ResponseRecord) {
     }
 }
 
-/// Build compact summaries from `mcp_list_tools` output items.
-///
-/// Each summary contains the `server_label` and an array of
-/// tool names (without schemas or descriptions).
-fn collect_mcp_tool_summaries(record: &ResponseRecord) -> Vec<Value> {
-    let mut summaries = Vec::new();
+/// Recover MCP tool listings from stored history and response output.
+fn collect_mcp_tool_listings(record: &ResponseRecord) -> Vec<Value> {
+    let mut listings = Vec::new();
     let mut seen = HashSet::new();
 
     if let Some(messages) = record.messages.as_array() {
-        collect_mcp_tool_summaries_from_items(messages, &mut seen, &mut summaries);
+        collect_mcp_tool_listings_from_items(messages, &mut seen, &mut listings);
     }
 
     if let Some(output) = record.response_object.get("output").and_then(Value::as_array) {
-        collect_mcp_tool_summaries_from_items(output, &mut seen, &mut summaries);
+        collect_mcp_tool_listings_from_items(output, &mut seen, &mut listings);
     }
 
-    summaries
+    listings
 }
 
-/// Append compact MCP tool summaries from a sequence of response items.
-fn collect_mcp_tool_summaries_from_items(
+/// Append MCP tool listings from a sequence of response items.
+fn collect_mcp_tool_listings_from_items(
     items: &[Value],
     seen: &mut HashSet<(String, Vec<String>)>,
-    summaries: &mut Vec<Value>,
+    listings: &mut Vec<Value>,
 ) {
-    summaries.extend(
-        items
-            .iter()
-            .filter(|item| item.get("type").and_then(Value::as_str) == Some("mcp_list_tools"))
-            .filter_map(|item| {
-                let label = item.get("server_label").and_then(Value::as_str)?;
-                let names: Vec<String> = item
-                    .get("tools")
-                    .and_then(Value::as_array)
-                    .map(|tools| {
-                        tools
-                            .iter()
-                            .filter_map(|t| t.get("name").and_then(Value::as_str).map(ToOwned::to_owned))
-                            .collect()
-                    })
-                    .unwrap_or_default();
-                if !seen.insert((label.to_owned(), names.clone())) {
-                    return None;
-                }
-                Some(serde_json::json!({
-                    "server_label": label,
-                    "tools": names,
-                }))
-            }),
-    );
+    listings.extend(items.iter().filter_map(|item| {
+        if item.get("type").and_then(Value::as_str) != Some("mcp_list_tools") {
+            return None;
+        }
+
+        let label = item.get("server_label").and_then(Value::as_str)?;
+        let tools = item.get("tools").and_then(Value::as_array)?;
+        let names = mcp_tool_names(tools);
+        let mut dedupe_names = names.clone();
+        dedupe_names.sort();
+        dedupe_names.dedup();
+
+        if !seen.insert((label.to_owned(), dedupe_names)) {
+            return None;
+        }
+
+        Some(serde_json::json!({
+            "server_label": label,
+            "tools": tools,
+        }))
+    }));
+}
+
+/// Build compact summaries from recovered MCP listings.
+fn compact_mcp_tool_summaries(listings: &[Value]) -> Vec<Value> {
+    listings
+        .iter()
+        .filter_map(|listing| {
+            let label = listing.get("server_label").and_then(Value::as_str)?;
+            let tools = listing.get("tools").and_then(Value::as_array)?;
+            let names = mcp_tool_names(tools);
+
+            Some(serde_json::json!({
+                "server_label": label,
+                "tools": names,
+            }))
+        })
+        .collect()
+}
+
+/// Extract tool names from MCP tool definitions.
+fn mcp_tool_names(tools: &[Value]) -> Vec<String> {
+    tools
+        .iter()
+        .filter_map(|tool| tool.get("name").and_then(Value::as_str).map(ToOwned::to_owned))
+        .collect()
 }
 
 /// Extract token usage from the previous response and set
 /// metadata keys for downstream auto-compaction.
 ///
-/// Reads `record.response_object["usage"]` and writes
-/// `input_tokens`, `output_tokens`, and `total_tokens` as
-/// individual string metadata values.
-fn extract_previous_usage(ctx: &mut HttpFilterContext<'_>, record: &ResponseRecord) {
-    let Some(usage) = record.response_object.get("usage") else {
+/// Writes `input_tokens`, `output_tokens`, and `total_tokens` as
+/// individual string metadata values when present.
+fn write_previous_usage_metadata(ctx: &mut HttpFilterContext<'_>, usage: Option<&Value>) {
+    let Some(usage) = usage else {
         return;
     };
 

--- a/filter/src/builtins/http/ai/openai/responses/rehydrate/mod.rs
+++ b/filter/src/builtins/http/ai/openai/responses/rehydrate/mod.rs
@@ -14,7 +14,7 @@
 use async_trait::async_trait;
 use bytes::Bytes;
 use serde_json::Value;
-use tracing::{debug, warn};
+use tracing::{debug, trace, warn};
 
 use super::{DEFAULT_STORE_NAME, DEFAULT_TENANT_ID, TENANT_METADATA_KEY, state::ResponsesState};
 use crate::{
@@ -24,6 +24,27 @@ use crate::{
     factory::parse_filter_config,
     filter::{HttpFilter, HttpFilterContext},
 };
+
+// Constants
+// -----------------------------------------------------------------------------
+
+/// Metadata key for MCP tools discovered in the previous response.
+const MCP_TOOLS_METADATA_KEY: &str = "responses.previous_mcp_tools";
+
+/// Metadata key for previous response input token count.
+const PREV_USAGE_INPUT_KEY: &str = "responses.previous_usage_input_tokens";
+
+/// Metadata key for previous response output token count.
+const PREV_USAGE_OUTPUT_KEY: &str = "responses.previous_usage_output_tokens";
+
+/// Metadata key for previous response total token count.
+const PREV_USAGE_TOTAL_KEY: &str = "responses.previous_usage_total_tokens";
+
+/// Maximum metadata value length (bytes). Matches the limit
+/// enforced by [`HttpFilterContext::set_metadata`].
+///
+/// [`HttpFilterContext::set_metadata`]: crate::filter::HttpFilterContext::set_metadata
+const MAX_METADATA_VALUE_BYTES: usize = 256;
 
 // -----------------------------------------------------------------------------
 // RehydrateFilter
@@ -161,6 +182,9 @@ async fn validate_previous_response(
         return Ok(action);
     }
 
+    extract_mcp_tools(ctx, &record);
+    extract_previous_usage(ctx, &record);
+
     ctx.extensions.insert(build_state(parsed_body, record.messages));
 
     debug!(previous_response_id = %prev_id, "previous response validated, state populated");
@@ -249,6 +273,99 @@ fn validate_response_status(record: &ResponseRecord) -> Result<(), FilterAction>
 }
 
 // -----------------------------------------------------------------------------
+// MCP Tool & Usage Extraction
+// -----------------------------------------------------------------------------
+
+/// Extract MCP tool listings from the previous response output
+/// and set a compact metadata signal for downstream filters.
+///
+/// Scans `record.response_object["output"]` for items with
+/// `"type": "mcp_list_tools"` and builds a compact JSON array
+/// of `{"server_label": "x", "tools": ["name1", "name2"]}`.
+///
+/// If the serialized value exceeds [`MAX_METADATA_VALUE_BYTES`],
+/// a boolean `"true"` is set instead.
+fn extract_mcp_tools(ctx: &mut HttpFilterContext<'_>, record: &ResponseRecord) {
+    let summaries = collect_mcp_tool_summaries(record);
+    if summaries.is_empty() {
+        return;
+    }
+
+    let compact = Value::Array(summaries);
+    match serde_json::to_string(&compact) {
+        Ok(s) if s.len() <= MAX_METADATA_VALUE_BYTES => {
+            trace!(mcp_tools = %s, "extracted MCP tool listings");
+            ctx.set_metadata(MCP_TOOLS_METADATA_KEY, s);
+        },
+        Ok(_) => {
+            trace!("MCP tool listings exceed metadata limit");
+            ctx.set_metadata(MCP_TOOLS_METADATA_KEY, "true");
+        },
+        Err(e) => {
+            warn!(error = %e, "failed to serialize MCP tool summary");
+        },
+    }
+}
+
+/// Build compact summaries from `mcp_list_tools` output items.
+///
+/// Each summary contains the `server_label` and an array of
+/// tool names (without schemas or descriptions).
+fn collect_mcp_tool_summaries(record: &ResponseRecord) -> Vec<Value> {
+    let Some(output) = record.response_object.get("output").and_then(Value::as_array) else {
+        return Vec::new();
+    };
+
+    output
+        .iter()
+        .filter(|item| item.get("type").and_then(Value::as_str) == Some("mcp_list_tools"))
+        .filter_map(|item| {
+            let label = item.get("server_label").and_then(Value::as_str)?;
+            let names: Vec<Value> = item
+                .get("tools")
+                .and_then(Value::as_array)
+                .map(|tools| {
+                    tools
+                        .iter()
+                        .filter_map(|t| t.get("name").and_then(Value::as_str).map(Value::from))
+                        .collect()
+                })
+                .unwrap_or_default();
+            Some(serde_json::json!({
+                "server_label": label,
+                "tools": names,
+            }))
+        })
+        .collect()
+}
+
+/// Extract token usage from the previous response and set
+/// metadata keys for downstream auto-compaction.
+///
+/// Reads `record.response_object["usage"]` and writes
+/// `input_tokens`, `output_tokens`, and `total_tokens` as
+/// individual string metadata values.
+fn extract_previous_usage(ctx: &mut HttpFilterContext<'_>, record: &ResponseRecord) {
+    let Some(usage) = record.response_object.get("usage") else {
+        return;
+    };
+
+    if let Some(input) = usage.get("input_tokens").and_then(Value::as_u64) {
+        ctx.set_metadata(PREV_USAGE_INPUT_KEY, input.to_string());
+    }
+
+    if let Some(output) = usage.get("output_tokens").and_then(Value::as_u64) {
+        ctx.set_metadata(PREV_USAGE_OUTPUT_KEY, output.to_string());
+    }
+
+    if let Some(total) = usage.get("total_tokens").and_then(Value::as_u64) {
+        ctx.set_metadata(PREV_USAGE_TOTAL_KEY, total.to_string());
+    }
+
+    trace!("extracted previous response usage");
+}
+
+// -----------------------------------------------------------------------------
 // Rejection Helpers
 // -----------------------------------------------------------------------------
 
@@ -296,6 +413,7 @@ fn reject_server_error(message: &str) -> FilterAction {
     clippy::unwrap_used,
     clippy::expect_used,
     clippy::indexing_slicing,
+    clippy::needless_pass_by_value,
     clippy::panic,
     clippy::needless_raw_strings,
     clippy::needless_raw_string_hashes,

--- a/filter/src/builtins/http/ai/openai/responses/rehydrate/mod.rs
+++ b/filter/src/builtins/http/ai/openai/responses/rehydrate/mod.rs
@@ -31,9 +31,6 @@ use crate::{
 // Constants
 // -----------------------------------------------------------------------------
 
-/// Metadata key for MCP tools discovered in the previous response.
-const MCP_TOOLS_METADATA_KEY: &str = "responses.previous_mcp_tools";
-
 /// Metadata key for previous response input token count.
 const PREV_USAGE_INPUT_KEY: &str = "responses.previous_usage_input_tokens";
 
@@ -42,12 +39,6 @@ const PREV_USAGE_OUTPUT_KEY: &str = "responses.previous_usage_output_tokens";
 
 /// Metadata key for previous response total token count.
 const PREV_USAGE_TOTAL_KEY: &str = "responses.previous_usage_total_tokens";
-
-/// Maximum metadata value length (bytes). Matches the limit
-/// enforced by [`HttpFilterContext::set_metadata`].
-///
-/// [`HttpFilterContext::set_metadata`]: crate::filter::HttpFilterContext::set_metadata
-const MAX_METADATA_VALUE_BYTES: usize = 256;
 
 // -----------------------------------------------------------------------------
 // RehydrateFilter
@@ -196,7 +187,6 @@ async fn validate_previous_response(
 /// Promote previous response metadata and insert request state.
 fn populate_state_and_metadata(ctx: &mut HttpFilterContext<'_>, parsed_body: Value, record: &ResponseRecord) {
     let previous_tools = collect_mcp_tool_listings(record);
-    write_mcp_tools_metadata(ctx, &previous_tools);
 
     let previous_usage = record.response_object.get("usage").filter(|usage| !usage.is_null());
     write_previous_usage_metadata(ctx, previous_usage);
@@ -219,7 +209,9 @@ fn build_state(
 ) -> ResponsesState {
     let mut state = ResponsesState::from_request_body(parsed_body);
     let stored = stored_messages_for_rehydrate(record);
-    state.messages.splice(0..0, stored);
+    let replay = replay_messages_from_stored(&stored);
+    state.messages.splice(0..0, replay);
+    state.persisted_messages.splice(0..0, stored);
     state.previous_tools = previous_tools;
     state.previous_usage = previous_usage;
     state
@@ -242,7 +234,7 @@ fn reconstruct_messages_from_public_response(record: &ResponseRecord) -> Vec<Val
     append_stored_input_items(&mut messages, record.input.clone());
 
     if let Some(output) = record.response_object.get("output").filter(|output| !output.is_null()) {
-        append_stored_output_items(&mut messages, output.clone());
+        append_stored_output_items(&mut messages, output);
     }
 
     messages
@@ -258,13 +250,27 @@ fn append_stored_input_items(messages: &mut Vec<Value>, input: Value) {
     }
 }
 
-/// Append stored response output items.
-fn append_stored_output_items(messages: &mut Vec<Value>, output: Value) {
+/// Append stored response output items to the persisted conversation history.
+fn append_stored_output_items(messages: &mut Vec<Value>, output: &Value) {
     if let Value::Array(items) = output {
-        messages.extend(items);
+        messages.extend(items.iter().cloned());
     } else {
-        messages.push(output);
+        messages.push(output.clone());
     }
+}
+
+/// Return stored items that should be replayed as backend request input.
+fn replay_messages_from_stored(stored: &[Value]) -> Vec<Value> {
+    stored
+        .iter()
+        .filter(|item| !is_output_only_metadata_item(item))
+        .cloned()
+        .collect()
+}
+
+/// Return whether a stored output item carries metadata rather than replay context.
+fn is_output_only_metadata_item(item: &Value) -> bool {
+    item.get("type").and_then(Value::as_str) == Some("mcp_list_tools")
 }
 
 /// Build a Responses API user message item from string input.
@@ -347,32 +353,6 @@ fn validate_response_status(record: &ResponseRecord) -> Result<(), FilterAction>
 // MCP Tool & Usage Extraction
 // -----------------------------------------------------------------------------
 
-/// Set a compact MCP tool metadata signal for downstream filters.
-///
-/// If the serialized value exceeds [`MAX_METADATA_VALUE_BYTES`],
-/// a boolean `"true"` is set instead.
-fn write_mcp_tools_metadata(ctx: &mut HttpFilterContext<'_>, listings: &[Value]) {
-    if listings.is_empty() {
-        return;
-    }
-
-    let summaries = compact_mcp_tool_summaries(listings);
-    let compact = Value::Array(summaries);
-    match serde_json::to_string(&compact) {
-        Ok(s) if s.len() <= MAX_METADATA_VALUE_BYTES => {
-            trace!(mcp_tools = %s, "extracted MCP tool listings");
-            ctx.set_metadata(MCP_TOOLS_METADATA_KEY, s);
-        },
-        Ok(_) => {
-            trace!("MCP tool listings exceed metadata limit");
-            ctx.set_metadata(MCP_TOOLS_METADATA_KEY, "true");
-        },
-        Err(e) => {
-            warn!(error = %e, "failed to serialize MCP tool summary");
-        },
-    }
-}
-
 /// Recover MCP tool listings from stored history and response output.
 fn collect_mcp_tool_listings(record: &ResponseRecord) -> Vec<Value> {
     let mut listings = Vec::new();
@@ -416,23 +396,6 @@ fn collect_mcp_tool_listings_from_items(
             "tools": tools,
         }))
     }));
-}
-
-/// Build compact summaries from recovered MCP listings.
-fn compact_mcp_tool_summaries(listings: &[Value]) -> Vec<Value> {
-    listings
-        .iter()
-        .filter_map(|listing| {
-            let label = listing.get("server_label").and_then(Value::as_str)?;
-            let tools = listing.get("tools").and_then(Value::as_array)?;
-            let names = mcp_tool_names(tools);
-
-            Some(serde_json::json!({
-                "server_label": label,
-                "tools": names,
-            }))
-        })
-        .collect()
 }
 
 /// Extract tool names from MCP tool definitions.

--- a/filter/src/builtins/http/ai/openai/responses/rehydrate/mod.rs
+++ b/filter/src/builtins/http/ai/openai/responses/rehydrate/mod.rs
@@ -11,6 +11,8 @@
 //!
 //! [`ResponsesState`]: super::state::ResponsesState
 
+use std::collections::HashSet;
+
 use async_trait::async_trait;
 use bytes::Bytes;
 use serde_json::Value;
@@ -276,12 +278,13 @@ fn validate_response_status(record: &ResponseRecord) -> Result<(), FilterAction>
 // MCP Tool & Usage Extraction
 // -----------------------------------------------------------------------------
 
-/// Extract MCP tool listings from the previous response output
-/// and set a compact metadata signal for downstream filters.
+/// Extract MCP tool listings from stored history or previous
+/// response output and set a compact metadata signal for downstream
+/// filters.
 ///
-/// Scans `record.response_object["output"]` for items with
-/// `"type": "mcp_list_tools"` and builds a compact JSON array
-/// of `{"server_label": "x", "tools": ["name1", "name2"]}`.
+/// Scans stored message history and `record.response_object["output"]`
+/// for items with `"type": "mcp_list_tools"` and builds a compact
+/// JSON array of `{"server_label": "x", "tools": ["name1", "name2"]}`.
 ///
 /// If the serialized value exceeds [`MAX_METADATA_VALUE_BYTES`],
 /// a boolean `"true"` is set instead.
@@ -312,31 +315,51 @@ fn extract_mcp_tools(ctx: &mut HttpFilterContext<'_>, record: &ResponseRecord) {
 /// Each summary contains the `server_label` and an array of
 /// tool names (without schemas or descriptions).
 fn collect_mcp_tool_summaries(record: &ResponseRecord) -> Vec<Value> {
-    let Some(output) = record.response_object.get("output").and_then(Value::as_array) else {
-        return Vec::new();
-    };
+    let mut summaries = Vec::new();
+    let mut seen = HashSet::new();
 
-    output
-        .iter()
-        .filter(|item| item.get("type").and_then(Value::as_str) == Some("mcp_list_tools"))
-        .filter_map(|item| {
-            let label = item.get("server_label").and_then(Value::as_str)?;
-            let names: Vec<Value> = item
-                .get("tools")
-                .and_then(Value::as_array)
-                .map(|tools| {
-                    tools
-                        .iter()
-                        .filter_map(|t| t.get("name").and_then(Value::as_str).map(Value::from))
-                        .collect()
-                })
-                .unwrap_or_default();
-            Some(serde_json::json!({
-                "server_label": label,
-                "tools": names,
-            }))
-        })
-        .collect()
+    if let Some(messages) = record.messages.as_array() {
+        collect_mcp_tool_summaries_from_items(messages, &mut seen, &mut summaries);
+    }
+
+    if let Some(output) = record.response_object.get("output").and_then(Value::as_array) {
+        collect_mcp_tool_summaries_from_items(output, &mut seen, &mut summaries);
+    }
+
+    summaries
+}
+
+/// Append compact MCP tool summaries from a sequence of response items.
+fn collect_mcp_tool_summaries_from_items(
+    items: &[Value],
+    seen: &mut HashSet<(String, Vec<String>)>,
+    summaries: &mut Vec<Value>,
+) {
+    summaries.extend(
+        items
+            .iter()
+            .filter(|item| item.get("type").and_then(Value::as_str) == Some("mcp_list_tools"))
+            .filter_map(|item| {
+                let label = item.get("server_label").and_then(Value::as_str)?;
+                let names: Vec<String> = item
+                    .get("tools")
+                    .and_then(Value::as_array)
+                    .map(|tools| {
+                        tools
+                            .iter()
+                            .filter_map(|t| t.get("name").and_then(Value::as_str).map(ToOwned::to_owned))
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                if !seen.insert((label.to_owned(), names.clone())) {
+                    return None;
+                }
+                Some(serde_json::json!({
+                    "server_label": label,
+                    "tools": names,
+                }))
+            }),
+    );
 }
 
 /// Extract token usage from the previous response and set

--- a/filter/src/builtins/http/ai/openai/responses/rehydrate/mod.rs
+++ b/filter/src/builtins/http/ai/openai/responses/rehydrate/mod.rs
@@ -176,7 +176,7 @@ async fn validate_previous_response(
         return Ok(action);
     }
 
-    populate_state_and_metadata(ctx, parsed_body, &record);
+    populate_state_and_usage_metadata(ctx, parsed_body, &record);
 
     debug!(previous_response_id = %prev_id, "previous response validated, state populated");
     ctx.set_metadata("responses.previous_response_id", prev_id);
@@ -184,8 +184,8 @@ async fn validate_previous_response(
     Ok(FilterAction::Release)
 }
 
-/// Promote previous response metadata and insert request state.
-fn populate_state_and_metadata(ctx: &mut HttpFilterContext<'_>, parsed_body: Value, record: &ResponseRecord) {
+/// Insert rehydrated request state and promote previous usage metadata.
+fn populate_state_and_usage_metadata(ctx: &mut HttpFilterContext<'_>, parsed_body: Value, record: &ResponseRecord) {
     let previous_tools = collect_mcp_tool_listings(record);
 
     let previous_usage = record.response_object.get("usage").filter(|usage| !usage.is_null());

--- a/filter/src/builtins/http/ai/openai/responses/rehydrate/tests.rs
+++ b/filter/src/builtins/http/ai/openai/responses/rehydrate/tests.rs
@@ -516,6 +516,16 @@ async fn extracts_mcp_tools_from_previous_response() {
     assert_eq!(tools.len(), 2, "should have two tool names");
     assert_eq!(tools[0], "get_weather", "first tool name should match");
     assert_eq!(tools[1], "search", "second tool name should match");
+
+    let state = ctx
+        .extensions
+        .get::<ResponsesState>()
+        .expect("ResponsesState should be populated");
+    assert_eq!(state.previous_tools.len(), 1, "should store full previous tool listing");
+    assert_eq!(
+        state.previous_tools[0]["tools"][0]["description"], "Get weather",
+        "ResponsesState should preserve full tool definitions"
+    );
 }
 
 #[tokio::test]
@@ -593,6 +603,83 @@ async fn extracts_mcp_tools_from_multiple_servers() {
         arr[1]["tools"].as_array().unwrap().len(),
         2,
         "second server should have two tools"
+    );
+}
+
+#[tokio::test]
+async fn deduplicates_mcp_tools_independent_of_tool_order() {
+    let mut records = std::collections::HashMap::new();
+    records.insert(
+        "resp_dedupe".to_owned(),
+        ResponseRecord {
+            id: "resp_dedupe".to_owned(),
+            tenant_id: "default".to_owned(),
+            created_at: 1000,
+            model: "gpt-4.1".to_owned(),
+            response_object: json!({
+                "id": "resp_dedupe",
+                "status": "completed",
+                "output": [{
+                    "id": "mcpl_output",
+                    "type": "mcp_list_tools",
+                    "server_label": "shared-server",
+                    "tools": [
+                        {"name": "beta", "description": "d", "input_schema": {}},
+                        {"name": "alpha", "description": "d", "input_schema": {}}
+                    ]
+                }]
+            }),
+            input: json!("Hello"),
+            messages: json!([
+                {
+                    "id": "mcpl_history",
+                    "type": "mcp_list_tools",
+                    "server_label": "shared-server",
+                    "tools": [
+                        {"name": "alpha", "description": "d", "input_schema": {}},
+                        {"name": "beta", "description": "d", "input_schema": {}}
+                    ]
+                }
+            ]),
+        },
+    );
+    let store = MockStore {
+        records,
+        should_fail: false,
+    };
+    let registry = setup_registry(store);
+
+    let filter = RehydrateFilter;
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.extensions.insert(registry.clone());
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+    let mut body = Some(Bytes::from(r#"{"input":"Next","previous_response_id":"resp_dedupe"}"#));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Release),
+        "should release after rehydration"
+    );
+
+    let mcp_meta = ctx
+        .get_metadata("responses.previous_mcp_tools")
+        .expect("should set MCP tools metadata");
+    let parsed: Value = serde_json::from_str(mcp_meta).unwrap();
+    assert_eq!(
+        parsed.as_array().unwrap().len(),
+        1,
+        "same server/tools should dedupe even when order differs"
+    );
+
+    let state = ctx
+        .extensions
+        .get::<ResponsesState>()
+        .expect("ResponsesState should be populated");
+    assert_eq!(
+        state.previous_tools.len(),
+        1,
+        "ResponsesState should not retain duplicate MCP listings"
     );
 }
 
@@ -690,6 +777,16 @@ async fn mcp_tools_overflow_sets_boolean_flag() {
         Some("true"),
         "should fall back to boolean flag when compact JSON exceeds 256 bytes"
     );
+
+    let state = ctx
+        .extensions
+        .get::<ResponsesState>()
+        .expect("ResponsesState should be populated");
+    assert_eq!(
+        state.previous_tools.len(),
+        1,
+        "metadata overflow should not drop full previous tools from state"
+    );
 }
 
 // -----------------------------------------------------------------------------
@@ -700,7 +797,7 @@ async fn mcp_tools_overflow_sets_boolean_flag() {
 async fn extracts_usage_from_previous_response() {
     let output = json!([{"type": "message", "content": [{"type": "output_text", "text": "Hi"}]}]);
     let usage = json!({"input_tokens": 500, "output_tokens": 200, "total_tokens": 700});
-    let store = MockStore::with_output_and_usage("resp_usage", output, usage);
+    let store = MockStore::with_output_and_usage("resp_usage", output, usage.clone());
     let registry = setup_registry(store);
 
     let filter = RehydrateFilter;
@@ -729,6 +826,16 @@ async fn extracts_usage_from_previous_response() {
         ctx.get_metadata("responses.previous_usage_total_tokens"),
         Some("700"),
         "total tokens"
+    );
+
+    let state = ctx
+        .extensions
+        .get::<ResponsesState>()
+        .expect("ResponsesState should be populated");
+    assert_eq!(
+        state.previous_usage.as_ref(),
+        Some(&usage),
+        "previous usage should be stored in ResponsesState"
     );
 }
 
@@ -761,6 +868,15 @@ async fn no_usage_metadata_when_usage_missing() {
     assert!(
         ctx.get_metadata("responses.previous_usage_total_tokens").is_none(),
         "should not set total tokens"
+    );
+
+    let state = ctx
+        .extensions
+        .get::<ResponsesState>()
+        .expect("ResponsesState should be populated");
+    assert!(
+        state.previous_usage.is_none(),
+        "missing usage should not populate previous_usage"
     );
 }
 
@@ -852,6 +968,27 @@ async fn fallback_reconstruction_includes_mcp_list_tools() {
         ctx.get_metadata("responses.previous_mcp_tools").is_some(),
         "should set MCP tools metadata even with empty messages"
     );
+
+    let state = ctx
+        .extensions
+        .get::<ResponsesState>()
+        .expect("ResponsesState should be populated");
+    assert_eq!(
+        state.messages.len(),
+        4,
+        "fallback should reconstruct previous input/output before current input"
+    );
+    assert_eq!(state.messages[0]["content"], "Hello", "previous input should be first");
+    assert_eq!(
+        state.messages[1]["type"], "mcp_list_tools",
+        "previous output items should be preserved"
+    );
+    assert_eq!(
+        state.messages[2]["type"], "message",
+        "previous message output should follow"
+    );
+    assert_eq!(state.messages[3]["content"], "Next", "current input should be last");
+    assert_eq!(state.previous_tools.len(), 1, "fallback should populate previous tools");
 }
 
 // -----------------------------------------------------------------------------
@@ -890,6 +1027,17 @@ impl MockStore {
 
     fn with_output_and_usage(id: &str, output: Value, usage: Value) -> Self {
         let mut records = std::collections::HashMap::new();
+        let mut response_object = json!({
+            "id": id,
+            "status": "completed",
+            "output": output,
+        });
+        if !usage.is_null() {
+            response_object
+                .as_object_mut()
+                .expect("response_object should be an object")
+                .insert("usage".to_owned(), usage);
+        }
         records.insert(
             id.to_owned(),
             ResponseRecord {
@@ -897,12 +1045,7 @@ impl MockStore {
                 tenant_id: "default".to_owned(),
                 created_at: 1000,
                 model: "gpt-4.1".to_owned(),
-                response_object: json!({
-                    "id": id,
-                    "status": "completed",
-                    "output": output,
-                    "usage": usage,
-                }),
+                response_object,
                 input: json!("Hello"),
                 messages: json!([
                     {"role": "user", "content": "Hello"},

--- a/filter/src/builtins/http/ai/openai/responses/rehydrate/tests.rs
+++ b/filter/src/builtins/http/ai/openai/responses/rehydrate/tests.rs
@@ -469,6 +469,329 @@ async fn rejects_when_store_fetch_fails() {
 }
 
 // -----------------------------------------------------------------------------
+// MCP Tool Recovery
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn extracts_mcp_tools_from_previous_response() {
+    let output = json!([
+        {"type": "message", "content": [{"type": "output_text", "text": "Hi"}]},
+        {
+            "id": "mcpl_abc",
+            "type": "mcp_list_tools",
+            "server_label": "my-server",
+            "tools": [
+                {"name": "get_weather", "description": "Get weather", "input_schema": {}},
+                {"name": "search", "description": "Search docs", "input_schema": {}}
+            ]
+        }
+    ]);
+    let usage = json!({"input_tokens": 100, "output_tokens": 50, "total_tokens": 150});
+    let store = MockStore::with_output_and_usage("resp_mcp", output, usage);
+    let registry = setup_registry(store);
+
+    let filter = RehydrateFilter;
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.extensions.insert(registry.clone());
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+    let mut body = Some(Bytes::from(
+        r#"{"input":"Follow up","previous_response_id":"resp_mcp"}"#,
+    ));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Release),
+        "should release after rehydration"
+    );
+
+    let mcp_meta = ctx
+        .get_metadata("responses.previous_mcp_tools")
+        .expect("should set MCP tools metadata");
+    let parsed: Value = serde_json::from_str(mcp_meta).unwrap();
+    let arr = parsed.as_array().unwrap();
+    assert_eq!(arr.len(), 1, "should have one server entry");
+    assert_eq!(arr[0]["server_label"], "my-server", "server label should match");
+    let tools = arr[0]["tools"].as_array().unwrap();
+    assert_eq!(tools.len(), 2, "should have two tool names");
+    assert_eq!(tools[0], "get_weather", "first tool name should match");
+    assert_eq!(tools[1], "search", "second tool name should match");
+}
+
+#[tokio::test]
+async fn no_mcp_metadata_when_output_has_no_mcp_items() {
+    let output = json!([
+        {"type": "message", "content": [{"type": "output_text", "text": "Hi"}]}
+    ]);
+    let usage = json!({"input_tokens": 10, "output_tokens": 5, "total_tokens": 15});
+    let store = MockStore::with_output_and_usage("resp_no_mcp", output, usage);
+    let registry = setup_registry(store);
+
+    let filter = RehydrateFilter;
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.extensions.insert(registry.clone());
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+    let mut body = Some(Bytes::from(r#"{"input":"Hi","previous_response_id":"resp_no_mcp"}"#));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Release),
+        "should release after rehydration"
+    );
+    assert!(
+        ctx.get_metadata("responses.previous_mcp_tools").is_none(),
+        "should not set MCP metadata when no mcp_list_tools items"
+    );
+}
+
+#[tokio::test]
+async fn extracts_mcp_tools_from_multiple_servers() {
+    let output = json!([
+        {
+            "id": "mcpl_1",
+            "type": "mcp_list_tools",
+            "server_label": "weather-server",
+            "tools": [{"name": "get_weather", "description": "d", "input_schema": {}}]
+        },
+        {"type": "message", "content": [{"type": "output_text", "text": "Hi"}]},
+        {
+            "id": "mcpl_2",
+            "type": "mcp_list_tools",
+            "server_label": "search-server",
+            "tools": [
+                {"name": "search", "description": "d", "input_schema": {}},
+                {"name": "index", "description": "d", "input_schema": {}}
+            ]
+        }
+    ]);
+    let store = MockStore::with_output_and_usage("resp_multi", output, Value::Null);
+    let registry = setup_registry(store);
+
+    let filter = RehydrateFilter;
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.extensions.insert(registry.clone());
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+    let mut body = Some(Bytes::from(r#"{"input":"Hi","previous_response_id":"resp_multi"}"#));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Release),
+        "should release after rehydration"
+    );
+
+    let mcp_meta = ctx
+        .get_metadata("responses.previous_mcp_tools")
+        .expect("should set MCP tools metadata");
+    let parsed: Value = serde_json::from_str(mcp_meta).unwrap();
+    let arr = parsed.as_array().unwrap();
+    assert_eq!(arr.len(), 2, "should have two server entries");
+    assert_eq!(arr[0]["server_label"], "weather-server", "first server label");
+    assert_eq!(arr[1]["server_label"], "search-server", "second server label");
+    assert_eq!(
+        arr[1]["tools"].as_array().unwrap().len(),
+        2,
+        "second server should have two tools"
+    );
+}
+
+#[tokio::test]
+async fn mcp_tools_overflow_sets_boolean_flag() {
+    let many_tools: Vec<Value> = (0..30)
+        .map(|i| json!({"name": format!("very_long_tool_name_number_{i}"), "description": "d", "input_schema": {}}))
+        .collect();
+    let output = json!([{
+        "id": "mcpl_big",
+        "type": "mcp_list_tools",
+        "server_label": "big-server",
+        "tools": many_tools,
+    }]);
+    let store = MockStore::with_output_and_usage("resp_big", output, Value::Null);
+    let registry = setup_registry(store);
+
+    let filter = RehydrateFilter;
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.extensions.insert(registry.clone());
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+    let mut body = Some(Bytes::from(r#"{"input":"Hi","previous_response_id":"resp_big"}"#));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Release),
+        "should release after rehydration"
+    );
+    assert_eq!(
+        ctx.get_metadata("responses.previous_mcp_tools"),
+        Some("true"),
+        "should fall back to boolean flag when compact JSON exceeds 256 bytes"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Usage Extraction
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn extracts_usage_from_previous_response() {
+    let output = json!([{"type": "message", "content": [{"type": "output_text", "text": "Hi"}]}]);
+    let usage = json!({"input_tokens": 500, "output_tokens": 200, "total_tokens": 700});
+    let store = MockStore::with_output_and_usage("resp_usage", output, usage);
+    let registry = setup_registry(store);
+
+    let filter = RehydrateFilter;
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.extensions.insert(registry.clone());
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+    let mut body = Some(Bytes::from(r#"{"input":"Hi","previous_response_id":"resp_usage"}"#));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Release),
+        "should release after rehydration"
+    );
+    assert_eq!(
+        ctx.get_metadata("responses.previous_usage_input_tokens"),
+        Some("500"),
+        "input tokens"
+    );
+    assert_eq!(
+        ctx.get_metadata("responses.previous_usage_output_tokens"),
+        Some("200"),
+        "output tokens"
+    );
+    assert_eq!(
+        ctx.get_metadata("responses.previous_usage_total_tokens"),
+        Some("700"),
+        "total tokens"
+    );
+}
+
+#[tokio::test]
+async fn no_usage_metadata_when_usage_missing() {
+    let output = json!([{"type": "message", "content": [{"type": "output_text", "text": "Hi"}]}]);
+    let store = MockStore::with_output_and_usage("resp_no_usage", output, Value::Null);
+    let registry = setup_registry(store);
+
+    let filter = RehydrateFilter;
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.extensions.insert(registry.clone());
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+    let mut body = Some(Bytes::from(r#"{"input":"Hi","previous_response_id":"resp_no_usage"}"#));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Release),
+        "should release after rehydration"
+    );
+    assert!(
+        ctx.get_metadata("responses.previous_usage_input_tokens").is_none(),
+        "should not set input tokens"
+    );
+    assert!(
+        ctx.get_metadata("responses.previous_usage_output_tokens").is_none(),
+        "should not set output tokens"
+    );
+    assert!(
+        ctx.get_metadata("responses.previous_usage_total_tokens").is_none(),
+        "should not set total tokens"
+    );
+}
+
+#[tokio::test]
+async fn extracts_partial_usage_fields() {
+    let output = json!([{"type": "message", "content": [{"type": "output_text", "text": "Hi"}]}]);
+    let usage = json!({"input_tokens": 42});
+    let store = MockStore::with_output_and_usage("resp_partial", output, usage);
+    let registry = setup_registry(store);
+
+    let filter = RehydrateFilter;
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.extensions.insert(registry.clone());
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+    let mut body = Some(Bytes::from(r#"{"input":"Hi","previous_response_id":"resp_partial"}"#));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Release),
+        "should release after rehydration"
+    );
+    assert_eq!(
+        ctx.get_metadata("responses.previous_usage_input_tokens"),
+        Some("42"),
+        "should set input tokens"
+    );
+    assert!(
+        ctx.get_metadata("responses.previous_usage_output_tokens").is_none(),
+        "should not set output tokens when missing"
+    );
+    assert!(
+        ctx.get_metadata("responses.previous_usage_total_tokens").is_none(),
+        "should not set total tokens when missing"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Fallback + MCP
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn fallback_reconstruction_includes_mcp_list_tools() {
+    let mut records = std::collections::HashMap::new();
+    records.insert(
+        "resp_mcp_fb".to_owned(),
+        ResponseRecord {
+            id: "resp_mcp_fb".to_owned(),
+            tenant_id: "default".to_owned(),
+            created_at: 1000,
+            model: "gpt-4.1".to_owned(),
+            response_object: json!({
+                "id": "resp_mcp_fb",
+                "status": "completed",
+                "output": [
+                    {
+                        "id": "mcpl_fb",
+                        "type": "mcp_list_tools",
+                        "server_label": "fb-server",
+                        "tools": [{"name": "fb_tool", "description": "d", "input_schema": {}}]
+                    },
+                    {"type": "message", "content": [{"type": "output_text", "text": "result"}]}
+                ]
+            }),
+            input: json!("Hello"),
+            messages: json!([]),
+        },
+    );
+    let store = MockStore {
+        records,
+        should_fail: false,
+    };
+    let registry = setup_registry(store);
+
+    let filter = RehydrateFilter;
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.extensions.insert(registry.clone());
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+    let mut body = Some(Bytes::from(r#"{"input":"Next","previous_response_id":"resp_mcp_fb"}"#));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Release),
+        "should release after fallback rehydration"
+    );
+
+    assert!(
+        ctx.get_metadata("responses.previous_mcp_tools").is_some(),
+        "should set MCP tools metadata even with empty messages"
+    );
+}
+
+// -----------------------------------------------------------------------------
 // Test Utilities
 // -----------------------------------------------------------------------------
 
@@ -494,6 +817,34 @@ impl MockStore {
                 }),
                 input,
                 messages,
+            },
+        );
+        Self {
+            records,
+            should_fail: false,
+        }
+    }
+
+    fn with_output_and_usage(id: &str, output: Value, usage: Value) -> Self {
+        let mut records = std::collections::HashMap::new();
+        records.insert(
+            id.to_owned(),
+            ResponseRecord {
+                id: id.to_owned(),
+                tenant_id: "default".to_owned(),
+                created_at: 1000,
+                model: "gpt-4.1".to_owned(),
+                response_object: json!({
+                    "id": id,
+                    "status": "completed",
+                    "output": output,
+                    "usage": usage,
+                }),
+                input: json!("Hello"),
+                messages: json!([
+                    {"role": "user", "content": "Hello"},
+                    {"role": "assistant", "content": "Hi"}
+                ]),
             },
         );
         Self {

--- a/filter/src/builtins/http/ai/openai/responses/rehydrate/tests.rs
+++ b/filter/src/builtins/http/ai/openai/responses/rehydrate/tests.rs
@@ -505,23 +505,20 @@ async fn extracts_mcp_tools_from_previous_response() {
         "should release after rehydration"
     );
 
-    let mcp_meta = ctx
-        .get_metadata("responses.previous_mcp_tools")
-        .expect("should set MCP tools metadata");
-    let parsed: Value = serde_json::from_str(mcp_meta).unwrap();
-    let arr = parsed.as_array().unwrap();
-    assert_eq!(arr.len(), 1, "should have one server entry");
-    assert_eq!(arr[0]["server_label"], "my-server", "server label should match");
-    let tools = arr[0]["tools"].as_array().unwrap();
-    assert_eq!(tools.len(), 2, "should have two tool names");
-    assert_eq!(tools[0], "get_weather", "first tool name should match");
-    assert_eq!(tools[1], "search", "second tool name should match");
-
     let state = ctx
         .extensions
         .get::<ResponsesState>()
         .expect("ResponsesState should be populated");
     assert_eq!(state.previous_tools.len(), 1, "should store full previous tool listing");
+    assert_eq!(
+        state.previous_tools[0]["server_label"], "my-server",
+        "server label should match"
+    );
+    assert_eq!(
+        state.previous_tools[0]["tools"].as_array().unwrap().len(),
+        2,
+        "should preserve both tools"
+    );
     assert_eq!(
         state.previous_tools[0]["tools"][0]["description"], "Get weather",
         "ResponsesState should preserve full tool definitions"
@@ -529,7 +526,7 @@ async fn extracts_mcp_tools_from_previous_response() {
 }
 
 #[tokio::test]
-async fn no_mcp_metadata_when_output_has_no_mcp_items() {
+async fn no_previous_tools_when_output_has_no_mcp_items() {
     let output = json!([
         {"type": "message", "content": [{"type": "output_text", "text": "Hi"}]}
     ]);
@@ -549,9 +546,13 @@ async fn no_mcp_metadata_when_output_has_no_mcp_items() {
         matches!(action, FilterAction::Release),
         "should release after rehydration"
     );
+    let state = ctx
+        .extensions
+        .get::<ResponsesState>()
+        .expect("ResponsesState should be populated");
     assert!(
-        ctx.get_metadata("responses.previous_mcp_tools").is_none(),
-        "should not set MCP metadata when no mcp_list_tools items"
+        state.previous_tools.is_empty(),
+        "should not store previous tools when no mcp_list_tools items"
     );
 }
 
@@ -591,16 +592,21 @@ async fn extracts_mcp_tools_from_multiple_servers() {
         "should release after rehydration"
     );
 
-    let mcp_meta = ctx
-        .get_metadata("responses.previous_mcp_tools")
-        .expect("should set MCP tools metadata");
-    let parsed: Value = serde_json::from_str(mcp_meta).unwrap();
-    let arr = parsed.as_array().unwrap();
-    assert_eq!(arr.len(), 2, "should have two server entries");
-    assert_eq!(arr[0]["server_label"], "weather-server", "first server label");
-    assert_eq!(arr[1]["server_label"], "search-server", "second server label");
+    let state = ctx
+        .extensions
+        .get::<ResponsesState>()
+        .expect("ResponsesState should be populated");
+    assert_eq!(state.previous_tools.len(), 2, "should have two server entries");
     assert_eq!(
-        arr[1]["tools"].as_array().unwrap().len(),
+        state.previous_tools[0]["server_label"], "weather-server",
+        "first server label"
+    );
+    assert_eq!(
+        state.previous_tools[1]["server_label"], "search-server",
+        "second server label"
+    );
+    assert_eq!(
+        state.previous_tools[1]["tools"].as_array().unwrap().len(),
         2,
         "second server should have two tools"
     );
@@ -660,16 +666,6 @@ async fn deduplicates_mcp_tools_independent_of_tool_order() {
     assert!(
         matches!(action, FilterAction::Release),
         "should release after rehydration"
-    );
-
-    let mcp_meta = ctx
-        .get_metadata("responses.previous_mcp_tools")
-        .expect("should set MCP tools metadata");
-    let parsed: Value = serde_json::from_str(mcp_meta).unwrap();
-    assert_eq!(
-        parsed.as_array().unwrap().len(),
-        1,
-        "same server/tools should dedupe even when order differs"
     );
 
     let state = ctx
@@ -734,20 +730,38 @@ async fn extracts_mcp_tools_from_stored_history_when_latest_output_has_none() {
         "should release after chained rehydration"
     );
 
-    let mcp_meta = ctx
-        .get_metadata("responses.previous_mcp_tools")
-        .expect("should set MCP tools metadata from stored history");
-    let parsed: Value = serde_json::from_str(mcp_meta).unwrap();
-    let arr = parsed.as_array().unwrap();
-    assert_eq!(arr.len(), 1, "should recover one earlier server entry");
-    assert_eq!(arr[0]["server_label"], "weather-server", "server label should match");
-    let tools = arr[0]["tools"].as_array().unwrap();
+    let state = ctx
+        .extensions
+        .get::<ResponsesState>()
+        .expect("ResponsesState should be populated");
+    assert_eq!(state.previous_tools.len(), 1, "should recover one earlier server entry");
+    assert_eq!(
+        state.previous_tools[0]["server_label"], "weather-server",
+        "server label should match"
+    );
+    let tools = state.previous_tools[0]["tools"].as_array().unwrap();
     assert_eq!(tools.len(), 1, "should recover one earlier tool");
-    assert_eq!(tools[0], "get_weather", "tool name should match");
+    assert_eq!(tools[0]["name"], "get_weather", "tool name should match");
+    assert!(
+        state
+            .messages
+            .iter()
+            .all(|item| item.get("type").and_then(Value::as_str) != Some("mcp_list_tools")),
+        "stored MCP list items should not be replayed as request input"
+    );
+    assert_eq!(
+        state.persisted_messages.len(),
+        4,
+        "persistence history should keep stored MCP metadata plus current input"
+    );
+    assert_eq!(
+        state.persisted_messages[1]["type"], "mcp_list_tools",
+        "persistence history should preserve stored MCP metadata"
+    );
 }
 
 #[tokio::test]
-async fn mcp_tools_overflow_sets_boolean_flag() {
+async fn large_mcp_tool_listing_is_preserved_in_state() {
     let many_tools: Vec<Value> = (0..30)
         .map(|i| json!({"name": format!("very_long_tool_name_number_{i}"), "description": "d", "input_schema": {}}))
         .collect();
@@ -772,12 +786,6 @@ async fn mcp_tools_overflow_sets_boolean_flag() {
         matches!(action, FilterAction::Release),
         "should release after rehydration"
     );
-    assert_eq!(
-        ctx.get_metadata("responses.previous_mcp_tools"),
-        Some("true"),
-        "should fall back to boolean flag when compact JSON exceeds 256 bytes"
-    );
-
     let state = ctx
         .extensions
         .get::<ResponsesState>()
@@ -785,7 +793,12 @@ async fn mcp_tools_overflow_sets_boolean_flag() {
     assert_eq!(
         state.previous_tools.len(),
         1,
-        "metadata overflow should not drop full previous tools from state"
+        "large listing should not drop previous tools from state"
+    );
+    assert_eq!(
+        state.previous_tools[0]["tools"].as_array().unwrap().len(),
+        30,
+        "large listing should preserve every tool definition"
     );
 }
 
@@ -919,7 +932,7 @@ async fn extracts_partial_usage_fields() {
 // -----------------------------------------------------------------------------
 
 #[tokio::test]
-async fn fallback_reconstruction_includes_mcp_list_tools() {
+async fn fallback_reconstruction_excludes_mcp_list_tools_but_preserves_outputs() {
     let mut records = std::collections::HashMap::new();
     records.insert(
         "resp_mcp_fb".to_owned(),
@@ -938,6 +951,7 @@ async fn fallback_reconstruction_includes_mcp_list_tools() {
                         "server_label": "fb-server",
                         "tools": [{"name": "fb_tool", "description": "d", "input_schema": {}}]
                     },
+                    {"id": "ws_fb", "type": "web_search_call", "status": "completed"},
                     {"type": "message", "content": [{"type": "output_text", "text": "result"}]}
                 ]
             }),
@@ -964,11 +978,6 @@ async fn fallback_reconstruction_includes_mcp_list_tools() {
         "should release after fallback rehydration"
     );
 
-    assert!(
-        ctx.get_metadata("responses.previous_mcp_tools").is_some(),
-        "should set MCP tools metadata even with empty messages"
-    );
-
     let state = ctx
         .extensions
         .get::<ResponsesState>()
@@ -976,18 +985,34 @@ async fn fallback_reconstruction_includes_mcp_list_tools() {
     assert_eq!(
         state.messages.len(),
         4,
-        "fallback should reconstruct previous input/output before current input"
+        "fallback should reconstruct previous replay items before current input"
     );
     assert_eq!(state.messages[0]["content"], "Hello", "previous input should be first");
+    assert!(
+        state
+            .messages
+            .iter()
+            .all(|item| item.get("type").and_then(Value::as_str) != Some("mcp_list_tools")),
+        "fallback should not replay output-only MCP list items as request input"
+    );
     assert_eq!(
-        state.messages[1]["type"], "mcp_list_tools",
-        "previous output items should be preserved"
+        state.messages[1]["type"], "web_search_call",
+        "non-MCP previous output should be preserved"
     );
     assert_eq!(
         state.messages[2]["type"], "message",
         "previous message output should follow"
     );
     assert_eq!(state.messages[3]["content"], "Next", "current input should be last");
+    assert_eq!(
+        state.persisted_messages.len(),
+        5,
+        "persistence history should keep previous input, all output items, and current input"
+    );
+    assert_eq!(
+        state.persisted_messages[1]["type"], "mcp_list_tools",
+        "fallback persistence history should preserve MCP list metadata"
+    );
     assert_eq!(state.previous_tools.len(), 1, "fallback should populate previous tools");
 }
 

--- a/filter/src/builtins/http/ai/openai/responses/rehydrate/tests.rs
+++ b/filter/src/builtins/http/ai/openai/responses/rehydrate/tests.rs
@@ -597,6 +597,69 @@ async fn extracts_mcp_tools_from_multiple_servers() {
 }
 
 #[tokio::test]
+async fn extracts_mcp_tools_from_stored_history_when_latest_output_has_none() {
+    let mut records = std::collections::HashMap::new();
+    records.insert(
+        "resp_chain".to_owned(),
+        ResponseRecord {
+            id: "resp_chain".to_owned(),
+            tenant_id: "default".to_owned(),
+            created_at: 1000,
+            model: "gpt-4.1".to_owned(),
+            response_object: json!({
+                "id": "resp_chain",
+                "status": "completed",
+                "output": [
+                    {"type": "message", "content": [{"type": "output_text", "text": "Latest turn"}]}
+                ]
+            }),
+            input: json!("Second turn"),
+            messages: json!([
+                {"type": "message", "role": "user", "content": "First turn"},
+                {
+                    "id": "mcpl_earlier",
+                    "type": "mcp_list_tools",
+                    "server_label": "weather-server",
+                    "tools": [{"name": "get_weather", "description": "d", "input_schema": {}}]
+                },
+                {"type": "message", "role": "assistant", "content": "Latest turn"}
+            ]),
+        },
+    );
+    let store = MockStore {
+        records,
+        should_fail: false,
+    };
+    let registry = setup_registry(store);
+
+    let filter = RehydrateFilter;
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.extensions.insert(registry.clone());
+    ctx.set_metadata("openai_responses_format.format", "openai_responses");
+    let mut body = Some(Bytes::from(
+        r#"{"input":"Third turn","previous_response_id":"resp_chain"}"#,
+    ));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Release),
+        "should release after chained rehydration"
+    );
+
+    let mcp_meta = ctx
+        .get_metadata("responses.previous_mcp_tools")
+        .expect("should set MCP tools metadata from stored history");
+    let parsed: Value = serde_json::from_str(mcp_meta).unwrap();
+    let arr = parsed.as_array().unwrap();
+    assert_eq!(arr.len(), 1, "should recover one earlier server entry");
+    assert_eq!(arr[0]["server_label"], "weather-server", "server label should match");
+    let tools = arr[0]["tools"].as_array().unwrap();
+    assert_eq!(tools.len(), 1, "should recover one earlier tool");
+    assert_eq!(tools[0], "get_weather", "tool name should match");
+}
+
+#[tokio::test]
 async fn mcp_tools_overflow_sets_boolean_flag() {
     let many_tools: Vec<Value> = (0..30)
         .map(|i| json!({"name": format!("very_long_tool_name_number_{i}"), "description": "d", "input_schema": {}}))

--- a/filter/src/builtins/http/ai/openai/responses/state.rs
+++ b/filter/src/builtins/http/ai/openai/responses/state.rs
@@ -78,6 +78,12 @@ pub(crate) struct ResponsesState {
     /// history for this response and prepends it to `messages`.
     pub previous_response_id: Option<String>,
 
+    /// MCP tool listings recovered from the previous response.
+    pub previous_tools: Vec<serde_json::Value>,
+
+    /// Token usage reported by the previous response.
+    pub previous_usage: Option<serde_json::Value>,
+
     /// Parsed request body as received from the client.
     pub request_body: serde_json::Value,
 
@@ -115,6 +121,8 @@ impl ResponsesState {
             .cloned()
             .unwrap_or_else(|| serde_json::Value::String("auto".to_owned()));
 
+        let tools = extract_array_field(&body, "tools");
+
         Self {
             context_management: body.get("context_management").cloned(),
             conversation: body.get("conversation").cloned(),
@@ -126,12 +134,14 @@ impl ResponsesState {
             output_items: Vec::new(),
             parallel_tool_calls: extract_bool_or(&body, "parallel_tool_calls", true),
             previous_response_id: extract_string(&body, "previous_response_id"),
+            previous_tools: Vec::new(),
+            previous_usage: None,
+            request_body: body,
             response_object: serde_json::Value::Null,
             tool_calls: Vec::new(),
             tool_choice,
-            tools: extract_array_field(&body, "tools"),
+            tools,
             usage: serde_json::Value::Null,
-            request_body: body,
         }
     }
 }

--- a/filter/src/builtins/http/ai/openai/responses/state.rs
+++ b/filter/src/builtins/http/ai/openai/responses/state.rs
@@ -62,7 +62,8 @@ pub(crate) struct ResponsesState {
     /// `previous_response_id` is set, `rehydrate` prepends stored
     /// history. `tool_dispatch` appends tool results during agentic
     /// loops. `responses_proxy` reads this as the authoritative
-    /// conversation to send to the backend.
+    /// conversation to send to the backend. Output-only metadata
+    /// items must be omitted from this field.
     pub messages: Vec<serde_json::Value>,
 
     /// Output items accumulated across the current response.
@@ -71,6 +72,13 @@ pub(crate) struct ResponsesState {
     /// Whether tool calls may execute concurrently within an
     /// iteration. Defaults to `true` per the API spec.
     pub parallel_tool_calls: bool,
+
+    /// Full message history to persist for future rehydration.
+    ///
+    /// This may include output-only metadata items omitted from
+    /// [`Self::messages`] because it is not forwarded to backend
+    /// inference.
+    pub persisted_messages: Vec<serde_json::Value>,
 
     /// ID of a previous response to continue from.
     ///
@@ -116,6 +124,7 @@ impl ResponsesState {
     /// Create initial state from a parsed request body.
     pub(crate) fn from_request_body(body: serde_json::Value) -> Self {
         let messages = normalize_input(&body);
+        let persisted_messages = messages.clone();
         let tool_choice = body
             .get("tool_choice")
             .cloned()
@@ -133,6 +142,7 @@ impl ResponsesState {
             messages,
             output_items: Vec::new(),
             parallel_tool_calls: extract_bool_or(&body, "parallel_tool_calls", true),
+            persisted_messages,
             previous_response_id: extract_string(&body, "previous_response_id"),
             previous_tools: Vec::new(),
             previous_usage: None,
@@ -278,6 +288,10 @@ mod tests {
         assert_eq!(
             state.input, state.messages,
             "input and messages should be identical at construction"
+        );
+        assert_eq!(
+            state.input, state.persisted_messages,
+            "input and persisted_messages should be identical at construction"
         );
     }
 

--- a/filter/src/builtins/http/ai/openai/responses/store/filter.rs
+++ b/filter/src/builtins/http/ai/openai/responses/store/filter.rs
@@ -34,8 +34,9 @@
 //! filter. The original request `input` is carried through typed
 //! per-filter state because it can be arbitrary JSON and is not part
 //! of the Responses API response object. When rehydrate populated
-//! [`ResponsesState`], that state is used as the stored message
-//! history.
+//! [`ResponsesState`], its persistence history is used as the
+//! stored message history so output-only metadata can survive
+//! future rehydration without being replayed as backend input.
 //!
 //! [`filter_metadata`]: crate::HttpFilterContext::filter_metadata
 //! [`ResponsesState`]: super::super::state::ResponsesState
@@ -719,7 +720,7 @@ impl HttpFilter for ResponseStoreFilter {
         let state_messages = ctx
             .extensions
             .get::<ResponsesState>()
-            .map(|state| state.messages.clone());
+            .map(|state| state.persisted_messages.clone());
         let Some(record) = parse_response_record(bytes, &tenant_id, request_input, state_messages) else {
             return Ok(FilterAction::Continue);
         };

--- a/filter/src/builtins/http/ai/openai/responses/store/tests.rs
+++ b/filter/src/builtins/http/ai/openai/responses/store/tests.rs
@@ -1260,6 +1260,139 @@ async fn pipeline_persists_rehydrated_messages_when_response_omits_input() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pipeline_persists_fallback_mcp_metadata_for_future_rehydrate() {
+    let (db_url, db_path) = temp_sqlite_url("pipeline_persists_fallback_mcp_metadata");
+    let seeded_store = SqliteResponseStore::new(&db_url, "test_responses", "test_conversations", None)
+        .await
+        .unwrap();
+    seeded_store
+        .upsert_response(&ResponseRecord {
+            id: "resp_prev".to_owned(),
+            tenant_id: "default".to_owned(),
+            created_at: 1_719_800_000,
+            model: "gpt-4.1".to_owned(),
+            response_object: json!({
+                "id": "resp_prev",
+                "created_at": 1_719_800_000,
+                "model": "gpt-4.1",
+                "status": "completed",
+                "output": [
+                    {
+                        "id": "mcpl_prev",
+                        "type": "mcp_list_tools",
+                        "server_label": "weather-server",
+                        "tools": [{"name": "get_weather", "description": "d", "input_schema": {}}]
+                    },
+                    {"type": "message", "role": "assistant", "content": "Tools loaded"}
+                ]
+            }),
+            input: json!("Hello"),
+            messages: json!([]),
+        })
+        .await
+        .unwrap();
+    drop(seeded_store);
+
+    let mut entries: Vec<FilterEntry> = serde_yaml::from_str(&format!(
+        r#"
+- filter: openai_responses_format
+- filter: openai_response_store
+  backend: sqlite
+  database_url: "{db_url}"
+  responses_table: test_responses
+  conversations_table: test_conversations
+- filter: openai_responses_rehydrate
+"#
+    ))
+    .unwrap();
+    let registry = FilterRegistry::with_builtins();
+    let pipeline = FilterPipeline::build(&mut entries, &registry).unwrap();
+
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/responses");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    if let Some(stores) = pipeline.response_stores() {
+        ctx.extensions.insert(stores.clone());
+    }
+
+    let request_json = json!({
+        "model": "gpt-4.1",
+        "input": "What next?",
+        "previous_response_id": "resp_prev"
+    });
+    let mut request_body = Some(Bytes::from(serde_json::to_vec(&request_json).unwrap()));
+    let request_body_action = pipeline
+        .execute_http_request_body(&mut ctx, &mut request_body, true)
+        .await
+        .unwrap();
+    assert!(
+        matches!(request_body_action, FilterAction::Release),
+        "request body phase should classify, register the store, and rehydrate"
+    );
+
+    let request_action = pipeline.execute_http_request(&mut ctx).await.unwrap();
+    assert!(
+        matches!(request_action, FilterAction::Continue),
+        "request phase should continue after pre-read rehydration"
+    );
+
+    let mut resp = crate::test_utils::make_response();
+    resp.headers
+        .insert(http::header::CONTENT_TYPE, "application/json".parse().unwrap());
+    ctx.response_header = Some(&mut resp);
+    let response_action = pipeline.execute_http_response(&mut ctx).await.unwrap();
+    assert!(
+        matches!(response_action, FilterAction::Continue),
+        "response phase should arm persistence buffering"
+    );
+    ctx.response_header = None;
+
+    let response_json = json!({
+        "id": "resp_next",
+        "created_at": 1_719_900_000,
+        "model": "gpt-4.1",
+        "status": "completed",
+        "output": [{"type": "message", "role": "assistant", "content": "Next answer"}]
+    });
+    let mut response_body = Some(Bytes::from(serde_json::to_vec(&response_json).unwrap()));
+    let response_body_action = pipeline
+        .execute_http_response_body(&mut ctx, &mut response_body, true)
+        .unwrap();
+    assert!(
+        matches!(response_body_action, FilterAction::Continue),
+        "response body phase should persist and continue"
+    );
+
+    let store = SqliteResponseStore::new(&db_url, "test_responses", "test_conversations", None)
+        .await
+        .unwrap();
+    let record = store
+        .get_response("default", "resp_next")
+        .await
+        .unwrap()
+        .expect("pipeline should persist the rehydrated response");
+    assert_eq!(
+        record.messages,
+        json!([
+            {"type": "message", "role": "user", "content": "Hello"},
+            {
+                "id": "mcpl_prev",
+                "type": "mcp_list_tools",
+                "server_label": "weather-server",
+                "tools": [{"name": "get_weather", "description": "d", "input_schema": {}}]
+            },
+            {"type": "message", "role": "assistant", "content": "Tools loaded"},
+            {"type": "message", "role": "user", "content": "What next?"},
+            {"type": "message", "role": "assistant", "content": "Next answer"}
+        ]),
+        "stored messages should preserve fallback MCP metadata for later continuations"
+    );
+
+    drop(store);
+    drop(pipeline);
+    cleanup_sqlite_file(&db_path);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn store_init_failure_is_permanent() {
     let yaml: serde_yaml::Value = serde_yaml::from_str(
         r#"


### PR DESCRIPTION
## Summary

- Recover full MCP tool listings (with descriptions and schemas) from stored conversation history and previous response output into `ResponsesState.previous_tools` for downstream filter consumption
- Keep output-only `mcp_list_tools` items out of backend replay input while preserving them in persisted response history for later `previous_response_id` continuations
- Extract `previous_usage` from the stored response into both `ResponsesState.previous_usage` and individual metadata keys for downstream auto-compaction
- Add fallback message reconstruction from `record.input` + `response_object["output"]` when stored messages are empty (backward compatibility with records created before hidden messages were persisted)
- Order-independent deduplication of MCP tool listings across history and output

Fixes praxis-proxy/ai#41

## Test plan

- [x] Rehydrate tests cover MCP extraction (single server, multiple servers, no items, large listings, chained history, order-independent dedup), usage extraction (full, missing, partial), and fallback reconstruction with ResponsesState assertions
- [x] Store tests cover persisting fallback MCP metadata for future rehydration
- [x] `cargo test -p praxis-proxy-filter builtins::http::ai::openai::responses::rehydrate --tests` (30 tests)
- [x] `cargo test -p praxis-proxy-filter builtins::http::ai::openai::responses::store --tests` (141 tests)
- [x] `cargo test -p praxis-proxy-filter builtins::http::ai::openai::responses::state --tests` (22 tests)
- [x] `cargo clippy -p praxis-proxy-filter --tests -- -D warnings`
- [x] touched-file `rustfmt --check` and `git diff --check`
