### PR TITLE
fix(filter): handle trailing slash in cancel endpoint validation

### DIFF
--- a/filter/src/builtins/http/ai/openai/responses/validate/mod.rs
+++ b/filter/src/builtins/http/ai/openai/responses/validate/mod.rs
@@ -179,10 +179,13 @@ fn parse_and_validate(ctx: &HttpFilterContext<'_>, body: &Option<Bytes>) -> Resu
 fn is_bodyless_responses_request(method: &http::Method, path: &str) -> bool {
     match *method {
         http::Method::GET | http::Method::DELETE => true,
-        http::Method::POST => matches!(
-            path.split('/').collect::<Vec<_>>().as_slice(),
-            ["", "v1", "responses", _, "cancel"]
-        ),
+        http::Method::POST => {
+            let path = path.strip_suffix('/').unwrap_or(path);
+            matches!(
+                path.split('/').collect::<Vec<_>>().as_slice(),
+                ["", "v1", "responses", _, "cancel"]
+            )
+        },
         _ => false,
     }
 }
@@ -653,6 +656,24 @@ mod tests {
         assert!(
             !ctx.filter_metadata.contains_key("responses.response_id"),
             "responses metadata should not be set for bodyless requests"
+        );
+    }
+
+    #[tokio::test]
+    async fn skips_post_cancel_with_trailing_slash() {
+        let filter = make_filter();
+        let req = Box::leak(Box::new(crate::test_utils::make_request(
+            http::Method::POST,
+            "/v1/responses/resp_abc123/cancel/",
+        )));
+        let mut ctx = crate::test_utils::make_filter_context(req);
+        ctx.set_metadata("openai_responses_format.format", "openai_responses");
+        let mut body = None;
+
+        let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+        assert!(
+            matches!(action, FilterAction::Release),
+            "POST /cancel/ with trailing slash should be released without body validation"
         );
     }
 


### PR DESCRIPTION
## Summary

The bodyless check in the Responses validate filter only matched the exact path `/v1/responses/{id}/cancel`. When the classifier normalized a trailing slash, `POST /v1/responses/{id}/cancel/` was incorrectly rejected as missing a JSON body.

- Strip trailing slashes in `is_bodyless_responses_request` before matching the cancel path pattern
- Add test confirming `POST /v1/responses/{id}/cancel/` is correctly recognized as bodyless
- Cargo.lock update is a pre-existing transitive dependency correction (not caused by this change)

## Test plan

- [x] Existing `skips_post_cancel_without_body` test still passes
- [x] New `skips_post_cancel_with_trailing_slash` test passes
- [x] All 30 validate tests pass
- [x] `make lint` and `make build` pass