### PR TITLE
feat(a2a): add agent-card routing example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -22,6 +22,7 @@ page.
 
 | File | Description |
 | ------ | ------------- |
+| [a2a-agent-card-routing.yaml](configs/ai/a2a-agent-card-routing.yaml) | Public agent-card discovery uses plain HTTP path routing because GET /.well-known/agent-card.json is not a JSON-RPC request |
 | [a2a-classifier-routing.yaml](configs/ai/a2a-classifier-routing.yaml) | Routes A2A requests by body-derived method, family, task ID, and streaming detection |
 | [a2a-task-routing.yaml](configs/ai/a2a-task-routing.yaml) | Captures task ownership from SendMessage JSON responses and SendStreamingMessage / SubscribeToTask SSE responses, then routes follow-up task operations back to the backend cluster that created the task |
 | [ai-inference-body-based-routing.yaml](configs/ai/ai-inference-body-based-routing.yaml) | Routes LLM API requests to different backends based on the `model` field in the JSON request body |

--- a/examples/configs/ai/a2a-agent-card-routing.yaml
+++ b/examples/configs/ai/a2a-agent-card-routing.yaml
@@ -1,0 +1,46 @@
+# A2A Agent Card Routing
+#
+# Public agent-card discovery uses plain HTTP path routing because
+# GET /.well-known/agent-card.json is not a JSON-RPC request.
+# Extended agent-card retrieval uses the A2A classifier because
+# GetExtendedAgentCard is a JSON-RPC method that requires body
+# parsing to identify.
+
+listeners:
+  - name: a2a
+    address: "127.0.0.1:8080"
+    filter_chains: [a2a-agent-card]
+
+filter_chains:
+  - name: a2a-agent-card
+    filters:
+      - filter: a2a
+        max_body_bytes: 65536
+        on_invalid: continue
+        headers:
+          method: x-praxis-a2a-method
+          family: x-praxis-a2a-family
+          version: x-praxis-a2a-version
+
+      - filter: router
+        routes:
+          - path: "/.well-known/agent-card.json"
+            cluster: "public-agent-card"
+          - path_prefix: "/a2a/"
+            headers:
+              x-praxis-a2a-method: "GetExtendedAgentCard"
+            cluster: "extended-agent-card"
+          - path_prefix: "/"
+            cluster: "default-backend"
+
+      - filter: load_balancer
+        clusters:
+          - name: "public-agent-card"
+            endpoints:
+              - "127.0.0.1:9101"
+          - name: "extended-agent-card"
+            endpoints:
+              - "127.0.0.1:9102"
+          - name: "default-backend"
+            endpoints:
+              - "127.0.0.1:9103"

--- a/tests/integration/tests/suite/examples/agentic_routing.rs
+++ b/tests/integration/tests/suite/examples/agentic_routing.rs
@@ -6,7 +6,7 @@
 use std::collections::HashMap;
 
 use praxis_test_utils::{
-    Backend, free_port, http_send, json_post, load_example_config, parse_body, parse_status,
+    Backend, free_port, http_get, http_send, json_post, load_example_config, parse_body, parse_status,
     start_backend_with_shutdown, start_proxy,
 };
 
@@ -489,9 +489,132 @@ fn a2a_task_routing_example_unknown_task_follows_fallback() {
     );
 }
 
+#[test]
+fn a2a_agent_card_example_routes_public_well_known_card() {
+    let public_guard = start_backend_with_shutdown("public-card-response");
+    let extended_guard = start_backend_with_shutdown("extended-card-response");
+    let default_guard = start_backend_with_shutdown("default-response");
+    let proxy_port = free_port();
+
+    let config = load_agent_card_example_config(
+        proxy_port,
+        public_guard.port(),
+        extended_guard.port(),
+        default_guard.port(),
+    );
+    let proxy = start_proxy(&config);
+
+    let (status, body) = http_get(proxy.addr(), "/.well-known/agent-card.json", None);
+    assert_eq!(status, 200, "public agent card GET should return 200");
+    assert_eq!(
+        body, "public-card-response",
+        "GET /.well-known/agent-card.json should route to public-agent-card cluster"
+    );
+}
+
+#[test]
+fn a2a_agent_card_example_exact_path_rejects_suffix() {
+    let public_guard = start_backend_with_shutdown("public-card-response");
+    let extended_guard = start_backend_with_shutdown("extended-card-response");
+    let default_guard = start_backend_with_shutdown("default-response");
+    let proxy_port = free_port();
+
+    let config = load_agent_card_example_config(
+        proxy_port,
+        public_guard.port(),
+        extended_guard.port(),
+        default_guard.port(),
+    );
+    let proxy = start_proxy(&config);
+
+    let (status, body) = http_get(proxy.addr(), "/.well-known/agent-card.json-extra", None);
+    assert_eq!(status, 200, "suffixed path should still return 200 via fallback");
+    assert_eq!(
+        body, "default-response",
+        "/.well-known/agent-card.json-extra must not match the exact public card route"
+    );
+}
+
+#[test]
+fn a2a_agent_card_example_routes_get_extended_agent_card() {
+    let public_guard = start_backend_with_shutdown("public-card-response");
+    let extended_guard = start_backend_with_shutdown("extended-card-response");
+    let default_guard = start_backend_with_shutdown("default-response");
+    let proxy_port = free_port();
+
+    let config = load_agent_card_example_config(
+        proxy_port,
+        public_guard.port(),
+        extended_guard.port(),
+        default_guard.port(),
+    );
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        &a2a_json_post(
+            "/a2a/",
+            r#"{"jsonrpc":"2.0","id":1,"method":"GetExtendedAgentCard","params":{}}"#,
+        ),
+    );
+    assert_eq!(parse_status(&raw), 200, "GetExtendedAgentCard should return 200");
+    assert_eq!(
+        parse_body(&raw),
+        "extended-card-response",
+        "GetExtendedAgentCard should route to extended-agent-card cluster"
+    );
+}
+
+#[test]
+fn a2a_agent_card_example_non_agent_card_falls_back() {
+    let public_guard = start_backend_with_shutdown("public-card-response");
+    let extended_guard = start_backend_with_shutdown("extended-card-response");
+    let default_guard = start_backend_with_shutdown("default-response");
+    let proxy_port = free_port();
+
+    let config = load_agent_card_example_config(
+        proxy_port,
+        public_guard.port(),
+        extended_guard.port(),
+        default_guard.port(),
+    );
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        &a2a_json_post(
+            "/a2a/",
+            r#"{"jsonrpc":"2.0","id":1,"method":"SendMessage","params":{"message":"Hello"}}"#,
+        ),
+    );
+    assert_eq!(parse_status(&raw), 200, "non-agent-card method should return 200");
+    assert_eq!(
+        parse_body(&raw),
+        "default-response",
+        "non-agent-card A2A method should route to default-backend, not agent-card clusters"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Test Utilities
 // ---------------------------------------------------------------------------
+
+fn load_agent_card_example_config(
+    proxy_port: u16,
+    public_port: u16,
+    extended_port: u16,
+    default_port: u16,
+) -> praxis_core::config::Config {
+    load_example_config(
+        "ai/a2a-agent-card-routing.yaml",
+        proxy_port,
+        HashMap::from([
+            ("127.0.0.1:9101", public_port),
+            ("127.0.0.1:9102", extended_port),
+            ("127.0.0.1:9103", default_port),
+        ]),
+    )
+}
 
 #[expect(clippy::too_many_arguments, reason = "test utility with all A2A example ports")]
 fn load_a2a_example_config(


### PR DESCRIPTION
  ## Summary

  Adds a focused A2A example showing how Praxis routes agent-card discovery traffic using existing routing behavior.

  This PR covers both A2A agent-card access patterns:

  - `GET /.well-known/agent-card.json` routes by exact HTTP path to a public agent-card backend
  - JSON-RPC `GetExtendedAgentCard` routes through the existing A2A classifier to an extended agent-card backend

  ## What Changed

  - Added `examples/configs/ai/a2a-agent-card-routing.yaml`
  - Added the example to `examples/README.md`
  - Added integration tests proving:
    - public well-known agent-card discovery routes to the public card backend
    - suffixed paths do not accidentally match the exact well-known route
    - `GetExtendedAgentCard` routes via A2A classifier metadata
    - non-agent-card A2A traffic falls through to the default backend

  ## Scope

  This PR is intentionally limited to example configuration and integration coverage. It does not modify A2A protocol parsing, task routing, classifier behavior,
  or runtime proxy logic.

  ## Notes

Agent-card discovery traffic is how an A2A client learns what an agent is, where to reach it, and what capabilities it exposes.

  There are two relevant paths:

  - Public discovery: GET /.well-known/agent-card.json
      - A normal HTTP request.
      - Used to fetch the public agent card without needing JSON-RPC parsing.
      - Praxis routes this by exact URL path.

  - Extended discovery: JSON-RPC GetExtendedAgentCard
      - An A2A protocol request.
      - Used when a client needs richer or protected agent-card details.
      - Praxis routes this through the A2A classifier because the route depends on the JSON-RPC method in the request body.
    
  The example uses the repo’s normal local HTTP listener pattern for integration tests. HTTPS/TLS remains configurable through existing Praxis listener settings; the routing behavior is transport-agnostic.

  `Cargo.lock` is updated only to include the already-declared optional `http` dependency for `praxis-proxy-core`; this PR does not introduce a new dependency.

The `Cargo.lock` change resolves a pre-existing lockfile inconsistency: `core/Cargo.toml` already declares `http = { workspace = true, optional = true }`, but the committed lockfile did not include it under `praxis-proxy-core`. Any `cargo test`, `cargo clippy`, or `cargo build` regenerates this entry automatically. This PR does not introduce a new dependency.

  ## Validation

  - `make lint`
  - `make test`
  - `cargo test -p praxis-tests-schema`
  - `cargo test -p praxis-tests-integration --test suite agentic_routing`
  - `git diff --check`

  Refs praxis-proxy/ai#148, praxis-proxy/ai#157