### PR TITLE
fix(filter): skip [DONE] sentinel in Responses SSE parser

### DIFF
--- a/filter/src/builtins/http/ai/openai/sse/frame.rs
+++ b/filter/src/builtins/http/ai/openai/sse/frame.rs
@@ -51,7 +51,7 @@ impl SseFrameParser {
 
     /// Feed a chunk of bytes, returning any complete SSE frames.
     pub fn parse_chunk(&mut self, chunk: &[u8]) -> Result<Vec<SseFrame>, SseParseError> {
-        self.parse_chunk_inner(chunk, None)
+        self.parse_chunk_inner(chunk, None, |_| true)
     }
 
     /// Feed a chunk and stop before emitting more frames than the event budget allows.
@@ -61,7 +61,18 @@ impl SseFrameParser {
         current_events: usize,
         max_events: usize,
     ) -> Result<Vec<SseFrame>, SseParseError> {
-        self.parse_chunk_inner(chunk, Some((current_events, max_events)))
+        self.parse_chunk_with_counted_event_limit(chunk, current_events, max_events, |_| true)
+    }
+
+    /// Feed a chunk and count only selected frames against the event budget.
+    pub fn parse_chunk_with_counted_event_limit(
+        &mut self,
+        chunk: &[u8],
+        current_events: usize,
+        max_events: usize,
+        count_frame: impl FnMut(&SseFrame) -> bool,
+    ) -> Result<Vec<SseFrame>, SseParseError> {
+        self.parse_chunk_inner(chunk, Some((current_events, max_events)), count_frame)
     }
 
     /// Feed a chunk with optional event-budget enforcement.
@@ -70,6 +81,7 @@ impl SseFrameParser {
         &mut self,
         chunk: &[u8],
         event_limit: Option<(usize, usize)>,
+        mut count_frame: impl FnMut(&SseFrame) -> bool,
     ) -> Result<Vec<SseFrame>, SseParseError> {
         if chunk.is_empty() {
             self.scratch_bytes = self.buffered_bytes();
@@ -77,6 +89,7 @@ impl SseFrameParser {
         }
 
         let mut frames = Vec::new();
+        let mut counted_in_chunk = 0;
         let mut i = 0;
 
         if self.prev_cr && chunk.first() == Some(&b'\n') {
@@ -86,10 +99,11 @@ impl SseFrameParser {
 
         while let Some(&b) = chunk.get(i) {
             if b == b'\n' || b == b'\r' {
-                if self.line_buf.is_empty() && self.has_data {
-                    Self::check_event_limit(event_limit, frames.len())?;
-                }
                 if let Some(frame) = self.process_line() {
+                    if count_frame(&frame) {
+                        Self::check_event_limit(event_limit, counted_in_chunk)?;
+                        counted_in_chunk = counted_in_chunk.saturating_add(1);
+                    }
                     frames.push(frame);
                 }
                 self.line_buf.clear();

--- a/filter/src/builtins/http/ai/openai/sse/responses/parser.rs
+++ b/filter/src/builtins/http/ai/openai/sse/responses/parser.rs
@@ -68,6 +68,10 @@ impl ResponsesSseParser {
         for frame in &frames {
             self.event_count += 1;
 
+            if is_done_sentinel(frame) {
+                continue;
+            }
+
             let event = ResponsesEvent::from_frame(frame)?;
             self.record_completion(&event, now)?;
             events.push(event);
@@ -136,6 +140,11 @@ impl ResponsesSseParser {
             self.completed_at = Some(now);
         }
     }
+}
+
+/// Return whether an SSE frame is the OpenAI-compatible stream sentinel.
+fn is_done_sentinel(frame: &super::super::SseFrame) -> bool {
+    frame.data == b"[DONE]"
 }
 
 #[cfg(test)]
@@ -261,12 +270,25 @@ mod tests {
     }
 
     #[test]
-    fn done_sentinel_is_rejected() {
+    fn done_sentinel_is_ignored() {
         let mut parser = ResponsesSseParser::new(&config());
-        let result = parser.parse_chunk(b"data: [DONE]\n\n");
+        let events = parser.parse_chunk(b"data: [DONE]\n\n").unwrap();
+        assert!(events.is_empty(), "[DONE] should not dispatch as a typed event");
+    }
+
+    #[test]
+    fn done_sentinel_after_terminal_is_allowed() {
+        let mut parser = ResponsesSseParser::new(&config());
+        parser
+            .parse_chunk(&sse_bytes("response.completed", &json!({"id": "resp_1"})))
+            .unwrap();
+
+        let events = parser.parse_chunk(b"data: [DONE]\n\n").unwrap();
+
+        assert!(events.is_empty(), "[DONE] should not dispatch as a typed event");
         assert!(
-            matches!(result, Err(SseParseError::MalformedJson { .. })),
-            "[DONE] is not a Responses JSON event"
+            parser.validate_complete().is_ok(),
+            "[DONE] after a terminal lifecycle event should not mark the stream invalid"
         );
     }
 

--- a/filter/src/builtins/http/ai/openai/sse/responses/parser.rs
+++ b/filter/src/builtins/http/ai/openai/sse/responses/parser.rs
@@ -60,17 +60,20 @@ impl ResponsesSseParser {
         self.started_at.get_or_insert(now);
         self.check_timeout(now)?;
 
-        let frames = self
-            .frame_parser
-            .parse_chunk_with_event_limit(chunk, self.event_count, self.max_events)?;
+        let frames = self.frame_parser.parse_chunk_with_counted_event_limit(
+            chunk,
+            self.event_count,
+            self.max_events,
+            |frame| !is_done_sentinel(frame),
+        )?;
         let mut events = Vec::with_capacity(frames.len());
 
         for frame in &frames {
-            self.event_count += 1;
-
             if is_done_sentinel(frame) {
                 continue;
             }
+
+            self.event_count += 1;
 
             let event = ResponsesEvent::from_frame(frame)?;
             self.record_completion(&event, now)?;
@@ -289,6 +292,26 @@ mod tests {
         assert!(
             parser.validate_complete().is_ok(),
             "[DONE] after a terminal lifecycle event should not mark the stream invalid"
+        );
+    }
+
+    #[test]
+    fn done_sentinel_after_max_event_terminal_is_allowed() {
+        let cfg = SseParserConfig {
+            max_events: 1,
+            ..config()
+        };
+        let mut parser = ResponsesSseParser::new(&cfg);
+        parser
+            .parse_chunk(&sse_bytes("response.completed", &json!({"id": "resp_1"})))
+            .unwrap();
+
+        let events = parser.parse_chunk(b"data: [DONE]\n\n").unwrap();
+
+        assert!(events.is_empty(), "[DONE] should not count against max_events");
+        assert!(
+            parser.validate_complete().is_ok(),
+            "[DONE] after the max counted terminal event should not exceed max_events"
         );
     }
 


### PR DESCRIPTION
## Summary

- The OpenAI Responses API stream always ends with `data: [DONE]\n\n`. The parser currently rejects this as malformed JSON (`MalformedJson`), which causes downstream filters to flag `responses.stream_parse_error` and skip persistence.
- Adds an `is_done_sentinel()` helper and skips `[DONE]` frames with `continue` instead of passing them to `ResponsesEvent::from_frame()`.
- Updates existing test and adds a new test verifying `[DONE]` after a terminal lifecycle event is accepted.

## Test plan

- [x] `done_sentinel_is_ignored` — parse succeeds and returns empty event vec
- [x] `done_sentinel_after_terminal_is_allowed` — `response.completed` then `[DONE]`, `validate_complete()` is ok
- [x] All 20 existing parser tests pass