### PR TITLE
test(filter): merge error passthrough tests into end-to-end test

### DIFF
--- a/filter/src/builtins/http/ai/anthropic/stream_events/mod.rs
+++ b/filter/src/builtins/http/ai/anthropic/stream_events/mod.rs
@@ -701,44 +701,28 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn error_response_preserves_headers() {
+    async fn error_response_passes_through_unchanged() {
         let filter = make_filter();
-        let req = crate::test_utils::make_request(http::Method::POST, "/v1/messages");
-        let mut ctx = crate::test_utils::make_filter_context(&req);
-        let mut resp = crate::test_utils::make_response();
-        resp.status = http::StatusCode::TOO_MANY_REQUESTS;
-        resp.headers.insert(
-            http::header::CONTENT_TYPE,
-            http::HeaderValue::from_static("application/json"),
-        );
+        let (mut ctx, mut resp) = make_error_context(http::StatusCode::TOO_MANY_REQUESTS);
         ctx.response_header = Some(&mut resp);
 
         drop(filter.on_response(&mut ctx).await.unwrap());
 
-        let content_type = ctx
-            .response_header
-            .as_ref()
-            .unwrap()
-            .headers
-            .get(http::header::CONTENT_TYPE);
         assert_eq!(
-            content_type,
+            ctx.response_header
+                .as_ref()
+                .unwrap()
+                .headers
+                .get(http::header::CONTENT_TYPE),
             Some(&http::HeaderValue::from_static("application/json")),
             "error response should preserve original content type"
         );
         assert!(
             !ctx.response_headers_modified,
-            "error response should not mark response headers modified"
+            "error response should not modify headers"
         );
-    }
 
-    #[test]
-    fn error_response_body_passes_through() {
-        let (filter, mut ctx) = make_filter_and_context();
-        ctx.set_metadata(ERROR_PASSTHROUGH_KEY, "true");
-
-        let error_body =
-            r#"{"type":"error","error":{"type":"rate_limit_error","message":"Rate limited"},"request_id":"req_test"}"#;
+        let error_body = r#"{"type":"error","error":{"type":"rate_limit_error","message":"Rate limited"}}"#;
         let mut body = Some(Bytes::from(error_body));
         drop(filter.on_response_body(&mut ctx, &mut body, true).unwrap());
 
@@ -762,6 +746,17 @@ mod tests {
     fn make_filter() -> Box<dyn HttpFilter> {
         let yaml: serde_yaml::Value = serde_yaml::from_str("{}").unwrap();
         AnthropicStreamEventsFilter::from_config(&yaml).unwrap()
+    }
+
+    fn make_error_context(status: http::StatusCode) -> (HttpFilterContext<'static>, crate::context::Response) {
+        let req = crate::test_utils::make_request(http::Method::POST, "/v1/messages");
+        let mut resp = crate::test_utils::make_response();
+        resp.status = status;
+        resp.headers.insert(
+            http::header::CONTENT_TYPE,
+            http::HeaderValue::from_static("application/json"),
+        );
+        (crate::test_utils::make_filter_context(Box::leak(Box::new(req))), resp)
     }
 
     fn make_filter_and_context() -> (Box<dyn HttpFilter>, HttpFilterContext<'static>) {


### PR DESCRIPTION
## Summary

Follow-up to #740 addressing review feedback:

- Replaces the split `error_response_preserves_headers` and `error_response_body_passes_through` tests with a single `error_response_passes_through_unchanged` test
- The merged test calls `on_response` then `on_response_body` on the same context, verifying the full metadata handoff without manual `ERROR_PASSTHROUGH_KEY` injection
- Extracts a `make_error_context` helper to stay under the clippy 30-line limit

The integration test for end-to-end error passthrough is deferred until #736 merges (response_conditions are not enforced during body hooks without it).

## Test plan

- [x] Unit tests pass (10/10 stream_events tests)
- [x] `make lint` passes