### PR TITLE
refactor(filter): use ..Default::default() in ResponsesState factory

### DIFF
--- a/filter/src/builtins/http/ai/openai/responses/state.rs
+++ b/filter/src/builtins/http/ai/openai/responses/state.rs
@@ -163,21 +163,15 @@ impl ResponsesState {
             conversation: body.get("conversation").cloned(),
             include: extract_string_array(&body, "include"),
             input: messages.clone(),
-            iteration: 0,
             max_tool_calls: extract_u32(&body, "max_tool_calls"),
             messages,
-            output_items: Vec::new(),
             parallel_tool_calls: extract_bool_or(&body, "parallel_tool_calls", true),
             persisted_messages,
             previous_response_id: extract_string(&body, "previous_response_id"),
-            previous_tools: Vec::new(),
-            previous_usage: None,
             request_body: body,
-            response_object: serde_json::Value::Null,
-            tool_calls: Vec::new(),
             tool_choice,
             tools,
-            usage: serde_json::Value::Null,
+            ..Default::default()
         }
     }
 }


### PR DESCRIPTION
## Summary

- Replaces 7 explicit default field values in `from_request_body` with `..Default::default()`
- New fields with sensible defaults no longer require updating the factory function, preventing the class of bug fixed in #743

Suggested by @alexsnaps in https://github.com/praxis-proxy/praxis/pull/741#issuecomment-4846525180.

## Test plan

- [x] `cargo build` succeeds — no behavioral change, purely structural

Signed-off-by: Sébastien Han <seb@redhat.com>