### PR TITLE
fix(ai): map Anthropic max_tokens to OpenAI max_completion_tokens

### DIFF
--- a/filter/src/builtins/http/ai/anthropic/to_openai/request.rs
+++ b/filter/src/builtins/http/ai/anthropic/to_openai/request.rs
@@ -33,7 +33,7 @@ pub(crate) fn transform_request(body: &[u8]) -> Result<Vec<u8>, String> {
     chat.insert("messages".to_owned(), Value::Array(messages));
 
     if let Some(max_tokens) = obj.get("max_tokens") {
-        chat.insert("max_tokens".to_owned(), max_tokens.clone());
+        chat.insert("max_completion_tokens".to_owned(), max_tokens.clone());
     }
 
     if let Some(stream) = obj.get("stream") {
@@ -455,7 +455,7 @@ mod tests {
         let parsed: Value = serde_json::from_slice(&result).unwrap();
 
         assert_eq!(parsed["model"], "claude-opus-4-8", "model preserved");
-        assert_eq!(parsed["max_tokens"], 1024, "max_tokens preserved");
+        assert_eq!(parsed["max_completion_tokens"], 1024, "max_tokens mapped to max_completion_tokens");
         assert_eq!(parsed["messages"][0]["role"], "user", "user message role");
         assert_eq!(parsed["messages"][0]["content"], "Hello", "user message content");
     }


### PR DESCRIPTION
## Summary

- The `anthropic_to_openai` request transform maps Anthropic's `max_tokens` to OpenAI's `max_tokens` in Chat Completions requests
- GPT-5.x and reasoning models (o1, o3) reject `max_tokens`, returning: *"Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead."*
- One-line fix: emit `max_completion_tokens` instead, which is backwards-compatible with older models

## Context

OpenAI has three different token limit parameters across their APIs:

| API | Parameter | Endpoint |
|-----|-----------|----------|
| Anthropic Messages | `max_tokens` | `/v1/messages` |
| OpenAI Chat Completions | `max_completion_tokens` | `/v1/chat/completions` |
| OpenAI Responses | `max_output_tokens` | `/v1/responses` |

The `max_completion_tokens` parameter was introduced with the o1 reasoning models (late 2024) to distinguish between reasoning tokens and output tokens. GPT-5.x models continued this convention, rejecting the legacy `max_tokens` entirely.

This fix addresses the Chat Completions path only. The Responses API (`/v1/responses`) uses `max_output_tokens` and would need separate translation logic when that path is implemented.

## Evidence

**Direct API error (GPT-5.5 via Chat Completions through praxis-proxy):**
```
"Unsupported parameter: 'max_tokens' is not supported with this model.
 Use 'max_completion_tokens' instead."
```

**OpenAI API reference** ([developers.openai.com/api/docs/api-reference/evals](https://developers.openai.com/api/docs/api-reference/evals)):
> The `max_completion_tokens` parameter sets the maximum number of tokens that can be included in the generated output from the model.

**Backwards compatibility:** `max_completion_tokens` is accepted by both legacy models (GPT-4.1, GPT-3.5-turbo) and current frontier models (GPT-5.x, o3). Safe to apply unconditionally.

## Verification

Tested locally with praxis-proxy proxying Anthropic-format requests to OpenAI:

| Test | Model | Result |
|------|-------|--------|
| Non-streaming | gpt-4.1-mini | Pass |
| Streaming SSE | gpt-4.1-mini | Pass |
| Tool calling | gpt-4.1-mini | Pass |
| Non-streaming | gpt-5.5 | Pass (failed before fix) |
| Streaming SSE | gpt-5.5 | Pass |

Existing unit tests updated and passing (14/14).

## Test plan

- [x] Existing `request.rs` unit tests pass (14/14)
- [x] Manual curl: GPT-5.5 non-streaming through proxy
- [x] Manual curl: GPT-5.5 streaming through proxy
- [x] Manual curl: GPT-4.1-mini still works (backwards compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)