### PR TITLE
feat(tls): expose downstream mTLS peer identity to HTTP filters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3137,6 +3137,7 @@ dependencies = [
  "metrics-exporter-prometheus",
  "percent-encoding",
  "praxis-proxy-core",
+ "praxis-proxy-tls",
  "rand 0.10.2",
  "regex",
  "serde",

--- a/benchmarks/microbenchmarks/common.rs
+++ b/benchmarks/microbenchmarks/common.rs
@@ -45,6 +45,7 @@ pub(crate) fn make_ctx(req: &Request) -> HttpFilterContext<'_> {
         cluster: None,
         current_filter_id: None,
         downstream_tls: false,
+        peer_identity: None,
         extensions: praxis_filter::RequestExtensions::default(),
         executed_filter_indices: Vec::new(),
         extra_request_headers: Vec::new(),

--- a/filter/Cargo.toml
+++ b/filter/Cargo.toml
@@ -32,6 +32,7 @@ http = { workspace = true }
 metrics = { workspace = true }
 percent-encoding = { workspace = true }
 praxis-core = { workspace = true }
+praxis-tls = { workspace = true }
 rand = { workspace = true }
 regex = { workspace = true }
 serde = { workspace = true }

--- a/filter/ext-proc/src/tests.rs
+++ b/filter/ext-proc/src/tests.rs
@@ -2371,6 +2371,7 @@ fn make_ctx(req: &praxis_filter::Request) -> HttpFilterContext<'_> {
         cluster: None,
         current_filter_id: None,
         downstream_tls: false,
+        peer_identity: None,
         extensions: praxis_filter::RequestExtensions::default(),
         executed_filter_indices: Vec::new(),
         extra_request_headers: Vec::new(),

--- a/filter/src/context.rs
+++ b/filter/src/context.rs
@@ -9,6 +9,7 @@ use http::{HeaderMap, Method, StatusCode, Uri, header::HeaderName};
 use praxis_core::{
     connectivity::Upstream, health::HealthRegistry, id::IdGenerator, kv::KvStoreRegistry, time::TimeSource,
 };
+use praxis_tls::TlsPeerIdentity;
 
 use crate::{body::BodyMode, extensions::RequestExtensions, pipeline::body::merge_body_mode, results::FilterResultSet};
 
@@ -18,81 +19,6 @@ use crate::{body::BodyMode, extensions::RequestExtensions, pipeline::body::merge
 /// send unique keys across many response messages. Existing keys
 /// can still be overwritten past this limit.
 const MAX_STRUCTURED_METADATA_KEYS: usize = 64;
-
-// -----------------------------------------------------------------------------
-// TlsPeerIdentity
-// -----------------------------------------------------------------------------
-
-/// Verified downstream TLS peer identity from the client certificate.
-///
-/// Populated by the protocol layer when the downstream connection uses
-/// mTLS and the peer presented a valid client certificate. Filters can
-/// read this to make trust decisions about the authenticated peer
-/// without parsing certificates themselves.
-///
-/// Fields are extracted from Pingora's SSL digest during request
-/// setup. SAN (Subject Alternative Name) and SPIFFE identity parsing
-/// are not yet included and are planned for a follow-up.
-///
-/// ```
-/// use praxis_filter::TlsPeerIdentity;
-///
-/// let identity = TlsPeerIdentity {
-///     cert_digest: vec![0xAB, 0xCD],
-///     organization: Some("example-org".to_owned()),
-///     serial_number: Some("12345".to_owned()),
-/// };
-/// assert_eq!(identity.hex_digest(), "abcd");
-/// assert_eq!(identity.organization.as_deref(), Some("example-org"));
-/// ```
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct TlsPeerIdentity {
-    /// Cryptographic digest of the peer's leaf certificate (DER-encoded).
-    pub cert_digest: Vec<u8>,
-
-    /// X.509 subject organization (`O=` field), if present.
-    pub organization: Option<String>,
-
-    /// Certificate serial number as a decimal string, if present.
-    pub serial_number: Option<String>,
-}
-
-impl TlsPeerIdentity {
-    /// Lowercase hex-encoded certificate digest for logging and
-    /// config display.
-    ///
-    /// ```
-    /// use praxis_filter::TlsPeerIdentity;
-    ///
-    /// let id = TlsPeerIdentity {
-    ///     cert_digest: vec![0xDE, 0xAD, 0xBE, 0xEF],
-    ///     organization: None,
-    ///     serial_number: None,
-    /// };
-    /// assert_eq!(id.hex_digest(), "deadbeef");
-    /// ```
-    #[must_use]
-    pub fn hex_digest(&self) -> String {
-        let mut hex = String::with_capacity(self.cert_digest.len() * 2);
-        for byte in &self.cert_digest {
-            hex.push(hex_digit(byte >> 4));
-            hex.push(hex_digit(byte & 0x0F));
-        }
-        hex
-    }
-}
-
-/// Convert a four-bit value to its lowercase hexadecimal character.
-fn hex_digit(nibble: u8) -> char {
-    match nibble {
-        0..=9 => (b'0' + nibble) as char,
-        _ => (b'a' + nibble - 10) as char,
-    }
-}
-
-// -----------------------------------------------------------------------------
-// TrustedHeaderMutation
-// -----------------------------------------------------------------------------
 
 /// Trusted header mutation recorded during pre-read body processing.
 ///
@@ -1670,52 +1596,5 @@ mod tests {
             ctx.get_structured_metadata("ns", "new-key").is_none(),
             "merge should drop new key past limit"
         );
-    }
-
-    #[test]
-    fn hex_digest_empty() {
-        let id = TlsPeerIdentity {
-            cert_digest: vec![],
-            organization: None,
-            serial_number: None,
-        };
-        assert_eq!(id.hex_digest(), "", "empty digest should produce empty string");
-    }
-
-    #[test]
-    fn hex_digest_typical_32_byte_length() {
-        let id = TlsPeerIdentity {
-            cert_digest: vec![0_u8; 32],
-            organization: None,
-            serial_number: None,
-        };
-        let hex = id.hex_digest();
-        assert_eq!(hex.len(), 64, "32-byte digest should produce 64 hex chars");
-        assert!(hex.chars().all(|c| c.is_ascii_hexdigit()), "all chars should be hex");
-        assert_eq!(hex, "0".repeat(64), "all-zero digest should be all-zero hex");
-    }
-
-    #[test]
-    fn hex_digest_all_zeros() {
-        let id = TlsPeerIdentity {
-            cert_digest: vec![0x00; 4],
-            organization: None,
-            serial_number: None,
-        };
-        assert_eq!(
-            id.hex_digest(),
-            "00000000",
-            "all-zero bytes should produce all-zero hex"
-        );
-    }
-
-    #[test]
-    fn hex_digest_all_0xff() {
-        let id = TlsPeerIdentity {
-            cert_digest: vec![0xFF; 4],
-            organization: None,
-            serial_number: None,
-        };
-        assert_eq!(id.hex_digest(), "ffffffff", "all-0xFF bytes should produce all-f hex");
     }
 }

--- a/filter/src/context.rs
+++ b/filter/src/context.rs
@@ -47,7 +47,7 @@ const MAX_STRUCTURED_METADATA_KEYS: usize = 64;
 /// ```
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TlsPeerIdentity {
-    /// SHA-256 digest of the peer's leaf certificate (DER-encoded).
+    /// Cryptographic digest of the peer's leaf certificate (DER-encoded).
     pub cert_digest: Vec<u8>,
 
     /// X.509 subject organization (`O=` field), if present.
@@ -1670,5 +1670,52 @@ mod tests {
             ctx.get_structured_metadata("ns", "new-key").is_none(),
             "merge should drop new key past limit"
         );
+    }
+
+    #[test]
+    fn hex_digest_empty() {
+        let id = TlsPeerIdentity {
+            cert_digest: vec![],
+            organization: None,
+            serial_number: None,
+        };
+        assert_eq!(id.hex_digest(), "", "empty digest should produce empty string");
+    }
+
+    #[test]
+    fn hex_digest_typical_32_byte_length() {
+        let id = TlsPeerIdentity {
+            cert_digest: vec![0_u8; 32],
+            organization: None,
+            serial_number: None,
+        };
+        let hex = id.hex_digest();
+        assert_eq!(hex.len(), 64, "32-byte digest should produce 64 hex chars");
+        assert!(hex.chars().all(|c| c.is_ascii_hexdigit()), "all chars should be hex");
+        assert_eq!(hex, "0".repeat(64), "all-zero digest should be all-zero hex");
+    }
+
+    #[test]
+    fn hex_digest_all_zeros() {
+        let id = TlsPeerIdentity {
+            cert_digest: vec![0x00; 4],
+            organization: None,
+            serial_number: None,
+        };
+        assert_eq!(
+            id.hex_digest(),
+            "00000000",
+            "all-zero bytes should produce all-zero hex"
+        );
+    }
+
+    #[test]
+    fn hex_digest_all_0xff() {
+        let id = TlsPeerIdentity {
+            cert_digest: vec![0xFF; 4],
+            organization: None,
+            serial_number: None,
+        };
+        assert_eq!(id.hex_digest(), "ffffffff", "all-0xFF bytes should produce all-f hex");
     }
 }

--- a/filter/src/context.rs
+++ b/filter/src/context.rs
@@ -20,6 +20,77 @@ use crate::{body::BodyMode, extensions::RequestExtensions, pipeline::body::merge
 const MAX_STRUCTURED_METADATA_KEYS: usize = 64;
 
 // -----------------------------------------------------------------------------
+// TlsPeerIdentity
+// -----------------------------------------------------------------------------
+
+/// Verified downstream TLS peer identity from the client certificate.
+///
+/// Populated by the protocol layer when the downstream connection uses
+/// mTLS and the peer presented a valid client certificate. Filters can
+/// read this to make trust decisions about the authenticated peer
+/// without parsing certificates themselves.
+///
+/// Fields are extracted from Pingora's SSL digest during request
+/// setup. SAN (Subject Alternative Name) and SPIFFE identity parsing
+/// are not yet included and are planned for a follow-up.
+///
+/// ```
+/// use praxis_filter::TlsPeerIdentity;
+///
+/// let identity = TlsPeerIdentity {
+///     cert_digest: vec![0xAB, 0xCD],
+///     organization: Some("example-org".to_owned()),
+///     serial_number: Some("12345".to_owned()),
+/// };
+/// assert_eq!(identity.hex_digest(), "abcd");
+/// assert_eq!(identity.organization.as_deref(), Some("example-org"));
+/// ```
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TlsPeerIdentity {
+    /// SHA-256 digest of the peer's leaf certificate (DER-encoded).
+    pub cert_digest: Vec<u8>,
+
+    /// X.509 subject organization (`O=` field), if present.
+    pub organization: Option<String>,
+
+    /// Certificate serial number as a decimal string, if present.
+    pub serial_number: Option<String>,
+}
+
+impl TlsPeerIdentity {
+    /// Lowercase hex-encoded certificate digest for logging and
+    /// config display.
+    ///
+    /// ```
+    /// use praxis_filter::TlsPeerIdentity;
+    ///
+    /// let id = TlsPeerIdentity {
+    ///     cert_digest: vec![0xDE, 0xAD, 0xBE, 0xEF],
+    ///     organization: None,
+    ///     serial_number: None,
+    /// };
+    /// assert_eq!(id.hex_digest(), "deadbeef");
+    /// ```
+    #[must_use]
+    pub fn hex_digest(&self) -> String {
+        let mut hex = String::with_capacity(self.cert_digest.len() * 2);
+        for byte in &self.cert_digest {
+            hex.push(hex_digit(byte >> 4));
+            hex.push(hex_digit(byte & 0x0F));
+        }
+        hex
+    }
+}
+
+/// Convert a four-bit value to its lowercase hexadecimal character.
+fn hex_digit(nibble: u8) -> char {
+    match nibble {
+        0..=9 => (b'0' + nibble) as char,
+        _ => (b'a' + nibble - 10) as char,
+    }
+}
+
+// -----------------------------------------------------------------------------
 // TrustedHeaderMutation
 // -----------------------------------------------------------------------------
 
@@ -132,6 +203,16 @@ pub struct HttpFilterContext<'a> {
     /// rather than the request URI scheme (which is absent
     /// in HTTP/1.1).
     pub downstream_tls: bool,
+
+    /// Verified downstream TLS peer identity, if the connection
+    /// is mTLS and the peer presented a valid client certificate.
+    ///
+    /// `None` for plain-TLS or non-TLS connections, or when the
+    /// client did not send a certificate (e.g. `client_cert_mode:
+    /// request` with no cert).  Populated once from the SSL digest
+    /// before the first filter runs and preserved across all
+    /// subsequent `build_filter_context()` calls for the request.
+    pub peer_identity: Option<TlsPeerIdentity>,
 
     /// Type-safe request-scoped extension container.
     ///

--- a/filter/src/lib.rs
+++ b/filter/src/lib.rs
@@ -34,12 +34,13 @@ pub use builtins::{
     normalize_rewritten_path,
 };
 pub use condition::{should_execute, should_execute_response, should_execute_response_ref};
-pub use context::{HttpFilterContext, PendingHeaderResult, Request, Response, TlsPeerIdentity, TrustedHeaderMutation};
+pub use context::{HttpFilterContext, PendingHeaderResult, Request, Response, TrustedHeaderMutation};
 pub use extensions::RequestExtensions;
 pub use factory::{FilterFactory, HttpFilterFactory, TcpFilterFactory, http_builtin, parse_filter_config, tcp_builtin};
 pub use filter::{Filter, FilterContext, FilterError, HttpFilter};
 pub use pipeline::{FilterPipeline, PipelineExtension};
 pub use praxis_core::config::{FailureMode, FilterEntry};
+pub use praxis_tls::TlsPeerIdentity;
 pub use registry::FilterRegistry;
 pub use results::FilterResultSet;
 pub use tcp_filter::{TcpFilter, TcpFilterContext};

--- a/filter/src/lib.rs
+++ b/filter/src/lib.rs
@@ -34,7 +34,7 @@ pub use builtins::{
     normalize_rewritten_path,
 };
 pub use condition::{should_execute, should_execute_response, should_execute_response_ref};
-pub use context::{HttpFilterContext, PendingHeaderResult, Request, Response, TrustedHeaderMutation};
+pub use context::{HttpFilterContext, PendingHeaderResult, Request, Response, TlsPeerIdentity, TrustedHeaderMutation};
 pub use extensions::RequestExtensions;
 pub use factory::{FilterFactory, HttpFilterFactory, TcpFilterFactory, http_builtin, parse_filter_config, tcp_builtin};
 pub use filter::{Filter, FilterContext, FilterError, HttpFilter};
@@ -413,6 +413,7 @@ pub(crate) mod test_utils {
             health_registry: None,
             id_generator: &TEST_ID_GENERATOR,
             kv_stores: None,
+            peer_identity: None,
             request: req,
             request_body_bytes: 0,
             request_body_mode: crate::body::BodyMode::Stream,

--- a/protocol/src/http/pingora/context.rs
+++ b/protocol/src/http/pingora/context.rs
@@ -72,6 +72,15 @@ pub struct PingoraRequestCtx {
     /// connections where the URI lacks a scheme.
     pub downstream_tls: bool,
 
+    /// Verified downstream TLS peer identity.
+    ///
+    /// Set once from the SSL digest in `request_filter` before
+    /// the first filter runs.  Cloned (not moved) into each
+    /// `HttpFilterContext` so it is available in both pre-read
+    /// body phases and the main filter pipeline.  `None` for
+    /// non-mTLS or no-client-cert connections.
+    pub peer_identity: Option<praxis_filter::TlsPeerIdentity>,
+
     /// Whether the connection was upgraded via 101 Switching Protocols.
     ///
     /// Set during `response_filter` when the upstream returns 101.
@@ -277,6 +286,7 @@ macro_rules! filter_context {
             filter_results: std::mem::take(&mut $ctx.filter_results),
             filter_state: std::mem::take(&mut $ctx.filter_state),
             health_registry: $pipeline.health_registry(),
+            peer_identity: $ctx.peer_identity.clone(),
             id_generator: $pipeline.id_generator(),
             kv_stores: $pipeline.kv_stores(),
             request: $request,
@@ -435,6 +445,7 @@ impl Default for PingoraRequestCtx {
             cluster: None,
             connection_upgraded: false,
             downstream_tls: false,
+            peer_identity: None,
             extensions: praxis_filter::RequestExtensions::new(),
             filter_metadata: std::collections::HashMap::new(),
             pre_read_mutations: Vec::new(),

--- a/protocol/src/http/pingora/context.rs
+++ b/protocol/src/http/pingora/context.rs
@@ -79,7 +79,7 @@ pub struct PingoraRequestCtx {
     /// `HttpFilterContext` so it is available in both pre-read
     /// body phases and the main filter pipeline.  `None` for
     /// non-mTLS or no-client-cert connections.
-    pub peer_identity: Option<praxis_filter::TlsPeerIdentity>,
+    pub peer_identity: Option<praxis_tls::TlsPeerIdentity>,
 
     /// Whether the connection was upgraded via 101 Switching Protocols.
     ///

--- a/protocol/src/http/pingora/handler/request_filter/mod.rs
+++ b/protocol/src/http/pingora/handler/request_filter/mod.rs
@@ -93,7 +93,7 @@ pub(in crate::http) async fn execute(
         if d.cert_digest.is_empty() {
             return None;
         }
-        Some(praxis_filter::TlsPeerIdentity {
+        Some(praxis_tls::TlsPeerIdentity {
             cert_digest: d.cert_digest.clone(),
             organization: d.organization.clone(),
             serial_number: d.serial_number.clone(),

--- a/protocol/src/http/pingora/handler/request_filter/mod.rs
+++ b/protocol/src/http/pingora/handler/request_filter/mod.rs
@@ -87,7 +87,18 @@ pub(in crate::http) async fn execute(
         .and_then(|a| a.as_inet())
         .map(std::net::SocketAddr::ip)
         .map(normalize_mapped_ipv4);
-    ctx.downstream_tls = session.digest().is_some_and(|d| d.ssl_digest.is_some());
+    let ssl_digest = session.digest().and_then(|d| d.ssl_digest.as_ref());
+    ctx.downstream_tls = ssl_digest.is_some();
+    ctx.peer_identity = ssl_digest.and_then(|d| {
+        if d.cert_digest.is_empty() {
+            return None;
+        }
+        Some(praxis_filter::TlsPeerIdentity {
+            cert_digest: d.cert_digest.clone(),
+            organization: d.organization.clone(),
+            serial_number: d.serial_number.clone(),
+        })
+    });
     ctx.request_is_idempotent = matches!(
         session.req_header().method,
         http::Method::GET | http::Method::HEAD | http::Method::OPTIONS

--- a/tests/integration/tests/suite/examples/payload_processing.rs
+++ b/tests/integration/tests/suite/examples/payload_processing.rs
@@ -15,7 +15,6 @@ use praxis_test_utils::{
 // Tests
 // -----------------------------------------------------------------------------
 
-
 #[test]
 fn multi_field_extraction_extracts_both_fields() {
     let backend_guard = start_header_echo_backend();

--- a/tests/integration/tests/suite/tls.rs
+++ b/tests/integration/tests/suite/tls.rs
@@ -2047,16 +2047,19 @@ filter_chains:
 // populated when the downstream connection uses mTLS and the peer
 // presents a valid client certificate.
 //
-// The tests use a small inline test filter `PeerIdentityRejectIfNone`
-// that rejects requests when `peer_identity` is None.  This is the
-// minimal filter needed to observe peer identity from outside the proxy —
-// no production filter is assumed to exist yet.
+// The tests use small inline test-only filters that observe peer_identity
+// and reject with a 403 when expectations are not met.  This is the
+// minimal approach to verify peer identity from outside the proxy without
+// depending on any production access-control filter.
+//
+// All fields extracted from the client certificate — cert_digest,
+// organization, and serial_number — are covered end-to-end below.
+//
+// Regression covered: peer_identity must survive StreamBuffer body
+// pre-read.  Root cause was `.take()` in filter_context! macro consuming
+// the value during pre_read_body; fixed by switching to `.clone()`.
 // -----------------------------------------------------------------------------
 
-/// Test-only filter: rejects the request with 403 if `peer_identity` is `None`.
-///
-/// Used to prove that peer identity is populated for mTLS connections
-/// without depending on any production access-control filter.
 struct PeerIdentityRejectIfNone;
 
 #[async_trait::async_trait]
@@ -2079,7 +2082,6 @@ impl praxis_filter::HttpFilter for PeerIdentityRejectIfNone {
     }
 }
 
-/// Test-only filter: rejects with 403 if `peer_identity` org doesn't match.
 struct PeerIdentityRequireOrg(&'static str);
 
 #[async_trait::async_trait]
@@ -2279,14 +2281,93 @@ filter_chains:
     assert_eq!(body, "peer-identity-org-ok", "request should reach backend");
 }
 
-/// Regression: peer_identity must survive StreamBuffer body pre-read.
-///
-/// Root cause: the `filter_context!` macro used `.take()` for `peer_identity`,
-/// which consumed it during `pre_read_body`. The main filter pipeline then
-/// saw `None`. Fix: `.clone()` in the macro so the value is preserved across
-/// all `build_filter_context()` calls within a single request.
+struct PeerIdentityRequireSerialNumber;
+
+#[async_trait::async_trait]
+impl praxis_filter::HttpFilter for PeerIdentityRequireSerialNumber {
+    fn name(&self) -> &'static str {
+        "test_peer_identity_require_serial_number"
+    }
+
+    async fn on_request(
+        &self,
+        ctx: &mut praxis_filter::HttpFilterContext<'_>,
+    ) -> Result<praxis_filter::FilterAction, praxis_filter::FilterError> {
+        let has_serial = ctx
+            .peer_identity
+            .as_ref()
+            .and_then(|id| id.serial_number.as_deref())
+            .is_some();
+        if has_serial {
+            Ok(praxis_filter::FilterAction::Continue)
+        } else {
+            Ok(praxis_filter::FilterAction::Reject(praxis_filter::Rejection::status(
+                403,
+            )))
+        }
+    }
+}
+
 #[test]
-fn peer_identity_survives_stream_buffer_pre_read() {
+fn peer_identity_has_serial_number_for_mtls_connection() {
+    let certs = TestCertificates::generate();
+    let client_cert = certs.generate_client_cert();
+    let client_config = certs.client_config_with_cert(&client_cert);
+
+    let backend_port_guard = start_backend_with_shutdown("peer-identity-serial-ok");
+    let backend_port = backend_port_guard.port();
+    let proxy_port = free_port();
+
+    let yaml = format!(
+        r#"
+listeners:
+  - name: secure
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains:
+      - main
+    tls:
+      certificates:
+        - cert_path: "{cert}"
+          key_path: "{key}"
+      client_ca:
+        ca_path: "{ca}"
+      client_cert_mode: require
+filter_chains:
+  - name: main
+    filters:
+      - filter: test_peer_identity_require_serial_number
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: backend
+      - filter: load_balancer
+        clusters:
+          - name: backend
+            endpoints:
+              - "127.0.0.1:{backend_port}"
+"#,
+        cert = certs.cert_path.display(),
+        key = certs.key_path.display(),
+        ca = certs.ca_cert_path.display(),
+    );
+
+    let config = Config::from_yaml(&yaml).unwrap();
+    let registry = registry_with("test_peer_identity_require_serial_number", || {
+        Box::new(PeerIdentityRequireSerialNumber)
+    });
+    let proxy = start_tls_proxy_no_wait_with_registry(&config, &registry);
+    wait_for_https(proxy.addr(), &client_config);
+
+    let (status, body) = https_get(proxy.addr(), "/", &client_config);
+    assert_eq!(
+        status, 200,
+        "peer_identity.serial_number must be populated for valid mTLS client cert (got {status}, body: {body})"
+    );
+    assert_eq!(body, "peer-identity-serial-ok", "request should reach backend");
+}
+
+#[test]
+fn peer_identity_survives_stream_buffer_pre_read_regression() {
     let certs = TestCertificates::generate();
     let client_cert = certs.generate_client_cert_with_org("test-org");
     let client_config = certs.client_config_with_cert(&client_cert);

--- a/tests/integration/tests/suite/tls.rs
+++ b/tests/integration/tests/suite/tls.rs
@@ -8,9 +8,10 @@ use std::sync::Arc;
 
 use praxis_core::config::Config;
 use praxis_test_utils::{
-    TestCertificates, free_port, http_get, https_get, start_backend_with_shutdown, start_full_proxy,
+    TestCertificates, free_port, http_get, https_get, registry_with, start_backend_with_shutdown, start_full_proxy,
     start_mtls_backend, start_proxy, start_tcp_echo_backend, start_tls_backend, start_tls_proxy,
-    start_tls_proxy_no_wait, tls_connection_rejected, tls_send_recv, wait_for_https, wait_for_tls,
+    start_tls_proxy_no_wait, start_tls_proxy_no_wait_with_registry, tls_connection_rejected, tls_send_recv,
+    wait_for_https, wait_for_tls,
 };
 
 // -----------------------------------------------------------------------------
@@ -2037,6 +2038,315 @@ filter_chains:
         result.is_err(),
         "TLS 1.2-only client should be rejected when only TLS 1.3 suites are configured"
     );
+}
+
+// -----------------------------------------------------------------------------
+// Downstream TLS peer identity tests
+//
+// These tests prove that `HttpFilterContext.peer_identity` is correctly
+// populated when the downstream connection uses mTLS and the peer
+// presents a valid client certificate.
+//
+// The tests use a small inline test filter `PeerIdentityRejectIfNone`
+// that rejects requests when `peer_identity` is None.  This is the
+// minimal filter needed to observe peer identity from outside the proxy —
+// no production filter is assumed to exist yet.
+// -----------------------------------------------------------------------------
+
+/// Test-only filter: rejects the request with 403 if `peer_identity` is `None`.
+///
+/// Used to prove that peer identity is populated for mTLS connections
+/// without depending on any production access-control filter.
+struct PeerIdentityRejectIfNone;
+
+#[async_trait::async_trait]
+impl praxis_filter::HttpFilter for PeerIdentityRejectIfNone {
+    fn name(&self) -> &'static str {
+        "test_peer_identity_reject_if_none"
+    }
+
+    async fn on_request(
+        &self,
+        ctx: &mut praxis_filter::HttpFilterContext<'_>,
+    ) -> Result<praxis_filter::FilterAction, praxis_filter::FilterError> {
+        if ctx.peer_identity.is_some() {
+            Ok(praxis_filter::FilterAction::Continue)
+        } else {
+            Ok(praxis_filter::FilterAction::Reject(praxis_filter::Rejection::status(
+                403,
+            )))
+        }
+    }
+}
+
+/// Test-only filter: rejects with 403 if `peer_identity` org doesn't match.
+struct PeerIdentityRequireOrg(&'static str);
+
+#[async_trait::async_trait]
+impl praxis_filter::HttpFilter for PeerIdentityRequireOrg {
+    fn name(&self) -> &'static str {
+        "test_peer_identity_require_org"
+    }
+
+    async fn on_request(
+        &self,
+        ctx: &mut praxis_filter::HttpFilterContext<'_>,
+    ) -> Result<praxis_filter::FilterAction, praxis_filter::FilterError> {
+        let matches = ctx
+            .peer_identity
+            .as_ref()
+            .and_then(|id| id.organization.as_deref())
+            .is_some_and(|org| org == self.0);
+        if matches {
+            Ok(praxis_filter::FilterAction::Continue)
+        } else {
+            Ok(praxis_filter::FilterAction::Reject(praxis_filter::Rejection::status(
+                403,
+            )))
+        }
+    }
+}
+
+#[test]
+fn peer_identity_set_for_mtls_connection() {
+    let certs = TestCertificates::generate();
+    let client_cert = certs.generate_client_cert();
+    let client_config = certs.client_config_with_cert(&client_cert);
+
+    let backend_port_guard = start_backend_with_shutdown("peer-identity-ok");
+    let backend_port = backend_port_guard.port();
+    let proxy_port = free_port();
+
+    let yaml = format!(
+        r#"
+listeners:
+  - name: secure
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains:
+      - main
+    tls:
+      certificates:
+        - cert_path: "{cert}"
+          key_path: "{key}"
+      client_ca:
+        ca_path: "{ca}"
+      client_cert_mode: require
+filter_chains:
+  - name: main
+    filters:
+      - filter: test_peer_identity_reject_if_none
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: backend
+      - filter: load_balancer
+        clusters:
+          - name: backend
+            endpoints:
+              - "127.0.0.1:{backend_port}"
+"#,
+        cert = certs.cert_path.display(),
+        key = certs.key_path.display(),
+        ca = certs.ca_cert_path.display(),
+    );
+
+    let config = Config::from_yaml(&yaml).unwrap();
+    let registry = registry_with("test_peer_identity_reject_if_none", || {
+        Box::new(PeerIdentityRejectIfNone)
+    });
+    let proxy = start_tls_proxy_no_wait_with_registry(&config, &registry);
+    wait_for_https(proxy.addr(), &client_config);
+
+    let (status, body) = https_get(proxy.addr(), "/", &client_config);
+    assert_eq!(
+        status, 200,
+        "peer_identity must be populated for valid mTLS client cert (got {status}, body: {body})"
+    );
+    assert_eq!(body, "peer-identity-ok", "request should reach backend");
+}
+
+#[test]
+fn peer_identity_is_none_without_client_cert() {
+    let certs = TestCertificates::generate();
+    let no_cert_config = certs.client_config();
+
+    let backend_port_guard = start_backend_with_shutdown("peer-identity-no-cert");
+    let backend_port = backend_port_guard.port();
+    let proxy_port = free_port();
+
+    let yaml = format!(
+        r#"
+listeners:
+  - name: secure
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains:
+      - main
+    tls:
+      certificates:
+        - cert_path: "{cert}"
+          key_path: "{key}"
+      client_ca:
+        ca_path: "{ca}"
+      client_cert_mode: request
+filter_chains:
+  - name: main
+    filters:
+      - filter: test_peer_identity_reject_if_none
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: backend
+      - filter: load_balancer
+        clusters:
+          - name: backend
+            endpoints:
+              - "127.0.0.1:{backend_port}"
+"#,
+        cert = certs.cert_path.display(),
+        key = certs.key_path.display(),
+        ca = certs.ca_cert_path.display(),
+    );
+
+    let config = Config::from_yaml(&yaml).unwrap();
+    let registry = registry_with("test_peer_identity_reject_if_none", || {
+        Box::new(PeerIdentityRejectIfNone)
+    });
+    let proxy = start_tls_proxy_no_wait_with_registry(&config, &registry);
+    wait_for_https(proxy.addr(), &no_cert_config);
+
+    let (status, _body) = https_get(proxy.addr(), "/", &no_cert_config);
+    assert_eq!(
+        status, 403,
+        "peer_identity must be None when no client cert is presented (got {status})"
+    );
+}
+
+#[test]
+fn peer_identity_has_organization_when_cert_has_org() {
+    let certs = TestCertificates::generate();
+    let client_cert = certs.generate_client_cert_with_org("my-org");
+    let client_config = certs.client_config_with_cert(&client_cert);
+
+    let backend_port_guard = start_backend_with_shutdown("peer-identity-org-ok");
+    let backend_port = backend_port_guard.port();
+    let proxy_port = free_port();
+
+    let yaml = format!(
+        r#"
+listeners:
+  - name: secure
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains:
+      - main
+    tls:
+      certificates:
+        - cert_path: "{cert}"
+          key_path: "{key}"
+      client_ca:
+        ca_path: "{ca}"
+      client_cert_mode: require
+filter_chains:
+  - name: main
+    filters:
+      - filter: test_peer_identity_require_org
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: backend
+      - filter: load_balancer
+        clusters:
+          - name: backend
+            endpoints:
+              - "127.0.0.1:{backend_port}"
+"#,
+        cert = certs.cert_path.display(),
+        key = certs.key_path.display(),
+        ca = certs.ca_cert_path.display(),
+    );
+
+    let config = Config::from_yaml(&yaml).unwrap();
+    let registry = registry_with("test_peer_identity_require_org", || {
+        Box::new(PeerIdentityRequireOrg("my-org"))
+    });
+    let proxy = start_tls_proxy_no_wait_with_registry(&config, &registry);
+    wait_for_https(proxy.addr(), &client_config);
+
+    let (status, body) = https_get(proxy.addr(), "/", &client_config);
+    assert_eq!(
+        status, 200,
+        "peer_identity.organization must match cert O= field (got {status}, body: {body})"
+    );
+    assert_eq!(body, "peer-identity-org-ok", "request should reach backend");
+}
+
+/// Regression: peer_identity must survive StreamBuffer body pre-read.
+///
+/// Root cause: the `filter_context!` macro used `.take()` for `peer_identity`,
+/// which consumed it during `pre_read_body`. The main filter pipeline then
+/// saw `None`. Fix: `.clone()` in the macro so the value is preserved across
+/// all `build_filter_context()` calls within a single request.
+#[test]
+fn peer_identity_survives_stream_buffer_pre_read() {
+    let certs = TestCertificates::generate();
+    let client_cert = certs.generate_client_cert_with_org("test-org");
+    let client_config = certs.client_config_with_cert(&client_cert);
+
+    let backend_port_guard = start_backend_with_shutdown("peer-identity-streambuf-ok");
+    let backend_port = backend_port_guard.port();
+    let proxy_port = free_port();
+
+    // json_body_field declares StreamBuffer body mode, so pre_read_body runs
+    // before the main pipeline. peer_identity must survive this.
+    let yaml = format!(
+        r#"
+listeners:
+  - name: secure
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains:
+      - main
+    tls:
+      certificates:
+        - cert_path: "{cert}"
+          key_path: "{key}"
+      client_ca:
+        ca_path: "{ca}"
+      client_cert_mode: require
+filter_chains:
+  - name: main
+    filters:
+      - filter: test_peer_identity_reject_if_none
+      - filter: json_body_field
+        field: model
+        header: X-Model
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: backend
+      - filter: load_balancer
+        clusters:
+          - name: backend
+            endpoints:
+              - "127.0.0.1:{backend_port}"
+"#,
+        cert = certs.cert_path.display(),
+        key = certs.key_path.display(),
+        ca = certs.ca_cert_path.display(),
+    );
+
+    let config = Config::from_yaml(&yaml).unwrap();
+    let registry = registry_with("test_peer_identity_reject_if_none", || {
+        Box::new(PeerIdentityRejectIfNone)
+    });
+    let proxy = start_tls_proxy_no_wait_with_registry(&config, &registry);
+    wait_for_https(proxy.addr(), &client_config);
+
+    // `json_body_field` always declares StreamBuffer, triggering pre_read_body.
+    let (status, body) = https_get(proxy.addr(), "/", &client_config);
+    assert_eq!(
+        status, 200,
+        "peer_identity must survive StreamBuffer pre-read (got {status}, body: {body})"
+    );
+    assert_eq!(body, "peer-identity-streambuf-ok", "request should reach backend");
 }
 
 // -----------------------------------------------------------------------------

--- a/tests/utils/src/lib.rs
+++ b/tests/utils/src/lib.rs
@@ -25,5 +25,5 @@ pub use net::*;
 pub use proxy::{
     ProxyGuard, ReloadableProxyGuard, build_pipeline, custom_filter_yaml, registry_with, simple_proxy_yaml,
     start_full_proxy, start_proxy, start_proxy_with_registry, start_reloadable_proxy, start_tls_proxy,
-    start_tls_proxy_no_wait,
+    start_tls_proxy_no_wait, start_tls_proxy_no_wait_with_registry,
 };

--- a/tests/utils/src/net/tls.rs
+++ b/tests/utils/src/net/tls.rs
@@ -199,6 +199,32 @@ impl TestCertificates {
         )
     }
 
+    /// Generate a client certificate with a specific `OrganizationName` (O= field).
+    ///
+    /// The cert is signed by this test CA so the TLS handshake succeeds.
+    /// Setting a custom org is useful for testing org-based access decisions.
+    ///
+    /// # Panics
+    ///
+    /// Panics if certificate generation or file I/O fails.
+    pub fn generate_client_cert_with_org(&self, org: &str) -> ClientCert {
+        let issuer = Issuer::from_params(&self.ca_params, &self.ca_key);
+        let client_key = KeyPair::generate().expect("client key generation");
+        let mut client_params = CertificateParams::new(vec!["localhost".to_owned()]).expect("client cert params");
+        client_params.distinguished_name.push(DnType::CommonName, "Test Client");
+        client_params.distinguished_name.push(DnType::OrganizationName, org);
+        let client_cert = client_params.signed_by(&client_key, &issuer).expect("client cert sign");
+
+        let n = self.client_cert_counter.fetch_add(1, Ordering::Relaxed);
+        let cert_path = self.temp_dir.path().join(format!("client-org-{n}.pem"));
+        let key_path = self.temp_dir.path().join(format!("client-org-{n}-key.pem"));
+
+        std::fs::write(&cert_path, client_cert.pem()).expect("write client cert PEM");
+        std::fs::write(&key_path, client_key.serialize_pem()).expect("write client key PEM");
+
+        ClientCert { cert_path, key_path }
+    }
+
     /// Generate a client certificate signed by this test CA.
     ///
     /// Returns a [`ClientCert`] with paths written into the same temp directory.

--- a/tests/utils/src/proxy.rs
+++ b/tests/utils/src/proxy.rs
@@ -456,6 +456,17 @@ pub fn start_tls_proxy_no_wait(config: &Config) -> ProxyGuard {
     spawn_proxy_server(config, &FilterRegistry::with_builtins())
 }
 
+/// Start a TLS-enabled proxy with a custom filter registry and return
+/// immediately without waiting for readiness.  The caller is responsible
+/// for calling [`wait_for_https`](crate::net::wait_for_https) or similar.
+///
+/// # Panics
+///
+/// Panics if `config.listeners` is empty.
+pub fn start_tls_proxy_no_wait_with_registry(config: &Config, registry: &FilterRegistry) -> ProxyGuard {
+    spawn_proxy_server(config, registry)
+}
+
 // -----------------------------------------------------------------------------
 // YAML Config Test Utilities
 // -----------------------------------------------------------------------------

--- a/tls/src/identity.rs
+++ b/tls/src/identity.rs
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! TLS peer identity types exposed to higher-level request processing.
+
+/// Verified downstream TLS peer identity from the client certificate.
+///
+/// Populated when the downstream connection uses mTLS and the peer
+/// presented a valid client certificate. Higher-level request handlers
+/// and filters can read this to make trust decisions about the
+/// authenticated peer without parsing certificates themselves.
+///
+/// Fields are extracted from Pingora's SSL digest during request setup.
+/// SAN (Subject Alternative Name) and SPIFFE identity parsing are not
+/// yet included and are planned for a follow-up.
+///
+/// ```
+/// use praxis_tls::TlsPeerIdentity;
+///
+/// let identity = TlsPeerIdentity {
+///     cert_digest: vec![0xAB, 0xCD],
+///     organization: Some("example-org".to_owned()),
+///     serial_number: Some("12345".to_owned()),
+/// };
+/// assert_eq!(identity.hex_digest(), "abcd");
+/// assert_eq!(identity.organization.as_deref(), Some("example-org"));
+/// ```
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TlsPeerIdentity {
+    /// Cryptographic digest of the peer's leaf certificate (DER-encoded).
+    pub cert_digest: Vec<u8>,
+
+    /// X.509 subject organization (`O=` field), if present.
+    pub organization: Option<String>,
+
+    /// Certificate serial number as a decimal string, if present.
+    pub serial_number: Option<String>,
+}
+
+impl TlsPeerIdentity {
+    /// Lowercase hex-encoded certificate digest for logging and
+    /// config display.
+    ///
+    /// ```
+    /// use praxis_tls::TlsPeerIdentity;
+    ///
+    /// let id = TlsPeerIdentity {
+    ///     cert_digest: vec![0xDE, 0xAD, 0xBE, 0xEF],
+    ///     organization: None,
+    ///     serial_number: None,
+    /// };
+    /// assert_eq!(id.hex_digest(), "deadbeef");
+    /// ```
+    #[must_use]
+    pub fn hex_digest(&self) -> String {
+        let mut hex = String::with_capacity(self.cert_digest.len() * 2);
+        for byte in &self.cert_digest {
+            hex.push(hex_digit(byte >> 4));
+            hex.push(hex_digit(byte & 0x0F));
+        }
+        hex
+    }
+}
+
+/// Convert a four-bit value to its lowercase hexadecimal character.
+fn hex_digit(nibble: u8) -> char {
+    match nibble {
+        0..=9 => (b'0' + nibble) as char,
+        _ => (b'a' + nibble - 10) as char,
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::allow_attributes, reason = "blanket test suppressions")]
+#[allow(clippy::unwrap_used, clippy::expect_used, reason = "tests")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hex_digest_empty() {
+        let id = TlsPeerIdentity {
+            cert_digest: vec![],
+            organization: None,
+            serial_number: None,
+        };
+        assert_eq!(id.hex_digest(), "", "empty digest should produce empty string");
+    }
+
+    #[test]
+    fn hex_digest_typical_32_byte_length() {
+        let id = TlsPeerIdentity {
+            cert_digest: vec![0_u8; 32],
+            organization: None,
+            serial_number: None,
+        };
+        let hex = id.hex_digest();
+        assert_eq!(hex.len(), 64, "32-byte digest should produce 64 hex chars");
+        assert!(hex.chars().all(|c| c.is_ascii_hexdigit()), "all chars should be hex");
+        assert_eq!(hex, "0".repeat(64), "all-zero digest should be all-zero hex");
+    }
+
+    #[test]
+    fn hex_digest_all_zeros() {
+        let id = TlsPeerIdentity {
+            cert_digest: vec![0x00; 4],
+            organization: None,
+            serial_number: None,
+        };
+        assert_eq!(
+            id.hex_digest(),
+            "00000000",
+            "all-zero bytes should produce all-zero hex"
+        );
+    }
+
+    #[test]
+    fn hex_digest_all_0xff() {
+        let id = TlsPeerIdentity {
+            cert_digest: vec![0xFF; 4],
+            organization: None,
+            serial_number: None,
+        };
+        assert_eq!(id.hex_digest(), "ffffffff", "all-0xFF bytes should produce all-f hex");
+    }
+}

--- a/tls/src/lib.rs
+++ b/tls/src/lib.rs
@@ -9,6 +9,7 @@ mod cached;
 mod client_auth;
 mod config;
 mod error;
+mod identity;
 #[cfg(feature = "hot-reload")]
 pub mod reload;
 pub mod setup;
@@ -23,3 +24,4 @@ pub mod watcher;
 pub use cached::{CachedCaCerts, CachedClientCert, CachedClusterTls};
 pub use config::{CaConfig, CertKeyPair, CipherSuiteId, ClientCertMode, ClusterTls, ListenerTls, TlsVersion};
 pub use error::TlsError;
+pub use identity::TlsPeerIdentity;


### PR DESCRIPTION
  ## Summary

  This PR captures downstream mTLS peer identity during TLS termination and exposes it through the request context for HTTP filters.

  The change gives filters a structured way to make routing or authorization decisions from the authenticated downstream client certificate, without reparsing TLS state inside individual filters.

  This is the foundation needed by Grid ingress trust enforcement and other certificate-aware filter behavior.

  Included in this PR:

  - captures downstream client certificate identity when mTLS is configured
  - stores peer identity in the request context
  - exposes certificate digest, organization, and serial details to HTTP filters
  - keeps peer identity absent when no verified downstream client certificate is available
  - adds integration coverage for peer identity propagation through the TLS path

  ## Behavior

  When a downstream connection presents a verified client certificate, Praxis records selected peer identity fields in request context:

  - certificate digest
  - organization information
  - serial details

  Filters can then read those fields from context and apply policy without coupling themselves to the TLS implementation.

  If no verified client certificate is present, the context does not fabricate identity data. Filters that require identity can fail closed at their own policy layer.

  ## Validation

  - Added TLS integration coverage for downstream mTLS peer identity propagation.
  - Verified that peer identity is available to HTTP filters when a verified client certificate is presented.
  - Verified that the change participates correctly in the combined Grid gateway-to-gateway validation branch: [`nerdalert/praxis:ai-grid-g2g-demo-validation`](https://github.com/nerdalert/praxis/tree/ai-grid-g2g-demo-validation).
  - Verified full Grid gateway-to-gateway mTLS trust validation passed 10/10; see the validation package in [`nerdalert/praxis-research-spikes`](https://github.com/nerdalert/praxis-research-spikes/tree/main/demo/ai-grid-gateway-to-gateway).
  - Ran diff-check and boundary audits before push.