### PR TITLE
fix(filter): reconcile security filter classification

### DIFF
--- a/filter/src/pipeline/checks.rs
+++ b/filter/src/pipeline/checks.rs
@@ -20,6 +20,8 @@ const SECURITY_FILTERS: &[&str] = &[
     "forwarded_headers",
     "guardrails",
     "ip_acl",
+    #[cfg(feature = "cpex-policy-engine")]
+    "policy",
     "rate_limit",
 ];
 
@@ -354,6 +356,20 @@ mod tests {
         branch::{RejoinTarget, ResolvedBranch},
         test_filters::{lb_filter, noop_filter_with_conditions, selector_filter},
     };
+
+    #[test]
+    fn security_filter_list_matches_registry_metadata() {
+        let registry = crate::FilterRegistry::with_builtins();
+        let mut expected = registry.security_filters();
+        let mut actual = SECURITY_FILTERS.to_vec();
+        expected.sort_unstable();
+        actual.sort_unstable();
+
+        assert_eq!(
+            actual, expected,
+            "pipeline checks and registry security metadata diverged"
+        );
+    }
 
     #[test]
     fn lb_without_router_errors() {

--- a/filter/src/registry.rs
+++ b/filter/src/registry.rs
@@ -246,7 +246,7 @@ fn register_http_builtins(filters: &mut HashMap<String, FilterRegistration>) {
     register_http_security(filters, "ip_acl", IpAclFilter::from_config);
     register_http(filters, "load_balancer", crate::LoadBalancerFilter::from_config);
     register_http(filters, "path_rewrite", PathRewriteFilter::from_config);
-    register_http(filters, "rate_limit", RateLimitFilter::from_config);
+    register_http_security(filters, "rate_limit", RateLimitFilter::from_config);
     register_http(filters, "redirect", RedirectFilter::from_config);
     register_http(filters, "request_id", RequestIdFilter::from_config);
     register_http(filters, "router", crate::RouterFilter::from_config);
@@ -465,6 +465,7 @@ mod tests {
             "forwarded_headers",
             "guardrails",
             "ip_acl",
+            "rate_limit",
         ];
 
         for name in &expected_security {
@@ -523,6 +524,7 @@ mod tests {
         );
         assert!(sec.contains(&"guardrails"), "guardrails should be in security_filters");
         assert!(sec.contains(&"ip_acl"), "ip_acl should be in security_filters");
+        assert!(sec.contains(&"rate_limit"), "rate_limit should be in security_filters");
         assert!(!sec.contains(&"router"), "router should not be in security_filters");
     }
 


### PR DESCRIPTION
## Summary
- classify `rate_limit` as security-critical, matching both its protective role and the existing pipeline safeguards
- include feature-gated `policy` in pipeline security checks
- add an equivalence regression test so the hardcoded pipeline list cannot drift from registry metadata again

## Verification
- `cargo test -p praxis-proxy-filter security_filter_list_matches_registry_metadata`
- `cargo test -p praxis-proxy-filter registry::tests::`
- `cargo test -p praxis-proxy-filter --features cpex-policy-engine security_filter_list_matches_registry_metadata`
- `cargo clippy -p praxis-proxy-filter --all-targets --all-features -- -D warnings`
- `cargo +nightly fmt --all -- --check`

Closes #841