### PR TITLE
refactor: extract common filter fields for writeback

### DIFF
--- a/protocol/src/http/pingora/context.rs
+++ b/protocol/src/http/pingora/context.rs
@@ -429,12 +429,9 @@ impl PingoraRequestCtx {
     }
 
     /// Writes back the fields common to every filter phase, taken from a
-    /// [`WriteBackContext`] built from an executed [`HttpFilterContext`].
-    ///
     /// Conditional fields (e.g. `cluster`, `upstream`) are not included
     /// callers write those back themselves after calling this.
-    /// [`HttpFilterContext`]: praxis_filter::HttpFilterContext
-    pub fn apply_writeback(&mut self, writeback: WriteBackContext) {
+    pub(crate) fn apply_writeback(&mut self, writeback: WriteBackContext) {
         self.cached_body_done_indices = writeback.body_done_indices;
         self.cached_executed_filter_indices = writeback.executed_filter_indices;
         self.extensions = writeback.extensions;
@@ -503,10 +500,9 @@ impl Default for PingoraRequestCtx {
 ///
 /// Consuming the filter context into this owned struct ends its borrow
 /// of the request context, so the caller can then apply the writeback
-/// via [`PingoraRequestCtx::apply_writeback`]. Conditional fields
-/// like `cluster`, `upstream`, body byte counts ...
+/// via [`PingoraRequestCtx::apply_writeback`].
 /// [`HttpFilterContext`]: praxis_filter::HttpFilterContext
-pub struct WriteBackContext {
+pub(crate) struct WriteBackContext {
     /// Per-filter body-done indices.
     body_done_indices: Vec<bool>,
     /// Per-filter execution indices.
@@ -851,6 +847,37 @@ mod tests {
             Some("42"),
             "multiple metadata keys should persist back"
         );
+    }
+
+    #[test]
+    fn writeback_context_roundtrip_fields() {
+        let registry = FilterRegistry::with_builtins();
+        let pipeline = FilterPipeline::build(&mut [], &registry).unwrap();
+        let request = Request {
+            method: Method::GET,
+            uri: "/".parse::<Uri>().unwrap(),
+            headers: HeaderMap::new(),
+        };
+        let mut ctx = default_ctx();
+        let mut fctx = ctx.build_filter_context(&pipeline, &request, None);
+
+        fctx.body_done_indices = vec![true];
+        fctx.executed_filter_indices = vec![false];
+        fctx.extensions.insert(37usize);
+        fctx.filter_metadata = std::collections::HashMap::from([("trace.id".to_string(), "abc-123".to_string())]);
+
+        let state: Box<dyn std::any::Any + Send + Sync> = Box::new(37);
+        fctx.filter_state = std::collections::HashMap::from([(0usize, state)]);
+
+        let writeback = WriteBackContext::from(fctx);
+        ctx.apply_writeback(writeback);
+
+        assert_eq!(ctx.cached_body_done_indices, vec![true]);
+        assert_eq!(ctx.cached_executed_filter_indices, vec![false]);
+        assert_eq!(ctx.extensions.get::<usize>(), Some(&37));
+        assert_eq!(ctx.filter_metadata.get("trace.id").map(String::as_str), Some("abc-123"));
+        let ret_state = ctx.filter_state.get(&0usize).unwrap();
+        assert_eq!(ret_state.downcast_ref(), Some(&37));
     }
 
     // -------------------------------------------------------------------------

--- a/protocol/src/http/pingora/context.rs
+++ b/protocol/src/http/pingora/context.rs
@@ -427,6 +427,20 @@ impl PingoraRequestCtx {
             .as_ref()
             .map_or_else(|| swap.load_full(), Arc::clone)
     }
+
+    /// Writes back the fields common to every filter phase, taken from a
+    /// [`WriteBackContext`] built from an executed [`HttpFilterContext`].
+    ///
+    /// Conditional fields (e.g. `cluster`, `upstream`) are not included
+    /// callers write those back themselves after calling this.
+    /// [`HttpFilterContext`]: praxis_filter::HttpFilterContext
+    pub fn apply_writeback(&mut self, writeback: WriteBackContext) {
+        self.cached_body_done_indices = writeback.body_done_indices;
+        self.cached_executed_filter_indices = writeback.executed_filter_indices;
+        self.extensions = writeback.extensions;
+        self.filter_metadata = writeback.filter_metadata;
+        self.filter_state = writeback.filter_state;
+    }
 }
 
 impl Default for PingoraRequestCtx {
@@ -476,6 +490,43 @@ impl Default for PingoraRequestCtx {
             selected_endpoint_index: None,
             upstream: None,
             upstream_for_retry: None,
+        }
+    }
+}
+
+// -----------------------------------------------------------------------------
+// WriteBackContext
+// -----------------------------------------------------------------------------
+
+/// Common Fields carried back from [`HttpFilterContext`] into the
+/// request context.
+///
+/// Consuming the filter context into this owned struct ends its borrow
+/// of the request context, so the caller can then apply the writeback
+/// via [`PingoraRequestCtx::apply_writeback`]. Conditional fields
+/// like `cluster`, `upstream`, body byte counts ...
+/// [`HttpFilterContext`]: praxis_filter::HttpFilterContext
+pub struct WriteBackContext {
+    /// Per-filter body-done indices.
+    body_done_indices: Vec<bool>,
+    /// Per-filter execution indices.
+    executed_filter_indices: Vec<bool>,
+    /// Request-scoped extension container.
+    extensions: praxis_filter::RequestExtensions,
+    /// Request-scoped metadata.
+    filter_metadata: std::collections::HashMap<String, String>,
+    /// Per-filter state, keyed by filter ID.
+    filter_state: std::collections::HashMap<usize, Box<dyn std::any::Any + Send + Sync>>,
+}
+
+impl From<praxis_filter::HttpFilterContext<'_>> for WriteBackContext {
+    fn from(fctx: praxis_filter::HttpFilterContext<'_>) -> Self {
+        Self {
+            body_done_indices: fctx.body_done_indices,
+            executed_filter_indices: fctx.executed_filter_indices,
+            extensions: fctx.extensions,
+            filter_metadata: fctx.filter_metadata,
+            filter_state: fctx.filter_state,
         }
     }
 }

--- a/protocol/src/http/pingora/handler/request_body_filter.rs
+++ b/protocol/src/http/pingora/handler/request_body_filter.rs
@@ -20,6 +20,8 @@ use praxis_core::config::ABSOLUTE_MAX_BODY_BYTES;
 use praxis_filter::{BodyBuffer, BodyMode, FilterAction, FilterPipeline, Rejection};
 use tracing::error;
 
+use crate::http::pingora::context::WriteBackContext;
+
 use super::super::{context::PingoraRequestCtx, convert::send_rejection};
 
 // -----------------------------------------------------------------------------
@@ -105,7 +107,7 @@ pub(super) async fn execute(
         _ => tracing::error!("unhandled BodyMode variant in request body filter"),
     }
 
-    let (result, body_bytes, cluster, upstream, extensions, filter_metadata, filter_state, executed_indices, body_done) = {
+    let (result, body_bytes, cluster, upstream, write_back) = {
         let mut fctx = ctx.filter_context_for(pipeline, None).ok_or_else(|| {
             pingora_core::Error::explain(
                 pingora_core::ErrorType::InternalError,
@@ -116,23 +118,15 @@ pub(super) async fn execute(
         (
             r,
             fctx.request_body_bytes,
-            fctx.cluster,
-            fctx.upstream,
-            fctx.extensions,
-            fctx.filter_metadata,
-            fctx.filter_state,
-            fctx.executed_filter_indices,
-            fctx.body_done_indices,
+            fctx.cluster.take(),
+            fctx.upstream.take(),
+            WriteBackContext::from(fctx),
         )
     };
     ctx.request_body_bytes = body_bytes;
     ctx.cluster = cluster;
     ctx.upstream = upstream;
-    ctx.extensions = extensions;
-    ctx.filter_metadata = filter_metadata;
-    ctx.filter_state = filter_state;
-    ctx.cached_executed_filter_indices = executed_indices;
-    ctx.cached_body_done_indices = body_done;
+    ctx.apply_writeback(write_back);
 
     match result {
         Ok(FilterAction::Continue | FilterAction::BodyDone) => {

--- a/protocol/src/http/pingora/handler/request_filter/mod.rs
+++ b/protocol/src/http/pingora/handler/request_filter/mod.rs
@@ -11,6 +11,8 @@ use praxis_core::connectivity::normalize_mapped_ipv4;
 use praxis_filter::{BodyMode, FilterAction, FilterError, FilterPipeline, Rejection, Request, TrustedHeaderMutation};
 use tracing::{error, warn};
 
+use crate::http::pingora::context::WriteBackContext;
+
 use super::super::{
     context::PingoraRequestCtx,
     convert::{request_header_from_session, send_rejection},
@@ -186,36 +188,28 @@ async fn run_pipeline(
         rewritten_path,
         request_body_mode,
         selected_endpoint_index,
-        extensions,
-        filter_metadata,
-        filter_state,
-        executed_indices,
-        body_done,
         // Pre-read mutations were consumed by endpoint_selector during
         // on_request. Cleared below to prevent stale provenance reuse.
         _pre_read_mutations,
         structured_metadata,
+        write_back,
     ) = {
         let mut filter_ctx = ctx.build_filter_context(pipeline, &request, None);
 
         let action = pipeline.execute_http_request(&mut filter_ctx).await;
         (
             action,
-            filter_ctx.extra_request_headers,
-            filter_ctx.request_headers_to_remove,
-            filter_ctx.request_headers_to_set,
-            filter_ctx.cluster,
-            filter_ctx.upstream,
-            filter_ctx.rewritten_path,
+            std::mem::take(&mut filter_ctx.extra_request_headers),
+            std::mem::take(&mut filter_ctx.request_headers_to_remove),
+            std::mem::take(&mut filter_ctx.request_headers_to_set),
+            filter_ctx.cluster.take(),
+            filter_ctx.upstream.take(),
+            filter_ctx.rewritten_path.take(),
             filter_ctx.request_body_mode,
             filter_ctx.selected_endpoint_index,
-            filter_ctx.extensions,
-            filter_ctx.filter_metadata,
-            filter_ctx.filter_state,
-            filter_ctx.executed_filter_indices,
-            filter_ctx.body_done_indices,
-            filter_ctx.pre_read_mutations,
-            filter_ctx.structured_metadata,
+            std::mem::take(&mut filter_ctx.pre_read_mutations),
+            std::mem::take(&mut filter_ctx.structured_metadata),
+            WriteBackContext::from(filter_ctx),
         )
     };
 
@@ -225,11 +219,6 @@ async fn run_pipeline(
         request.headers.remove(name);
     }
     ctx.request_snapshot = Some(request);
-    ctx.extensions = extensions;
-    ctx.filter_metadata = filter_metadata;
-    ctx.filter_state = filter_state;
-    ctx.cached_executed_filter_indices = executed_indices;
-    ctx.cached_body_done_indices = body_done;
     // Pre-read mutations were consumed by the request pipeline (e.g.
     // endpoint_selector). Clear them so later phases cannot reuse stale
     // routing authority from a previous request phase.
@@ -237,6 +226,7 @@ async fn run_pipeline(
     ctx.structured_metadata = structured_metadata;
     ctx.metrics_cluster_shared = cluster.as_ref().map(|c| ::metrics::SharedString::from(Arc::clone(c)));
     ctx.metrics_cluster.clone_from(&cluster);
+    ctx.apply_writeback(write_back);
 
     match action {
         Ok(FilterAction::Continue | FilterAction::Release | FilterAction::BodyDone) => {

--- a/protocol/src/http/pingora/handler/response_body_filter.rs
+++ b/protocol/src/http/pingora/handler/response_body_filter.rs
@@ -19,6 +19,8 @@ use praxis_core::config::ABSOLUTE_MAX_BODY_BYTES;
 use praxis_filter::{BodyBuffer, BodyMode, FilterAction, FilterPipeline};
 use tracing::{debug, error};
 
+use crate::http::pingora::context::WriteBackContext;
+
 use super::super::context::PingoraRequestCtx;
 
 // -----------------------------------------------------------------------------
@@ -91,7 +93,7 @@ pub(super) fn execute(
         _ => tracing::error!("unhandled BodyMode variant in response body filter"),
     }
 
-    let (result, body_bytes, cluster, upstream, extensions, filter_metadata, filter_state, executed_indices, body_done) = {
+    let (result, body_bytes, cluster, upstream, write_back) = {
         let (mut fctx, response_header) = ctx.response_body_context_for(pipeline).ok_or_else(|| {
             pingora_core::Error::explain(
                 pingora_core::ErrorType::InternalError,
@@ -103,23 +105,15 @@ pub(super) fn execute(
         (
             r,
             fctx.response_body_bytes,
-            fctx.cluster,
-            fctx.upstream,
-            fctx.extensions,
-            fctx.filter_metadata,
-            fctx.filter_state,
-            fctx.executed_filter_indices,
-            fctx.body_done_indices,
+            fctx.cluster.take(),
+            fctx.upstream.take(),
+            WriteBackContext::from(fctx),
         )
     };
     ctx.response_body_bytes = body_bytes;
     ctx.cluster = cluster;
     ctx.upstream = upstream;
-    ctx.extensions = extensions;
-    ctx.filter_metadata = filter_metadata;
-    ctx.filter_state = filter_state;
-    ctx.cached_executed_filter_indices = executed_indices;
-    ctx.cached_body_done_indices = body_done;
+    ctx.apply_writeback(write_back);
 
     match result {
         Ok(FilterAction::Continue | FilterAction::BodyDone) => {

--- a/protocol/src/http/pingora/handler/response_filter.rs
+++ b/protocol/src/http/pingora/handler/response_filter.rs
@@ -13,6 +13,8 @@ use pingora_core::Result;
 use praxis_filter::{FilterAction, FilterPipeline};
 use tracing::{debug, error, warn};
 
+use crate::http::pingora::context::WriteBackContext;
+
 use super::super::{context::PingoraRequestCtx, convert::response_header_from_pingora};
 
 // -----------------------------------------------------------------------------
@@ -75,17 +77,7 @@ async fn run_response_pipeline(
     resp: &mut praxis_filter::Response,
 ) -> Result<(std::result::Result<FilterAction, praxis_filter::FilterError>, bool)> {
     let baseline_response_body_mode = ctx.response_body_mode;
-    let (
-        r,
-        headers_modified,
-        response_body_mode,
-        cluster,
-        extensions,
-        filter_metadata,
-        filter_state,
-        executed_indices,
-        body_done,
-    ) = {
+    let (r, headers_modified, response_body_mode, cluster, write_back) = {
         let mut fctx = ctx.filter_context_for(pipeline, Some(resp)).ok_or_else(|| {
             pingora_core::Error::explain(
                 pingora_core::ErrorType::InternalError,
@@ -97,21 +89,13 @@ async fn run_response_pipeline(
             r,
             fctx.response_headers_modified,
             fctx.response_body_mode,
-            fctx.cluster,
-            fctx.extensions,
-            fctx.filter_metadata,
-            fctx.filter_state,
-            fctx.executed_filter_indices,
-            fctx.body_done_indices,
+            fctx.cluster.take(),
+            WriteBackContext::from(fctx),
         )
     };
     ctx.cluster = cluster;
     ctx.response_body_mode = super::clamp_body_mode_to_ceiling(response_body_mode, baseline_response_body_mode);
-    ctx.extensions = extensions;
-    ctx.filter_metadata = filter_metadata;
-    ctx.filter_state = filter_state;
-    ctx.cached_executed_filter_indices = executed_indices;
-    ctx.cached_body_done_indices = body_done;
+    ctx.apply_writeback(write_back);
     Ok((r, headers_modified))
 }
 


### PR DESCRIPTION
### What does this PR do?
ctx.apply_writeback(&mut fctx) can't be called directly where fctx borrows ctx. This commit introduces a small owned WriteBackContext struct: From<HttpFilterContext> consumes fctx (ending its borrow of ctx), then PingoraRequestCtx::apply_writeback applies the 5 common fields. Phase-specific fields (cluster, upstream, etc.) remain handled per call site.

### Which issue(s) does this relate to?

Fixes #833

### Checklist

- [X] Signed off all commits (`git commit -s`)
- [ ] Tests added or updated
- [ ] Documentation updated (if applicable)
- [X] `make lint && make test` passes locally

### Does this introduce a breaking change?
No.
<!-- If yes, describe the impact and migration
path. -->
