### PR TITLE
feat(filter): add random load balancing strategy

### DIFF
--- a/core/src/config/cluster/load_balancer_strategy.rs
+++ b/core/src/config/cluster/load_balancer_strategy.rs
@@ -40,6 +40,9 @@ pub enum SimpleStrategy {
     /// Sample two random endpoints; pick the less loaded one.
     #[serde(rename = "p2c")]
     PowerOfTwoChoices,
+
+    /// Uniform random endpoint selection, weighted by endpoint weight.
+    Random,
 }
 
 /// Load-balancing strategies that carry parameters.
@@ -133,6 +136,17 @@ consistent_hash:
             strategy,
             LoadBalancerStrategy::Simple(SimpleStrategy::PowerOfTwoChoices),
             "should parse 'p2c' string"
+        );
+    }
+
+    #[test]
+    fn load_balancer_strategy_parses_random() {
+        let yaml = "random";
+        let strategy: LoadBalancerStrategy = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(
+            strategy,
+            LoadBalancerStrategy::Simple(SimpleStrategy::Random),
+            "should parse 'random' string"
         );
     }
 

--- a/docs/filters/http/traffic_management/load_balancer.md
+++ b/docs/filters/http/traffic_management/load_balancer.md
@@ -30,7 +30,7 @@ Supported strategies: - `round_robin` (default): cycles through endpoints in ord
 | `clusters[].health_check.timeout_ms` | integer | no | Probe timeout in milliseconds. Must be less than `interval_ms`. |
 | `clusters[].health_check.unhealthy_threshold` | integer | no | Consecutive failures required to mark an endpoint unhealthy. |
 | `clusters[].idle_timeout_ms` | integer | no | Idle connection timeout in milliseconds. Closes pooled upstream connections that have been idle longer than this duration. `None` uses Pingora's default. |
-| `clusters[].load_balancer_strategy` | `round_robin` \| `least_connections` \| `p2c` \| `consistent_hash` | no | Load-balancing algorithm for this cluster. Defaults to `round_robin`. |
+| `clusters[].load_balancer_strategy` | `round_robin` \| `least_connections` \| `p2c` \| `random` \| `consistent_hash` | no | Load-balancing algorithm for this cluster. Defaults to `round_robin`. |
 | `clusters[].max_connections` | integer | no | Maximum concurrent in-flight requests to this cluster. When set, excess requests receive 503. Prevents a single slow upstream from consuming all available capacity. |
 | `clusters[].read_timeout_ms` | integer | no | Per-read timeout in milliseconds. Applies to each individual read operation on an established upstream connection. A timeout fires a 502 response to the client. Use [`total_connection_timeout_ms`] to bound the entire exchange instead. |
 | `clusters[].tls` | ClusterTls | no | TLS settings for upstream connections. Presence implies TLS is enabled. Omit for plaintext HTTP. |

--- a/docs/filters/tcp/traffic_management/tcp_load_balancer.md
+++ b/docs/filters/tcp/traffic_management/tcp_load_balancer.md
@@ -32,7 +32,7 @@ If all endpoints are unhealthy, the filter enters panic mode and routes to all e
 | `clusters[].health_check.timeout_ms` | integer | no | Probe timeout in milliseconds. Must be less than `interval_ms`. |
 | `clusters[].health_check.unhealthy_threshold` | integer | no | Consecutive failures required to mark an endpoint unhealthy. |
 | `clusters[].idle_timeout_ms` | integer | no | Idle connection timeout in milliseconds. Closes pooled upstream connections that have been idle longer than this duration. `None` uses Pingora's default. |
-| `clusters[].load_balancer_strategy` | `round_robin` \| `least_connections` \| `p2c` \| `consistent_hash` | no | Load-balancing algorithm for this cluster. Defaults to `round_robin`. |
+| `clusters[].load_balancer_strategy` | `round_robin` \| `least_connections` \| `p2c` \| `random` \| `consistent_hash` | no | Load-balancing algorithm for this cluster. Defaults to `round_robin`. |
 | `clusters[].max_connections` | integer | no | Maximum concurrent in-flight requests to this cluster. When set, excess requests receive 503. Prevents a single slow upstream from consuming all available capacity. |
 | `clusters[].read_timeout_ms` | integer | no | Per-read timeout in milliseconds. Applies to each individual read operation on an established upstream connection. A timeout fires a 502 response to the client. Use [`total_connection_timeout_ms`] to bound the entire exchange instead. |
 | `clusters[].tls` | ClusterTls | no | TLS settings for upstream connections. Presence implies TLS is enabled. Omit for plaintext HTTP. |

--- a/examples/README.md
+++ b/examples/README.md
@@ -136,6 +136,7 @@ page.
 | [least-connections.yaml](configs/traffic-management/least-connections.yaml) | Routes each request to the backend with the fewest in-flight requests |
 | [p2c.yaml](configs/traffic-management/p2c.yaml) | Samples two random endpoints and picks the one with fewer in-flight requests |
 | [path-based-routing.yaml](configs/traffic-management/path-based-routing.yaml) | Routes by URL path prefix |
+| [random.yaml](configs/traffic-management/random.yaml) | Selects an upstream endpoint at random, weighted by endpoint weight |
 | [rate-limiting.yaml](configs/traffic-management/rate-limiting.yaml) | Token bucket rate limiter with per-IP or global modes |
 | [redirect.yaml](configs/traffic-management/redirect.yaml) | Returns a 3xx redirect without contacting any upstream |
 | [round-robin.yaml](configs/traffic-management/round-robin.yaml) | Default strategy |

--- a/examples/configs/traffic-management/random.yaml
+++ b/examples/configs/traffic-management/random.yaml
@@ -1,0 +1,31 @@
+# Random Load Balancing
+#
+# Selects an upstream endpoint at random, weighted by endpoint weight.
+# With equal weights this reduces to uniform random selection.
+#
+# Usage:
+#   cargo run -p praxis-proxy -- -c examples/configs/traffic-management/random.yaml
+#   curl http://localhost:8080/
+
+listeners:
+  - name: default
+    address: "127.0.0.1:8080"
+    filter_chains:
+      - main
+
+filter_chains:
+  - name: main
+    filters:
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: backend
+
+      - filter: load_balancer
+        clusters:
+          - name: backend
+            load_balancer_strategy: random
+            endpoints:
+              - "127.0.0.1:3001"
+              - "127.0.0.1:3002"
+              - "127.0.0.1:3003"

--- a/filter/src/load_balancing/mod.rs
+++ b/filter/src/load_balancing/mod.rs
@@ -18,10 +18,10 @@ pub(crate) mod strategy;
 // -----------------------------------------------------------------------------
 
 /// Multiplier for the LCG RNG (Knuth MMIX, truncated to 64 bits).
-pub(super) const LCG_A: u64 = 6_364_136_223_846_793_005;
+const LCG_A: u64 = 6_364_136_223_846_793_005;
 
 /// Increment for the LCG RNG.
-pub(super) const LCG_C: u64 = 1_442_695_040_888_963_407;
+const LCG_C: u64 = 1_442_695_040_888_963_407;
 
 /// Advance an atomic LCG state and return the new value.
 fn next_random(rng: &AtomicU64) -> u64 {

--- a/filter/src/load_balancing/mod.rs
+++ b/filter/src/load_balancing/mod.rs
@@ -3,9 +3,30 @@
 
 //! Protocol-agnostic load-balancing strategies and endpoint types.
 
+use std::sync::atomic::{AtomicU64, Ordering};
+
 pub(crate) mod consistent_hash;
 pub(crate) mod endpoint;
 pub(crate) mod least_connections;
 pub(crate) mod p2c;
+pub(crate) mod random;
 pub(crate) mod round_robin;
 pub(crate) mod strategy;
+
+// -----------------------------------------------------------------------------
+// Shared LCG RNG
+// -----------------------------------------------------------------------------
+
+/// Multiplier for the LCG RNG (Knuth MMIX, truncated to 64 bits).
+pub(super) const LCG_A: u64 = 6_364_136_223_846_793_005;
+
+/// Increment for the LCG RNG.
+pub(super) const LCG_C: u64 = 1_442_695_040_888_963_407;
+
+/// Advance an atomic LCG state and return the new value.
+fn next_random(rng: &AtomicU64) -> u64 {
+    rng.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |s| {
+        Some(s.wrapping_mul(LCG_A).wrapping_add(LCG_C))
+    })
+    .unwrap_or(0)
+}

--- a/filter/src/load_balancing/p2c.rs
+++ b/filter/src/load_balancing/p2c.rs
@@ -17,16 +17,6 @@ use smallvec::SmallVec;
 use super::endpoint::WeightedEndpoint;
 
 // -----------------------------------------------------------------------------
-// Constants
-// -----------------------------------------------------------------------------
-
-/// Multiplier for the LCG RNG (Knuth MMIX, truncated to 64 bits).
-const LCG_A: u64 = 6_364_136_223_846_793_005;
-
-/// Increment for the LCG RNG.
-const LCG_C: u64 = 1_442_695_040_888_963_407;
-
-// -----------------------------------------------------------------------------
 // PowerOfTwoChoices
 // -----------------------------------------------------------------------------
 
@@ -126,24 +116,15 @@ impl PowerOfTwoChoices {
         reason = "modulo total_weight bounds the result to usize range"
     )]
     fn pick_two(&self, total_weight: usize) -> (usize, usize) {
-        let r1 = self.next_random();
-        let mut r2 = self.next_random();
+        let r1 = super::next_random(&self.rng);
+        let mut r2 = super::next_random(&self.rng);
         let a = (r1 as usize) % total_weight;
         let mut b = (r2 as usize) % total_weight;
         while b == a {
-            r2 = r2.wrapping_mul(LCG_A).wrapping_add(LCG_C);
+            r2 = r2.wrapping_mul(super::LCG_A).wrapping_add(super::LCG_C);
             b = (r2 as usize) % total_weight;
         }
         (a, b)
-    }
-
-    /// Advance the LCG and return the new state.
-    fn next_random(&self) -> u64 {
-        self.rng
-            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |s| {
-                Some(s.wrapping_mul(LCG_A).wrapping_add(LCG_C))
-            })
-            .unwrap_or(0)
     }
 
     /// Filter to healthy endpoints, falling back to all on panic mode.

--- a/filter/src/load_balancing/random.rs
+++ b/filter/src/load_balancing/random.rs
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Weighted random endpoint selection.
+
+use std::{
+    borrow::Borrow,
+    sync::{Arc, atomic::AtomicU64},
+};
+
+use praxis_core::health::ClusterHealthState;
+use smallvec::SmallVec;
+
+use super::endpoint::WeightedEndpoint;
+
+// -----------------------------------------------------------------------------
+// Random
+// -----------------------------------------------------------------------------
+
+/// Uniform random endpoint selection, weighted by endpoint weight.
+///
+/// Each endpoint's probability of selection is proportional to its weight
+/// relative to the total weight of all (healthy) endpoints. With equal
+/// weights this reduces to uniform random selection.
+pub(crate) struct Random {
+    /// Deduplicated endpoint list with weights and original indices.
+    endpoints: Vec<WeightedEndpoint>,
+
+    /// Sum of all endpoint weights (pre-computed, widened to `usize`).
+    total_weight: usize,
+
+    /// Deterministic RNG state.
+    rng: AtomicU64,
+}
+
+impl Random {
+    /// Create a random selector from a deduplicated weighted endpoint list.
+    pub(crate) fn new(endpoints: Vec<WeightedEndpoint>) -> Self {
+        let total_weight: usize = endpoints.iter().map(|ep| ep.weight as usize).sum();
+        Self {
+            endpoints,
+            total_weight,
+            rng: AtomicU64::new(1),
+        }
+    }
+
+    /// Return a randomly selected healthy endpoint address.
+    ///
+    /// Selection probability is proportional to endpoint weight. Falls back
+    /// to the first healthy endpoint when all healthy candidates have zero
+    /// weight, or to all endpoints (panic mode) when none are healthy.
+    #[inline]
+    pub(crate) fn select(&self, health: Option<&ClusterHealthState>) -> Option<Arc<str>> {
+        if self.total_weight == 0 {
+            return None;
+        }
+
+        if let Some(state) = health {
+            let healthy = self.healthy_candidates(state);
+            if let Some(first) = healthy.first() {
+                let total: usize = healthy.iter().map(|ep| ep.weight as usize).sum();
+                if total > 0 {
+                    return Some(pick(&healthy, super::next_random(&self.rng), total));
+                }
+                return Some(Arc::clone(&first.address));
+            }
+        }
+
+        Some(pick(&self.endpoints, super::next_random(&self.rng), self.total_weight))
+    }
+
+    /// Filter to healthy endpoints.
+    #[expect(clippy::indexing_slicing, reason = "bounds checked by ep.index < len()")]
+    fn healthy_candidates(&self, state: &ClusterHealthState) -> SmallVec<[&WeightedEndpoint; 8]> {
+        self.endpoints
+            .iter()
+            .filter(|ep| ep.index < state.endpoints().len() && state.endpoints()[ep.index].is_healthy())
+            .collect()
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Utilities
+// -----------------------------------------------------------------------------
+
+/// Map a random value to an endpoint via cumulative weight buckets.
+#[expect(clippy::cast_possible_truncation, reason = "modulo total_weight bounds the result")]
+#[expect(clippy::expect_used, reason = "total_weight > 0 guaranteed by caller")]
+fn pick<E: Borrow<WeightedEndpoint>>(endpoints: &[E], random: u64, total_weight: usize) -> Arc<str> {
+    let slot = (random as usize) % total_weight;
+    let mut cumulative = 0_usize;
+    for ep in endpoints {
+        let ep = ep.borrow();
+        cumulative += ep.weight as usize;
+        if slot < cumulative {
+            return Arc::clone(&ep.address);
+        }
+    }
+    Arc::clone(&endpoints.last().expect("endpoints must be non-empty").borrow().address)
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[cfg(test)]
+#[expect(clippy::allow_attributes, reason = "blanket test suppressions")]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    clippy::too_many_lines,
+    reason = "tests"
+)]
+mod tests {
+    use std::sync::Arc;
+
+    use praxis_core::health::{ClusterHealthEntry, EndpointHealth};
+
+    use super::*;
+
+    #[test]
+    fn single_endpoint_always_selected() {
+        let r = Random::new(vec![ep("10.0.0.1:80", 1, 0)]);
+        for _ in 0..10 {
+            assert_eq!(
+                &*r.select(None).unwrap(),
+                "10.0.0.1:80",
+                "single endpoint must always be returned"
+            );
+        }
+    }
+
+    #[test]
+    fn distributes_across_endpoints() {
+        let r = Random::new(vec![
+            ep("10.0.0.1:80", 1, 0),
+            ep("10.0.0.2:80", 1, 1),
+            ep("10.0.0.3:80", 1, 2),
+        ]);
+
+        let mut counts = std::collections::HashMap::new();
+        for _ in 0..300 {
+            *counts.entry(r.select(None).unwrap()).or_insert(0_u32) += 1;
+        }
+
+        assert_eq!(counts.len(), 3, "random should use all 3 endpoints");
+        for (addr, count) in &counts {
+            assert!((50..=200).contains(count), "expected ~100 for {addr}, got {count}");
+        }
+    }
+
+    #[test]
+    fn weighted_bias() {
+        let r = Random::new(vec![ep("10.0.0.1:80", 1, 0), ep("10.0.0.2:80", 9, 1)]);
+
+        let mut counts = std::collections::HashMap::new();
+        for _ in 0..1000 {
+            *counts.entry(r.select(None).unwrap()).or_insert(0_u32) += 1;
+        }
+
+        let heavy = counts.get("10.0.0.2:80").copied().unwrap_or(0);
+        assert!(
+            heavy > 700,
+            "weight-9 endpoint should get ~90% of traffic: heavy={heavy}"
+        );
+    }
+
+    #[test]
+    fn skips_unhealthy() {
+        let r = Random::new(vec![ep("10.0.0.1:80", 1, 0), ep("10.0.0.2:80", 1, 1)]);
+        let state = health_state(2);
+        state.endpoints()[0].mark_unhealthy();
+
+        for _ in 0..10 {
+            assert_eq!(
+                &*r.select(Some(&state)).unwrap(),
+                "10.0.0.2:80",
+                "should skip unhealthy endpoint"
+            );
+        }
+    }
+
+    #[test]
+    fn panic_mode_when_all_unhealthy() {
+        let r = Random::new(vec![ep("10.0.0.1:80", 1, 0), ep("10.0.0.2:80", 1, 1)]);
+        let state = health_state(2);
+        state.endpoints()[0].mark_unhealthy();
+        state.endpoints()[1].mark_unhealthy();
+
+        let addr = r.select(Some(&state)).unwrap();
+        assert!(
+            &*addr == "10.0.0.1:80" || &*addr == "10.0.0.2:80",
+            "panic mode should still return an endpoint"
+        );
+    }
+
+    #[test]
+    fn empty_endpoints_returns_none() {
+        let r = Random::new(vec![]);
+        assert!(r.select(None).is_none(), "empty endpoint list should return None");
+    }
+
+    #[test]
+    fn empty_endpoints_with_health_returns_none() {
+        let r = Random::new(vec![]);
+        let state: ClusterHealthState = Arc::new(ClusterHealthEntry::new(vec![], vec![], None, None));
+        assert!(
+            r.select(Some(&state)).is_none(),
+            "empty endpoint list with health state should return None"
+        );
+    }
+
+    #[test]
+    fn all_zero_weight_returns_none() {
+        let r = Random::new(vec![ep("10.0.0.1:80", 0, 0), ep("10.0.0.2:80", 0, 1)]);
+        assert!(r.select(None).is_none(), "all-zero-weight endpoints should return None");
+    }
+
+    #[test]
+    fn zero_weight_healthy_returns_first_healthy() {
+        let r = Random::new(vec![ep("10.0.0.1:80", 0, 0), ep("10.0.0.2:80", 5, 1)]);
+        let state = health_state(2);
+        state.endpoints()[1].mark_unhealthy();
+
+        let addr = r.select(Some(&state)).unwrap();
+        assert_eq!(
+            &*addr, "10.0.0.1:80",
+            "should return first healthy endpoint when healthy candidates have zero total weight"
+        );
+    }
+
+    #[test]
+    fn pick_exact_bucket_boundaries() {
+        let endpoints = vec![ep("A", 1, 0), ep("B", 3, 1), ep("C", 1, 2)];
+        // total_weight = 5, buckets: A=[0], B=[1,2,3], C=[4]
+        assert_eq!(&*pick(&endpoints, 0, 5), "A", "slot 0 → A");
+        assert_eq!(&*pick(&endpoints, 1, 5), "B", "slot 1 → B");
+        assert_eq!(&*pick(&endpoints, 2, 5), "B", "slot 2 → B");
+        assert_eq!(&*pick(&endpoints, 3, 5), "B", "slot 3 → B");
+        assert_eq!(&*pick(&endpoints, 4, 5), "C", "slot 4 → C");
+        // values beyond total_weight wrap via modulo
+        assert_eq!(&*pick(&endpoints, 5, 5), "A", "slot 5 wraps to 0 → A");
+        assert_eq!(&*pick(&endpoints, 9, 5), "C", "slot 9 wraps to 4 → C");
+    }
+
+    #[test]
+    fn pick_with_borrowed_refs() {
+        let endpoints = [ep("A", 2, 0), ep("B", 2, 1)];
+        let refs: Vec<&WeightedEndpoint> = endpoints.iter().collect();
+        // total_weight = 4, buckets: A=[0,1], B=[2,3]
+        assert_eq!(&*pick(&refs, 0, 4), "A", "slot 0 → A via refs");
+        assert_eq!(&*pick(&refs, 1, 4), "A", "slot 1 → A via refs");
+        assert_eq!(&*pick(&refs, 2, 4), "B", "slot 2 → B via refs");
+        assert_eq!(&*pick(&refs, 3, 4), "B", "slot 3 → B via refs");
+    }
+
+    // -------------------------------------------------------------------------
+    // Test Utilities
+    // -------------------------------------------------------------------------
+
+    fn ep(addr: &str, weight: u32, index: usize) -> WeightedEndpoint {
+        WeightedEndpoint {
+            address: Arc::from(addr),
+            weight,
+            index,
+        }
+    }
+
+    fn health_state(n: usize) -> ClusterHealthState {
+        let healths: Vec<_> = (0..n).map(|_| EndpointHealth::new()).collect();
+        let addrs: Vec<_> = (0..n).map(|i| Arc::from(format!("10.0.0.{i}:80").as_str())).collect();
+        Arc::new(ClusterHealthEntry::new(healths, addrs, None, None))
+    }
+}

--- a/filter/src/load_balancing/strategy.rs
+++ b/filter/src/load_balancing/strategy.rs
@@ -12,7 +12,7 @@ use praxis_core::{
 
 use super::{
     consistent_hash::ConsistentHash, endpoint::WeightedEndpoint, least_connections::LeastConnections,
-    p2c::PowerOfTwoChoices, round_robin::RoundRobin,
+    p2c::PowerOfTwoChoices, random::Random, round_robin::RoundRobin,
 };
 
 // -----------------------------------------------------------------------------
@@ -32,6 +32,9 @@ pub(crate) enum Strategy {
 
     /// Sample two random endpoints; pick the less loaded one.
     PowerOfTwoChoices(PowerOfTwoChoices),
+
+    /// Uniform random selection, weighted by endpoint weight.
+    Random(Random),
 }
 
 impl Strategy {
@@ -45,6 +48,7 @@ impl Strategy {
             Self::LeastConnections(lc) => lc.select(health),
             Self::ConsistentHash(ch) => ch.select(hash_key, health),
             Self::PowerOfTwoChoices(p2c) => p2c.select(health),
+            Self::Random(r) => r.select(health),
         }
     }
 
@@ -54,7 +58,7 @@ impl Strategy {
         match self {
             Self::LeastConnections(lc) => lc.release(addr),
             Self::PowerOfTwoChoices(p2c) => p2c.release(addr),
-            Self::RoundRobin(_) | Self::ConsistentHash(_) => {},
+            Self::RoundRobin(_) | Self::ConsistentHash(_) | Self::Random(_) => {},
         }
     }
 }
@@ -69,6 +73,7 @@ pub(crate) fn build_strategy(lb_strategy: &LoadBalancerStrategy, endpoints: Vec<
         LoadBalancerStrategy::Simple(SimpleStrategy::PowerOfTwoChoices) => {
             Strategy::PowerOfTwoChoices(PowerOfTwoChoices::new(endpoints))
         },
+        LoadBalancerStrategy::Simple(SimpleStrategy::Random) => Strategy::Random(Random::new(endpoints)),
         LoadBalancerStrategy::Parameterised(ParameterisedStrategy::ConsistentHash(opts)) => {
             Strategy::ConsistentHash(ConsistentHash::new(endpoints, opts.header.clone()))
         },
@@ -134,11 +139,26 @@ mod tests {
     }
 
     #[test]
+    fn build_strategy_random() {
+        let strategy = build_strategy(&LoadBalancerStrategy::Simple(SimpleStrategy::Random), make_endpoints());
+        assert!(
+            matches!(strategy, Strategy::Random(_)),
+            "SimpleStrategy::Random should produce Strategy::Random"
+        );
+    }
+
+    #[test]
     fn release_round_robin_is_noop() {
         let strategy = build_strategy(
             &LoadBalancerStrategy::Simple(SimpleStrategy::RoundRobin),
             make_endpoints(),
         );
+        strategy.release("10.0.0.1:80");
+    }
+
+    #[test]
+    fn release_random_is_noop() {
+        let strategy = build_strategy(&LoadBalancerStrategy::Simple(SimpleStrategy::Random), make_endpoints());
         strategy.release("10.0.0.1:80");
     }
 
@@ -238,6 +258,15 @@ mod tests {
         }
         strategy.release("10.0.0.1:80");
         strategy.release("10.0.0.2:80");
+    }
+
+    #[test]
+    fn select_random_returns_some() {
+        let strategy = build_strategy(&LoadBalancerStrategy::Simple(SimpleStrategy::Random), make_endpoints());
+        assert!(
+            strategy.select(None, None).is_some(),
+            "Random select should return Some with healthy endpoints"
+        );
     }
 
     #[test]

--- a/tests/integration/tests/suite/examples/mod.rs
+++ b/tests/integration/tests/suite/examples/mod.rs
@@ -48,6 +48,7 @@ mod policy;
 mod policy_http;
 mod protocol_examples;
 mod protocols;
+mod random;
 mod redirect;
 mod round_robin;
 mod security_examples;

--- a/tests/integration/tests/suite/examples/random.rs
+++ b/tests/integration/tests/suite/examples/random.rs
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Tests for random load balancing behavior.
+
+use std::collections::HashMap;
+
+use praxis_test_utils::{free_port, http_get, start_backend_with_shutdown, start_proxy};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn random_distributes_across_backends() {
+    let port_a_guard = start_backend_with_shutdown("random-a");
+    let port_a = port_a_guard.port();
+    let port_b_guard = start_backend_with_shutdown("random-b");
+    let port_b = port_b_guard.port();
+    let port_c_guard = start_backend_with_shutdown("random-c");
+    let port_c = port_c_guard.port();
+    let proxy_port = free_port();
+    let config = super::load_example_config(
+        "traffic-management/random.yaml",
+        proxy_port,
+        HashMap::from([
+            ("127.0.0.1:3001", port_a),
+            ("127.0.0.1:3002", port_b),
+            ("127.0.0.1:3003", port_c),
+        ]),
+    );
+    let proxy = start_proxy(&config);
+
+    let total = 30_u32;
+    let mut counts: HashMap<String, u32> = HashMap::new();
+    for _ in 0..total {
+        let (status, body) = http_get(proxy.addr(), "/", None);
+        assert_eq!(status, 200, "random request should return 200");
+        *counts.entry(body).or_default() += 1;
+    }
+
+    assert_eq!(counts.len(), 3, "random should use all 3 backends");
+
+    for (backend, count) in &counts {
+        assert!(
+            (4..=16).contains(count),
+            "expected ~10 for backend {backend}, got {count}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds a `random` load balancing strategy that selects endpoints with probability proportional to their configured weight. With equal weights this reduces to uniform random selection.

**Behavior:**
- Unhealthy endpoints are excluded from selection
- When all endpoints are unhealthy, falls back to panic mode (selects from all endpoints)
- When all healthy endpoints have zero weight, returns the first healthy endpoint
- `release` is a no-op — random selection does not track in-flight connections

**Changes:**
- Extracts shared LCG RNG from `p2c` into `load_balancing::mod` for reuse
- Adds `Random` variant to `SimpleStrategy` and `Strategy` enums
- Adds example config, integration test, and doc updates

Part of #109