### PR TITLE
feat(filter): open the policy filter's CPEX registry to host plugin factories

### DIFF
--- a/filter/src/builtins/http/security/policy/filter.rs
+++ b/filter/src/builtins/http/security/policy/filter.rs
@@ -106,28 +106,56 @@ pub struct PolicyFilter {
 }
 
 impl PolicyFilter {
-    /// Construct a filter from a parsed config. Loads the CPEX YAML
-    /// referenced by `cfg.config_path`, registers bundled plugin
-    /// factories, wires the APL visitor, and initializes the manager.
-    /// Errors abort filter chain construction at server startup —
-    /// failing fast is what we want for misconfigured policy.
+    /// Construct a filter from a parsed config with the bundled CPEX
+    /// factories only. Equivalent to [`Self::new_with_factories`] with
+    /// no extra factories.
     ///
     /// # Errors
     ///
     /// Returns [`FilterError`] if the referenced YAML cannot be read,
     /// the policy document fails to parse, or plugin initialization
     /// fails (e.g., a JWKS endpoint is unreachable).
+    pub fn new(cfg: PolicyFilterConfig) -> Result<Self, FilterError> {
+        Self::new_with_factories(cfg, Vec::new())
+    }
+
+    /// Like [`Self::new`], but registers additional host-supplied CPEX
+    /// plugin factories before the policy document loads.
+    ///
+    /// The bundled factories from `cpex::install_builtins` cover the
+    /// common identity / delegation / PII / audit cases, but the CPEX
+    /// plugin model is explicitly open: hosts embedding praxis may
+    /// author their own in-process plugins against `cpex-sdk` and
+    /// reference them from APL `run(...)` steps. Without this seam the
+    /// registry is closed — a custom `kind:` in the CPEX YAML fails
+    /// config load with "no factory registered for kind".
+    ///
+    /// Each entry is the `kind:` string operators write in the CPEX
+    /// YAML plus the factory that creates instances of it. Factories
+    /// register AFTER the builtins, so a host `kind` that collides
+    /// with a builtin kind shadows it — prefer namespaced kinds
+    /// (e.g. `acme/audit-sink`).
+    ///
+    /// # Errors
+    ///
+    /// Same failure modes as [`Self::new`].
     #[expect(
         clippy::too_many_lines,
         reason = "linear construction + init steps; splitting obscures the startup flow"
     )]
-    pub fn new(cfg: PolicyFilterConfig) -> Result<Self, FilterError> {
+    pub fn new_with_factories(
+        cfg: PolicyFilterConfig,
+        extra_factories: Vec<(&'static str, Box<dyn cpex::cpex_core::factory::PluginFactory>)>,
+    ) -> Result<Self, FilterError> {
         let yaml = std::fs::read_to_string(&cfg.config_path).map_err(|e| -> FilterError {
             format!("policy: failed to read config_path {}: {e}", cfg.config_path).into()
         })?;
 
         let mgr = Arc::new(PluginManager::default());
         cpex::install_builtins(&mgr);
+        for (kind, factory) in extra_factories {
+            mgr.register_factory(kind, factory);
+        }
 
         mgr.load_config_yaml(&yaml)
             .map_err(|e: Box<PluginError>| -> FilterError {


### PR DESCRIPTION
## Motivation

The `policy` filter embeds CPEX in-process: it builds a `PluginManager`, calls `cpex::install_builtins(&mgr)`, and loads the operator's policy YAML — all inside `PolicyFilter::new`. That makes the plugin registry **closed**: only the bundled builtin kinds (`identity/jwt`, `audit/logger`, `pii/scanner`, ...) can appear in the CPEX config.

CPEX's own plugin model is explicitly open. Plugins authored against `cpex-sdk` are registered as (`kind` → factory) pairs and referenced from APL route steps (`run(my-plugin)`). A host that embeds praxis via `run_server_with_registry` and wants its own in-process plugin in the policy pipeline — e.g. a custom audit sink, a revocation check, a domain-specific redactor — currently has no supported path: a custom `kind:` in the CPEX YAML fails at config load with *no factory registered for kind*.

## Change

Add one constructor:

```rust
PolicyFilter::new_with_factories(
    cfg: PolicyFilterConfig,
    extra_factories: Vec<(&'static str, Box<dyn PluginFactory>)>,
) -> Result<Self, FilterError>
```

The extra factories are registered **after** `install_builtins` and **before** `load_config_yaml`, so host kinds are resolvable by the policy document. `PolicyFilter::new` delegates with an empty vec — **no behavior change** for existing users, and the YAML-facing configuration is untouched.

Hosts embedding praxis wrap construction in their own filter factory:

```rust
let factories = vec![("acme/audit-sink", Box::new(AuditSinkFactory) as Box<dyn PluginFactory>)];
registry.register("acme-policy", FilterFactory::Http(Arc::new(move |yaml| {
    let cfg: PolicyFilterConfig = parse_filter_config("acme-policy", yaml)?;
    Ok(Box::new(PolicyFilter::new_with_factories(cfg, factories.clone())?))
})));
```

(A real embedding that motivated this: an MCP gateway running the praxis-ai `mcp` classifier in front of `policy`, with a forge-owned `forge/stub-logger` plugin fired by an APL `run(...)` step on `cmf.tool_pre_invoke`.)

## Notes / alternatives considered

- A registry-mutation callback (`FnOnce(&PluginManager)`) is more general but easier to misuse (hosts could remove builtin factories or skip the APL visitor); the (`kind`, factory) list is the smallest seam that covers the use case.
- Factory kinds registered after the builtins shadow a colliding builtin kind; the doc comment recommends namespaced kinds (`acme/...`).
- Based on commit `ed46eb53` (2026-07-29); happy to rebase.

## Verification

- `cargo check -p praxis-proxy-filter --features cpex-policy-engine` — clean (one pre-existing unrelated `unfulfilled_lint_expectations` warning at line 43, also present on the base rev).
- `cargo test -p praxis-proxy-filter --features cpex-policy-engine policy` — 77 passed, 0 failed.