### PR TITLE
feat(load-balancer): support upstream authority override

### DIFF
--- a/benchmarks/microbenchmarks/load_balancer.rs
+++ b/benchmarks/microbenchmarks/load_balancer.rs
@@ -65,6 +65,21 @@ fn bench_load_balancer(c: &mut Criterion) {
         }
     }
 
+    let mut authority_cluster = make_cluster(LoadBalancerStrategy::Simple(SimpleStrategy::RoundRobin), 10);
+    authority_cluster.authority = Some("api.example.com".into());
+    let authority_lb = LoadBalancerFilter::new(&[authority_cluster]).unwrap();
+    group.bench_function("round_robin_authority/10", |b| {
+        let authority_lb = &authority_lb;
+        b.to_async(&rt).iter_batched(
+            || make_request("/api/v1/users"),
+            |req| async move {
+                let mut ctx = make_ctx_with_cluster(&req, "bench");
+                let _result = black_box(authority_lb.on_request(black_box(&mut ctx)).await.unwrap());
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
     group.finish();
 }
 
@@ -83,6 +98,7 @@ fn make_ctx_with_cluster<'a>(req: &'a praxis_filter::Request, cluster: &str) -> 
 fn make_cluster(strategy: LoadBalancerStrategy, n: usize) -> Cluster {
     let endpoints: Vec<String> = (0..n).map(|i| format!("10.0.{}.{}:8080", i / 256, i % 256)).collect();
     Cluster {
+        authority: None,
         connection_timeout_ms: None,
         endpoints: endpoints.into_iter().map(Into::into).collect(),
         health_check: None,

--- a/core/src/config/cluster/mod.rs
+++ b/core/src/config/cluster/mod.rs
@@ -21,6 +21,8 @@ pub use retry_policy::{
 };
 use serde::{Deserialize, Serialize};
 
+use crate::errors::ProxyError;
+
 // -----------------------------------------------------------------------------
 // Cluster
 // -----------------------------------------------------------------------------
@@ -46,6 +48,36 @@ use serde::{Deserialize, Serialize};
 pub struct Cluster {
     /// Unique name for the cluster.
     pub name: Arc<str>,
+
+    /// Override the upstream HTTP `Host` header. **HTTP only** — this
+    /// field has no effect on TCP load balancers, which do not process
+    /// HTTP headers.
+    ///
+    /// When set, the proxy rewrites the `Host` header sent to the
+    /// upstream instead of forwarding the downstream value. Upstream
+    /// connections use HTTP/1.1; the `:authority` pseudo-header on
+    /// the downstream HTTP/2 side is not forwarded upstream. TLS SNI
+    /// remains independent — configure `tls.sni` separately when
+    /// needed.
+    ///
+    /// Must be a valid HTTP authority: a hostname with an optional
+    /// port, or a bracketed IPv6 address with an optional port. URI
+    /// schemes, paths, userinfo, and fragments are rejected.
+    ///
+    /// ```
+    /// # use praxis_core::config::Cluster;
+    /// let yaml = r#"
+    /// name: "api"
+    /// endpoints: ["10.0.0.1:443"]
+    /// authority: "api.example.com"
+    /// tls:
+    ///   sni: "api.example.com"
+    /// "#;
+    /// let cluster: Cluster = serde_yaml::from_str(yaml).unwrap();
+    /// assert_eq!(cluster.authority.as_deref(), Some("api.example.com"));
+    /// ```
+    #[serde(default)]
+    pub authority: Option<Arc<str>>,
 
     /// TCP connection timeout in milliseconds.
     ///
@@ -138,6 +170,20 @@ pub struct Cluster {
 }
 
 impl Cluster {
+    /// Validate the optional upstream HTTP authority override.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProxyError::Config`] when the authority is not a
+    /// supported hostname with an optional port or a bracketed IPv6
+    /// address with an optional port.
+    pub fn validate_authority(&self) -> Result<(), ProxyError> {
+        let Some(authority) = self.authority.as_deref() else {
+            return Ok(());
+        };
+        super::validate::cluster::validate_authority(authority, &self.name)
+    }
+
     /// Build a cluster with only a name and endpoints; all other
     /// fields use their defaults (no timeouts, no TLS, no health
     /// check, `round_robin` strategy).
@@ -157,6 +203,7 @@ impl Cluster {
     pub fn with_defaults(name: &str, endpoints: Vec<Endpoint>) -> Self {
         Self {
             name: Arc::from(name),
+            authority: None,
             connection_timeout_ms: None,
             endpoints,
             health_check: None,

--- a/core/src/config/validate/cluster/authority.rs
+++ b/core/src/config/validate/cluster/authority.rs
@@ -1,0 +1,414 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024 Praxis Contributors
+
+//! HTTP authority validation for per-cluster upstream authority override.
+
+use crate::errors::ProxyError;
+
+/// Maximum DNS hostname length without a trailing root label.
+const MAX_HOSTNAME_LEN: usize = 253;
+
+/// Validate a per-cluster authority override value.
+///
+/// The supported form is `host [ ":" port ]`, where `host` is an
+/// ASCII DNS hostname or bracketed IPv6 address. Schemes, paths,
+/// userinfo, query strings, and fragments are rejected.
+pub(super) fn validate_authority(authority: &str, cluster_name: &str) -> Result<(), ProxyError> {
+    if authority.is_empty() {
+        return Err(ProxyError::Config(format!(
+            "cluster '{cluster_name}': authority must not be empty"
+        )));
+    }
+
+    reject_control_chars(authority, cluster_name)?;
+    reject_whitespace(authority, cluster_name)?;
+    reject_uri_components(authority, cluster_name)?;
+    validate_host_port(authority, cluster_name)
+}
+
+/// Reject ASCII control characters (C0 range and DEL).
+fn reject_control_chars(authority: &str, cluster_name: &str) -> Result<(), ProxyError> {
+    if authority.bytes().any(|b| b < 0x20 || b == 0x7F) {
+        return Err(ProxyError::Config(format!(
+            "cluster '{cluster_name}': authority contains control characters"
+        )));
+    }
+    Ok(())
+}
+
+/// Reject space and tab characters.
+fn reject_whitespace(authority: &str, cluster_name: &str) -> Result<(), ProxyError> {
+    if authority.bytes().any(|b| b == b' ' || b == b'\t') {
+        return Err(ProxyError::Config(format!(
+            "cluster '{cluster_name}': authority contains whitespace"
+        )));
+    }
+    Ok(())
+}
+
+/// Reject URI components that are not part of a bare authority.
+fn reject_uri_components(authority: &str, cluster_name: &str) -> Result<(), ProxyError> {
+    if authority.contains("://") {
+        return Err(ProxyError::Config(format!(
+            "cluster '{cluster_name}': authority must not contain a URI scheme"
+        )));
+    }
+    if authority.contains('/') {
+        return Err(ProxyError::Config(format!(
+            "cluster '{cluster_name}': authority must not contain a path"
+        )));
+    }
+    if authority.contains('@') {
+        return Err(ProxyError::Config(format!(
+            "cluster '{cluster_name}': authority must not contain userinfo"
+        )));
+    }
+    if authority.contains('#') {
+        return Err(ProxyError::Config(format!(
+            "cluster '{cluster_name}': authority must not contain a fragment"
+        )));
+    }
+    if authority.contains('?') {
+        return Err(ProxyError::Config(format!(
+            "cluster '{cluster_name}': authority must not contain a query string"
+        )));
+    }
+    Ok(())
+}
+
+/// Validate the host and optional port components.
+fn validate_host_port(authority: &str, cluster_name: &str) -> Result<(), ProxyError> {
+    if let Some(rest) = authority.strip_prefix('[') {
+        validate_bracketed_ipv6(rest, cluster_name)
+    } else {
+        validate_hostname_port(authority, cluster_name)
+    }
+}
+
+/// Validate `[ipv6]:port` or `[ipv6]` form.
+fn validate_bracketed_ipv6(rest: &str, cluster_name: &str) -> Result<(), ProxyError> {
+    let Some(bracket_end) = rest.find(']') else {
+        return Err(ProxyError::Config(format!(
+            "cluster '{cluster_name}': authority has unclosed IPv6 bracket"
+        )));
+    };
+    let ipv6 = rest.get(..bracket_end).unwrap_or_default();
+    if ipv6.parse::<std::net::Ipv6Addr>().is_err() {
+        return Err(ProxyError::Config(format!(
+            "cluster '{cluster_name}': authority contains invalid IPv6 address"
+        )));
+    }
+    let after = rest.get(bracket_end + 1..).unwrap_or_default();
+    if after.is_empty() {
+        return Ok(());
+    }
+    if let Some(port_str) = after.strip_prefix(':') {
+        validate_port(port_str, cluster_name)
+    } else {
+        Err(ProxyError::Config(format!(
+            "cluster '{cluster_name}': authority has unexpected characters after IPv6 address"
+        )))
+    }
+}
+
+/// Validate `hostname:port` or `hostname` form.
+fn validate_hostname_port(authority: &str, cluster_name: &str) -> Result<(), ProxyError> {
+    let (host, port) = match authority.rsplit_once(':') {
+        Some((h, p)) if p.bytes().all(|b| b.is_ascii_digit()) && !p.is_empty() => (h, Some(p)),
+        _ => (authority, None),
+    };
+
+    if host.is_empty() {
+        return Err(ProxyError::Config(format!(
+            "cluster '{cluster_name}': authority hostname is empty"
+        )));
+    }
+
+    for b in host.bytes() {
+        if !b.is_ascii_alphanumeric() && b != b'-' && b != b'.' {
+            return Err(ProxyError::Config(format!(
+                "cluster '{cluster_name}': authority hostname contains invalid characters"
+            )));
+        }
+    }
+
+    validate_dns_labels(host, cluster_name)?;
+
+    if let Some(p) = port {
+        validate_port(p, cluster_name)?;
+    }
+
+    Ok(())
+}
+
+/// Validate DNS label rules (RFC 1035 §2.3.1).
+///
+/// Each label must be 1-63 characters and must not start or end with a hyphen.
+fn validate_dns_labels(host: &str, cluster_name: &str) -> Result<(), ProxyError> {
+    let hostname = host.strip_suffix('.').unwrap_or(host);
+    if hostname.is_empty() {
+        return Err(ProxyError::Config(format!(
+            "cluster '{cluster_name}': authority hostname is empty"
+        )));
+    }
+    if hostname.len() > MAX_HOSTNAME_LEN {
+        return Err(ProxyError::Config(format!(
+            "cluster '{cluster_name}': authority hostname exceeds {MAX_HOSTNAME_LEN} characters"
+        )));
+    }
+    for label in hostname.split('.') {
+        if label.is_empty() {
+            return Err(ProxyError::Config(format!(
+                "cluster '{cluster_name}': authority hostname contains an empty label"
+            )));
+        }
+        if label.len() > 63 {
+            return Err(ProxyError::Config(format!(
+                "cluster '{cluster_name}': authority hostname label exceeds 63 characters"
+            )));
+        }
+        if label.starts_with('-') || label.ends_with('-') {
+            return Err(ProxyError::Config(format!(
+                "cluster '{cluster_name}': authority hostname label must not start or end with a hyphen"
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Validate the port number (1..=65535).
+fn validate_port(port_str: &str, cluster_name: &str) -> Result<(), ProxyError> {
+    if port_str.is_empty() {
+        return Err(ProxyError::Config(format!(
+            "cluster '{cluster_name}': authority has empty port"
+        )));
+    }
+    let port: u32 = port_str
+        .parse()
+        .map_err(|_e| ProxyError::Config(format!("cluster '{cluster_name}': authority has invalid port")))?;
+    if port == 0 || port > 65535 {
+        return Err(ProxyError::Config(format!(
+            "cluster '{cluster_name}': authority port out of range"
+        )));
+    }
+    Ok(())
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[cfg(test)]
+#[expect(clippy::allow_attributes, reason = "blanket test suppressions")]
+#[allow(
+    clippy::panic,
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::needless_raw_strings,
+    clippy::needless_raw_string_hashes,
+    reason = "tests use unwrap/expect/panic/raw strings for brevity"
+)]
+mod tests {
+    use super::*;
+
+    fn ok(authority: &str) {
+        validate_authority(authority, "test").unwrap_or_else(|e| panic!("expected Ok for {authority:?}, got: {e}"));
+    }
+
+    fn err(authority: &str) -> String {
+        validate_authority(authority, "test").unwrap_err().to_string()
+    }
+
+    #[test]
+    fn accept_simple_hostname() {
+        ok("api.example.com");
+    }
+
+    #[test]
+    fn accept_hostname_with_port() {
+        ok("api.example.com:443");
+    }
+
+    #[test]
+    fn accept_localhost() {
+        ok("localhost");
+    }
+
+    #[test]
+    fn accept_localhost_with_port() {
+        ok("localhost:8080");
+    }
+
+    #[test]
+    fn accept_single_label() {
+        ok("backend");
+    }
+
+    #[test]
+    fn accept_bracketed_ipv6() {
+        ok("[::1]");
+    }
+
+    #[test]
+    fn accept_bracketed_ipv6_with_port() {
+        ok("[::1]:8443");
+    }
+
+    #[test]
+    fn accept_full_ipv6() {
+        ok("[2001:db8::1]:443");
+    }
+
+    #[test]
+    fn reject_empty() {
+        assert!(err("").contains("must not be empty"));
+    }
+
+    #[test]
+    fn reject_control_char() {
+        assert!(err("api\x00.example.com").contains("control characters"));
+    }
+
+    #[test]
+    fn reject_newline() {
+        assert!(err("api\nexample.com").contains("control characters"));
+    }
+
+    #[test]
+    fn reject_space() {
+        assert!(err("api example.com").contains("whitespace"));
+    }
+
+    #[test]
+    fn reject_tab() {
+        assert!(err("api\texample.com").contains("control characters"));
+    }
+
+    #[test]
+    fn reject_scheme() {
+        assert!(err("https://api.example.com").contains("URI scheme"));
+    }
+
+    #[test]
+    fn reject_path() {
+        assert!(err("api.example.com/v1").contains("path"));
+    }
+
+    #[test]
+    fn reject_userinfo() {
+        assert!(err("user@api.example.com").contains("userinfo"));
+    }
+
+    #[test]
+    fn reject_fragment() {
+        assert!(err("api.example.com#section").contains("fragment"));
+    }
+
+    #[test]
+    fn reject_query() {
+        assert!(err("api.example.com?key=val").contains("query"));
+    }
+
+    #[test]
+    fn reject_overlong() {
+        let long = "a".repeat(254);
+        assert!(err(&long).contains("253"));
+    }
+
+    #[test]
+    fn accept_at_253_chars() {
+        let host = format!(
+            "{}.{}.{}.{}",
+            "a".repeat(63),
+            "b".repeat(63),
+            "c".repeat(63),
+            "d".repeat(61)
+        );
+        assert_eq!(host.len(), 253, "test host should exercise the boundary");
+        ok(&host);
+    }
+
+    #[test]
+    fn accept_253_character_hostname_with_port() {
+        let host = format!(
+            "{}.{}.{}.{}",
+            "a".repeat(63),
+            "b".repeat(63),
+            "c".repeat(63),
+            "d".repeat(61)
+        );
+        ok(&format!("{host}:65535"));
+    }
+
+    #[test]
+    fn accept_fully_qualified_hostname() {
+        ok("api.example.com.");
+    }
+
+    #[test]
+    fn reject_port_zero() {
+        assert!(err("api.example.com:0").contains("port out of range"));
+    }
+
+    #[test]
+    fn reject_port_too_large() {
+        assert!(err("api.example.com:65536").contains("port out of range"));
+    }
+
+    #[test]
+    fn accept_port_65535() {
+        ok("api.example.com:65535");
+    }
+
+    #[test]
+    fn reject_unclosed_ipv6_bracket() {
+        assert!(err("[::1").contains("unclosed"));
+    }
+
+    #[test]
+    fn reject_invalid_ipv6() {
+        assert!(err("[not-ipv6]").contains("invalid IPv6"));
+    }
+
+    #[test]
+    fn reject_underscore_in_hostname() {
+        assert!(err("api_server.example.com").contains("invalid characters"));
+    }
+
+    #[test]
+    fn reject_leading_hyphen() {
+        assert!(err("-bad.example.com").contains("hyphen"));
+    }
+
+    #[test]
+    fn reject_trailing_hyphen() {
+        assert!(err("bad-.example.com").contains("hyphen"));
+    }
+
+    #[test]
+    fn reject_leading_dot() {
+        assert!(err(".example.com").contains("empty label"));
+    }
+
+    #[test]
+    fn reject_consecutive_dots() {
+        assert!(err("example..com").contains("empty label"));
+    }
+
+    #[test]
+    fn reject_label_over_63_chars() {
+        let long_label = "a".repeat(64);
+        assert!(err(&format!("{long_label}.example.com")).contains("63 characters"));
+    }
+
+    #[test]
+    fn accept_label_at_63_chars() {
+        let label = "a".repeat(63);
+        ok(&format!("{label}.example.com"));
+    }
+
+    #[test]
+    fn accept_hyphen_in_middle() {
+        ok("my-api.example.com");
+    }
+}

--- a/core/src/config/validate/cluster/mod.rs
+++ b/core/src/config/validate/cluster/mod.rs
@@ -3,6 +3,7 @@
 
 //! Cluster validation: endpoints, weights, SNI hostnames, timeouts, and health check addresses.
 
+mod authority;
 mod endpoints;
 mod health_check;
 mod timeouts;
@@ -11,6 +12,11 @@ mod tls;
 pub use health_check::is_ssrf_sensitive;
 
 use crate::{config::InsecureOptions, errors::ProxyError};
+
+/// Validate the configured authority override for one cluster.
+pub(in crate::config) fn validate_authority(authority: &str, cluster_name: &str) -> Result<(), ProxyError> {
+    authority::validate_authority(authority, cluster_name)
+}
 
 // -----------------------------------------------------------------------------
 // Cluster Validation Constants
@@ -54,6 +60,7 @@ pub(in crate::config::validate) fn validate_clusters(
             return Err(ProxyError::Config("cluster name must not be empty".into()));
         }
         super::validate_name_chars(&cluster.name, "cluster")?;
+        cluster.validate_authority()?;
         endpoints::validate_endpoints(cluster, insecure_options)?;
         tls::validate_tls_settings(cluster, insecure_options)?;
         timeouts::validate_timeouts(cluster)?;
@@ -168,6 +175,137 @@ clusters:
         assert!(
             err.to_string().contains("exceeds maximum"),
             "should reject cluster max_connections > 1M: {err}"
+        );
+    }
+
+    #[test]
+    fn accept_cluster_with_authority() {
+        let yaml = r#"
+listeners:
+  - name: web
+    address: "0.0.0.0:80"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: static_response
+        status: 200
+clusters:
+  - name: api
+    endpoints: ["10.0.0.1:443"]
+    authority: "api.example.com"
+"#;
+        Config::from_yaml(yaml).unwrap();
+    }
+
+    #[test]
+    fn accept_cluster_with_authority_and_port() {
+        let yaml = r#"
+listeners:
+  - name: web
+    address: "0.0.0.0:80"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: static_response
+        status: 200
+clusters:
+  - name: api
+    endpoints: ["10.0.0.1:8443"]
+    authority: "api.example.com:8443"
+"#;
+        Config::from_yaml(yaml).unwrap();
+    }
+
+    #[test]
+    fn accept_cluster_without_authority() {
+        let yaml = r#"
+listeners:
+  - name: web
+    address: "0.0.0.0:80"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: static_response
+        status: 200
+clusters:
+  - name: backend
+    endpoints: ["10.0.0.1:80"]
+"#;
+        Config::from_yaml(yaml).unwrap();
+    }
+
+    #[test]
+    fn reject_cluster_with_empty_authority() {
+        let yaml = r#"
+listeners:
+  - name: web
+    address: "0.0.0.0:80"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: static_response
+        status: 200
+clusters:
+  - name: backend
+    endpoints: ["10.0.0.1:80"]
+    authority: ""
+"#;
+        let err = Config::from_yaml(yaml).unwrap_err();
+        assert!(
+            err.to_string().contains("must not be empty"),
+            "should reject empty authority: {err}"
+        );
+    }
+
+    #[test]
+    fn reject_cluster_with_scheme_in_authority() {
+        let yaml = r#"
+listeners:
+  - name: web
+    address: "0.0.0.0:80"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: static_response
+        status: 200
+clusters:
+  - name: backend
+    endpoints: ["10.0.0.1:443"]
+    authority: "https://api.example.com"
+"#;
+        let err = Config::from_yaml(yaml).unwrap_err();
+        assert!(
+            err.to_string().contains("URI scheme"),
+            "should reject authority with scheme: {err}"
+        );
+    }
+
+    #[test]
+    fn reject_cluster_with_path_in_authority() {
+        let yaml = r#"
+listeners:
+  - name: web
+    address: "0.0.0.0:80"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: static_response
+        status: 200
+clusters:
+  - name: backend
+    endpoints: ["10.0.0.1:443"]
+    authority: "api.example.com/v1"
+"#;
+        let err = Config::from_yaml(yaml).unwrap_err();
+        assert!(
+            err.to_string().contains("path"),
+            "should reject authority with path: {err}"
         );
     }
 

--- a/core/src/config/validate/mod.rs
+++ b/core/src/config/validate/mod.rs
@@ -7,7 +7,7 @@ use crate::errors::ProxyError;
 
 mod branch_chain;
 pub use branch_chain::{MAX_BRANCH_DEPTH, MAX_ITERATIONS_CEILING};
-mod cluster;
+pub(in crate::config) mod cluster;
 mod filter_chain;
 mod inline_clusters;
 mod listener;

--- a/core/src/connectivity/upstream.rs
+++ b/core/src/connectivity/upstream.rs
@@ -5,6 +5,7 @@
 
 use std::sync::Arc;
 
+use http::header::HeaderValue;
 use praxis_tls::CachedClusterTls;
 
 use super::ConnectionOptions;
@@ -26,11 +27,13 @@ use super::ConnectionOptions;
 ///
 /// let upstream = Upstream {
 ///     address: Arc::from("127.0.0.1:8080"),
+///     authority: None,
 ///     tls: None,
 ///     connection: Arc::new(ConnectionOptions::default()),
 /// };
 ///
 /// assert_eq!(&*upstream.address, "127.0.0.1:8080");
+/// assert!(upstream.authority.is_none());
 /// assert!(upstream.tls.is_none());
 /// ```
 ///
@@ -39,6 +42,14 @@ use super::ConnectionOptions;
 pub struct Upstream {
     /// Address in `host:port` form.
     pub address: Arc<str>,
+
+    /// Pre-parsed upstream HTTP authority override.
+    ///
+    /// When set, the proxy sends this value as the upstream HTTP/1.1
+    /// `Host` header instead of forwarding the downstream value.
+    /// Parsed at config load time to avoid per-request `HeaderValue`
+    /// conversion.
+    pub authority: Option<HeaderValue>,
 
     /// Connection tuning for this upstream.
     pub connection: Arc<ConnectionOptions>,
@@ -121,6 +132,7 @@ mod tests {
     fn make_upstream(address: &str, tls: Option<CachedClusterTls>) -> Upstream {
         Upstream {
             address: Arc::from(address),
+            authority: None,
             tls,
             connection: Arc::new(ConnectionOptions::default()),
         }

--- a/docs/filters/http/traffic_management/load_balancer.md
+++ b/docs/filters/http/traffic_management/load_balancer.md
@@ -15,6 +15,7 @@ Supported strategies: - `round_robin` (default): cycles through endpoints in ord
 |-------|------|---------|-------------|
 | `clusters` | Cluster[] | no | Cluster definitions. |
 | `clusters[].name` | string | yes | Unique name for the cluster. |
+| `clusters[].authority` | string | no | Override the upstream HTTP `Host` header. **HTTP only** — this field has no effect on TCP load balancers, which do not process HTTP headers. When set, the proxy rewrites the `Host` header sent to the upstream instead of forwarding the downstream value. Upstream connections use HTTP/1.1; the `:authority` pseudo-header on the downstream HTTP/2 side is not forwarded upstream. TLS SNI remains independent — configure `tls.sni` separately when needed. Must be a valid HTTP authority: a hostname with an optional port, or a bracketed IPv6 address with an optional port. URI schemes, paths, userinfo, and fragments are rejected. |
 | `clusters[].connection_timeout_ms` | integer | no | TCP connection timeout in milliseconds. Applies to the TCP handshake only (before TLS). When exceeded, the connection attempt fails and the load balancer may retry on the next endpoint. `None` (the default) uses Pingora's built-in timeout. |
 | `clusters[].endpoints` | (string \| object)[] | yes | List of endpoints for the cluster. Each entry is either a plain `"host:port"` string or a `{ address, weight }` object. |
 | `clusters[].endpoints[].address` | string | yes | Socket address as `host:port`. |

--- a/docs/filters/tcp/traffic_management/tcp_load_balancer.md
+++ b/docs/filters/tcp/traffic_management/tcp_load_balancer.md
@@ -19,6 +19,7 @@ If all endpoints are unhealthy, the filter enters panic mode and routes to all e
 |-------|------|---------|-------------|
 | `clusters` | Cluster[] | no | Cluster definitions. |
 | `clusters[].name` | string | yes | Unique name for the cluster. |
+| `clusters[].authority` | string | no | Override the upstream HTTP `Host` header. **HTTP only** — this field has no effect on TCP load balancers, which do not process HTTP headers. When set, the proxy rewrites the `Host` header sent to the upstream instead of forwarding the downstream value. Upstream connections use HTTP/1.1; the `:authority` pseudo-header on the downstream HTTP/2 side is not forwarded upstream. TLS SNI remains independent — configure `tls.sni` separately when needed. Must be a valid HTTP authority: a hostname with an optional port, or a bracketed IPv6 address with an optional port. URI schemes, paths, userinfo, and fragments are rejected. |
 | `clusters[].connection_timeout_ms` | integer | no | TCP connection timeout in milliseconds. Applies to the TCP handshake only (before TLS). When exceeded, the connection attempt fails and the load balancer may retry on the next endpoint. `None` (the default) uses Pingora's built-in timeout. |
 | `clusters[].endpoints` | (string \| object)[] | yes | List of endpoints for the cluster. Each entry is either a plain `"host:port"` string or a `{ address, weight }` object. |
 | `clusters[].endpoints[].address` | string | yes | Socket address as `host:port`. |

--- a/examples/README.md
+++ b/examples/README.md
@@ -124,6 +124,7 @@ page.
 
 | File | Description |
 | ------ | ------------- |
+| [authority-override.yaml](configs/traffic-management/authority-override.yaml) | Demonstrates overriding the HTTP Host header sent to a specific upstream cluster, including requests received over HTTP/2 |
 | [basic-reverse-proxy.yaml](configs/traffic-management/basic-reverse-proxy.yaml) | Minimal config: one listener, one upstream, default filter chain |
 | [canary-routing.yaml](configs/traffic-management/canary-routing.yaml) | Sends ~10% of traffic to a canary backend while the stable backend handles the remaining ~90% |
 | [circuit-breaker.yaml](configs/traffic-management/circuit-breaker.yaml) | Prevents cascading failures by tracking consecutive upstream errors per cluster |

--- a/examples/configs/traffic-management/authority-override.yaml
+++ b/examples/configs/traffic-management/authority-override.yaml
@@ -1,0 +1,35 @@
+# Per-Cluster Upstream Authority Override
+#
+# Demonstrates overriding the HTTP Host header sent to a specific
+# upstream cluster, including requests received over HTTP/2.
+#
+# The proxy replaces the downstream Host header with the configured
+# authority value before forwarding to the upstream. TLS SNI is
+# independent and configured separately via `tls.sni`.
+#
+# Usage:
+#   cargo run -p praxis-proxy -- -c examples/configs/traffic-management/authority-override.yaml
+#
+#   curl -H "Host: anything.example.com" http://localhost:8080/
+#
+# The upstream receives Host: api.example.com regardless of
+# the downstream request's Host header.
+
+listeners:
+  - name: default
+    address: "0.0.0.0:8080"
+    filter_chains: [main]
+
+filter_chains:
+  - name: main
+    filters:
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: backend
+      - filter: load_balancer
+        clusters:
+          - name: backend
+            endpoints:
+              - "localhost:9000"
+            authority: "api.example.com"

--- a/examples/configs/traffic-management/authority-override.yaml
+++ b/examples/configs/traffic-management/authority-override.yaml
@@ -20,6 +20,11 @@ listeners:
     address: "0.0.0.0:8080"
     filter_chains: [main]
 
+# The example targets a local test backend; production configurations should
+# keep private-endpoint protection enabled unless this is explicitly required.
+insecure_options:
+  allow_private_endpoints: true
+
 filter_chains:
   - name: main
     filters:

--- a/filter/src/builtins/http/observability/access_log.rs
+++ b/filter/src/builtins/http/observability/access_log.rs
@@ -469,6 +469,10 @@ mod tests {
     }
 
     #[tokio::test]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "test fixture exercises the complete populated context"
+    )]
     async fn on_response_with_populated_context_continues() {
         use praxis_core::connectivity::{ConnectionOptions, Upstream};
 
@@ -488,6 +492,7 @@ mod tests {
         ctx.cluster = Some(std::sync::Arc::from("backend"));
         ctx.upstream = Some(Upstream {
             address: std::sync::Arc::from("10.0.0.2:8080"),
+            authority: None,
             connection: std::sync::Arc::new(ConnectionOptions::default()),
             tls: None,
         });

--- a/filter/src/builtins/http/traffic_management/endpoint_selector.rs
+++ b/filter/src/builtins/http/traffic_management/endpoint_selector.rs
@@ -391,6 +391,7 @@ impl HttpFilter for EndpointSelectorFilter {
 
         let upstream = Upstream {
             address: Arc::from(value.as_str()),
+            authority: None,
             connection: Arc::clone(&self.connection),
             tls: self.tls.clone(),
         };

--- a/filter/src/builtins/http/traffic_management/iterative_request_router/tests.rs
+++ b/filter/src/builtins/http/traffic_management/iterative_request_router/tests.rs
@@ -3166,6 +3166,7 @@ async fn build_peer_applies_tls_with_explicit_sni() {
     let cached = praxis_tls::CachedClusterTls::try_from_config(&tls).unwrap();
     let upstream = praxis_core::connectivity::Upstream {
         address: std::sync::Arc::from("127.0.0.1:9443"),
+        authority: None,
         connection: std::sync::Arc::new(praxis_core::connectivity::ConnectionOptions::default()),
         tls: Some(cached),
     };
@@ -3180,6 +3181,7 @@ async fn build_peer_derives_sni_from_hostname_address() {
     let cached = praxis_tls::CachedClusterTls::try_from_config(&tls).unwrap();
     let upstream = praxis_core::connectivity::Upstream {
         address: std::sync::Arc::from("localhost:9443"),
+        authority: None,
         connection: std::sync::Arc::new(praxis_core::connectivity::ConnectionOptions::default()),
         tls: Some(cached),
     };

--- a/filter/src/builtins/http/traffic_management/load_balancer/entry.rs
+++ b/filter/src/builtins/http/traffic_management/load_balancer/entry.rs
@@ -5,6 +5,7 @@
 
 use std::sync::Arc;
 
+use http::header::HeaderValue;
 use praxis_core::{
     config::{CachedClusterTls, Cluster, RetryPolicy},
     connectivity::{ConnectionOptions, Upstream},
@@ -16,7 +17,7 @@ use super::{
     reselector::EndpointReselector,
     strategy::{Strategy, build_strategy},
 };
-use crate::{filter::HttpFilterContext, load_balancing::endpoint::build_weighted_endpoints};
+use crate::{FilterError, filter::HttpFilterContext, load_balancing::endpoint::build_weighted_endpoints};
 
 // -----------------------------------------------------------------------------
 // ClusterEntry
@@ -24,6 +25,9 @@ use crate::{filter::HttpFilterContext, load_balancing::endpoint::build_weighted_
 
 /// Resolved state for a single cluster.
 pub(super) struct ClusterEntry {
+    /// Pre-parsed upstream authority override.
+    pub(super) authority: Option<HeaderValue>,
+
     /// Connection options derived from the cluster config, [`Arc`]-wrapped
     /// to avoid per-request cloning.
     pub(super) opts: Arc<ConnectionOptions>,
@@ -65,6 +69,7 @@ impl ClusterEntry {
         });
         Upstream {
             address: addr,
+            authority: self.authority.clone(),
             connection: Arc::clone(&self.opts),
             tls,
         }
@@ -135,16 +140,29 @@ pub(super) fn build_cluster_entry(cluster: &Cluster) -> Result<ClusterEntry, cra
         })
         .transpose()?;
 
+    let authority = build_authority(cluster)?;
     let strategy = Arc::new(build_strategy(&cluster.load_balancer_strategy, endpoints));
     let retry_policy = Arc::new(cluster.retry_policy.clone().unwrap_or_else(RetryPolicy::legacy_default));
     let retry_state = Arc::new(ClusterRetryState::new(retry_policy.retry_budget.as_ref()));
     Ok(ClusterEntry {
+        authority,
         opts: Arc::new(ConnectionOptions::from(cluster)),
         strategy,
         tls,
         retry_policy,
         retry_state,
     })
+}
+
+/// Validate and pre-parse the optional upstream authority override.
+fn build_authority(cluster: &Cluster) -> Result<Option<HeaderValue>, FilterError> {
+    let Some(authority) = cluster.authority.as_deref() else {
+        return Ok(None);
+    };
+    cluster.validate_authority().map_err(|error| error.to_string())?;
+    HeaderValue::from_str(authority)
+        .map(Some)
+        .map_err(|error| format!("cluster '{}': invalid authority header: {error}", cluster.name).into())
 }
 
 // -----------------------------------------------------------------------------

--- a/filter/src/builtins/http/traffic_management/load_balancer/entry.rs
+++ b/filter/src/builtins/http/traffic_management/load_balancer/entry.rs
@@ -85,6 +85,7 @@ impl ClusterEntry {
             Arc::clone(&self.strategy),
             Arc::clone(&self.opts),
             self.tls.clone(),
+            self.authority.clone(),
             hash_key,
             retry_policy,
             Arc::clone(&self.retry_state),
@@ -116,7 +117,7 @@ fn strip_host_port(host: &str) -> &str {
     clippy::too_many_lines,
     reason = "sequential setup steps, splitting harms readability"
 )]
-pub(super) fn build_cluster_entry(cluster: &Cluster) -> Result<ClusterEntry, crate::FilterError> {
+pub(super) fn build_cluster_entry(cluster: &Cluster) -> Result<ClusterEntry, FilterError> {
     let endpoints = build_weighted_endpoints(cluster);
     let total_weight: u32 = endpoints.iter().map(|ep| ep.weight).sum();
     debug!(
@@ -130,7 +131,7 @@ pub(super) fn build_cluster_entry(cluster: &Cluster) -> Result<ClusterEntry, cra
         .tls
         .as_ref()
         .map(|t| {
-            CachedClusterTls::try_from_config(t).map_err(|e| -> crate::FilterError {
+            CachedClusterTls::try_from_config(t).map_err(|e| -> FilterError {
                 format!(
                     "cluster '{}': failed to load TLS material: {e}; refusing to fall back to plaintext",
                     cluster.name

--- a/filter/src/builtins/http/traffic_management/load_balancer/mod.rs
+++ b/filter/src/builtins/http/traffic_management/load_balancer/mod.rs
@@ -110,6 +110,11 @@ impl LoadBalancerFilter {
 
     /// Fallible constructor retained as an explicit alias for callers that
     /// use the authority validation path directly.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FilterError`] when a cluster's TLS or authority configuration
+    /// cannot be loaded or validated.
     pub fn try_new(clusters: &[Cluster]) -> Result<Self, FilterError> {
         Self::new(clusters)
     }

--- a/filter/src/builtins/http/traffic_management/load_balancer/mod.rs
+++ b/filter/src/builtins/http/traffic_management/load_balancer/mod.rs
@@ -98,14 +98,20 @@ impl LoadBalancerFilter {
     ///
     /// # Errors
     ///
-    /// Returns [`FilterError`] when a cluster's TLS material cannot be
-    /// loaded (missing or unparsable CA / client-cert files).
+    /// Returns [`FilterError`] when a cluster's TLS or authority configuration
+    /// cannot be loaded or validated.
     pub fn new(clusters: &[Cluster]) -> Result<Self, FilterError> {
         let map = clusters
             .iter()
             .map(|c| Ok((Arc::clone(&c.name), build_cluster_entry(c)?)))
             .collect::<Result<_, FilterError>>()?;
         Ok(Self { clusters: map })
+    }
+
+    /// Fallible constructor retained as an explicit alias for callers that
+    /// use the authority validation path directly.
+    pub fn try_new(clusters: &[Cluster]) -> Result<Self, FilterError> {
+        Self::new(clusters)
     }
 
     /// Create a load balancer from parsed YAML config.

--- a/filter/src/builtins/http/traffic_management/load_balancer/reselector.rs
+++ b/filter/src/builtins/http/traffic_management/load_balancer/reselector.rs
@@ -5,6 +5,7 @@
 
 use std::sync::Arc;
 
+use http::header::HeaderValue;
 use praxis_core::{
     config::{CachedClusterTls, RetryPolicy},
     connectivity::{ConnectionOptions, Upstream},
@@ -27,6 +28,8 @@ pub struct EndpointReselector {
     opts: Arc<ConnectionOptions>,
     /// Optional TLS configuration for the cluster.
     tls: Option<CachedClusterTls>,
+    /// Pre-parsed upstream authority override.
+    authority: Option<HeaderValue>,
     /// Hash key captured at first selection (for consistent-hash).
     hash_key: Option<Arc<str>>,
     /// Resolved retry policy for this cluster.
@@ -46,6 +49,7 @@ impl EndpointReselector {
         strategy: Arc<Strategy>,
         opts: Arc<ConnectionOptions>,
         tls: Option<CachedClusterTls>,
+        authority: Option<HeaderValue>,
         hash_key: Option<Arc<str>>,
         retry_policy: Arc<RetryPolicy>,
         retry_state: Arc<ClusterRetryState>,
@@ -54,6 +58,7 @@ impl EndpointReselector {
             strategy,
             opts,
             tls,
+            authority,
             hash_key,
             retry_policy,
             retry_state,
@@ -70,6 +75,7 @@ impl EndpointReselector {
     pub fn build_upstream(&self, addr: Arc<str>) -> Upstream {
         Upstream {
             address: addr,
+            authority: self.authority.clone(),
             connection: Arc::clone(&self.opts),
             tls: self.tls.clone(),
         }

--- a/filter/src/builtins/http/traffic_management/load_balancer/tests.rs
+++ b/filter/src/builtins/http/traffic_management/load_balancer/tests.rs
@@ -32,6 +32,43 @@ fn new_creates_clusters() {
 }
 
 #[test]
+fn try_new_rejects_semantically_invalid_authority() {
+    let cluster = Cluster {
+        authority: Some(Arc::from("https://api.example.com")),
+        ..test_cluster("api", &["127.0.0.1:8080"])
+    };
+
+    let error = LoadBalancerFilter::try_new(&[cluster])
+        .err()
+        .expect("scheme-bearing authority should be rejected");
+    assert!(
+        error.to_string().contains("URI scheme"),
+        "error should identify the invalid authority component: {error}"
+    );
+}
+
+#[test]
+fn from_config_rejects_semantically_invalid_authority() {
+    let config: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+clusters:
+  - name: api
+    endpoints: ["127.0.0.1:8080"]
+    authority: "api.example.com/v1"
+"#,
+    )
+    .unwrap();
+
+    let error = LoadBalancerFilter::from_config(&config)
+        .err()
+        .expect("path-bearing authority should be rejected");
+    assert!(
+        error.to_string().contains("path"),
+        "error should identify the invalid authority component: {error}"
+    );
+}
+
+#[test]
 fn new_multiple_clusters() {
     let clusters = vec![
         test_cluster("web", &["127.0.0.1:8080"]),
@@ -499,6 +536,7 @@ fn build_strategy_consistent_hash() {
 #[tokio::test]
 async fn tls_and_sni_wired_from_cluster() {
     let cluster = Cluster {
+        authority: Some(Arc::from("public.example.com")),
         tls: Some(praxis_core::config::ClusterTls {
             sni: Some("api.example.com".into()),
             ..praxis_core::config::ClusterTls::default()
@@ -511,6 +549,11 @@ async fn tls_and_sni_wired_from_cluster() {
     ctx.cluster = Some(Arc::from("secure"));
     drop(lb.on_request(&mut ctx).await.unwrap());
     let upstream = ctx.upstream.unwrap();
+    assert_eq!(
+        upstream.authority.as_ref().and_then(|value| value.to_str().ok()),
+        Some("public.example.com"),
+        "HTTP authority should remain independent from TLS SNI"
+    );
     assert!(upstream.tls.is_some(), "TLS should be enabled from cluster config");
     assert_eq!(
         upstream.tls.as_ref().unwrap().sni(),

--- a/filter/src/context.rs
+++ b/filter/src/context.rs
@@ -827,6 +827,7 @@ mod tests {
         let mut ctx = crate::test_utils::make_filter_context(&req);
         ctx.upstream = Some(Upstream {
             address: Arc::from("10.0.0.1:8080"),
+            authority: None,
             tls: None,
             connection: Arc::new(praxis_core::connectivity::ConnectionOptions::default()),
         });

--- a/protocol/src/http/pingora/context.rs
+++ b/protocol/src/http/pingora/context.rs
@@ -687,6 +687,7 @@ mod tests {
         let mut ctx = default_ctx();
         let upstream = Upstream {
             address: Arc::from("10.0.0.1:80"),
+            authority: None,
             tls: None,
             connection: Arc::new(praxis_core::connectivity::ConnectionOptions::default()),
         };

--- a/protocol/src/http/pingora/handler/mod.rs
+++ b/protocol/src/http/pingora/handler/mod.rs
@@ -1328,6 +1328,7 @@ mod tests {
             cluster: Some(Arc::from("test-cluster")),
             upstream: Some(Upstream {
                 address: Arc::from("10.0.0.1:80"),
+                authority: None,
                 connection: Arc::new(ConnectionOptions::default()),
                 tls: None,
             }),

--- a/protocol/src/http/pingora/handler/mod.rs
+++ b/protocol/src/http/pingora/handler/mod.rs
@@ -1525,6 +1525,7 @@ mod tests {
         ctx.metrics_cluster = Some(Arc::from("api-cluster"));
         ctx.upstream_for_retry = Some(Upstream {
             address: Arc::from("10.0.0.1:80"),
+            authority: None,
             connection: Arc::new(ConnectionOptions::default()),
             tls: None,
         });

--- a/protocol/src/http/pingora/handler/upstream_peer.rs
+++ b/protocol/src/http/pingora/handler/upstream_peer.rs
@@ -264,6 +264,7 @@ mod tests {
         };
         let upstream = Upstream {
             address: Arc::from("127.0.0.1:8443"),
+            authority: None,
             connection: Arc::new(ConnectionOptions::default()),
             tls: Some(CachedClusterTls::try_from_config(&tls).unwrap()),
         };
@@ -291,6 +292,7 @@ mod tests {
     async fn build_peer_without_tls() {
         let upstream = Upstream {
             address: Arc::from("127.0.0.1:8080"),
+            authority: None,
             connection: Arc::new(ConnectionOptions::default()),
             tls: None,
         };
@@ -307,6 +309,7 @@ mod tests {
         };
         let upstream = Upstream {
             address: Arc::from("127.0.0.1:8443"),
+            authority: None,
             connection: Arc::new(ConnectionOptions::default()),
             tls: Some(CachedClusterTls::try_from_config(&tls).unwrap()),
         };
@@ -331,6 +334,7 @@ mod tests {
         };
         let upstream = Upstream {
             address: Arc::from("127.0.0.1:8443"),
+            authority: None,
             connection: Arc::new(ConnectionOptions::default()),
             tls: Some(CachedClusterTls::try_from_config(&tls).unwrap()),
         };
@@ -473,6 +477,7 @@ mod tests {
         };
         let upstream = Upstream {
             address: Arc::from("127.0.0.1:8443"),
+            authority: None,
             connection: Arc::new(ConnectionOptions::default()),
             tls: Some(CachedClusterTls::try_from_config(&tls).unwrap()),
         };
@@ -517,6 +522,7 @@ mod tests {
     fn make_upstream(address: &str) -> Upstream {
         Upstream {
             address: Arc::from(address),
+            authority: None,
             connection: Arc::new(ConnectionOptions::default()),
             tls: None,
         }

--- a/protocol/src/http/pingora/handler/upstream_request.rs
+++ b/protocol/src/http/pingora/handler/upstream_request.rs
@@ -60,7 +60,11 @@ pub(crate) fn strip_hop_by_hop(req: &mut RequestHeader, is_upgrade: bool) {
 ///
 /// Returns a Pingora error if the URI cannot be rebuilt.
 pub(crate) fn apply_authority_override(req: &mut RequestHeader, ctx: &PingoraRequestCtx) -> pingora_core::Result<()> {
-    let Some(authority) = ctx.upstream_for_retry.as_ref().and_then(|upstream| upstream.authority.as_ref()) else {
+    let Some(authority) = ctx
+        .upstream_for_retry
+        .as_ref()
+        .and_then(|upstream| upstream.authority.as_ref())
+    else {
         return Ok(());
     };
     req.insert_header(http::header::HOST, authority).map_err(|error| {
@@ -70,21 +74,37 @@ pub(crate) fn apply_authority_override(req: &mut RequestHeader, ctx: &PingoraReq
         )
     })?;
 
+    normalize_uri_authority(req, authority)
+}
+
+/// Replace an absolute-form URI authority while preserving its scheme,
+/// path, and query.
+///
+/// # Errors
+///
+/// Returns a Pingora error if the authority is not UTF-8 or the rebuilt URI is
+/// invalid.
+fn normalize_uri_authority(req: &mut RequestHeader, authority: &http::header::HeaderValue) -> pingora_core::Result<()> {
     let uri = &req.uri;
     if uri.authority().is_none() && uri.scheme().is_none() {
         return Ok(());
     }
     let authority = authority.to_str().map_err(|error| {
-        pingora_core::Error::explain(pingora_core::ErrorType::InternalError, format!("invalid authority: {error}"))
+        pingora_core::Error::explain(
+            pingora_core::ErrorType::InternalError,
+            format!("invalid authority: {error}"),
+        )
     })?;
     let scheme = uri.scheme_str().unwrap_or("https");
     let path_and_query = uri.path_and_query().map_or("/", http::uri::PathAndQuery::as_str);
-    let rebuilt = format!("{scheme}://{authority}{path_and_query}").parse::<Uri>().map_err(|error| {
-        pingora_core::Error::explain(
-            pingora_core::ErrorType::InternalError,
-            format!("failed to rebuild URI with upstream authority: {error}"),
-        )
-    })?;
+    let rebuilt = format!("{scheme}://{authority}{path_and_query}")
+        .parse::<Uri>()
+        .map_err(|error| {
+            pingora_core::Error::explain(
+                pingora_core::ErrorType::InternalError,
+                format!("failed to rebuild URI with upstream authority: {error}"),
+            )
+        })?;
     req.set_uri(rebuilt);
     Ok(())
 }

--- a/protocol/src/http/pingora/handler/upstream_request.rs
+++ b/protocol/src/http/pingora/handler/upstream_request.rs
@@ -51,6 +51,44 @@ pub(crate) fn strip_hop_by_hop(req: &mut RequestHeader, is_upgrade: bool) {
     }
 }
 
+/// Apply the selected upstream's pre-validated HTTP authority override.
+///
+/// The request `Host` header is replaced without reparsing configuration on
+/// the request path. Absolute-form URIs are normalized to the same authority.
+///
+/// # Errors
+///
+/// Returns a Pingora error if the URI cannot be rebuilt.
+pub(crate) fn apply_authority_override(req: &mut RequestHeader, ctx: &PingoraRequestCtx) -> pingora_core::Result<()> {
+    let Some(authority) = ctx.upstream_for_retry.as_ref().and_then(|upstream| upstream.authority.as_ref()) else {
+        return Ok(());
+    };
+    req.insert_header(http::header::HOST, authority).map_err(|error| {
+        pingora_core::Error::explain(
+            pingora_core::ErrorType::InternalError,
+            format!("failed to set upstream Host header: {error}"),
+        )
+    })?;
+
+    let uri = &req.uri;
+    if uri.authority().is_none() && uri.scheme().is_none() {
+        return Ok(());
+    }
+    let authority = authority.to_str().map_err(|error| {
+        pingora_core::Error::explain(pingora_core::ErrorType::InternalError, format!("invalid authority: {error}"))
+    })?;
+    let scheme = uri.scheme_str().unwrap_or("https");
+    let path_and_query = uri.path_and_query().map_or("/", http::uri::PathAndQuery::as_str);
+    let rebuilt = format!("{scheme}://{authority}{path_and_query}").parse::<Uri>().map_err(|error| {
+        pingora_core::Error::explain(
+            pingora_core::ErrorType::InternalError,
+            format!("failed to rebuild URI with upstream authority: {error}"),
+        )
+    })?;
+    req.set_uri(rebuilt);
+    Ok(())
+}
+
 // -----------------------------------------------------------------------------
 // Path Rewriting
 // -----------------------------------------------------------------------------

--- a/protocol/src/http/pingora/handler/with_body.rs
+++ b/protocol/src/http/pingora/handler/with_body.rs
@@ -306,6 +306,7 @@ impl ProxyHttp for PingoraHttpHandler {
         let is_upgrade = session.is_upgrade_req();
         upstream_request::strip_hop_by_hop(upstream_request, is_upgrade);
         upstream_request.strip_reserved_internal();
+        upstream_request::apply_authority_override(upstream_request, ctx)?;
         upstream_request::apply_rewritten_path(upstream_request, ctx)?;
         upstream_request::apply_mutated_content_length(upstream_request, ctx);
         let client_ver = ctx.client_http_version.unwrap_or(http::Version::HTTP_11);

--- a/tests/integration/tests/suite/examples/authority_override.rs
+++ b/tests/integration/tests/suite/examples/authority_override.rs
@@ -102,6 +102,8 @@ filter_chains:
           - name: without-authority
             endpoints:
               - "127.0.0.1:{passthrough_port}"
+insecure_options:
+  allow_private_endpoints: true
 "#,
         override_port = override_backend.port(),
         passthrough_port = passthrough_backend.port(),

--- a/tests/integration/tests/suite/examples/authority_override.rs
+++ b/tests/integration/tests/suite/examples/authority_override.rs
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Tests for the per-cluster authority override example configuration.
+
+use std::collections::HashMap;
+
+use praxis_core::config::Config;
+use praxis_test_utils::{free_port, h2c_get, http_get, start_header_echo_backend};
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn authority_override_replaces_host() {
+    let backend = start_header_echo_backend();
+    let proxy_port = free_port();
+    let config = super::load_example_config(
+        "traffic-management/authority-override.yaml",
+        proxy_port,
+        HashMap::from([("localhost:9000", backend.port())]),
+    );
+    let proxy = praxis_test_utils::start_proxy(&config);
+    let (status, body) = http_get(proxy.addr(), "/", Some("anything.example.com"));
+    assert_eq!(status, 200, "authority override example should return 200");
+    let body_lower = body.to_lowercase();
+    assert!(
+        body_lower.contains("host: api.example.com"),
+        "upstream should receive the configured authority, not the downstream Host; got:\n{body}"
+    );
+}
+
+#[test]
+fn authority_override_does_not_leak_downstream_host() {
+    let backend = start_header_echo_backend();
+    let proxy_port = free_port();
+    let config = super::load_example_config(
+        "traffic-management/authority-override.yaml",
+        proxy_port,
+        HashMap::from([("localhost:9000", backend.port())]),
+    );
+    let proxy = praxis_test_utils::start_proxy(&config);
+    let (status, body) = http_get(proxy.addr(), "/test", Some("attacker.evil.com"));
+    assert_eq!(status, 200);
+    let body_lower = body.to_lowercase();
+    assert!(
+        !body_lower.contains("attacker.evil.com"),
+        "downstream Host must not leak to upstream when authority override is set; got:\n{body}"
+    );
+    assert!(
+        body_lower.contains("host: api.example.com"),
+        "upstream should receive the configured authority; got:\n{body}"
+    );
+}
+
+#[test]
+fn authority_override_works_over_h2c_downstream() {
+    let backend = start_header_echo_backend();
+    let proxy_port = free_port();
+    let config = super::load_example_config(
+        "traffic-management/authority-override.yaml",
+        proxy_port,
+        HashMap::from([("localhost:9000", backend.port())]),
+    );
+    let proxy = praxis_test_utils::start_proxy(&config);
+    let (status, body) = h2c_get(proxy.addr(), "/", Some("anything.example.com"));
+    assert_eq!(status, 200, "H2 request through authority override should return 200");
+    let body_lower = body.to_lowercase();
+    assert!(
+        body_lower.contains("host: api.example.com"),
+        "upstream should receive the configured authority when client connects via H2; got:\n{body}"
+    );
+}
+
+#[test]
+fn two_clusters_authority_isolation() {
+    let override_backend = start_header_echo_backend();
+    let passthrough_backend = start_header_echo_backend();
+    let proxy_port = free_port();
+    let yaml = format!(
+        r#"
+listeners:
+  - name: default
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: router
+        routes:
+          - path_prefix: "/override/"
+            cluster: with-authority
+          - path_prefix: "/passthrough/"
+            cluster: without-authority
+      - filter: load_balancer
+        clusters:
+          - name: with-authority
+            endpoints:
+              - "127.0.0.1:{override_port}"
+            authority: "api.example.com"
+          - name: without-authority
+            endpoints:
+              - "127.0.0.1:{passthrough_port}"
+"#,
+        override_port = override_backend.port(),
+        passthrough_port = passthrough_backend.port(),
+    );
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = praxis_test_utils::start_proxy(&config);
+
+    let (status, body) = http_get(proxy.addr(), "/override/test", Some("client.example.com"));
+    assert_eq!(status, 200);
+    let body_lower = body.to_lowercase();
+    assert!(
+        body_lower.contains("host: api.example.com"),
+        "override cluster should replace Host; got:\n{body}"
+    );
+
+    let (status, body) = http_get(proxy.addr(), "/passthrough/test", Some("client.example.com"));
+    assert_eq!(status, 200);
+    let body_lower = body.to_lowercase();
+    assert!(
+        body_lower.contains("host: client.example.com"),
+        "passthrough cluster should forward original Host; got:\n{body}"
+    );
+    assert!(
+        !body_lower.contains("host: api.example.com"),
+        "passthrough cluster must not receive the other cluster's authority; got:\n{body}"
+    );
+}
+
+#[test]
+fn authority_override_stable_across_sequential_requests() {
+    let backend = start_header_echo_backend();
+    let proxy_port = free_port();
+    let config = super::load_example_config(
+        "traffic-management/authority-override.yaml",
+        proxy_port,
+        HashMap::from([("localhost:9000", backend.port())]),
+    );
+    let proxy = praxis_test_utils::start_proxy(&config);
+
+    for i in 0..5 {
+        let (status, body) = http_get(proxy.addr(), &format!("/req-{i}"), Some("varying-host.example.com"));
+        assert_eq!(status, 200, "request {i} should succeed");
+        let body_lower = body.to_lowercase();
+        assert!(
+            body_lower.contains("host: api.example.com"),
+            "request {i}: authority override should be stable across requests; got:\n{body}"
+        );
+    }
+}

--- a/tests/integration/tests/suite/examples/mod.rs
+++ b/tests/integration/tests/suite/examples/mod.rs
@@ -10,6 +10,7 @@ pub use test_utils::load_example_config;
 mod access_logging;
 mod admin_interface;
 mod api_key_filter;
+mod authority_override;
 mod basic_reverse_proxy;
 mod branching;
 mod canary_routing;

--- a/tests/schema/tests/suite/cluster.rs
+++ b/tests/schema/tests/suite/cluster.rs
@@ -551,6 +551,216 @@ clusters:
 }
 
 #[test]
+fn accept_cluster_with_authority() {
+    let yaml = r#"
+listeners:
+  - name: web
+    address: "127.0.0.1:8080"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: static_response
+        status: 200
+clusters:
+  - name: api
+    endpoints: ["10.0.0.1:443"]
+    authority: "api.example.com"
+"#;
+    let config = Config::from_yaml(yaml).unwrap();
+    assert_eq!(
+        config.clusters[0].authority.as_deref(),
+        Some("api.example.com"),
+        "authority should be parsed"
+    );
+}
+
+#[test]
+fn accept_cluster_with_authority_and_tls_sni_independent() {
+    let yaml = r#"
+listeners:
+  - name: web
+    address: "127.0.0.1:8080"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: static_response
+        status: 200
+clusters:
+  - name: api
+    endpoints: ["10.0.0.1:443"]
+    authority: "api.example.com:8443"
+    tls:
+      sni: "backend.internal.com"
+"#;
+    let config = Config::from_yaml(yaml).unwrap();
+    assert_eq!(
+        config.clusters[0].authority.as_deref(),
+        Some("api.example.com:8443"),
+        "authority should be independent of SNI"
+    );
+    assert_eq!(
+        config.clusters[0].tls.as_ref().unwrap().sni.as_deref(),
+        Some("backend.internal.com"),
+        "SNI should be independent of authority"
+    );
+}
+
+#[test]
+fn accept_cluster_without_authority_preserves_default() {
+    let yaml = r#"
+listeners:
+  - name: web
+    address: "127.0.0.1:8080"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: static_response
+        status: 200
+clusters:
+  - name: backend
+    endpoints: ["10.0.0.1:80"]
+"#;
+    let config = Config::from_yaml(yaml).unwrap();
+    assert!(
+        config.clusters[0].authority.is_none(),
+        "authority should default to None"
+    );
+}
+
+#[test]
+fn reject_authority_with_scheme() {
+    let yaml = r#"
+listeners:
+  - name: web
+    address: "127.0.0.1:8080"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: static_response
+        status: 200
+clusters:
+  - name: backend
+    endpoints: ["10.0.0.1:443"]
+    authority: "https://api.example.com"
+"#;
+    let err = Config::from_yaml(yaml).unwrap_err();
+    assert!(
+        err.to_string().contains("URI scheme"),
+        "should reject authority with scheme: {err}"
+    );
+}
+
+#[test]
+fn reject_authority_with_path() {
+    let yaml = r#"
+listeners:
+  - name: web
+    address: "127.0.0.1:8080"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: static_response
+        status: 200
+clusters:
+  - name: backend
+    endpoints: ["10.0.0.1:443"]
+    authority: "api.example.com/v1"
+"#;
+    let err = Config::from_yaml(yaml).unwrap_err();
+    assert!(
+        err.to_string().contains("path"),
+        "should reject authority with path: {err}"
+    );
+}
+
+#[test]
+fn reject_authority_empty() {
+    let yaml = r#"
+listeners:
+  - name: web
+    address: "127.0.0.1:8080"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: static_response
+        status: 200
+clusters:
+  - name: backend
+    endpoints: ["10.0.0.1:443"]
+    authority: ""
+"#;
+    let err = Config::from_yaml(yaml).unwrap_err();
+    assert!(
+        err.to_string().contains("must not be empty"),
+        "should reject empty authority: {err}"
+    );
+}
+
+#[test]
+fn authority_roundtrips_via_serde() {
+    let yaml = r#"
+listeners:
+  - name: web
+    address: "127.0.0.1:8080"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: static_response
+        status: 200
+clusters:
+  - name: api
+    endpoints: ["10.0.0.1:443"]
+    authority: "api.example.com"
+"#;
+    let config = Config::from_yaml(yaml).unwrap();
+    let value = serde_yaml::to_value(&config.clusters[0]).unwrap();
+    let back: praxis_core::config::Cluster = serde_yaml::from_value(value).unwrap();
+    assert_eq!(
+        back.authority.as_deref(),
+        Some("api.example.com"),
+        "authority should roundtrip through serde"
+    );
+}
+
+#[test]
+fn accept_two_clusters_mixed_authority() {
+    let yaml = r#"
+listeners:
+  - name: web
+    address: "127.0.0.1:8080"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: static_response
+        status: 200
+clusters:
+  - name: with-authority
+    endpoints: ["10.0.0.1:443"]
+    authority: "api.example.com"
+  - name: without-authority
+    endpoints: ["10.0.0.2:80"]
+"#;
+    let config = Config::from_yaml(yaml).unwrap();
+    assert_eq!(
+        config.clusters[0].authority.as_deref(),
+        Some("api.example.com"),
+        "first cluster should have authority"
+    );
+    assert!(
+        config.clusters[1].authority.is_none(),
+        "second cluster should have no authority"
+    );
+}
+
+#[test]
 fn accept_consistent_hash_without_header() {
     let yaml = r#"
 listeners:

--- a/tests/utils/src/net/http_client.rs
+++ b/tests/utils/src/net/http_client.rs
@@ -113,6 +113,56 @@ pub fn json_post(path: &str, body: &str) -> String {
 }
 
 // -----------------------------------------------------------------------------
+// H2C (HTTP/2 Cleartext) Client
+// -----------------------------------------------------------------------------
+
+/// Send an h2c (HTTP/2 cleartext, prior-knowledge) GET and return `(status, body)`.
+///
+/// Connects via plain TCP and performs the HTTP/2 handshake directly
+/// (no upgrade from HTTP/1.1). The `host` parameter sets both the
+/// `:authority` pseudo-header and the `host` header.
+///
+/// # Panics
+///
+/// Panics if the TCP connection, H2 handshake, or response read fails.
+pub fn h2c_get(addr: &str, path: &str, host: Option<&str>) -> (u16, String) {
+    let host_value = host.unwrap_or("localhost");
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime for h2c");
+
+    rt.block_on(async {
+        let tcp = tokio::net::TcpStream::connect(addr).await.expect("TCP connect for h2c");
+
+        let (mut client, h2_conn) = h2::client::handshake(tcp).await.expect("h2c handshake");
+        tokio::spawn(async move {
+            let _result = h2_conn.await;
+        });
+
+        let request = http::Request::get(path)
+            .header("host", host_value)
+            .body(())
+            .expect("build h2c request");
+
+        let (response_fut, _) = client.send_request(request, true).expect("send h2c request");
+        let response = response_fut.await.expect("h2c response");
+        let status = response.status().as_u16();
+        let mut body_stream = response.into_body();
+
+        let mut body = Vec::new();
+        while let Some(chunk) = body_stream.data().await {
+            let data = chunk.expect("h2c body chunk");
+            body.extend_from_slice(&data);
+            drop(body_stream.flow_control().release_capacity(data.len()));
+        }
+
+        (status, String::from_utf8_lossy(&body).into_owned())
+    })
+}
+
+// -----------------------------------------------------------------------------
 // Connection Utilities
 // -----------------------------------------------------------------------------
 

--- a/tests/utils/src/net/mod.rs
+++ b/tests/utils/src/net/mod.rs
@@ -18,8 +18,8 @@ pub use backend::{
     start_stateful_backend, start_uri_echo_backend, start_websocket_echo_backend,
 };
 pub use http_client::{
-    http_get, http_get_retry, http_get_v6, http_post, http_send, json_post, parse_body, parse_header, parse_header_all,
-    parse_status,
+    h2c_get, http_get, http_get_retry, http_get_v6, http_post, http_send, json_post, parse_body, parse_header,
+    parse_header_all, parse_status,
 };
 pub use port::{PortGuard, bind_unique_port, free_port, free_port_guard, free_port_v6, ipv6_available};
 pub use postgres::{PostgresGuard, start_postgres};


### PR DESCRIPTION
## Summary

  Adds an optional per-cluster HTTP authority override to the Praxis load_balancer.

  When a cluster configures authority, Praxis replaces the downstream Host header before sending the request upstream. TLS SNI remains independently configured through tls.sni.

```yaml
  clusters:
    - name: openai-api
      endpoints:
        - api.openai.com:443
      authority: api.openai.com
      tls:
        sni: api.openai.com
        verify: true
```

  This allows Praxis to proxy through internal routing layers while still presenting the authority expected by the final upstream service.

  ## Why This Is Needed

  A downstream request may enter Praxis using an internal or public Grid hostname:

```
  client
    Host: api.grid.example.com
      |
      v
  consumer gateway
      |
      | authenticated provider hop
      | Host may identify the provider gateway
      v
  provider gateway
      |
      | TLS SNI: api.openai.com
      | Host: api.openai.com
      v
  OpenAI
```

  Selecting api.openai.com:443 and setting TLS SNI are not sufficient by themselves. Without an authority override, the HTTP request can retain a downstream hostname such as:

```
  Host: api.grid.example.com
```

  or:
```
  Host: east-provider.grid.internal
```

  The TLS handshake may succeed because SNI is api.openai.com, but the HTTP request still names a different virtual host. Virtual-hosted upstream services can reject that request or route it
  incorrectly.

  The new field makes the final upstream request internally consistent:

```
  TCP endpoint: api.openai.com:443
  TLS SNI:     api.openai.com
  HTTP Host:   api.openai.com
```

  ## Why This Belongs In load_balancer

  intelligent_route selects a configured cluster. It does not construct the upstream HTTP request or own transport behavior.

```
  request classification
    -> intelligent_route selects "openai-api"
    -> load_balancer resolves the cluster endpoint
    -> load_balancer constructs the upstream
    -> protocol handler prepares the upstream HTTP request
```

  The authority override is a property of the selected upstream cluster, alongside its endpoints, connection settings, TLS configuration, and SNI. The load-balancing path is where that
  cluster configuration becomes a concrete upstream connection and request.

  Implementing this in intelligent_route would create several problems:

  - It would make generic HTTP upstream behavior depend on an AI-specific routing filter.
  - Routes that use router and load_balancer without intelligent_route would not receive the override.
  - Another filter selecting the same cluster could behave differently.
  - intelligent_route would need knowledge of HTTP transport details that it does not otherwise own.
  - The authority value would need to travel through request metadata instead of remaining part of validated cluster state.
  - Downstream-supplied Host values could be handled inconsistently across routing paths.

  Keeping the feature in load_balancer preserves the existing ownership boundary:

  - Routing filters select a cluster.
  - Cluster configuration describes how to reach that upstream.
  - The load balancer resolves the selected cluster.
  - The protocol layer applies the selected upstream’s HTTP authority.

  There is no Grid-specific API or runtime dependency in this change.

  ## Configuration Contract

  The new cluster field is optional:

```
  authority: api.example.com
```

  Supported forms include:

```
  api.example.com
  api.example.com:8443
  localhost
  localhost:8080
  [2001:db8::1]
  [2001:db8::1]:8443
```

  Configuration validation rejects:

  - Empty values
  - Control characters or whitespace
  - URI schemes
  - Paths
  - Query strings
  - Fragments
  - User information
  - Invalid DNS labels
  - Unbracketed IPv6 addresses
  - Empty, zero, malformed, or out-of-range ports
  - DNS hostnames over 253 characters (the optional port is validated separately)

  An invalid authority fails filter construction. Praxis does not silently ignore the value and fall back to forwarding the downstream Host.

  ## Runtime Behavior

  When authority is configured:

  1. The value is validated during configuration loading.
  2. It is parsed into an HTTP HeaderValue while building the cluster entry.
  3. The parsed value is carried with the selected Upstream.
  4. The upstream request handler replaces the Host header after reserved and hop-by-hop header stripping.
  5. Absolute-form request URIs also have their authority component replaced.
  6. Origin-form request URIs retain their existing path and query representation.

  When authority is absent, existing behavior is unchanged and the downstream Host continues through the normal request path.

  Praxis currently uses HTTP/1.1 for upstream connections, so the active behavior is an upstream Host replacement. The implementation also keeps URI authority handling consistent if an HTTP/2
  upstream path is added later.

  ## TLS SNI Independence

  authority does not modify TLS SNI.

  This separation is intentional because the connection identity and HTTP virtual host can differ:

```
  authority: tenant-api.example.com
  tls:
    sni: shared-edge.example.net
```

  Operators must configure both values when the upstream requires both a specific TLS server name and a specific HTTP virtual host.

  ## Security Properties

  - Invalid authority values fail during startup.
  - Downstream-controlled Host values are replaced when an override is configured.
  - The override is applied after reserved and hop-by-hop header stripping.
  - Authority is cluster-local and cannot leak between clusters.
  - Absolute-form URIs cannot retain a conflicting downstream authority.
  - No routing metadata or caller header can dynamically choose the override.
  - The change does not weaken TLS certificate or SNI verification.

  This supports external provider routing without making caller-controlled headers authoritative at the final upstream hop.

  ## Performance

  The expected request-path cost is small and applies only to clusters that configure authority.

  The implementation avoids repeated parsing:

  - Configuration stores the source value once.
  - Cluster construction parses it into HeaderValue once.
  - Requests reuse the cached value.
  - Cloning HeaderValue is inexpensive because its backing storage is shared.
  - Normal origin-form requests perform one header replacement and do not rebuild the URI.
  - Absolute-form requests rebuild the URI to replace its authority; these are uncommon in the normal reverse-proxy path.
  - Clusters without authority take an early return and preserve the existing request behavior.

  Memory overhead is one optional cached HeaderValue per configured cluster plus the inexpensive value carried by the selected per-request Upstream.

  The implementation does not add:

  - Per-request DNS work
  - File or environment reads
  - Kubernetes or Grid queries
  - New shared locks
  - Unbounded caches
  - Request-body copies
  - Credential processing
  - String-to-header parsing on every request

  ## Testing

  Coverage includes:

  - Valid hostname, port, localhost, and bracketed IPv6 forms
  - Invalid DNS labels and ports
  - Schemes, paths, fragments, user information, whitespace, and control characters
  - Schema acceptance and rejection
  - Serialization round trips
  - Independence between authority and tls.sni
  - Startup failure for semantically invalid embedded and programmatic authority values
  - Host replacement for HTTP/1.1 requests
  - HTTP/2 downstream requests forwarded to an HTTP/1.1 upstream
  - Downstream Host replacement
  - Absolute-form URI normalization
  - Origin-form URI preservation
  - Isolation between clusters with and without an override
  - Stability across sequential requests
  - Functional proxy traffic through the example configuration

  The Grid integration was also validated with a live OpenAI request:

  client
    -> Grid consumer gateway
    -> authenticated provider gateway
    -> credential replacement
    -> OpenAI

  Observed evidence included:

  - HTTP 200 from the OpenAI Responses API
  - OpenAI response-object validation
  - Selected Grid edge
  - Authenticated provider gateway
  - Exact OpenAI candidate
  - Provider-local openai-api cluster
  - Exact serving overlay revision
  - Successful replacement of deliberately invalid caller authorization

  ## Validation

  - make lint
  - make test
  - make doc
  - cargo check --workspace
  - cargo clippy --workspace --all-targets --all-features -- -D warnings
  - RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
  - cargo xtask lint-filter-docs
  - cargo xtask lint-example-tests
  - cargo xtask sync-example-readme
  - git diff --check
  - Cold Grid quick demo with a live OpenAI provider
  - Cold normal-mode Grid regression with no external-provider resources

  ## Scope

  This PR adds a generic per-cluster HTTP authority override.

  It does not add:

  - Grid-aware behavior to Praxis core
  - AI model or provider selection
  - Provider credentials
  - API translation
  - Dynamic cluster creation
  - DNS or Kubernetes lookups
  - HTTP/2 upstream transport
  - Automatic inference-provider configuration

  Grid and Praxis AI consume this generic cluster capability in their own configuration and routing layers.

