### PR TITLE
feat(core): OTLP exporter configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3145,6 +3145,7 @@ dependencies = [
  "serde",
  "thiserror 2.0.20",
  "tokio",
+ "tonic",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -21,6 +21,7 @@ otel = [
     "dep:opentelemetry",
     "dep:opentelemetry_sdk",
     "dep:opentelemetry-otlp",
+    "dep:tonic",
     "dep:tracing-opentelemetry",
 ]
 
@@ -39,7 +40,9 @@ regex = { workspace = true }
 serde = { workspace = true }
 serde_yaml = { workspace = true }
 thiserror = { workspace = true }
+
 tokio = { workspace = true, features = ["rt", "sync", "time"] }
+tonic = { workspace = true, optional = true }
 tracing = { workspace = true }
 tracing-opentelemetry = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true }

--- a/core/src/config/mod.rs
+++ b/core/src/config/mod.rs
@@ -50,6 +50,8 @@ use parse::check_yaml_safety;
 pub use praxis_tls::{CachedClusterTls, ClusterTls};
 pub use route::{PathMatch, Route};
 pub use runtime::{DEFAULT_SUBREQUEST_POOL_SIZE, RuntimeConfig};
+#[cfg(feature = "otel")]
+pub(crate) use telemetry::OTLP_PROTOCOL_ENV_VAR;
 pub use telemetry::TelemetryConfig;
 pub use validate::{MAX_BRANCH_DEPTH, MAX_ITERATIONS_CEILING, TERMINAL_FILTERS, is_ssrf_sensitive};
 

--- a/core/src/config/telemetry.rs
+++ b/core/src/config/telemetry.rs
@@ -3,14 +3,30 @@
 
 //! OpenTelemetry and distributed tracing configuration.
 
+use std::{collections::HashMap, fmt};
+
 use serde::{Deserialize, Serialize};
 
 // -----------------------------------------------------------------------------
 // Constants
 // -----------------------------------------------------------------------------
 
+/// OTel-standard environment variable for resource attributes
+/// (format: `key1=value1,key2=value2`).
+const OTEL_RESOURCE_ATTRIBUTES_ENV_VAR: &str = "OTEL_RESOURCE_ATTRIBUTES";
+
+/// OTel-standard environment variable for the service name.
+const OTEL_SERVICE_NAME_ENV_VAR: &str = "OTEL_SERVICE_NAME";
+
 /// OTel-standard environment variable for the OTLP exporter endpoint.
 const OTLP_ENDPOINT_ENV_VAR: &str = "OTEL_EXPORTER_OTLP_ENDPOINT";
+
+/// Standard `OTel` environment variable for OTLP exporter headers.
+const OTLP_HEADERS_ENV_VAR: &str = "OTEL_EXPORTER_OTLP_HEADERS";
+
+/// OTel-standard environment variable for the OTLP exporter protocol.
+#[cfg(feature = "otel")]
+pub(crate) const OTLP_PROTOCOL_ENV_VAR: &str = "OTEL_EXPORTER_OTLP_PROTOCOL";
 
 // -----------------------------------------------------------------------------
 // TelemetryConfig
@@ -37,15 +53,39 @@ const OTLP_ENDPOINT_ENV_VAR: &str = "OTEL_EXPORTER_OTLP_ENDPOINT";
 ///     Some("http://localhost:4317")
 /// );
 /// ```
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Default, Deserialize, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct TelemetryConfig {
+    /// Batch export interval in seconds.
+    ///
+    /// Controls how frequently the batch span processor flushes pending spans
+    /// to the OTLP collector. Defaults to 5 seconds when not set.
+    pub batch_interval_secs: Option<u64>,
+
+    /// Maximum number of spans per batch export.
+    ///
+    /// Controls the maximum batch size for the batch span processor.
+    /// Defaults to 512 when not set.
+    pub batch_size: Option<usize>,
+
+    /// Deployment environment resource attribute (`deployment.environment`).
+    ///
+    /// Falls back to `deployment.environment` in the `OTEL_RESOURCE_ATTRIBUTES`
+    /// env var when not set in config.
+    pub environment: Option<String>,
+
     /// OTLP collector endpoint (e.g. `http://localhost:4317`).
     ///
     /// When set, enables the OTLP trace exporter (requires the `otel`
     /// feature). Falls back to `OTEL_EXPORTER_OTLP_ENDPOINT` env var
     /// if not set in config.
     pub otlp_endpoint: Option<String>,
+
+    /// Custom headers for the OTLP exporter (e.g. API keys).
+    ///
+    /// Sent as gRPC metadata on every export request.
+    #[serde(skip_serializing)]
+    pub otlp_headers: Option<HashMap<String, String>>,
 
     /// Head-based trace sampling rate between `0.0` (drop all) and `1.0`
     /// (sample all).
@@ -58,34 +98,68 @@ pub struct TelemetryConfig {
     /// When `None` (the default), the `OTel` default sampler is used
     /// (`ParentBased(AlwaysOn)`), preserving backward compatibility.
     pub sampling_rate: Option<f64>,
+
+    /// `OTel` `service.name` resource attribute.
+    ///
+    /// Falls back to `OTEL_SERVICE_NAME` env var when not set in config.
+    /// Defaults to `"praxis"` when neither is set.
+    pub service_name: Option<String>,
+
+    /// `OTel` `service.version` resource attribute.
+    ///
+    /// Falls back to `service.version` in the `OTEL_RESOURCE_ATTRIBUTES`
+    /// env var when not set in config.
+    pub service_version: Option<String>,
+}
+
+impl fmt::Debug for TelemetryConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TelemetryConfig")
+            .field("batch_interval_secs", &self.batch_interval_secs)
+            .field("batch_size", &self.batch_size)
+            .field("environment", &self.environment)
+            .field("otlp_endpoint", &self.otlp_endpoint)
+            .field(
+                "otlp_headers",
+                &self
+                    .otlp_headers
+                    .as_ref()
+                    .map(|h| format!("<{} header(s) redacted>", h.len())),
+            )
+            .field("sampling_rate", &self.sampling_rate)
+            .field("service_name", &self.service_name)
+            .field("service_version", &self.service_version)
+            .finish()
+    }
 }
 
 impl TelemetryConfig {
-    /// Snapshot telemetry settings by merging config with environment.
-    ///
-    /// Config values take precedence over environment variables.
-    /// Call once at startup — the returned config should be stored
-    /// rather than re-evaluated per request.
-    pub(crate) fn resolve(&self) -> Self {
-        Self {
-            otlp_endpoint: self.otlp_endpoint.clone().or_else(|| {
-                std::env::var(OTLP_ENDPOINT_ENV_VAR)
-                    .ok()
-                    .filter(|s| !s.trim().is_empty())
-            }),
-            sampling_rate: self.sampling_rate,
-        }
-    }
+    /// Default batch export interval in seconds.
+    #[cfg(any(feature = "otel", test))]
+    pub(crate) const DEFAULT_BATCH_INTERVAL_SECS: u64 = 5;
+    /// Default maximum number of spans per batch export.
+    #[cfg(any(feature = "otel", test))]
+    pub(crate) const DEFAULT_BATCH_SIZE: usize = 512;
+    /// Default `OTel` service name when not configured.
+    #[cfg(any(feature = "otel", test))]
+    pub(crate) const DEFAULT_SERVICE_NAME: &'static str = "praxis";
 
     /// Validate telemetry configuration values.
     ///
-    /// Returns an error if `otlp_endpoint` is empty/whitespace-only or
-    /// `sampling_rate` is outside the `0.0..=1.0` range (including NaN/Inf).
+    /// # Errors
+    ///
+    /// Returns an error if `batch_size` or `batch_interval_secs` is
+    /// explicitly set to zero, `otlp_endpoint` is empty/whitespace-only,
+    /// or `sampling_rate` is outside the `0.0..=1.0` range.
     pub(crate) fn validate(&self) -> Result<(), String> {
-        if let Some(endpoint) = &self.otlp_endpoint
-            && endpoint.trim().is_empty()
-        {
-            return Err("telemetry.otlp_endpoint must not be empty or whitespace-only".to_owned());
+        if self.batch_size == Some(0) {
+            return Err("telemetry.batch_size must be > 0".to_owned());
+        }
+        if self.batch_interval_secs == Some(0) {
+            return Err("telemetry.batch_interval_secs must be > 0".to_owned());
+        }
+        if self.otlp_endpoint.as_ref().is_some_and(|e| e.trim().is_empty()) {
+            return Err("telemetry.otlp_endpoint must not be empty (omit the field to disable OTLP)".to_owned());
         }
         if let Some(rate) = self.sampling_rate
             && (!rate.is_finite() || !(0.0..=1.0).contains(&rate))
@@ -97,19 +171,106 @@ impl TelemetryConfig {
         Ok(())
     }
 
+    /// Snapshot telemetry settings by merging config with environment.
+    ///
+    /// Config values take precedence over environment variables.
+    /// Fallback order for `service_name`:
+    ///   1. `service_name` in config
+    ///   2. `OTEL_SERVICE_NAME` env var
+    ///   3. `service.name` in `OTEL_RESOURCE_ATTRIBUTES` env var
+    ///   4. `"praxis"` (via `DEFAULT_SERVICE_NAME` at the call site)
+    ///
+    /// Call once at startup — the returned config should be stored
+    /// rather than re-evaluated per request.
+    pub(crate) fn resolve(&self) -> Self {
+        Self {
+            batch_interval_secs: self.batch_interval_secs,
+            batch_size: self.batch_size,
+            environment: self
+                .environment
+                .clone()
+                .or_else(|| extract_resource_attribute_from_env("deployment.environment")),
+            otlp_endpoint: self.otlp_endpoint.clone().or_else(|| {
+                std::env::var(OTLP_ENDPOINT_ENV_VAR)
+                    .ok()
+                    .filter(|s| !s.trim().is_empty())
+            }),
+            otlp_headers: self.otlp_headers.clone().or_else(parse_otlp_headers_from_env),
+            sampling_rate: self.sampling_rate,
+            service_name: self
+                .service_name
+                .clone()
+                .or_else(|| std::env::var(OTEL_SERVICE_NAME_ENV_VAR).ok())
+                .or_else(|| extract_resource_attribute_from_env("service.name")),
+            service_version: self
+                .service_version
+                .clone()
+                .or_else(|| extract_resource_attribute_from_env("service.version")),
+        }
+    }
+
     /// Build from explicit values (for testing without env var mutation).
     ///
-    /// This deliberately bypasses [`resolve()`](Self::resolve) to avoid
-    /// mutating process-wide environment variables in tests. It tests
-    /// the *merge precedence* logic (config > env) in isolation. The
-    /// real `resolve()` path is exercised by `resolve_preserves_sampling_rate`.
+    /// This intentionally bypasses [`resolve()`](Self::resolve) because
+    /// `resolve()` reads real environment variables, and mutating the
+    /// process environment in tests is inherently racy (`env::set_var`
+    /// is `unsafe` since Rust 1.66 for good reason). Instead, callers
+    /// pass the "would-have-come-from-env" value as `env_endpoint` and
+    /// the helper simulates the config-then-env precedence inline.
     #[cfg(test)]
     fn resolved(config_endpoint: Option<&str>, env_endpoint: Option<&str>) -> Self {
         Self {
             otlp_endpoint: config_endpoint.or(env_endpoint).map(ToOwned::to_owned),
-            sampling_rate: None,
+            ..Default::default()
         }
     }
+}
+
+// -----------------------------------------------------------------------------
+// Resource Attribute Parsing
+// -----------------------------------------------------------------------------
+
+/// Extract a single attribute from the `OTEL_RESOURCE_ATTRIBUTES` env var.
+///
+/// The env var format is `key1=value1,key2=value2`. Returns the value
+/// for the first matching `key`, or `None` if the env var is unset or
+/// the key is absent.
+fn extract_resource_attribute_from_env(key: &str) -> Option<String> {
+    let attrs = std::env::var(OTEL_RESOURCE_ATTRIBUTES_ENV_VAR).ok()?;
+    extract_resource_attribute(&attrs, key)
+}
+
+/// Extract a single attribute value from an `OTel` resource-attributes string.
+///
+/// Parses the `key1=value1,key2=value2` format used by
+/// `OTEL_RESOURCE_ATTRIBUTES`. Returns the trimmed value for the first
+/// entry whose trimmed key matches `target_key`.
+fn extract_resource_attribute(attrs: &str, target_key: &str) -> Option<String> {
+    attrs
+        .split(',')
+        .filter_map(|pair| pair.split_once('='))
+        .find(|(k, _)| k.trim() == target_key)
+        .map(|(_, v)| v.trim().to_owned())
+        .filter(|v| !v.is_empty())
+}
+
+// -----------------------------------------------------------------------------
+// OTLP Headers Environment Variable
+// -----------------------------------------------------------------------------
+
+/// Parse `OTEL_EXPORTER_OTLP_HEADERS` into a header map.
+///
+/// Format: `key1=value1,key2=value2`. Returns `None` if the env var
+/// is unset or yields no valid pairs.
+fn parse_otlp_headers_from_env() -> Option<HashMap<String, String>> {
+    let raw = std::env::var(OTLP_HEADERS_ENV_VAR).ok()?;
+    let headers: HashMap<String, String> = raw
+        .split(',')
+        .filter_map(|pair| pair.split_once('='))
+        .map(|(k, v)| (k.trim().to_owned(), v.trim().to_owned()))
+        .filter(|(k, _)| !k.is_empty())
+        .collect();
+    if headers.is_empty() { None } else { Some(headers) }
 }
 
 // -----------------------------------------------------------------------------
@@ -127,6 +288,10 @@ impl TelemetryConfig {
 mod tests {
     use super::*;
 
+    // -------------------------------------------------------------------------
+    // Default & Parse Tests
+    // -------------------------------------------------------------------------
+
     #[test]
     fn defaults_to_no_endpoint() {
         let telemetry = TelemetryConfig::default();
@@ -137,11 +302,23 @@ mod tests {
     }
 
     #[test]
-    fn defaults_to_no_sampling_rate() {
+    fn defaults_all_new_fields_to_none() {
         let telemetry = TelemetryConfig::default();
+        assert!(
+            telemetry.batch_interval_secs.is_none(),
+            "batch_interval_secs should default to None"
+        );
+        assert!(telemetry.batch_size.is_none(), "batch_size should default to None");
+        assert!(telemetry.environment.is_none(), "environment should default to None");
+        assert!(telemetry.otlp_headers.is_none(), "otlp_headers should default to None");
         assert!(
             telemetry.sampling_rate.is_none(),
             "sampling_rate should default to None"
+        );
+        assert!(telemetry.service_name.is_none(), "service_name should default to None");
+        assert!(
+            telemetry.service_version.is_none(),
+            "service_version should default to None"
         );
     }
 
@@ -179,6 +356,18 @@ mod tests {
     }
 
     #[test]
+    fn parse_batch_fields() {
+        let yaml = "batch_size: 1024\nbatch_interval_secs: 10\n";
+        let telemetry: TelemetryConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(telemetry.batch_size, Some(1024), "batch_size should be parsed");
+        assert_eq!(
+            telemetry.batch_interval_secs,
+            Some(10),
+            "batch_interval_secs should be parsed"
+        );
+    }
+
+    #[test]
     fn parse_sampling_rate_zero() {
         let telemetry: TelemetryConfig = serde_yaml::from_str("sampling_rate: 0.0").unwrap();
         assert_eq!(telemetry.sampling_rate, Some(0.0), "sampling_rate 0.0 should be parsed");
@@ -201,10 +390,95 @@ mod tests {
     }
 
     #[test]
+    fn parse_resource_fields() {
+        let yaml = r#"
+service_name: "my-gateway"
+service_version: "1.2.3"
+environment: "production"
+"#;
+        let telemetry: TelemetryConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(
+            telemetry.service_name.as_deref(),
+            Some("my-gateway"),
+            "service_name should be parsed"
+        );
+        assert_eq!(
+            telemetry.service_version.as_deref(),
+            Some("1.2.3"),
+            "service_version should be parsed"
+        );
+        assert_eq!(
+            telemetry.environment.as_deref(),
+            Some("production"),
+            "environment should be parsed"
+        );
+    }
+
+    #[test]
+    fn parse_otlp_headers() {
+        let yaml = r#"
+otlp_headers:
+  x-api-key: "secret-key-123"
+  x-custom: "value"
+"#;
+        let telemetry: TelemetryConfig = serde_yaml::from_str(yaml).unwrap();
+        let headers = telemetry.otlp_headers.as_ref().expect("headers should be Some");
+        assert_eq!(
+            headers.get("x-api-key").map(String::as_str),
+            Some("secret-key-123"),
+            "x-api-key header should be parsed"
+        );
+        assert_eq!(
+            headers.get("x-custom").map(String::as_str),
+            Some("value"),
+            "x-custom header should be parsed"
+        );
+    }
+
+    #[test]
+    fn parse_full_config_endpoint_and_batch() {
+        let yaml = "otlp_endpoint: \"http://collector:4317\"\nbatch_size: 256\nbatch_interval_secs: 3\n";
+        let telemetry: TelemetryConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(
+            telemetry.otlp_endpoint.as_deref(),
+            Some("http://collector:4317"),
+            "otlp_endpoint mismatch"
+        );
+        assert_eq!(telemetry.batch_size, Some(256), "batch_size mismatch");
+        assert_eq!(telemetry.batch_interval_secs, Some(3), "batch_interval_secs mismatch");
+    }
+
+    #[test]
+    fn parse_full_config_resource_and_headers() {
+        let yaml = "service_name: \"praxis-test\"\nservice_version: \"0.1.0\"\nenvironment: \"staging\"\notlp_headers:\n  authorization: \"Bearer tok\"\n";
+        let telemetry: TelemetryConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(
+            telemetry.service_name.as_deref(),
+            Some("praxis-test"),
+            "service_name mismatch"
+        );
+        assert_eq!(
+            telemetry.service_version.as_deref(),
+            Some("0.1.0"),
+            "service_version mismatch"
+        );
+        assert_eq!(
+            telemetry.environment.as_deref(),
+            Some("staging"),
+            "environment mismatch"
+        );
+        assert!(telemetry.otlp_headers.is_some(), "otlp_headers should be present");
+    }
+
+    #[test]
     fn reject_unknown_field() {
         let result = serde_yaml::from_str::<TelemetryConfig>("bogus_field: true");
         assert!(result.is_err(), "unknown field should be rejected");
     }
+
+    // -------------------------------------------------------------------------
+    // Env Var Constant Tests
+    // -------------------------------------------------------------------------
 
     #[test]
     fn otlp_env_var_name_matches_otel_spec() {
@@ -213,6 +487,49 @@ mod tests {
             "env var name must match the OTel specification"
         );
     }
+
+    #[test]
+    fn service_name_env_var_matches_otel_spec() {
+        assert_eq!(
+            OTEL_SERVICE_NAME_ENV_VAR, "OTEL_SERVICE_NAME",
+            "env var name must match the OTel specification"
+        );
+    }
+
+    #[test]
+    fn resource_attributes_env_var_matches_otel_spec() {
+        assert_eq!(
+            OTEL_RESOURCE_ATTRIBUTES_ENV_VAR, "OTEL_RESOURCE_ATTRIBUTES",
+            "env var name must match the OTel specification"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Default Constant Tests
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn default_constants_match_otel_sdk_defaults() {
+        assert_eq!(
+            TelemetryConfig::DEFAULT_BATCH_SIZE,
+            512,
+            "default batch size should match OTel SDK default"
+        );
+        assert_eq!(
+            TelemetryConfig::DEFAULT_BATCH_INTERVAL_SECS,
+            5,
+            "default batch interval should match OTel SDK default (5s)"
+        );
+        assert_eq!(
+            TelemetryConfig::DEFAULT_SERVICE_NAME,
+            "praxis",
+            "default service name should be 'praxis'"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Resolve Tests
+    // -------------------------------------------------------------------------
 
     #[test]
     fn resolve_prefers_config_over_env() {
@@ -246,8 +563,8 @@ mod tests {
     #[test]
     fn resolve_preserves_sampling_rate() {
         let config = TelemetryConfig {
-            otlp_endpoint: None,
             sampling_rate: Some(0.5),
+            ..Default::default()
         };
         let resolved = config.resolve();
         assert_eq!(
@@ -257,8 +574,91 @@ mod tests {
         );
     }
 
+    #[test]
+    fn resolve_passes_through_batch_fields() {
+        let config = TelemetryConfig {
+            batch_size: Some(1024),
+            batch_interval_secs: Some(10),
+            ..Default::default()
+        };
+        let resolved = config.resolve();
+        assert_eq!(
+            resolved.batch_size,
+            Some(1024),
+            "batch_size should pass through resolve"
+        );
+        assert_eq!(
+            resolved.batch_interval_secs,
+            Some(10),
+            "batch_interval_secs should pass through resolve"
+        );
+    }
+
+    #[test]
+    fn resolve_passes_through_headers() {
+        let mut headers = HashMap::new();
+        headers.insert("x-api-key".to_owned(), "secret".to_owned());
+        let config = TelemetryConfig {
+            otlp_headers: Some(headers),
+            ..Default::default()
+        };
+        let resolved = config.resolve();
+        assert_eq!(
+            resolved
+                .otlp_headers
+                .as_ref()
+                .and_then(|h| h.get("x-api-key"))
+                .map(String::as_str),
+            Some("secret"),
+            "otlp_headers should pass through resolve"
+        );
+    }
+
+    #[test]
+    fn resolve_uses_config_service_name_over_env() {
+        // When config has a value, it should always be used regardless of env.
+        let config = TelemetryConfig {
+            service_name: Some("from-config".to_owned()),
+            ..Default::default()
+        };
+        let resolved = config.resolve();
+        assert_eq!(
+            resolved.service_name.as_deref(),
+            Some("from-config"),
+            "config service_name should take precedence"
+        );
+    }
+
+    #[test]
+    fn resolve_uses_config_environment_over_env() {
+        let config = TelemetryConfig {
+            environment: Some("staging".to_owned()),
+            ..Default::default()
+        };
+        let resolved = config.resolve();
+        assert_eq!(
+            resolved.environment.as_deref(),
+            Some("staging"),
+            "config environment should take precedence"
+        );
+    }
+
+    #[test]
+    fn resolve_uses_config_service_version_over_env() {
+        let config = TelemetryConfig {
+            service_version: Some("1.0.0".to_owned()),
+            ..Default::default()
+        };
+        let resolved = config.resolve();
+        assert_eq!(
+            resolved.service_version.as_deref(),
+            Some("1.0.0"),
+            "config service_version should take precedence"
+        );
+    }
+
     // -------------------------------------------------------------------------
-    // Validation
+    // Validation Tests
     // -------------------------------------------------------------------------
 
     #[test]
@@ -360,28 +760,166 @@ mod tests {
     }
 
     #[test]
-    fn validate_empty_otlp_endpoint_rejected() {
+    fn validate_rejects_zero_batch_size() {
+        let config = TelemetryConfig {
+            batch_size: Some(0),
+            ..Default::default()
+        };
+        let err = config.validate().unwrap_err();
+        assert!(
+            err.contains("batch_size must be > 0"),
+            "expected batch_size error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_zero_batch_interval_secs() {
+        let config = TelemetryConfig {
+            batch_interval_secs: Some(0),
+            ..Default::default()
+        };
+        let err = config.validate().unwrap_err();
+        assert!(
+            err.contains("batch_interval_secs must be > 0"),
+            "expected batch_interval_secs error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_accepts_positive_batch_values() {
+        let config = TelemetryConfig {
+            batch_size: Some(512),
+            batch_interval_secs: Some(5),
+            ..Default::default()
+        };
+        assert!(config.validate().is_ok(), "positive values should pass validation");
+    }
+
+    #[test]
+    fn validate_accepts_none_batch_values() {
+        let config = TelemetryConfig::default();
+        assert!(config.validate().is_ok(), "None values should pass validation");
+    }
+
+    #[test]
+    fn validate_rejects_empty_otlp_endpoint() {
         let config = TelemetryConfig {
             otlp_endpoint: Some(String::new()),
             ..Default::default()
         };
         let err = config.validate().unwrap_err();
         assert!(
-            err.contains("must not be empty"),
-            "empty otlp_endpoint should be rejected: {err}"
+            err.contains("otlp_endpoint must not be empty"),
+            "expected otlp_endpoint error, got: {err}"
         );
     }
 
     #[test]
-    fn validate_whitespace_otlp_endpoint_rejected() {
+    fn validate_rejects_whitespace_only_otlp_endpoint() {
         let config = TelemetryConfig {
             otlp_endpoint: Some("   ".to_owned()),
             ..Default::default()
         };
-        let err = config.validate().unwrap_err();
         assert!(
-            err.contains("must not be empty"),
-            "whitespace-only otlp_endpoint should be rejected: {err}"
+            config.validate().is_err(),
+            "whitespace-only endpoint should be rejected"
+        );
+    }
+
+    #[test]
+    fn validate_accepts_valid_otlp_endpoint() {
+        let config = TelemetryConfig {
+            otlp_endpoint: Some("http://collector:4317".to_owned()),
+            ..Default::default()
+        };
+        assert!(config.validate().is_ok(), "valid endpoint should pass validation");
+    }
+
+    // -------------------------------------------------------------------------
+    // Resource Attribute Extraction Tests
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn extract_resource_attribute_single() {
+        let attrs = "deployment.environment=production";
+        assert_eq!(
+            extract_resource_attribute(attrs, "deployment.environment"),
+            Some("production".to_owned()),
+            "should extract single attribute"
+        );
+    }
+
+    #[test]
+    fn extract_resource_attribute_multiple() {
+        let attrs = "service.version=1.2.3,deployment.environment=staging,service.namespace=team-a";
+        assert_eq!(
+            extract_resource_attribute(attrs, "deployment.environment"),
+            Some("staging".to_owned()),
+            "should extract from multi-attribute string"
+        );
+        assert_eq!(
+            extract_resource_attribute(attrs, "service.version"),
+            Some("1.2.3".to_owned()),
+            "should extract service.version from multi-attribute string"
+        );
+    }
+
+    #[test]
+    fn extract_resource_attribute_with_whitespace() {
+        let attrs = " service.version = 1.0.0 , deployment.environment = prod ";
+        assert_eq!(
+            extract_resource_attribute(attrs, "service.version"),
+            Some("1.0.0".to_owned()),
+            "should trim whitespace around key and value"
+        );
+        assert_eq!(
+            extract_resource_attribute(attrs, "deployment.environment"),
+            Some("prod".to_owned()),
+            "should trim whitespace around key and value"
+        );
+    }
+
+    #[test]
+    fn extract_resource_attribute_missing_key() {
+        let attrs = "service.name=praxis,service.version=1.0.0";
+        assert_eq!(
+            extract_resource_attribute(attrs, "deployment.environment"),
+            None,
+            "should return None for missing key"
+        );
+    }
+
+    #[test]
+    fn extract_resource_attribute_empty_string() {
+        assert_eq!(
+            extract_resource_attribute("", "deployment.environment"),
+            None,
+            "should return None for empty attribute string"
+        );
+    }
+
+    #[test]
+    fn extract_resource_attribute_no_equals() {
+        let attrs = "malformed-entry,deployment.environment=ok";
+        assert_eq!(
+            extract_resource_attribute(attrs, "deployment.environment"),
+            Some("ok".to_owned()),
+            "should skip entries without '=' and find valid ones"
+        );
+    }
+
+    #[test]
+    fn extract_resource_attribute_empty_value() {
+        let attrs = "service.name=,deployment.environment=prod";
+        assert_eq!(
+            extract_resource_attribute(attrs, "service.name"),
+            None,
+            "empty value should return None to allow default fallback"
+        );
+        assert_eq!(
+            extract_resource_attribute(attrs, "deployment.environment"),
+            Some("prod".to_owned()),
+            "non-empty value should still be extracted"
         );
     }
 }

--- a/core/src/config/validate/rules.rs
+++ b/core/src/config/validate/rules.rs
@@ -92,7 +92,7 @@ impl Config {
         validate_subrequest_circuit_breaker(self.runtime.subrequest_circuit_breaker.as_ref())?;
         validate_global_queue_interval(self.runtime.global_queue_interval)?;
         validate_shutdown_timeout(self.shutdown_timeout_secs)?;
-        self.telemetry.validate().map_err(ProxyError::Config)?;
+        validate_telemetry(&self.telemetry)?;
 
         Ok(())
     }
@@ -401,6 +401,11 @@ fn validate_shutdown_timeout(secs: u64) -> Result<(), ProxyError> {
         )));
     }
     Ok(())
+}
+
+/// Reject invalid telemetry batch settings.
+fn validate_telemetry(telemetry: &crate::config::TelemetryConfig) -> Result<(), ProxyError> {
+    telemetry.validate().map_err(ProxyError::Config)
 }
 
 // -----------------------------------------------------------------------------

--- a/core/src/logging.rs
+++ b/core/src/logging.rs
@@ -196,29 +196,34 @@ fn init_fmt_only(env_filter: tracing_subscriber::EnvFilter, json: bool) {
 ///
 /// Returns `Some(provider)` when an OTLP endpoint is configured,
 /// `None` otherwise. Sets the global tracer provider.
+///
+/// Applies configured batch settings (size, interval), custom headers
+/// (as gRPC metadata or HTTP headers), and resource attributes
+/// (service name/version, deployment environment).
 #[cfg(feature = "otel")]
 fn build_otel_provider(
     config: &crate::config::TelemetryConfig,
 ) -> Result<Option<opentelemetry_sdk::trace::SdkTracerProvider>, ProxyError> {
-    use opentelemetry_otlp::WithExportConfig as _;
-
     let Some(endpoint) = config.otlp_endpoint.as_deref() else {
         return Ok(None);
     };
 
-    let exporter = opentelemetry_otlp::SpanExporter::builder()
-        .with_tonic()
-        .with_endpoint(endpoint)
-        .build()
-        .map_err(|e| ProxyError::Config(format!("failed to build OTLP span exporter: {e}")))?;
+    if let Ok(protocol) = std::env::var(crate::config::OTLP_PROTOCOL_ENV_VAR)
+        && protocol != "grpc"
+    {
+        return Err(ProxyError::Config(format!(
+            "Praxis supports only gRPC for OTLP export, but {}={protocol}",
+            crate::config::OTLP_PROTOCOL_ENV_VAR,
+        )));
+    }
+
+    let exporter = build_span_exporter(endpoint, &config.otlp_headers)?;
+    let batch_processor = build_batch_processor(exporter, config);
+    let resource = build_otel_resource(config);
 
     let mut provider_builder = opentelemetry_sdk::trace::SdkTracerProvider::builder()
-        .with_batch_exporter(exporter)
-        .with_resource(
-            opentelemetry_sdk::Resource::builder()
-                .with_service_name("praxis")
-                .build(),
-        );
+        .with_span_processor(batch_processor)
+        .with_resource(resource);
 
     // When a sampling rate is configured, wrap TraceIdRatioBased in
     // ParentBased so root spans are sampled at the given rate while
@@ -234,6 +239,129 @@ fn build_otel_provider(
     opentelemetry::global::set_tracer_provider(provider.clone());
 
     Ok(Some(provider))
+}
+
+// -----------------------------------------------------------------------------
+// OTLP Exporter Builder
+// -----------------------------------------------------------------------------
+
+/// Build the OTLP span exporter with endpoint and optional gRPC headers.
+#[cfg(feature = "otel")]
+fn build_span_exporter(
+    endpoint: &str,
+    headers: &Option<std::collections::HashMap<String, String>>,
+) -> Result<opentelemetry_otlp::SpanExporter, ProxyError> {
+    use opentelemetry_otlp::{WithExportConfig as _, WithTonicConfig as _};
+
+    let mut builder = opentelemetry_otlp::SpanExporter::builder()
+        .with_tonic()
+        .with_endpoint(endpoint);
+
+    if let Some(hdrs) = headers {
+        builder = builder.with_metadata(build_metadata_map(hdrs)?);
+    }
+
+    builder
+        .build()
+        .map_err(|e| ProxyError::Config(format!("failed to build OTLP span exporter: {e}")))
+}
+
+// -----------------------------------------------------------------------------
+// Batch Processor Builder
+// -----------------------------------------------------------------------------
+
+/// Build a batch span processor with configured size and interval.
+///
+/// Uses explicit defaults so Praxis controls batch behaviour even if the
+/// `OTel` SDK changes its own defaults.
+#[cfg(feature = "otel")]
+fn build_batch_processor(
+    exporter: opentelemetry_otlp::SpanExporter,
+    config: &crate::config::TelemetryConfig,
+) -> opentelemetry_sdk::trace::BatchSpanProcessor {
+    let batch_size = config
+        .batch_size
+        .unwrap_or(crate::config::TelemetryConfig::DEFAULT_BATCH_SIZE);
+    let batch_interval = config
+        .batch_interval_secs
+        .unwrap_or(crate::config::TelemetryConfig::DEFAULT_BATCH_INTERVAL_SECS);
+
+    let batch_config = opentelemetry_sdk::trace::BatchConfigBuilder::default()
+        .with_max_export_batch_size(batch_size)
+        .with_max_queue_size(2048)
+        .with_scheduled_delay(std::time::Duration::from_secs(batch_interval))
+        .build();
+
+    opentelemetry_sdk::trace::BatchSpanProcessor::builder(exporter)
+        .with_batch_config(batch_config)
+        .build()
+}
+
+// -----------------------------------------------------------------------------
+// Resource Builder
+// -----------------------------------------------------------------------------
+
+/// Build the `OTel` [`Resource`] from configured service metadata.
+///
+/// Uses the SDK's [`EnvResourceDetector`] to pick up all attributes from
+/// `OTEL_RESOURCE_ATTRIBUTES`, then layers config-supplied values on top
+/// (config takes precedence over env-detected values).
+///
+/// [`Resource`]: opentelemetry_sdk::Resource
+/// [`EnvResourceDetector`]: opentelemetry_sdk::resource::EnvResourceDetector
+#[cfg(feature = "otel")]
+fn build_otel_resource(config: &crate::config::TelemetryConfig) -> opentelemetry_sdk::Resource {
+    use opentelemetry_sdk::resource::EnvResourceDetector;
+
+    let service_name = config
+        .service_name
+        .clone()
+        .unwrap_or_else(|| crate::config::TelemetryConfig::DEFAULT_SERVICE_NAME.to_owned());
+
+    // Order matters: later attributes override earlier ones in the SDK builder.
+    // Detector runs first (picks up OTEL_RESOURCE_ATTRIBUTES), then explicit
+    // config values override any colliding keys.
+    let mut builder = opentelemetry_sdk::Resource::builder()
+        .with_detector(Box::new(EnvResourceDetector::new()))
+        .with_service_name(service_name);
+
+    if let Some(version) = &config.service_version {
+        builder = builder.with_attribute(opentelemetry::KeyValue::new("service.version", version.clone()));
+    }
+    if let Some(env) = &config.environment {
+        builder = builder.with_attribute(opentelemetry::KeyValue::new("deployment.environment", env.clone()));
+    }
+
+    builder.build()
+}
+
+// -----------------------------------------------------------------------------
+// Metadata Builder
+// -----------------------------------------------------------------------------
+
+/// Build a tonic [`MetadataMap`] from the configured OTLP headers.
+///
+/// # Errors
+///
+/// Returns [`ProxyError::Config`] if any header name or value is invalid.
+///
+/// [`MetadataMap`]: tonic::metadata::MetadataMap
+/// [`ProxyError::Config`]: crate::errors::ProxyError::Config
+#[cfg(feature = "otel")]
+fn build_metadata_map(
+    headers: &std::collections::HashMap<String, String>,
+) -> Result<tonic::metadata::MetadataMap, ProxyError> {
+    let mut metadata = tonic::metadata::MetadataMap::new();
+    for (key, value) in headers {
+        let name: tonic::metadata::MetadataKey<tonic::metadata::Ascii> = key
+            .parse()
+            .map_err(|e| ProxyError::Config(format!("invalid OTLP header name '{key}': {e}")))?;
+        let val: tonic::metadata::MetadataValue<tonic::metadata::Ascii> = value
+            .parse()
+            .map_err(|e| ProxyError::Config(format!("invalid OTLP header value for '{key}': {e}")))?;
+        metadata.insert(name, val);
+    }
+    Ok(metadata)
 }
 
 // -----------------------------------------------------------------------------

--- a/examples/configs/observability/tracing-otlp.yaml
+++ b/examples/configs/observability/tracing-otlp.yaml
@@ -31,3 +31,10 @@ telemetry:
   # child spans inherit the parent decision via W3C traceparent.
   # Omit or remove to use the OTel default (ParentBased(AlwaysOn)).
   sampling_rate: 0.01
+  # service_name: "praxis"          # OTel service.name (default: "praxis")
+  # service_version: "0.1.0"        # OTel service.version
+  # environment: "production"       # deployment.environment resource attribute
+  # batch_size: 512                 # max spans per batch export (default: 512)
+  # batch_interval_secs: 5          # export interval in seconds (default: 5)
+  # otlp_headers:                   # custom gRPC metadata (e.g. API keys)
+  #   x-api-key: "your-key-here"


### PR DESCRIPTION
## What
Extend TelemetryConfig with configurable OTLP exporter settings: headers, batch size/interval, resource attributes (service.name, service.version, environment).

## Why
#315 hardcodes `service.name = "praxis"` and uses default batch config. Production deployments need custom headers (API keys), tuned batch sizes, and proper resource attributes for trace identification.

## How
- Add 6 new fields to TelemetryConfig (all Optional with serde defaults)
- Env var fallbacks per OTel spec: OTEL_SERVICE_NAME, OTEL_RESOURCE_ATTRIBUTES
- Refactor build_otel_provider into focused functions: build_span_exporter, build_batch_processor, build_otel_resource
- 20 new tests

**Depends on** #315 (PR #836)

Closes #299