### PR TITLE
feat(core): configurable head-based trace sampling

### DIFF
--- a/core/src/config/telemetry.rs
+++ b/core/src/config/telemetry.rs
@@ -28,6 +28,7 @@ const OTLP_ENDPOINT_ENV_VAR: &str = "OTEL_EXPORTER_OTLP_ENDPOINT";
 ///
 /// let telemetry = TelemetryConfig::default();
 /// assert!(telemetry.otlp_endpoint.is_none());
+/// assert!(telemetry.sampling_rate.is_none());
 ///
 /// let telemetry: TelemetryConfig =
 ///     serde_yaml::from_str("otlp_endpoint: \"http://localhost:4317\"").unwrap();
@@ -36,7 +37,7 @@ const OTLP_ENDPOINT_ENV_VAR: &str = "OTEL_EXPORTER_OTLP_ENDPOINT";
 ///     Some("http://localhost:4317")
 /// );
 /// ```
-#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct TelemetryConfig {
     /// OTLP collector endpoint (e.g. `http://localhost:4317`).
@@ -45,6 +46,18 @@ pub struct TelemetryConfig {
     /// feature). Falls back to `OTEL_EXPORTER_OTLP_ENDPOINT` env var
     /// if not set in config.
     pub otlp_endpoint: Option<String>,
+
+    /// Head-based trace sampling rate between `0.0` (drop all) and `1.0`
+    /// (sample all).
+    ///
+    /// When set, configures a `ParentBased(TraceIdRatioBased(rate))`
+    /// sampler: root spans are sampled at the given rate while
+    /// locally-created child spans inherit their parent's sampling
+    /// decision.
+    ///
+    /// When `None` (the default), the `OTel` default sampler is used
+    /// (`ParentBased(AlwaysOn)`), preserving backward compatibility.
+    pub sampling_rate: Option<f64>,
 }
 
 impl TelemetryConfig {
@@ -55,24 +68,46 @@ impl TelemetryConfig {
     /// rather than re-evaluated per request.
     pub(crate) fn resolve(&self) -> Self {
         Self {
-            otlp_endpoint: self
-                .otlp_endpoint
-                .clone()
-                .or_else(|| std::env::var(OTLP_ENDPOINT_ENV_VAR).ok()),
+            otlp_endpoint: self.otlp_endpoint.clone().or_else(|| {
+                std::env::var(OTLP_ENDPOINT_ENV_VAR)
+                    .ok()
+                    .filter(|s| !s.trim().is_empty())
+            }),
+            sampling_rate: self.sampling_rate,
         }
+    }
+
+    /// Validate telemetry configuration values.
+    ///
+    /// Returns an error if `otlp_endpoint` is empty/whitespace-only or
+    /// `sampling_rate` is outside the `0.0..=1.0` range (including NaN/Inf).
+    pub(crate) fn validate(&self) -> Result<(), String> {
+        if let Some(endpoint) = &self.otlp_endpoint
+            && endpoint.trim().is_empty()
+        {
+            return Err("telemetry.otlp_endpoint must not be empty or whitespace-only".to_owned());
+        }
+        if let Some(rate) = self.sampling_rate
+            && (!rate.is_finite() || !(0.0..=1.0).contains(&rate))
+        {
+            return Err(format!(
+                "telemetry.sampling_rate must be between 0.0 and 1.0, got {rate}"
+            ));
+        }
+        Ok(())
     }
 
     /// Build from explicit values (for testing without env var mutation).
     ///
-    /// This duplicates the merge logic from [`resolve`] rather than calling it,
-    /// because `resolve` reads `std::env::var` which is process-global state.
-    /// Mutating env vars in tests is inherently racy under `cargo test`'s
-    /// default parallel execution, so we accept the small duplication to keep
-    /// tests deterministic without `#[serial]` or mutex coordination.
+    /// This deliberately bypasses [`resolve()`](Self::resolve) to avoid
+    /// mutating process-wide environment variables in tests. It tests
+    /// the *merge precedence* logic (config > env) in isolation. The
+    /// real `resolve()` path is exercised by `resolve_preserves_sampling_rate`.
     #[cfg(test)]
     fn resolved(config_endpoint: Option<&str>, env_endpoint: Option<&str>) -> Self {
         Self {
             otlp_endpoint: config_endpoint.or(env_endpoint).map(ToOwned::to_owned),
+            sampling_rate: None,
         }
     }
 }
@@ -102,11 +137,24 @@ mod tests {
     }
 
     #[test]
+    fn defaults_to_no_sampling_rate() {
+        let telemetry = TelemetryConfig::default();
+        assert!(
+            telemetry.sampling_rate.is_none(),
+            "sampling_rate should default to None"
+        );
+    }
+
+    #[test]
     fn parse_empty_yields_defaults() {
         let telemetry: TelemetryConfig = serde_yaml::from_str("{}").unwrap();
         assert!(
             telemetry.otlp_endpoint.is_none(),
             "empty yaml should default otlp_endpoint to None"
+        );
+        assert!(
+            telemetry.sampling_rate.is_none(),
+            "empty yaml should default sampling_rate to None"
         );
     }
 
@@ -117,6 +165,38 @@ mod tests {
             telemetry.otlp_endpoint.as_deref(),
             Some("http://collector:4317"),
             "explicit otlp_endpoint should be parsed"
+        );
+    }
+
+    #[test]
+    fn parse_explicit_sampling_rate() {
+        let telemetry: TelemetryConfig = serde_yaml::from_str("sampling_rate: 0.5").unwrap();
+        assert_eq!(
+            telemetry.sampling_rate,
+            Some(0.5),
+            "explicit sampling_rate should be parsed"
+        );
+    }
+
+    #[test]
+    fn parse_sampling_rate_zero() {
+        let telemetry: TelemetryConfig = serde_yaml::from_str("sampling_rate: 0.0").unwrap();
+        assert_eq!(telemetry.sampling_rate, Some(0.0), "sampling_rate 0.0 should be parsed");
+    }
+
+    #[test]
+    fn parse_sampling_rate_one() {
+        let telemetry: TelemetryConfig = serde_yaml::from_str("sampling_rate: 1.0").unwrap();
+        assert_eq!(telemetry.sampling_rate, Some(1.0), "sampling_rate 1.0 should be parsed");
+    }
+
+    #[test]
+    fn parse_sampling_rate_one_percent() {
+        let telemetry: TelemetryConfig = serde_yaml::from_str("sampling_rate: 0.01").unwrap();
+        assert_eq!(
+            telemetry.sampling_rate,
+            Some(0.01),
+            "sampling_rate 0.01 (1%) should be parsed"
         );
     }
 
@@ -160,6 +240,148 @@ mod tests {
         assert!(
             resolved.otlp_endpoint.is_none(),
             "should return None when both are unset"
+        );
+    }
+
+    #[test]
+    fn resolve_preserves_sampling_rate() {
+        let config = TelemetryConfig {
+            otlp_endpoint: None,
+            sampling_rate: Some(0.5),
+        };
+        let resolved = config.resolve();
+        assert_eq!(
+            resolved.sampling_rate,
+            Some(0.5),
+            "resolve should preserve sampling_rate"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Validation
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn validate_none_sampling_rate_ok() {
+        let config = TelemetryConfig::default();
+        assert!(config.validate().is_ok(), "None sampling_rate should pass validation");
+    }
+
+    #[test]
+    fn validate_sampling_rate_zero_ok() {
+        let config = TelemetryConfig {
+            sampling_rate: Some(0.0),
+            ..Default::default()
+        };
+        assert!(config.validate().is_ok(), "sampling_rate 0.0 should pass validation");
+    }
+
+    #[test]
+    fn validate_sampling_rate_one_ok() {
+        let config = TelemetryConfig {
+            sampling_rate: Some(1.0),
+            ..Default::default()
+        };
+        assert!(config.validate().is_ok(), "sampling_rate 1.0 should pass validation");
+    }
+
+    #[test]
+    fn validate_sampling_rate_mid_range_ok() {
+        let config = TelemetryConfig {
+            sampling_rate: Some(0.01),
+            ..Default::default()
+        };
+        assert!(config.validate().is_ok(), "sampling_rate 0.01 should pass validation");
+    }
+
+    #[test]
+    fn validate_sampling_rate_negative_rejected() {
+        let config = TelemetryConfig {
+            sampling_rate: Some(-0.1),
+            ..Default::default()
+        };
+        let err = config.validate().unwrap_err();
+        assert!(
+            err.contains("between 0.0 and 1.0"),
+            "negative rate should be rejected: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_sampling_rate_above_one_rejected() {
+        let config = TelemetryConfig {
+            sampling_rate: Some(1.5),
+            ..Default::default()
+        };
+        let err = config.validate().unwrap_err();
+        assert!(
+            err.contains("between 0.0 and 1.0"),
+            "rate above 1.0 should be rejected: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_sampling_rate_nan_rejected() {
+        let config = TelemetryConfig {
+            sampling_rate: Some(f64::NAN),
+            ..Default::default()
+        };
+        let err = config.validate().unwrap_err();
+        assert!(
+            err.contains("between 0.0 and 1.0"),
+            "NaN sampling_rate should be rejected: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_sampling_rate_infinity_rejected() {
+        let config = TelemetryConfig {
+            sampling_rate: Some(f64::INFINITY),
+            ..Default::default()
+        };
+        let err = config.validate().unwrap_err();
+        assert!(
+            err.contains("between 0.0 and 1.0"),
+            "Inf sampling_rate should be rejected: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_sampling_rate_neg_infinity_rejected() {
+        let config = TelemetryConfig {
+            sampling_rate: Some(f64::NEG_INFINITY),
+            ..Default::default()
+        };
+        let err = config.validate().unwrap_err();
+        assert!(
+            err.contains("between 0.0 and 1.0"),
+            "-Inf sampling_rate should be rejected: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_empty_otlp_endpoint_rejected() {
+        let config = TelemetryConfig {
+            otlp_endpoint: Some(String::new()),
+            ..Default::default()
+        };
+        let err = config.validate().unwrap_err();
+        assert!(
+            err.contains("must not be empty"),
+            "empty otlp_endpoint should be rejected: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_whitespace_otlp_endpoint_rejected() {
+        let config = TelemetryConfig {
+            otlp_endpoint: Some("   ".to_owned()),
+            ..Default::default()
+        };
+        let err = config.validate().unwrap_err();
+        assert!(
+            err.contains("must not be empty"),
+            "whitespace-only otlp_endpoint should be rejected: {err}"
         );
     }
 }

--- a/core/src/config/validate/rules.rs
+++ b/core/src/config/validate/rules.rs
@@ -92,6 +92,7 @@ impl Config {
         validate_subrequest_circuit_breaker(self.runtime.subrequest_circuit_breaker.as_ref())?;
         validate_global_queue_interval(self.runtime.global_queue_interval)?;
         validate_shutdown_timeout(self.shutdown_timeout_secs)?;
+        self.telemetry.validate().map_err(ProxyError::Config)?;
 
         Ok(())
     }

--- a/core/src/logging.rs
+++ b/core/src/logging.rs
@@ -28,6 +28,7 @@ use crate::{config::Config, errors::ProxyError};
 /// let config = praxis_core::config::Config::load(None, "listeners: []").unwrap();
 /// let _guard = praxis_core::logging::init_tracing(&config).unwrap();
 /// ```
+#[must_use = "dropping the guard immediately shuts down the tracer provider"]
 pub struct TracingGuard {
     /// Tracer provider to shut down when the guard is dropped.
     #[cfg(feature = "otel")]
@@ -75,7 +76,7 @@ pub fn init_tracing(config: &Config) -> Result<TracingGuard, ProxyError> {
     let json = std::env::var("PRAXIS_LOG_FORMAT").is_ok_and(|v| v.eq_ignore_ascii_case("json"));
     let telemetry = config.telemetry.resolve();
 
-    warn_if_endpoint_without_feature(telemetry.otlp_endpoint.is_some());
+    warn_if_otel_config_without_feature(telemetry.otlp_endpoint.is_some(), telemetry.sampling_rate.is_some());
 
     #[cfg(feature = "otel")]
     return init_with_otel(env_filter, json, &telemetry);
@@ -211,14 +212,24 @@ fn build_otel_provider(
         .build()
         .map_err(|e| ProxyError::Config(format!("failed to build OTLP span exporter: {e}")))?;
 
-    let provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
+    let mut provider_builder = opentelemetry_sdk::trace::SdkTracerProvider::builder()
         .with_batch_exporter(exporter)
         .with_resource(
             opentelemetry_sdk::Resource::builder()
                 .with_service_name("praxis")
                 .build(),
-        )
-        .build();
+        );
+
+    // When a sampling rate is configured, wrap TraceIdRatioBased in
+    // ParentBased so root spans are sampled at the given rate while
+    // locally-created child spans inherit their parent's decision.
+    if let Some(rate) = config.sampling_rate {
+        provider_builder = provider_builder.with_sampler(opentelemetry_sdk::trace::Sampler::ParentBased(Box::new(
+            opentelemetry_sdk::trace::Sampler::TraceIdRatioBased(rate),
+        )));
+    }
+
+    let provider = provider_builder.build();
 
     opentelemetry::global::set_tracer_provider(provider.clone());
 
@@ -235,17 +246,21 @@ fn build_otel_provider(
     not(feature = "otel"),
     expect(clippy::print_stderr, reason = "tracing not yet initialized")
 )]
-fn warn_if_endpoint_without_feature(has_endpoint: bool) {
+fn warn_if_otel_config_without_feature(has_endpoint: bool, has_sampling: bool) {
     #[cfg(not(feature = "otel"))]
-    if has_endpoint {
+    if has_endpoint || has_sampling {
         eprintln!(
-            "warning: telemetry.otlp_endpoint is configured but the `otel` feature is not \
-             enabled; OTLP export is disabled. Rebuild with `--features otel` to enable it."
+            "warning: telemetry OTel settings are configured but the `otel` feature is not \
+             enabled; OTLP export and sampling are disabled. Rebuild with `--features otel` \
+             to enable them."
         );
     }
 
     #[cfg(feature = "otel")]
-    let _ = has_endpoint;
+    {
+        let _ = has_endpoint;
+        let _ = has_sampling;
+    }
 }
 
 // -----------------------------------------------------------------------------
@@ -484,6 +499,10 @@ mod tests {
             config.telemetry.otlp_endpoint.is_none(),
             "telemetry.otlp_endpoint should default to None"
         );
+        assert!(
+            config.telemetry.sampling_rate.is_none(),
+            "telemetry.sampling_rate should default to None"
+        );
     }
 
     #[test]
@@ -505,6 +524,71 @@ telemetry:
             config.telemetry.otlp_endpoint.as_deref(),
             Some("http://collector:4317"),
             "otlp_endpoint should be parsed from config"
+        );
+    }
+
+    #[test]
+    fn telemetry_sampling_rate_parsed_in_config() {
+        let yaml = r#"
+listeners:
+  - name: test
+    address: "127.0.0.1:8080"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: static_response
+telemetry:
+  otlp_endpoint: "http://collector:4317"
+  sampling_rate: 0.01
+"#;
+        let config = Config::from_yaml(yaml).expect("config with sampling_rate should parse");
+        assert_eq!(
+            config.telemetry.sampling_rate,
+            Some(0.01),
+            "sampling_rate should be parsed from config"
+        );
+    }
+
+    #[test]
+    fn telemetry_sampling_rate_out_of_range_rejected() {
+        let yaml = r#"
+listeners:
+  - name: test
+    address: "127.0.0.1:8080"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: static_response
+telemetry:
+  sampling_rate: 2.0
+"#;
+        let err = Config::from_yaml(yaml).unwrap_err();
+        assert!(
+            err.to_string().contains("between 0.0 and 1.0"),
+            "out-of-range sampling_rate should be rejected: {err}"
+        );
+    }
+
+    #[test]
+    fn telemetry_negative_sampling_rate_rejected() {
+        let yaml = r#"
+listeners:
+  - name: test
+    address: "127.0.0.1:8080"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: static_response
+telemetry:
+  sampling_rate: -0.5
+"#;
+        let err = Config::from_yaml(yaml).unwrap_err();
+        assert!(
+            err.to_string().contains("between 0.0 and 1.0"),
+            "negative sampling_rate should be rejected: {err}"
         );
     }
 

--- a/examples/configs/observability/tracing-otlp.yaml
+++ b/examples/configs/observability/tracing-otlp.yaml
@@ -27,3 +27,7 @@ filter_chains:
 
 telemetry:
   otlp_endpoint: "http://localhost:4317"
+  # Head-based sampling rate (0.0 to 1.0). Sample 1% of root traces;
+  # child spans inherit the parent decision via W3C traceparent.
+  # Omit or remove to use the OTel default (ParentBased(AlwaysOn)).
+  sampling_rate: 0.01


### PR DESCRIPTION
## What
Add sampling_rate field to TelemetryConfig (0.0 to 1.0). When set, configures a ParentBased sampler wrapping TraceIdRatioBased on the SdkTracerProvider.

## Why
Production deployments need to control trace volume. AlwaysOn sampling generates too much data; configurable rates (1-10%) with always-on-error preserve visibility while managing cost.

## How
- New `sampling_rate: Option<f64>` on TelemetryConfig
- Validation at config load (reject < 0.0 or > 1.0)
- ParentBased(TraceIdRatioBased) when rate is set
- TODO: always-sample-on-error requires #301 for error detection at span close
- 15 new tests

**Depends on** #315 (PR #836)

Closes #311