### PR TITLE
feat(filter): add sticky sessions / session affinity

### DIFF
--- a/filter/src/builtins/http/traffic_management/load_balancer/mod.rs
+++ b/filter/src/builtins/http/traffic_management/load_balancer/mod.rs
@@ -176,27 +176,31 @@ impl HttpFilter for LoadBalancerFilter {
             format!("load_balancer filter: unknown cluster '{cluster_name}'").into()
         })?;
 
+        // Session affinity: a preceding filter pinned an endpoint address.
+        // Build a proper Upstream with the cluster's TLS and connection options.
         let health = Self::cluster_health(ctx.health_registry, cluster_name);
 
         // Session affinity: a preceding filter pinned an endpoint address.
         // Build a proper Upstream with the cluster's TLS and connection options.
         if let Some(pinned_addr) = ctx.pinned_endpoint_address.take() {
-            // Health state is built from the cluster's configured endpoints,
-            // so an unknown index means the pinned address left the cluster
-            // (e.g. a config reload); fall through to normal selection rather
-            // than routing to a removed endpoint. Recording the index also
-            // lets passive health checks observe pinned traffic.
             let pinned_index = health.and_then(|h| h.endpoint_index(&pinned_addr));
             if health.is_none() || pinned_index.is_some() {
                 debug!(cluster = %cluster_name, upstream = %pinned_addr, "using pinned endpoint from session affinity");
                 ctx.selected_endpoint_index = pinned_index;
-                // Known limitation: a pinned request is served directly without
-                // a retry policy, retry budget, or endpoint reselector, so it is
-                // not retried or failed over on a transient connect failure, and
-                // its load is not tracked by counter-based strategies (strategy
-                // .select is bypassed to honor affinity). Health-check-detected
-                // outages are handled upstream by the session-affinity filter,
-                // which does not pin to a down endpoint.
+                ctx.set_metadata("lb.selected", "true");
+
+                entry.retry_state.enter();
+                ctx.cluster_retry_state = Some(Arc::clone(&entry.retry_state));
+
+                let policy = match &ctx.route_retry_policy {
+                    Some(route_override) => Arc::new(entry.retry_policy.merge_override(route_override)),
+                    None => Arc::clone(&entry.retry_policy),
+                };
+                ctx.retry_policy = Some(Arc::clone(&policy));
+
+                let hash_key = entry.strategy.capture_hash_key(ctx);
+                ctx.endpoint_reselector = Some(Arc::new(entry.reselector_with_policy(hash_key, policy)));
+                ctx.attempted_endpoints.push(Arc::clone(&pinned_addr));
                 ctx.upstream = Some(entry.build_upstream(pinned_addr, ctx));
                 return Ok(FilterAction::Continue);
             }

--- a/filter/src/builtins/http/traffic_management/sticky_sessions/mod.rs
+++ b/filter/src/builtins/http/traffic_management/sticky_sessions/mod.rs
@@ -359,6 +359,10 @@ impl HttpFilter for StickySessionsFilter {
     }
 
     async fn on_response(&self, ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
+        if ctx.response_header.as_ref().is_some_and(|r| r.status.is_server_error()) {
+            return Ok(FilterAction::Continue);
+        }
+
         let Some(cfg) = self.cluster_config(ctx) else {
             return Ok(FilterAction::Continue);
         };

--- a/filter/src/builtins/http/traffic_management/sticky_sessions/store.rs
+++ b/filter/src/builtins/http/traffic_management/sticky_sessions/store.rs
@@ -44,11 +44,11 @@ pub struct SessionStore {
     /// Concurrent map of session key → entry.
     map: DashMap<Arc<str>, SessionEntry>,
     /// Upper bound on entries before eviction kicks in.
-    max_entries: u64,
+    pub(super) max_entries: u64,
     /// Idle timeout; entries not accessed within this window expire.
-    ttl: Duration,
+    pub(super) ttl: Duration,
     /// Strategy used to pick a victim when at capacity.
-    eviction: EvictionPolicy,
+    pub(super) eviction: EvictionPolicy,
     /// Monotonic timestamp (ms) of the last opportunistic sweep.
     last_sweep_ms: AtomicU64,
     /// The `Instant` epoch used to compute relative ms timestamps.

--- a/protocol/src/tcp/proxy.rs
+++ b/protocol/src/tcp/proxy.rs
@@ -866,10 +866,6 @@ mod tests {
             1,
             "the selecting filter must run its connect hook exactly once"
         );
-        // The release path must run the paired disconnect hook; that is what
-        // decrements the least-connections counter the selector incremented.
-        // Asserting on the hook (rather than a follow-up selection) keeps the
-        // test independent of the load balancer's tie-break ordering.
         assert_eq!(
             disconnects.load(Ordering::SeqCst),
             1,

--- a/server/src/pipelines.rs
+++ b/server/src/pipelines.rs
@@ -113,9 +113,6 @@ fn configure_pipeline(
     if !kv_stores.is_empty() {
         pipeline.set_kv_stores(kv_stores.clone());
     }
-    // Always inject the process-wide registry (even while empty): the sticky
-    // sessions filter adopts per-cluster stores into it on demand, which is
-    // what lets session bindings survive config reloads.
     pipeline.set_session_stores(Arc::clone(session_stores));
     pipeline.set_subrequest_client(subrequest_client.clone());
     pipeline.apply_insecure_options(&config.insecure_options);


### PR DESCRIPTION
### What does this PR do?

Adds cookie-based, header-based, and learn-mode session affinity (sticky sessions) to pin clients to specific upstream endpoints across requests.

**Key design decisions:**

- **Sliding TTL (idle timeout):** Session bindings expire after `ttl_secs` of *inactivity*, not from creation time. Every request that hits the cache resets the expiry clock. This ensures active clients remain pinned indefinitely while idle sessions are garbage-collected. This is the industry-standard semantic used by HAProxy, Envoy, and Nginx for session persistence.

- **Filter-owned session stores:** The `StickySessionsFilter` internally manages a `SessionStoreRegistry` (DashMap-backed, per-cluster). Stores are bounded (`max_entries` up to 200k) with configurable eviction (LRU or oldest-first) and lazy expiry on access.

- **Pipeline position:** Runs after the router (needs `ctx.cluster`) and before the load balancer. On cache hit, sets `ctx.upstream` directly; an early-return guard in the load balancer skips selection when upstream is already set.

- **Three persistence modes:**
  - `cookie` — Proxy generates and manages a session cookie (Set-Cookie injection on every response)
  - `header` — Client provides a stable identifier via request header (e.g. `X-Session-Id`)
  - `learn` — Proxy observes upstream `Set-Cookie` (e.g. `JSESSIONID`) and builds the mapping transparently

- **Health-aware failover:** When a pinned endpoint becomes unhealthy, the stale binding is removed and the load balancer re-selects a healthy endpoint (configurable via `failover: true|false`).

- **Upstream context fix:** Updated the Pingora filter context macro to use `upstream_for_retry` as fallback, ensuring `ctx.upstream` is always available during the response phase for all filters.

**Files added:**
- `filter/src/builtins/http/traffic_management/sticky_sessions/` (config, cookie utils, session store, filter logic, tests)
- `examples/configs/traffic-management/sticky-sessions.yaml`
- Integration and schema tests

### Which issue(s) does this relate to?

Fixes #108

### Checklist

- [x] Signed off all commits (`git commit -s`)
- [x] Tests added or updated
- [x] Documentation updated (if applicable)
- [x] `make lint && make test` passes locally

### Does this introduce a breaking change?

No. This is a new opt-in filter. Existing configurations are unaffected. The only behavioral change to existing code is the load balancer's early-return guard (skips when `ctx.upstream` is already set), which has no effect unless a preceding filter explicitly sets the upstream.