### PR TITLE
feat(filter,protocol): span events for rejection, timeout, retry, error

### DIFF
--- a/filter/src/builtins/http/traffic_management/circuit_breaker/mod.rs
+++ b/filter/src/builtins/http/traffic_management/circuit_breaker/mod.rs
@@ -24,7 +24,7 @@ use metrics::SharedString;
 use praxis_core::circuit::{
     CircuitBreaker, CircuitBreakerConfig as CoreCircuitBreakerConfig, CircuitCheck, CircuitState, CircuitToken,
 };
-use tracing::{debug, info, warn};
+use tracing::{debug, warn};
 
 use self::config::CircuitBreakerConfig;
 use crate::{
@@ -243,7 +243,7 @@ impl HttpFilter for CircuitBreakerFilter {
                 Ok(FilterAction::Continue)
             },
             CircuitCheck::Rejected => {
-                info!(cluster = %cluster_name, "circuit open, rejecting request");
+                warn!(cluster = %cluster_name, "circuit breaker tripped, rejecting request");
                 Ok(FilterAction::Reject(
                     Rejection::status(503).with_header("X-Circuit-State", "open"),
                 ))

--- a/filter/src/pipeline/http_utils.rs
+++ b/filter/src/pipeline/http_utils.rs
@@ -122,10 +122,10 @@ pub(super) fn dispatch_body_result(
             Ok(BodyFilterOutcome::Released)
         },
         Ok(FilterAction::Reject(rejection)) => {
-            debug!(
+            warn!(
                 filter = filter_name,
                 status = rejection.status,
-                "filter rejected {phase}"
+                "{phase} rejected by filter"
             );
             Ok(BodyFilterOutcome::Rejected(rejection))
         },
@@ -210,10 +210,10 @@ pub(super) async fn run_request_filter(
             Ok(HeaderFilterOutcome::Continue)
         },
         Ok(FilterAction::Reject(rejection)) => {
-            debug!(
+            warn!(
                 filter = http_filter.name(),
                 status = rejection.status,
-                "filter rejected request"
+                "request rejected by filter"
             );
             Ok(HeaderFilterOutcome::Rejected(rejection))
         },
@@ -328,7 +328,7 @@ pub(super) async fn run_response_filter(
             warn!(
                 filter = http_filter.name(),
                 status = rejection.status,
-                "filter rejected response"
+                "response rejected by filter"
             );
             Ok(HeaderFilterOutcome::Rejected(rejection))
         },
@@ -564,6 +564,70 @@ mod tests {
     }
 
     // -------------------------------------------------------------------------
+    // Span Event Tests
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn dispatch_body_result_rejection_returns_status() {
+        let rejection = Rejection::status(413);
+        let outcome = dispatch_body_result(
+            Ok(FilterAction::Reject(rejection)),
+            "size_limit",
+            "request body",
+            FailureMode::Closed,
+        )
+        .unwrap();
+        assert!(
+            matches!(&outcome, BodyFilterOutcome::Rejected(r) if r.status == 413),
+            "body rejection should carry status 413 for span event"
+        );
+    }
+
+    #[test]
+    fn dispatch_body_result_response_rejection_returns_status() {
+        let rejection = Rejection::status(500);
+        let outcome = dispatch_body_result(
+            Ok(FilterAction::Reject(rejection)),
+            "transform_filter",
+            "response body",
+            FailureMode::Closed,
+        )
+        .unwrap();
+        assert!(
+            matches!(&outcome, BodyFilterOutcome::Rejected(r) if r.status == 500),
+            "response body rejection should carry status 500 for span event"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_request_filter_rejection_returns_rejected_outcome() {
+        let filter = RejectingFilter(429);
+        let req = crate::test_utils::make_request(http::Method::GET, "/");
+        let mut ctx = crate::test_utils::make_filter_context(&req);
+        let outcome = run_request_filter(&filter, &mut ctx, FailureMode::Closed, false)
+            .await
+            .unwrap();
+        assert!(
+            matches!(&outcome, HeaderFilterOutcome::Rejected(r) if r.status == 429),
+            "rejecting filter should produce Rejected outcome with status for span event"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_response_filter_rejection_returns_rejected_outcome() {
+        let filter = ResponseRejectingFilter(503);
+        let req = crate::test_utils::make_request(http::Method::GET, "/");
+        let mut ctx = crate::test_utils::make_filter_context(&req);
+        let outcome = run_response_filter(&filter, &mut ctx, FailureMode::Closed, false)
+            .await
+            .unwrap();
+        assert!(
+            matches!(&outcome, HeaderFilterOutcome::Rejected(r) if r.status == 503),
+            "response rejection should produce Rejected outcome with status for span event"
+        );
+    }
+
+    // -------------------------------------------------------------------------
     // Test Utilities
     // -------------------------------------------------------------------------
 
@@ -578,6 +642,38 @@ mod tests {
 
         async fn on_request(&self, _ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
             Ok(FilterAction::Continue)
+        }
+    }
+
+    /// HTTP filter that always rejects requests with the given status.
+    struct RejectingFilter(u16);
+
+    #[async_trait::async_trait]
+    impl HttpFilter for RejectingFilter {
+        fn name(&self) -> &'static str {
+            "rejecting_filter"
+        }
+
+        async fn on_request(&self, _ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
+            Ok(FilterAction::Reject(Rejection::status(self.0)))
+        }
+    }
+
+    /// HTTP filter that always rejects responses with the given status.
+    struct ResponseRejectingFilter(u16);
+
+    #[async_trait::async_trait]
+    impl HttpFilter for ResponseRejectingFilter {
+        fn name(&self) -> &'static str {
+            "response_rejecting_filter"
+        }
+
+        async fn on_request(&self, _ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
+            Ok(FilterAction::Continue)
+        }
+
+        async fn on_response(&self, _ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
+            Ok(FilterAction::Reject(Rejection::status(self.0)))
         }
     }
 }

--- a/filter/src/pipeline/mod.rs
+++ b/filter/src/pipeline/mod.rs
@@ -394,7 +394,9 @@ pub(crate) fn check_failure_mode(
             warn!(
                 filter = filter_name,
                 error = %error,
-                "filter error during {phase}, continuing (failure_mode=open)"
+                phase,
+                failure_mode = "open",
+                "filter error, continuing"
             );
             Ok(())
         },
@@ -402,7 +404,9 @@ pub(crate) fn check_failure_mode(
             error!(
                 filter = filter_name,
                 error = %error,
-                "filter error during {phase}, aborting"
+                phase,
+                failure_mode = "closed",
+                "filter error, aborting request"
             );
             Err(error)
         },

--- a/protocol/src/http/pingora/handler/fail_to_proxy.rs
+++ b/protocol/src/http/pingora/handler/fail_to_proxy.rs
@@ -33,6 +33,7 @@ struct ProxyError {
 /// response), dead downstream connections, and HEAD requests (body
 /// suppressed). Writable downstream failures (e.g. client body read
 /// timeout) receive a structured 400 response.
+#[expect(clippy::too_many_lines, reason = "upstream error event adds structured fields")]
 pub(super) async fn execute(session: &mut Session, e: &pingora_core::Error, ctx: &PingoraRequestCtx) -> FailToProxy {
     let etype = e.etype().clone();
     let formatter = ctx.extensions.get::<ErrorResponseFormatterHandle>();
@@ -47,6 +48,18 @@ pub(super) async fn execute(session: &mut Session, e: &pingora_core::Error, ctx:
     }
 
     let err = classify_error(&etype, source);
+
+    let upstream_address = ctx
+        .upstream_for_retry
+        .as_ref()
+        .map_or("unknown", |u| u.address.as_ref());
+    error!(
+        error_code = err.code,
+        error_message = err.message,
+        status = err.status,
+        upstream_address,
+        "upstream error"
+    );
 
     if final_response_written(session) {
         debug!(

--- a/protocol/src/http/pingora/handler/mod.rs
+++ b/protocol/src/http/pingora/handler/mod.rs
@@ -259,17 +259,24 @@ fn handle_connect_failure(ctx: &mut PingoraRequestCtx, e: Box<pingora_core::Erro
 }
 
 /// Decide whether an idempotent request may retry after a connect failure.
+#[expect(clippy::too_many_lines, reason = "retry span events add structured fields")]
 fn maybe_retry_idempotent_connect(
     ctx: &mut PingoraRequestCtx,
     cluster: ::metrics::SharedString,
     e: Box<pingora_core::Error>,
 ) -> Box<pingora_core::Error> {
+    let upstream_address = ctx
+        .upstream_for_retry
+        .as_ref()
+        .map_or("unknown", |u| u.address.as_ref());
+
     let mutated_len = ctx.mutated_request_body_len.unwrap_or(0) as u64;
     if std::cmp::max(ctx.request_body_bytes, mutated_len) > RETRY_BODY_LIMIT {
         warn!(
             body_bytes = ctx.request_body_bytes,
             mutated_len = ?ctx.mutated_request_body_len,
             limit = RETRY_BODY_LIMIT,
+            upstream_address,
             "skipping retry: request body exceeds Pingora retry buffer limit"
         );
         record_retry_exhausted_if_attempted(ctx, cluster);
@@ -277,19 +284,23 @@ fn maybe_retry_idempotent_connect(
     }
     if (ctx.retries as usize) < MAX_RETRIES {
         ctx.retries += 1;
-        debug!(
-            retries = ctx.retries,
-            max = MAX_RETRIES,
-            "retrying idempotent request after connect failure"
+        warn!(
+            attempt = ctx.retries,
+            max_retries = MAX_RETRIES,
+            upstream_address,
+            reason = %e,
+            "retry attempt after upstream connect failure"
         );
         let mut e = e;
         e.set_retry(true);
         return e;
     }
     warn!(
-        retries = ctx.retries,
-        max = MAX_RETRIES,
-        "retry limit reached for idempotent request"
+        attempt = ctx.retries,
+        max_retries = MAX_RETRIES,
+        upstream_address,
+        reason = %e,
+        "retry limit exhausted"
     );
     metrics::record_upstream_retry(cluster, metrics::RETRY_RESULT_EXHAUSTED);
     e
@@ -1266,6 +1277,69 @@ mod tests {
         );
         ctx.request_span.record("upstream.cluster", "api-cluster");
         ctx.request_span.record("upstream.address", "10.0.0.1:80");
+    }
+
+    // -------------------------------------------------------------------------
+    // Span Event Tests
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn retry_with_upstream_address_sets_retry_flag() {
+        let mut ctx = PingoraRequestCtx::default();
+        ctx.request_is_idempotent = true;
+        ctx.upstream_for_retry = Some(Upstream {
+            address: Arc::from("10.0.0.1:8080"),
+            connection: Arc::new(ConnectionOptions::default()),
+            tls: None,
+        });
+        let e = handle_connect_failure(&mut ctx, make_error());
+        assert!(e.retry(), "should retry with upstream address present");
+        assert_eq!(ctx.retries, 1, "retry counter should increment to 1");
+    }
+
+    #[test]
+    fn retry_without_upstream_address_uses_fallback() {
+        let mut ctx = PingoraRequestCtx::default();
+        ctx.request_is_idempotent = true;
+        ctx.upstream_for_retry = None;
+        let e = handle_connect_failure(&mut ctx, make_error());
+        assert!(
+            e.retry(),
+            "should retry even when upstream_for_retry is None (address defaults to unknown)"
+        );
+        assert_eq!(ctx.retries, 1, "retry counter should increment to 1");
+    }
+
+    #[test]
+    fn retry_exhausted_with_upstream_address_does_not_retry() {
+        let mut ctx = PingoraRequestCtx::default();
+        ctx.request_is_idempotent = true;
+        ctx.retries = MAX_RETRIES as u32;
+        ctx.upstream_for_retry = Some(Upstream {
+            address: Arc::from("10.0.0.2:443"),
+            connection: Arc::new(ConnectionOptions::default()),
+            tls: None,
+        });
+        let e = handle_connect_failure(&mut ctx, make_error());
+        assert!(
+            !e.retry(),
+            "should not retry after MAX_RETRIES even with upstream address"
+        );
+    }
+
+    #[test]
+    fn large_body_skip_with_upstream_address() {
+        let mut ctx = PingoraRequestCtx::default();
+        ctx.request_is_idempotent = true;
+        ctx.request_body_bytes = RETRY_BODY_LIMIT + 1;
+        ctx.upstream_for_retry = Some(Upstream {
+            address: Arc::from("10.0.0.3:8080"),
+            connection: Arc::new(ConnectionOptions::default()),
+            tls: None,
+        });
+        let e = handle_connect_failure(&mut ctx, make_error());
+        assert!(!e.retry(), "should not retry large body even with upstream address");
+        assert_eq!(ctx.retries, 0, "retry counter should not increment");
     }
 
     // -------------------------------------------------------------------------

--- a/protocol/src/http/pingora/handler/request_filter/mod.rs
+++ b/protocol/src/http/pingora/handler/request_filter/mod.rs
@@ -922,9 +922,6 @@ mod tests {
             "span should be disabled before pipeline runs"
         );
         drop(run_pipeline(&empty_pipeline(), make_request(), &mut ctx).await.unwrap());
-        // The span is created in execute() before run_pipeline, but
-        // run_pipeline tests don't go through execute(). Verify
-        // the default is disabled, which confirms no premature creation.
         assert!(
             ctx.request_span.is_disabled(),
             "run_pipeline alone should not create the request span"
@@ -938,7 +935,6 @@ mod tests {
         ctx.request_span = span;
 
         let result = run_pipeline(&empty_pipeline(), make_request(), &mut ctx).await.unwrap();
-        // Empty pipeline produces no extra headers containing x-request-id.
         assert!(
             result
                 .extra_headers


### PR DESCRIPTION
## Summary

- Add structured span events for key request lifecycle moments
- Events: rejection by filter, request timeout, retry attempts, upstream errors
- Structured fields on events for grep-friendly tracing output

Closes #309

## Dependencies

Depends on #908 (root span per request) — first commit is the #301 dependency.

## Test plan

- [ ] Verify rejection events appear on span
- [ ] Verify retry events include attempt count and reason
- [ ] Verify error events include upstream address and error details