### PR TITLE
feat(filter): access log trace ID correlation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3166,6 +3166,7 @@ dependencies = [
  "jsonwebtoken",
  "metrics",
  "metrics-exporter-prometheus",
+ "opentelemetry",
  "percent-encoding",
  "praxis-proxy-core",
  "praxis-proxy-tls",
@@ -3182,6 +3183,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tokio",
  "tracing",
+ "tracing-opentelemetry",
  "yaml_serde",
  "zeroize",
 ]

--- a/filter/Cargo.toml
+++ b/filter/Cargo.toml
@@ -23,6 +23,10 @@ basic-auth-filter = [
     "dep:sha2",
     "dep:subtle",
 ]
+otel = [
+    "dep:opentelemetry",
+    "dep:tracing-opentelemetry",
+]
 
 [lints]
 workspace = true
@@ -35,6 +39,7 @@ cpex = { workspace = true, optional = true }
 dashmap = { workspace = true }
 http = { workspace = true }
 metrics = { workspace = true }
+opentelemetry = { workspace = true, optional = true }
 percent-encoding = { workspace = true }
 pingora-core = { workspace = true }
 praxis-core = { workspace = true }
@@ -53,6 +58,7 @@ thiserror = { workspace = true }
 # construction and JWT identity plugins that fetch JWKS at init time.
 tokio = { workspace = true, features = ["rt", "sync", "time", "net"] }
 tracing = { workspace = true }
+tracing-opentelemetry = { workspace = true, optional = true }
 zeroize = { workspace = true }
 
 [dev-dependencies]

--- a/filter/src/builtins/http/observability/access_log.rs
+++ b/filter/src/builtins/http/observability/access_log.rs
@@ -118,22 +118,70 @@ impl AccessLogFilter {
     }
 
     /// Emit a structured access log entry for the current request.
+    ///
+    /// When the `otel` feature is enabled and a valid `OpenTelemetry` context
+    /// is attached to the current tracing span, the entry includes `trace_id`
+    /// (32-char hex, W3C format) and `span_id` (16-char hex) fields for
+    /// correlation with OTLP-exported traces. The fields are omitted when
+    /// no `OTel` context is available.
+    #[expect(clippy::too_many_lines, reason = "dual info! paths for optional OTel trace fields")]
     fn emit_access_log(ctx: &HttpFilterContext<'_>, status: u16) {
         let path = sanitize_for_log(ctx.request.uri.path());
         let client_ip = ctx.client_addr.map(|a| a.to_string()).unwrap_or_default();
+
+        #[cfg(feature = "otel")]
+        if let Some((trace_id, span_id)) = Self::extract_otel_ids() {
+            info!(
+                method = %ctx.request.method,
+                path = %path,
+                client_ip = %client_ip,
+                cluster = ctx.cluster_name().unwrap_or("-"),
+                duration_ms = truncate_u128(ctx.request_start.elapsed().as_millis()),
+                request_body_bytes = ctx.request_body_bytes,
+                request_id = ctx.request_id().unwrap_or("-"),
+                response_body_bytes = ctx.response_body_bytes,
+                span_id = %span_id,
+                status,
+                trace_id = %trace_id,
+                upstream = ctx.upstream_addr().unwrap_or("-"),
+                "access"
+            );
+            return;
+        }
+
         info!(
             method = %ctx.request.method,
             path = %path,
             client_ip = %client_ip,
-            status,
-            duration_ms = truncate_u128(ctx.request_start.elapsed().as_millis()),
             cluster = ctx.cluster_name().unwrap_or("-"),
-            upstream = ctx.upstream_addr().unwrap_or("-"),
-            request_id = ctx.request_id().unwrap_or("-"),
+            duration_ms = truncate_u128(ctx.request_start.elapsed().as_millis()),
             request_body_bytes = ctx.request_body_bytes,
+            request_id = ctx.request_id().unwrap_or("-"),
             response_body_bytes = ctx.response_body_bytes,
+            status,
+            upstream = ctx.upstream_addr().unwrap_or("-"),
             "access"
         );
+    }
+
+    /// Extract `trace_id` and `span_id` from the `OpenTelemetry` context
+    /// attached to the current tracing span.
+    ///
+    /// Returns `None` when no `OTel` layer is active or the span context
+    /// is invalid (e.g. tracing is not configured with OTLP export).
+    #[cfg(feature = "otel")]
+    fn extract_otel_ids() -> Option<(String, String)> {
+        use opentelemetry::trace::TraceContextExt as _;
+        use tracing_opentelemetry::OpenTelemetrySpanExt as _;
+
+        let span = tracing::Span::current();
+        let otel_ctx = span.context();
+        let span_ref = otel_ctx.span();
+        let span_context = span_ref.span_context();
+
+        span_context
+            .is_valid()
+            .then(|| (span_context.trace_id().to_string(), span_context.span_id().to_string()))
     }
 }
 
@@ -653,6 +701,52 @@ mod tests {
             mapped.to_string(),
             "::ffff:10.0.0.1",
             "un-normalized mapped address keeps ::ffff: prefix in Display"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // OTel Trace ID Correlation
+    // -------------------------------------------------------------------------
+
+    #[cfg(feature = "otel")]
+    #[test]
+    fn extract_otel_ids_returns_none_without_otel_subscriber() {
+        let span = tracing::info_span!("test_no_otel");
+        let _guard = span.enter();
+        assert!(
+            AccessLogFilter::extract_otel_ids().is_none(),
+            "extract_otel_ids should return None without an OTel subscriber"
+        );
+    }
+
+    #[cfg(feature = "otel")]
+    #[test]
+    fn extract_otel_ids_returns_none_with_no_active_span() {
+        assert!(
+            AccessLogFilter::extract_otel_ids().is_none(),
+            "extract_otel_ids should return None when no span is active"
+        );
+    }
+
+    #[cfg(feature = "otel")]
+    #[tokio::test]
+    async fn emit_access_log_continues_without_otel_context() {
+        let filter = AccessLogFilter {
+            sample_every: 1,
+            counter: AtomicU64::default(),
+        };
+        let req = crate::test_utils::make_request(http::Method::GET, "/");
+        let mut ctx = crate::test_utils::make_filter_context(&req);
+        ctx.current_filter_id = Some(42);
+        let mut resp = crate::context::Response {
+            headers: http::HeaderMap::new(),
+            status: http::StatusCode::OK,
+        };
+        ctx.response_header = Some(&mut resp);
+        let action = filter.on_response(&mut ctx).await.unwrap();
+        assert!(
+            matches!(action, FilterAction::Continue),
+            "on_response should continue without OTel context"
         );
     }
 }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -51,4 +51,4 @@ cpex-policy-engine = ["praxis-filter/cpex-policy-engine"]
 # Marker feature activated transitively by any experimental feature.
 # Used to gate the startup warning in startup_checks::warn_experimental_features.
 experimental = []
-otel = ["praxis-core/otel"]
+otel = ["praxis-core/otel", "praxis-filter/otel"]


### PR DESCRIPTION
## Summary

- Add trace ID field to access log output for log-trace correlation
- Enables operators to jump from access log entries to distributed traces

Closes #317

## Dependencies

Depends on #908 (root span per request) — first commit is the #301 dependency.

## Test plan

- [ ] Verify trace_id appears in access log output
- [ ] Verify correlation works with OTel collector
- [ ] Unit tests for trace ID extraction