### PR TITLE
feat(protocol): add missing OTel HTTP semantic convention attributes

### DIFF
--- a/protocol/src/http/pingora/context.rs
+++ b/protocol/src/http/pingora/context.rs
@@ -212,8 +212,9 @@ pub struct PingoraRequestCtx {
     ///
     /// Created during `request_filter` with OpenTelemetry HTTP semantic
     /// convention attributes. Response-phase attributes
-    /// (`http.response.status_code`, `upstream.address`, `upstream.cluster`)
-    /// are recorded in the `logging` hook before the span is dropped.
+    /// (`http.response.status_code`, `http.route`, `error.type`,
+    /// `upstream.address`, `upstream.cluster`) are recorded in the
+    /// `logging` hook before the span is dropped.
     pub request_span: Span,
 
     /// When this request was received.

--- a/protocol/src/http/pingora/handler/mod.rs
+++ b/protocol/src/http/pingora/handler/mod.rs
@@ -475,7 +475,15 @@ fn record_response_span_attributes(session: &Session, ctx: &PingoraRequestCtx) {
         }
         if resp.status.is_server_error() {
             ctx.request_span.record("otel.status_code", "ERROR");
+            ctx.request_span.record("error.type", status.to_string().as_str());
         }
+    }
+
+    if let Some(route) = &ctx.metrics_route {
+        ctx.request_span.record("http.route", route.as_ref());
+        let method = session.req_header().method.as_str();
+        ctx.request_span
+            .record("otel.name", format!("{method} {route}").as_str());
     }
 
     if let Some(upstream) = &ctx.upstream_for_retry {

--- a/protocol/src/http/pingora/handler/request_filter/mod.rs
+++ b/protocol/src/http/pingora/handler/request_filter/mod.rs
@@ -546,15 +546,21 @@ fn apply_pre_read_mutations_to_session(session: &mut Session, mutations: &[Trust
 /// convention attributes.
 ///
 /// Creates an [`info_span!`] named `"http_request"` with the
-/// [OTel span name] set to `{method}` and span kind set to
-/// `SERVER`. Response-phase attributes (`http.response.status_code`,
-/// `upstream.address`) are declared as [`Empty`] and recorded later via
-/// [`record_response_span_attributes`].
+/// [OTel span name] initially set to `{method}`, upgraded to
+/// `{method} {route}` when a route is matched. Span kind is `SERVER`.
+/// Response-phase attributes (`http.response.status_code`,
+/// `http.route`, `error.type`, `upstream.address`, `upstream.cluster`,
+/// `otel.status_code`) are declared as [`Empty`] and recorded later
+/// via [`record_response_span_attributes`].
 ///
 /// [`info_span!`]: tracing::info_span
 /// [OTel span name]: https://opentelemetry.io/docs/specs/semconv/http/http-spans/
 /// [`Empty`]: tracing::field::Empty
 /// [`record_response_span_attributes`]: super::record_response_span_attributes
+#[expect(
+    clippy::too_many_lines,
+    reason = "OTel semantic convention attributes require many span fields"
+)]
 fn create_request_span(session: &Session, ctx: &PingoraRequestCtx) -> tracing::Span {
     let method = session.req_header().method.as_str();
     let path = session.req_header().uri.path();
@@ -563,6 +569,12 @@ fn create_request_span(session: &Session, ctx: &PingoraRequestCtx) -> tracing::S
     let host = session.req_header().headers.get("host").and_then(|v| v.to_str().ok());
     let server_address = host.map(|h| h.split(':').next().unwrap_or(h));
     let server_port = host.and_then(|h| h.split_once(':').and_then(|(_, p)| p.parse::<u16>().ok()));
+    let url_scheme = if ctx.downstream_tls { "https" } else { "http" };
+    let user_agent = session
+        .req_header()
+        .headers
+        .get("user-agent")
+        .and_then(|v| v.to_str().ok());
 
     let span = tracing::info_span!(
         "http_request",
@@ -570,13 +582,17 @@ fn create_request_span(session: &Session, ctx: &PingoraRequestCtx) -> tracing::S
         "otel.kind" = "server",
         "otel.status_code" = tracing::field::Empty,
         "http.request.method" = method,
+        "http.route" = tracing::field::Empty,
+        "url.scheme" = url_scheme,
         "url.path" = path,
         "http.response.status_code" = tracing::field::Empty,
+        "error.type" = tracing::field::Empty,
         "server.address" = server_address,
         "server.port" = server_port,
         "client.address" = tracing::field::Empty,
         "upstream.address" = tracing::field::Empty,
         "network.protocol.version" = protocol_version,
+        "user_agent.original" = user_agent,
         "upstream.cluster" = tracing::field::Empty,
         request_id = tracing::field::Empty,
     );


### PR DESCRIPTION
## Summary

Followup to #908 — adds required and recommended attributes per the
[OTel HTTP server span semantic conventions](https://opentelemetry.io/docs/specs/semconv/http/http-spans/):

- **`url.scheme`** (Required): `"http"` / `"https"` from downstream TLS state
- **`http.route`** (Conditionally Required): matched route pattern from router filter; also upgrades `otel.name` from `{method}` to `{method} {route}` when available
- **`error.type`** (Conditionally Required): status code string on 5xx errors
- **`user_agent.original`** (Recommended): from `User-Agent` header

Also fixes doc comments to accurately describe attribute lifecycle
(set at creation vs recorded in logging hook).

## Dependencies

None — builds on merged #908.

## Test plan

- [ ] Verify `url.scheme` appears as `http` or `https` in spans
- [ ] Verify `http.route` populated after router filter matches
- [ ] Verify `otel.name` upgrades to `{method} {route}` when route available
- [ ] Verify `error.type` set on 5xx responses
- [ ] Verify `user_agent.original` captured from request headers