### PR TITLE
feat(core): support HTTP/protobuf OTLP export protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1018,7 +1018,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "cpex-core",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tokio",
@@ -1035,7 +1035,7 @@ dependencies = [
  "base64",
  "chrono",
  "cpex-core",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tokio",
@@ -1054,7 +1054,7 @@ dependencies = [
  "cpex-core",
  "futures",
  "jsonwebtoken",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tokio",
@@ -2850,6 +2850,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry-http"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry",
+ "reqwest 0.13.4",
+]
+
+[[package]]
 name = "opentelemetry-otlp"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2857,9 +2870,11 @@ checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
  "http",
  "opentelemetry",
+ "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
+ "reqwest 0.13.4",
  "thiserror 2.0.20",
  "tokio",
  "tonic",
@@ -3137,6 +3152,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
+ "percent-encoding",
  "praxis-proxy-tls",
  "quixotic-plecostomus-core",
  "quixotic-plecostomus-http",
@@ -3999,6 +4015,35 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ nix = { version = "0.31.3", default-features = false, features = ["process", "si
 notify = "8.2.0"
 opentelemetry = { version = "0.32.0", default-features = false, features = ["trace"] }
 opentelemetry_sdk = { version = "0.32.1", default-features = false, features = ["trace", "rt-tokio"] }
-opentelemetry-otlp = { version = "0.32.0", default-features = false, features = ["grpc-tonic", "trace"] }
+opentelemetry-otlp = { version = "0.32.0", default-features = false, features = ["grpc-tonic", "http-proto", "reqwest-client", "trace"] }
 # Temporary fork: https://github.com/praxis-proxy/pingora
 pingora-core = { version = "0.8.2", package = "quixotic-plecostomus-core", features = ["rustls"] }
 pingora-http = { version = "0.8.2", package = "quixotic-plecostomus-http" }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -32,6 +32,7 @@ http = { workspace = true }
 opentelemetry = { workspace = true, optional = true }
 opentelemetry_sdk = { workspace = true, optional = true }
 opentelemetry-otlp = { workspace = true, optional = true }
+percent-encoding = { workspace = true }
 pingora-core = { workspace = true }
 pingora-http = { workspace = true }
 praxis-tls = { workspace = true }

--- a/core/src/config/telemetry.rs
+++ b/core/src/config/telemetry.rs
@@ -168,6 +168,12 @@ impl TelemetryConfig {
                 "telemetry.sampling_rate must be between 0.0 and 1.0, got {rate}"
             ));
         }
+        if self.service_name.as_ref().is_some_and(|s| s.trim().is_empty()) {
+            return Err("telemetry.service_name must not be empty when set".to_owned());
+        }
+        if self.service_version.as_ref().is_some_and(|s| s.trim().is_empty()) {
+            return Err("telemetry.service_version must not be empty when set".to_owned());
+        }
         Ok(())
     }
 
@@ -267,10 +273,17 @@ fn parse_otlp_headers_from_env() -> Option<HashMap<String, String>> {
     let headers: HashMap<String, String> = raw
         .split(',')
         .filter_map(|pair| pair.split_once('='))
-        .map(|(k, v)| (k.trim().to_owned(), v.trim().to_owned()))
+        .map(|(k, v)| (percent_decode(k.trim()), percent_decode(v.trim())))
         .filter(|(k, _)| !k.is_empty())
         .collect();
     if headers.is_empty() { None } else { Some(headers) }
+}
+
+/// Percent-decode a string per RFC 3986.
+fn percent_decode(input: &str) -> String {
+    percent_encoding::percent_decode_str(input)
+        .decode_utf8_lossy()
+        .into_owned()
 }
 
 // -----------------------------------------------------------------------------

--- a/core/src/logging.rs
+++ b/core/src/logging.rs
@@ -208,16 +208,8 @@ fn build_otel_provider(
         return Ok(None);
     };
 
-    if let Ok(protocol) = std::env::var(crate::config::OTLP_PROTOCOL_ENV_VAR)
-        && protocol != "grpc"
-    {
-        return Err(ProxyError::Config(format!(
-            "Praxis supports only gRPC for OTLP export, but {}={protocol}",
-            crate::config::OTLP_PROTOCOL_ENV_VAR,
-        )));
-    }
-
-    let exporter = build_span_exporter(endpoint, &config.otlp_headers)?;
+    let protocol = resolve_otlp_protocol();
+    let exporter = build_span_exporter(endpoint, &config.otlp_headers, &protocol)?;
     let batch_processor = build_batch_processor(exporter, config);
     let resource = build_otel_resource(config);
 
@@ -245,9 +237,35 @@ fn build_otel_provider(
 // OTLP Exporter Builder
 // -----------------------------------------------------------------------------
 
-/// Build the OTLP span exporter with endpoint and optional gRPC headers.
+/// Resolve the OTLP export protocol from `OTEL_EXPORTER_OTLP_PROTOCOL`
+/// env var, defaulting to `"grpc"`.
+#[cfg(feature = "otel")]
+fn resolve_otlp_protocol() -> String {
+    std::env::var(crate::config::OTLP_PROTOCOL_ENV_VAR)
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| "grpc".to_owned())
+}
+
+/// Build the OTLP span exporter for the selected protocol.
 #[cfg(feature = "otel")]
 fn build_span_exporter(
+    endpoint: &str,
+    headers: &Option<std::collections::HashMap<String, String>>,
+    protocol: &str,
+) -> Result<opentelemetry_otlp::SpanExporter, ProxyError> {
+    match protocol {
+        "grpc" => build_grpc_exporter(endpoint, headers),
+        "http/protobuf" => build_http_exporter(endpoint, headers),
+        other => Err(ProxyError::Config(format!(
+            "unsupported OTLP protocol \"{other}\"; supported: \"grpc\", \"http/protobuf\""
+        ))),
+    }
+}
+
+/// Build a gRPC (tonic) OTLP span exporter.
+#[cfg(feature = "otel")]
+fn build_grpc_exporter(
     endpoint: &str,
     headers: &Option<std::collections::HashMap<String, String>>,
 ) -> Result<opentelemetry_otlp::SpanExporter, ProxyError> {
@@ -263,7 +281,29 @@ fn build_span_exporter(
 
     builder
         .build()
-        .map_err(|e| ProxyError::Config(format!("failed to build OTLP span exporter: {e}")))
+        .map_err(|e| ProxyError::Config(format!("failed to build OTLP gRPC exporter: {e}")))
+}
+
+/// Build an HTTP/protobuf OTLP span exporter.
+#[cfg(feature = "otel")]
+fn build_http_exporter(
+    endpoint: &str,
+    headers: &Option<std::collections::HashMap<String, String>>,
+) -> Result<opentelemetry_otlp::SpanExporter, ProxyError> {
+    use opentelemetry_otlp::{WithExportConfig as _, WithHttpConfig as _};
+
+    let mut builder = opentelemetry_otlp::SpanExporter::builder()
+        .with_http()
+        .with_endpoint(endpoint);
+
+    if let Some(hdrs) = headers {
+        let http_headers: std::collections::HashMap<String, String> = hdrs.clone();
+        builder = builder.with_headers(http_headers);
+    }
+
+    builder
+        .build()
+        .map_err(|e| ProxyError::Config(format!("failed to build OTLP HTTP exporter: {e}")))
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add HTTP/protobuf as alternative transport for OTLP span export
- Protocol selected via standard `OTEL_EXPORTER_OTLP_PROTOCOL` env var (default: `grpc`)
- Supported values: `grpc`, `http/protobuf`; unsupported values rejected at startup
- Headers sent as gRPC metadata (tonic) or HTTP headers (reqwest) depending on protocol

## Dependencies

Depends on #906 (OTLP exporter configuration) — first commit is the #299 dependency.

## Test plan

- [ ] Verify gRPC export works (default)
- [ ] Verify HTTP/protobuf export works with `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`
- [ ] Verify unsupported protocol rejected at startup with clear error
- [ ] Verify headers sent correctly for both transports