### PR TITLE
fix(metrics): run recorder upkeep independently of scrapes

### DIFF
--- a/docs/operating/observability.md
+++ b/docs/operating/observability.md
@@ -90,6 +90,11 @@ Praxis records two categories of Prometheus metrics:
 HTTP request metrics (always on when admin is
 enabled) and per-filter duration histograms (opt-in).
 
+Recorder upkeep runs every five seconds whenever the
+admin endpoint is enabled. It is independent of
+Prometheus scrape traffic, so histogram buffers are
+drained even when `/metrics` is not being scraped.
+
 ### HTTP Request Metrics
 
 These are recorded automatically for every proxied

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -43,4 +43,4 @@ rcgen = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 tempfile = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["test-util"] }

--- a/protocol/src/http/pingora/health/mod.rs
+++ b/protocol/src/http/pingora/health/mod.rs
@@ -12,6 +12,7 @@ mod service;
 
 pub(in crate::http::pingora) use service::escape_json_string;
 pub use service::{
-    PingoraAdminService, PingoraHealthService, add_admin_endpoints_to_pingora_server,
-    add_health_endpoint_to_pingora_server,
+    PingoraAdminService, PingoraHealthService, PrometheusAdminRecorder, add_admin_endpoints_to_pingora_server,
+    add_admin_endpoints_to_pingora_server_with_recorder, add_health_endpoint_to_pingora_server,
+    install_prometheus_admin_recorder,
 };

--- a/protocol/src/http/pingora/health/service.rs
+++ b/protocol/src/http/pingora/health/service.rs
@@ -3,15 +3,27 @@
 
 //! Admin health-check HTTP service.
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use http::Response;
 use pingora_core::{
-    apps::http_app::ServeHttp, protocols::http::ServerSession, server::Server, services::listening::Service,
+    apps::http_app::ServeHttp,
+    protocols::http::ServerSession,
+    server::Server,
+    services::{
+        background::{BackgroundService, background_service},
+        listening::Service,
+    },
 };
 use praxis_core::{health::HealthRegistry, kv::KvStoreRegistry};
-use tracing::info;
+use tokio::time::Duration;
+use tracing::{error, info};
 
 use crate::http::pingora::{json::json_response, kv::dispatch_kv_request, metrics};
+
+/// Recorder upkeep runs independently of Prometheus scrape traffic.
+const PROMETHEUS_UPKEEP_INTERVAL: Duration = Duration::from_secs(5);
 
 // -----------------------------------------------------------------------------
 // JSON Escaping
@@ -203,6 +215,74 @@ fn prometheus_response() -> Response<Vec<u8>> {
     }
 }
 
+/// Pingora-managed recorder maintenance service.
+struct PrometheusUpkeepService {
+    /// Exporter handle used by each recorder maintenance pass.
+    handle: metrics_exporter_prometheus::PrometheusHandle,
+}
+
+/// Recorder installed for the combined admin endpoint.
+///
+/// The concrete exporter handle stays private so applications cannot create a
+/// second lifecycle for the recorder. Pass this value to
+/// [`add_admin_endpoints_to_pingora_server_with_recorder`].
+pub struct PrometheusAdminRecorder {
+    /// Exporter handle shared by metrics rendering and recorder upkeep.
+    handle: metrics_exporter_prometheus::PrometheusHandle,
+}
+
+/// Install the admin Prometheus recorder before startup instrumentation runs.
+#[must_use]
+pub fn install_prometheus_admin_recorder() -> PrometheusAdminRecorder {
+    PrometheusAdminRecorder {
+        handle: metrics::install_prometheus_recorder().clone(),
+    }
+}
+
+#[async_trait]
+impl BackgroundService for PrometheusUpkeepService {
+    async fn start(&self, shutdown: pingora_core::server::ShutdownWatch) {
+        let handle = self.handle.clone();
+        run_prometheus_upkeep(
+            shutdown,
+            PROMETHEUS_UPKEEP_INTERVAL,
+            Arc::new(move || handle.run_upkeep()),
+        )
+        .await;
+    }
+}
+
+/// Closure used for one recorder maintenance pass.
+type UpkeepFn = Arc<dyn Fn() + Send + Sync>;
+
+/// Run non-overlapping upkeep passes until Pingora begins shutdown.
+async fn run_prometheus_upkeep(
+    mut shutdown: pingora_core::server::ShutdownWatch,
+    interval: Duration,
+    upkeep: UpkeepFn,
+) {
+    loop {
+        tokio::select! {
+            _ = shutdown.changed() => break,
+            () = tokio::time::sleep(interval) => {
+                let upkeep = Arc::clone(&upkeep);
+                let task = tokio::task::spawn_blocking(move || upkeep());
+                tokio::select! {
+                    // Dropping the JoinHandle does not cancel a pass that is already
+                    // running, but shutdown remains responsive and no new pass is
+                    // scheduled.
+                    _ = shutdown.changed() => break,
+                    result = task => {
+                        if let Err(error) = result {
+                            error!(?error, "Prometheus recorder upkeep task failed");
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// Add admin endpoints to a Pingora server.
 ///
 /// Installs the global Prometheus metrics recorder and binds a
@@ -225,7 +305,36 @@ pub fn add_admin_endpoints_to_pingora_server(
     kv_registry: Option<KvStoreRegistry>,
     verbose: bool,
 ) {
-    let _handle = metrics::install_prometheus_recorder();
+    add_admin_endpoints_to_pingora_server_with_recorder(
+        server,
+        admin_addr,
+        health_registry,
+        kv_registry,
+        verbose,
+        install_prometheus_admin_recorder(),
+    );
+}
+
+/// Add admin endpoints using an already-installed Prometheus recorder.
+///
+/// This entry point lets applications install the recorder before
+/// startup instrumentation begins while keeping `/metrics` and upkeep on the
+/// same handle.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "preserve the existing admin endpoint argument shape while passing the recorder handle"
+)]
+pub fn add_admin_endpoints_to_pingora_server_with_recorder(
+    server: &mut Server,
+    admin_addr: &str,
+    health_registry: Option<HealthRegistry>,
+    kv_registry: Option<KvStoreRegistry>,
+    verbose: bool,
+    recorder: PrometheusAdminRecorder,
+) {
+    let handle = recorder.handle;
+    let upkeep = PrometheusUpkeepService { handle };
+    server.add_service(background_service("Prometheus upkeep", upkeep));
     let admin = PingoraAdminService::new(health_registry, kv_registry, verbose);
     let mut service = Service::new("admin".to_owned(), admin);
     service.add_tcp(admin_addr);
@@ -375,11 +484,97 @@ fn format_ready_body(status_str: &str, agg: &HealthAggregate) -> String {
 #[expect(clippy::allow_attributes, reason = "blanket test suppressions")]
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing, reason = "tests")]
 mod tests {
-    use std::{collections::HashMap, sync::Arc};
+    use std::{
+        collections::HashMap,
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+    };
 
     use praxis_core::health::{ClusterHealthEntry, EndpointHealth};
+    use tokio::sync::Notify;
 
     use super::*;
+
+    #[tokio::test(start_paused = true)]
+    async fn prometheus_upkeep_waits_for_interval_and_does_not_catch_up() {
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+        let calls = Arc::new(AtomicUsize::new(0));
+        let completed = Arc::new(Notify::new());
+        let observed = Arc::clone(&calls);
+        let observed_completed = Arc::clone(&completed);
+        let task = tokio::spawn(run_prometheus_upkeep(
+            shutdown_rx,
+            Duration::from_secs(5),
+            Arc::new(move || {
+                observed.fetch_add(1, Ordering::SeqCst);
+                observed_completed.notify_one();
+            }),
+        ));
+
+        tokio::task::yield_now().await;
+        assert_eq!(calls.load(Ordering::SeqCst), 0, "upkeep must not run immediately");
+
+        tokio::time::advance(Duration::from_secs(15)).await;
+        completed.notified().await;
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "missed intervals must not queue passes"
+        );
+
+        shutdown_tx.send(true).unwrap();
+        task.await.unwrap();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn prometheus_upkeep_stops_before_the_first_pass() {
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+        let calls = Arc::new(AtomicUsize::new(0));
+        let observed = Arc::clone(&calls);
+        let task = tokio::spawn(run_prometheus_upkeep(
+            shutdown_rx,
+            Duration::from_secs(5),
+            Arc::new(move || {
+                observed.fetch_add(1, Ordering::SeqCst);
+            }),
+        ));
+
+        shutdown_tx.send(true).unwrap();
+        task.await.unwrap();
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn prometheus_upkeep_observes_shutdown_during_a_blocking_pass() {
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+        let started = Arc::new(AtomicUsize::new(0));
+        let release = Arc::new(AtomicUsize::new(0));
+        let started_signal = Arc::new(Notify::new());
+        let observed_started = Arc::clone(&started);
+        let observed_release = Arc::clone(&release);
+        let observed_signal = Arc::clone(&started_signal);
+        let task = tokio::spawn(run_prometheus_upkeep(
+            shutdown_rx,
+            Duration::from_secs(5),
+            Arc::new(move || {
+                observed_started.store(1, Ordering::SeqCst);
+                observed_signal.notify_one();
+                while observed_release.load(Ordering::SeqCst) == 0 {
+                    std::thread::yield_now();
+                }
+            }),
+        ));
+
+        tokio::time::advance(Duration::from_secs(5)).await;
+        started_signal.notified().await;
+        assert_eq!(started.load(Ordering::SeqCst), 1);
+
+        shutdown_tx.send(true).unwrap();
+        task.await.unwrap();
+        release.store(1, Ordering::SeqCst);
+    }
 
     #[test]
     fn json_response_200() {

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -90,12 +90,13 @@ pub fn run_server_with_registry(config: Config, registry: FilterRegistry, config
     init_runtime_limits(&config.runtime);
     warn_insecure_key_permissions(&config);
 
-    // Install the Prometheus recorder before health checks (or any other
-    // instrumentation) start emitting, so the first probe transitions are not
-    // dropped by `is_recorder_installed()` gates.
-    if config.admin.address.is_some() {
-        let _handle = praxis_protocol::http::pingora::metrics::install_prometheus_recorder();
-    }
+    // Install before pipelines and health checks emit startup metrics. The same
+    // handle is later shared by `/metrics` and the managed upkeep service.
+    let prometheus_recorder = config
+        .admin
+        .address
+        .as_ref()
+        .map(|_| praxis_protocol::http::pingora::health::install_prometheus_admin_recorder());
 
     let health_registry = build_health_registry(&config.clusters);
     let state = build_server_state(&config, &registry, &health_registry);
@@ -103,7 +104,13 @@ pub fn run_server_with_registry(config: Config, registry: FilterRegistry, config
     info!("initializing server");
     let mut server = PingoraServerRuntime::new(&config);
     let _cert_shutdowns = register_protocols(&mut server, &config, &state.pipelines);
-    register_admin_endpoints(&mut server, &config, health_registry, &state.kv_stores);
+    register_admin_endpoints(
+        &mut server,
+        &config,
+        health_registry,
+        &state.kv_stores,
+        prometheus_recorder,
+    );
 
     let _watcher = spawn_watcher(config_path, config, registry, state);
 
@@ -250,14 +257,16 @@ fn register_admin_endpoints(
     config: &Config,
     health_registry: HealthRegistry,
     kv_stores: &praxis_core::kv::KvStoreRegistry,
+    prometheus_recorder: Option<praxis_protocol::http::pingora::health::PrometheusAdminRecorder>,
 ) {
-    if let Some(admin_addr) = &config.admin.address {
-        praxis_protocol::http::pingora::health::add_admin_endpoints_to_pingora_server(
+    if let (Some(admin_addr), Some(prometheus_recorder)) = (&config.admin.address, prometheus_recorder) {
+        praxis_protocol::http::pingora::health::add_admin_endpoints_to_pingora_server_with_recorder(
             server.server_mut(),
             admin_addr,
             Some(health_registry),
             Some(kv_stores.clone()),
             config.admin.verbose,
+            prometheus_recorder,
         );
     }
 }


### PR DESCRIPTION
## Summary

  Add scrape-independent Prometheus recorder upkeep to the shared Praxis admin and metrics integration.

  Praxis installs a Prometheus recorder when the admin endpoint is enabled. The recorder buffers histogram observations internally, but installing it does not automatically start its upkeep task. Previously, those buffers were drained as a side effect of rendering `/metrics`. If the endpoint was not scraped, buffered histogram state could accumulate over time.

  This change registers a Pingora-managed background service that calls the recorder’s public `run_upkeep()` API at 5s intervals.

  The implementation applies to all applications using the Praxis admin endpoint. Applications do not need to install another recorder or manage their own maintenance task.

  ## Behavior

  When `admin.address` is configured, Praxis now:

  1. Installs the Prometheus recorder before startup instrumentation begins.
  2. Retains an opaque reference to the installed recorder.
  3. Registers the existing admin endpoints, including /metrics.
  4. Registers one Pingora-managed recorder upkeep service.
  5. Waits five seconds before the first upkeep pass.
  6. Runs each pass on Tokio’s blocking thread pool.
  7. Waits for a pass to finish before scheduling another.
  8. Stops scheduling work when Pingora begins shutdown.

  When the admin endpoint is disabled, the recorder and upkeep service are not installed.

  ## Recorder Ownership

  Recorder installation remains centralized in the shared Praxis admin path.

  The server receives an opaque PrometheusAdminRecorder rather than the raw `PrometheusHandle`. This allows the recorder to be installed before health checks and filter pipelines emit startup metrics while keeping exporter ownership inside the protocol implementation.

  The same process-global recorder is used for:

  - HTTP request metrics;
  - filter histograms;
  - `/metrics` rendering;
  - periodic recorder upkeep.

  No second recorder or exporter is created.

  ## Startup Ordering

  The recorder is installed before pipelines and health-check tasks are built.

  This preserves existing startup behavior and prevents early metric observations from being dropped by recorder-presence checks. The installed recorder is then transferred to admin registration, so it is not looked up or installed a second time during service setup.

  ## Concurrency and Shutdown

  `PrometheusHandle::run_upkeep()` is synchronous and may perform more work as metric cardinality grows. It therefore runs through:

```rust
  tokio::task::spawn_blocking(...)
```

  This keeps recorder maintenance off Pingora and Tokio asynchronous workers.

  Only one upkeep pass may run at a time. The scheduler awaits the current pass before starting the next five-second interval, so slow passes cannot overlap or accumulate in a queue.

  The scheduler continues observing Pingora’s shutdown signal while a blocking pass is running. If shutdown begins, the scheduler returns and does not schedule another pass. Tokio cannot forcibly cancel a blocking closure that has already started, so that individual pass may finish in the blocking pool.

  Join failures are logged without panicking the proxy. Successful maintenance passes do not generate recurring log messages.

  ## Performance

  This change introduces no request-path work.

  It does not:

  - inspect requests or responses;
  - add per-request allocations;
  - change metric recording calls;
  - change filter execution;
  - block proxy workers;
  - create a dedicated operating-system thread;
  - render the Prometheus exposition format during upkeep.

  The only new work is one background maintenance pass after each five-second interval. Each pass drains recorder histogram buffers and publishes pending metric descriptions
  using the recorder’s existing public API.

  ## Alternatives Considered

**- Perform upkeep only while rendering /metrics**

  This leaves histogram maintenance dependent on an external Prometheus scraper. If scraping is absent or interrupted, recorder buffers are not maintained regularly.

**- Start an unmanaged Tokio task**

  A standalone recurring task would not participate in Pingora’s managed service lifecycle or receive its shutdown signal.

**- Run upkeep directly in the asynchronous scheduler**

  This could block an async worker under high metric cardinality and delay shutdown observation. The implementation uses `spawn_blocking` instead.

  ## Performance and Risk

  This change adds no work to the request path. Requests do not perform additional lookups, allocations, synchronization, or recorder maintenance.

  The background service runs one upkeep pass after each five-second interval. It waits for the current pass to finish before scheduling the next, preventing slow passes from overlapping or accumulating.

  The cost of an upkeep pass depends on the amount of buffered histogram and metric-description state. Running it through Tokio’s blocking pool prevents that work from blocking proxy workers, but it still consumes a blocking-pool slot briefly.

  If shutdown begins during upkeep, the scheduler stops immediately and does not schedule another pass. Tokio cannot cancel a blocking closure that has already started, so that individual pass may finish in the background.

  **Primary risks and mitigations:**

  - High metric cardinality: upkeep may take longer, but it remains outside async request workers and cannot overlap with another pass.
  - Missing Prometheus scraper: upkeep continues independently and prevents histogram buffers from depending on scrape traffic.
  - Task failure: join failures are logged without panicking the proxy.
  - Duplicate recorder ownership: one recorder is installed and shared by `/metrics` and upkeep.
  - Shutdown delay: the scheduler observes shutdown while upkeep runs and returns without waiting for the blocking pass.
  - Operational noise: successful five-second passes do not emit logs.

  ## Compatibility

  The existing admin registration API remains available and now automatically registers recorder upkeep.

  The following behavior is unchanged:

  - /metrics route and response format;
  - Prometheus metric names and labels;
  - counters, gauges, and histogram definitions;
  - histogram buckets and quantiles;
  - readiness and health endpoints;
  - KV administration endpoints;
  - behavior when admin.address is omitted.

  No configuration migration is required.

  ## Documentation

  The observability documentation now explains that recorder upkeep runs every five seconds when the admin endpoint is enabled and does not depend on Prometheus scrape traffic.

  ## Test Coverage

  Focused scheduler tests verify that:

  - upkeep does not run immediately at startup;
  - the first pass waits for the configured interval;
  - missed intervals do not queue catch-up passes;
  - shutdown before the first pass prevents upkeep;
  - shutdown remains responsive while a blocking pass is in progress.

  The scheduler tests use paused Tokio time and Notify synchronization. They do not sleep for five seconds of wall-clock time or depend on bounded yield loops.

  ## Validation

  - [x] Formatting check
  - [x] git diff --check
  - [x] Focused upkeep scheduler tests
  - [x] Protocol health tests: 62 passed
  - [x] Praxis tests: 109 + 35 passed
  - [x] Protocol Clippy with warnings denied
  - [x] Server Clippy with warnings denied
  - [x] make lint
  - [x] make test
  - [x] Workspace documentation with warnings denied

  Commands included:

  cargo +nightly-2026-03-28 fmt --all -- --check
  git diff --check
  cargo test -p praxis-proxy-protocol prometheus_upkeep_waits_for_interval_and_does_not_catch_up
  cargo test -p praxis-proxy-protocol prometheus_upkeep_stops_before_the_first_pass
  cargo test -p praxis-proxy-protocol prometheus_upkeep_observes_shutdown_during_a_blocking_pass
  cargo test -p praxis-proxy-protocol health
  cargo test -p praxis-proxy
  cargo clippy -p praxis-proxy-protocol --all-targets -- -D warnings
  cargo clippy -p praxis-proxy --all-targets -- -D warnings
  make lint
  make test
  RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items

  ## Breaking Changes

  None.
  
  Supersedes: https://github.com/praxis-proxy/ai/pull/736
  Closes: https://github.com/praxis-proxy/ai/issues/734