### PR TITLE
feat(core): add streaming SubRequestClient response transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3133,7 +3133,10 @@ version = "0.5.2"
 dependencies = [
  "bytes",
  "dashmap 6.2.1",
+ "h2",
  "http",
+ "metrics",
+ "metrics-exporter-prometheus",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -28,6 +28,7 @@ otel = [
 bytes = { workspace = true }
 dashmap = { workspace = true }
 http = { workspace = true }
+metrics = { workspace = true }
 opentelemetry = { workspace = true, optional = true }
 opentelemetry_sdk = { workspace = true, optional = true }
 opentelemetry-otlp = { workspace = true, optional = true }
@@ -45,4 +46,6 @@ tracing-opentelemetry = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true }
 
 [dev-dependencies]
+h2 = { workspace = true }
+metrics-exporter-prometheus = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time", "net"] }

--- a/core/src/subrequest/body.rs
+++ b/core/src/subrequest/body.rs
@@ -1,0 +1,317 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+use std::time::Duration;
+
+use bytes::Bytes;
+use metrics::{counter, histogram};
+use pingora_core::{connectors::http::Connector, protocols::http::client::HttpSession, upstreams::peer::HttpPeer};
+use tracing::{debug, warn};
+
+use super::{
+    internals::{
+        SUBREQUEST_STREAM_BYTES_TOTAL, SUBREQUEST_STREAM_DURATION_SECONDS, SUBREQUEST_STREAMS_TOTAL,
+        check_clean_completion,
+    },
+    types::{SubRequestError, SubResponseBody},
+};
+
+/// Dispose of a session after abnormal termination (cancel, timeout,
+/// error). H2 streams are released through the connector so the
+/// multiplexed connection survives. H1/Custom sessions are shut down
+/// without pooling because unread response bytes would corrupt the
+/// next response on a reused connection.
+pub(super) async fn dispose_session_abnormal(
+    session: HttpSession<()>,
+    peer: Option<&HttpPeer>,
+    connector: Option<&Connector>,
+) {
+    let mut session = session;
+    session.shutdown().await;
+    if matches!(session, HttpSession::H2(_))
+        && let (Some(peer), Some(connector)) = (peer, connector)
+    {
+        connector.release_http_session(session, peer, None).await;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SubResponseBody
+// ---------------------------------------------------------------------------
+
+impl SubResponseBody {
+    /// Create a body in the completed state (for header-time completion).
+    pub(super) fn new_done() -> Self {
+        Self {
+            session: None,
+            peer: None,
+            connector: None,
+            permit: None,
+            read_timeout: None,
+            idle_timeout: Duration::from_secs(30),
+            stream_deadline: None,
+            max_total_bytes: None,
+            received_bytes: 0,
+            chunk_count: 0,
+            stream_started_at: tokio::time::Instant::now(),
+            done: true,
+        }
+    }
+
+    /// Whether this body has completed (EOF, error, or cancel).
+    pub fn is_done(&self) -> bool {
+        self.done
+    }
+
+    /// Total bytes received so far.
+    pub fn received_bytes(&self) -> usize {
+        self.received_bytes
+    }
+
+    /// Number of chunks received so far.
+    pub fn chunk_count(&self) -> u64 {
+        self.chunk_count
+    }
+
+    /// Pull the next body chunk from the upstream.
+    ///
+    /// Returns:
+    /// - `Ok(Some(chunk))` — a data chunk.
+    /// - `Ok(None)` — clean EOF; the session has been released to the pool.
+    ///
+    /// # Errors
+    ///
+    /// - `Err(StreamIdleTimeout)` — upstream stalled for `idle_timeout`.
+    /// - `Err(DeadlineExceeded)` — `max_stream_duration` expired.
+    /// - `Err(ResponseTooLarge)` — cumulative bytes exceeded `max_total_bytes`.
+    /// - `Err(Io)` — transport error or unclean EOF.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the session is `None` when `done` is `false` (internal
+    /// invariant violation).
+    #[expect(clippy::large_stack_frames, reason = "Pingora session types are large")]
+    #[expect(clippy::too_many_lines, reason = "inline chunk read and deadline enforcement")]
+    #[expect(
+        clippy::expect_used,
+        reason = "session is an invariant: None only when done=true; caller checked !done"
+    )]
+    pub async fn next_chunk(&mut self) -> Result<Option<Bytes>, SubRequestError> {
+        if self.done {
+            return Ok(None);
+        }
+
+        // Check stream deadline before reading.
+        if let Some(deadline) = self.stream_deadline
+            && tokio::time::Instant::now() >= deadline
+        {
+            self.shutdown_and_done("deadline_exceeded").await;
+            return Err(SubRequestError::DeadlineExceeded);
+        }
+
+        let session = self.session.as_mut().expect("session must be present when not done");
+
+        // Compute effective timeout: min(read_timeout, idle_timeout, remaining stream deadline).
+        let mut effective_timeout = self.idle_timeout;
+        if let Some(rt) = self.read_timeout {
+            effective_timeout = effective_timeout.min(rt);
+        }
+        if let Some(deadline) = self.stream_deadline {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                self.shutdown_and_done("deadline_exceeded").await;
+                return Err(SubRequestError::DeadlineExceeded);
+            }
+            effective_timeout = effective_timeout.min(remaining);
+        }
+
+        // Read one chunk with timeout.
+        let read_result = tokio::time::timeout(effective_timeout, session.read_response_body()).await;
+
+        match read_result {
+            Ok(Ok(Some(chunk))) => {
+                self.received_bytes += chunk.len();
+                self.chunk_count += 1;
+
+                // Check byte limit.
+                if let Some(limit) = self.max_total_bytes
+                    && self.received_bytes > limit
+                {
+                    self.shutdown_and_done("byte_limit").await;
+                    return Err(SubRequestError::ResponseTooLarge {
+                        actual: self.received_bytes,
+                        limit,
+                    });
+                }
+
+                // Check for immediate completion after this chunk.
+                match check_clean_completion(self.session.as_mut().expect("session present")) {
+                    Ok(true) => self.release_session().await,
+                    Ok(false) => {},
+                    Err(e) => {
+                        self.shutdown_and_done("h2_error").await;
+                        return Err(e);
+                    },
+                }
+
+                Ok(Some(chunk))
+            },
+            Ok(Ok(None)) => {
+                // No more data. Check clean completion.
+                match check_clean_completion(self.session.as_mut().expect("session present")) {
+                    Ok(true) => {
+                        self.release_session().await;
+                        Ok(None)
+                    },
+                    Ok(false) => {
+                        self.shutdown_and_done("io_error").await;
+                        Err(SubRequestError::Io("upstream closed without clean EOF".to_owned()))
+                    },
+                    Err(e) => {
+                        self.shutdown_and_done("io_error").await;
+                        Err(e)
+                    },
+                }
+            },
+            Ok(Err(e)) => {
+                self.shutdown_and_done("io_error").await;
+                Err(SubRequestError::Io(e.to_string()))
+            },
+            Err(_elapsed) => {
+                // Distinguish stream deadline, read timeout, and idle timeout.
+                if let Some(deadline) = self.stream_deadline
+                    && tokio::time::Instant::now() >= deadline
+                {
+                    self.shutdown_and_done("deadline_exceeded").await;
+                    return Err(SubRequestError::DeadlineExceeded);
+                }
+                if let Some(rt) = self.read_timeout
+                    && rt < self.idle_timeout
+                {
+                    self.shutdown_and_done("read_timeout").await;
+                    return Err(SubRequestError::Io("upstream read timeout".to_owned()));
+                }
+                let idle_timeout = self.idle_timeout;
+                self.shutdown_and_done("idle_timeout").await;
+                Err(SubRequestError::StreamIdleTimeout { idle_timeout })
+            },
+        }
+    }
+
+    /// Shut down the session and mark the body as done.
+    ///
+    /// `done` is set before the first `.await`, so cancellation of
+    /// the cleanup future leaves the body in a valid terminal state.
+    /// The permit is moved into the boxed future so cancellation
+    /// releases it immediately.
+    async fn shutdown_and_done(&mut self, termination: &str) {
+        debug!(
+            termination,
+            duration_s = self.stream_started_at.elapsed().as_secs_f64(),
+            bytes = self.received_bytes,
+            chunks = self.chunk_count,
+            "sub-request: stream terminated"
+        );
+        self.record_stream_metrics(termination);
+        self.done = true;
+        if let Some(session) = self.session.take() {
+            let permit = self.permit.take();
+            let peer_ref = self.peer.as_ref();
+            let conn_ref = self
+                .connector
+                .as_ref()
+                .map(super::internals::SubRequestConnector::connector);
+            Box::pin(async move {
+                dispose_session_abnormal(session, peer_ref, conn_ref).await;
+                drop(permit);
+            })
+            .await;
+        }
+        self.peer.take();
+        self.connector.take();
+    }
+
+    /// Release the session to the connection pool and mark done.
+    ///
+    /// `done` is set before the first `.await`, so cancellation of
+    /// the release future leaves the body in a valid terminal state.
+    /// The permit is moved into the boxed future so cancellation
+    /// releases it immediately.
+    async fn release_session(&mut self) {
+        debug!(
+            duration_s = self.stream_started_at.elapsed().as_secs_f64(),
+            bytes = self.received_bytes,
+            chunks = self.chunk_count,
+            "sub-request: stream completed"
+        );
+        self.record_stream_metrics("eof");
+        self.done = true;
+        if let (Some(session), Some(peer), Some(connector)) =
+            (self.session.take(), self.peer.as_ref(), self.connector.as_ref())
+        {
+            let permit = self.permit.take();
+            Box::pin(async move {
+                connector.connector().release_http_session(session, peer, None).await;
+                drop(permit);
+            })
+            .await;
+        }
+        self.peer.take();
+        self.connector.take();
+    }
+
+    /// Explicitly cancel the streaming response.
+    ///
+    /// Shuts down the upstream session and releases the admission
+    /// permit. Consumes `self`. No-op if the body is already done
+    /// (EOF, error, or prior cancel).
+    pub async fn cancel(mut self) {
+        if !self.done {
+            self.shutdown_and_done("cancel").await;
+        }
+    }
+
+    /// Record stream termination metrics.
+    fn record_stream_metrics(&self, termination: &str) {
+        let elapsed = self.stream_started_at.elapsed().as_secs_f64();
+        counter!(
+            SUBREQUEST_STREAMS_TOTAL,
+            "termination" => termination.to_owned(),
+        )
+        .increment(1);
+        histogram!(SUBREQUEST_STREAM_DURATION_SECONDS).record(elapsed);
+        counter!(SUBREQUEST_STREAM_BYTES_TOTAL).increment(self.received_bytes as u64);
+    }
+}
+
+impl Drop for SubResponseBody {
+    fn drop(&mut self) {
+        if self.done || self.session.is_none() {
+            return;
+        }
+        warn!(
+            duration_s = self.stream_started_at.elapsed().as_secs_f64(),
+            bytes = self.received_bytes,
+            chunks = self.chunk_count,
+            "sub-request: stream dropped without cancel"
+        );
+        self.record_stream_metrics("drop");
+        let Some(session) = self.session.take() else {
+            return;
+        };
+        let peer = self.peer.take();
+        let connector = self.connector.take();
+        let permit = self.permit.take();
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            handle.spawn(async move {
+                Box::pin(dispose_session_abnormal(
+                    session,
+                    peer.as_ref(),
+                    connector.as_ref().map(super::internals::SubRequestConnector::connector),
+                ))
+                .await;
+                drop(permit);
+            });
+        }
+    }
+}

--- a/core/src/subrequest/client.rs
+++ b/core/src/subrequest/client.rs
@@ -1,174 +1,26 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Praxis Contributors
 
-//! Shared HTTP connector and hardened sub-request executor.
-
-use std::{sync::Arc, time::Duration};
+use std::time::Duration;
 
 use bytes::Bytes;
 use http::HeaderMap;
-use pingora_core::{
-    connectors::{ConnectorOptions, http::Connector},
-    upstreams::peer::{HttpPeer, Peer as _},
-};
-use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use metrics::histogram;
+use pingora_core::upstreams::peer::{HttpPeer, Peer as _};
 use tracing::{debug, warn};
 
 use super::{
+    body::dispose_session_abnormal,
     internals::{
-        clamp_peer_timeouts, empty_body_needs_framing, ensure_host_header, min_timeout, strip_hop_by_hop_headers,
-        strip_request_framing_headers, strip_reserved_headers,
+        CircuitGuard, RawExchange, SUBREQUEST_HEADER_DURATION_SECONDS, SubRequestConnector, check_clean_completion,
+        clamp_peer_timeouts, classify_timeout, empty_body_needs_framing, ensure_host_header, min_timeout,
+        record_header_termination, strip_hop_by_hop_headers, strip_request_framing_headers, strip_reserved_headers,
     },
-    types::{FrameworkHeaders, SubRequest, SubRequestError, SubResponse},
+    types::{
+        FrameworkHeaders, StreamLimits, StreamingSubResponse, SubRequest, SubRequestError, SubResponse, SubResponseBody,
+    },
 };
-use crate::circuit::{CircuitBreakerConfig, CircuitBreakerRegistry, CircuitCheck, CircuitToken, PeerKey};
-
-// ---------------------------------------------------------------------------
-// SubRequestConnector
-// ---------------------------------------------------------------------------
-
-/// Options for constructing a [`SubRequestConnector`].
-#[derive(Debug)]
-pub struct SubRequestConnectorOptions {
-    /// Number of idle connections to keep in the pool.
-    pub keepalive_pool_size: usize,
-
-    /// Maximum number of concurrently active exchanges.
-    pub max_connections: Option<usize>,
-
-    /// Circuit breaker configuration for peer-level failure tracking.
-    pub circuit_breaker: Option<CircuitBreakerConfig>,
-}
-
-/// Shared HTTP connector for sub-requests.
-///
-/// Wraps Pingora's [`Connector`] behind an [`Arc`] so that all
-/// filter instances share a single connection pool. Created once at
-/// server startup and passed through unchanged on config reload.
-///
-/// An optional admission semaphore limits the number of concurrently
-/// active sub-request exchanges.
-///
-/// ```
-/// use praxis_core::subrequest::SubRequestConnector;
-///
-/// let connector = SubRequestConnector::new(128, None);
-/// let _clone = connector.clone();
-/// ```
-///
-/// [`Arc`]: std::sync::Arc
-/// [`Connector`]: pingora_core::connectors::http::Connector
-#[derive(Clone)]
-pub struct SubRequestConnector {
-    /// Shared Pingora HTTP connector.
-    pub(super) inner: Arc<Connector<()>>,
-
-    /// Admission semaphore bounding concurrently active exchanges.
-    pub(super) admission: Option<Arc<Semaphore>>,
-
-    /// The configured concurrency limit, retained for error reporting.
-    pub(super) configured_max_connections: Option<usize>,
-
-    /// Per-peer circuit breaker registry.
-    pub(super) circuit_breakers: Option<Arc<CircuitBreakerRegistry>>,
-}
-
-impl SubRequestConnector {
-    /// Create a connector with the given keepalive pool size and
-    /// optional active-connection limit.
-    ///
-    /// ```
-    /// use praxis_core::subrequest::SubRequestConnector;
-    ///
-    /// let connector = SubRequestConnector::new(64, None);
-    /// let bounded = SubRequestConnector::new(64, Some(256));
-    /// ```
-    pub fn new(keepalive_pool_size: usize, max_connections: Option<usize>) -> Self {
-        let options = ConnectorOptions::new(keepalive_pool_size);
-        Self {
-            inner: Arc::new(Connector::new(Some(options))),
-            admission: max_connections.map(|n| Arc::new(Semaphore::new(n))),
-            configured_max_connections: max_connections,
-            circuit_breakers: None,
-        }
-    }
-
-    /// Create a connector from [`SubRequestConnectorOptions`].
-    ///
-    /// ```
-    /// use praxis_core::subrequest::{SubRequestConnector, SubRequestConnectorOptions};
-    ///
-    /// let connector = SubRequestConnector::with_options(SubRequestConnectorOptions {
-    ///     keepalive_pool_size: 64,
-    ///     max_connections: Some(256),
-    ///     circuit_breaker: None,
-    /// });
-    /// ```
-    pub fn with_options(opts: SubRequestConnectorOptions) -> Self {
-        let options = ConnectorOptions::new(opts.keepalive_pool_size);
-        Self {
-            inner: Arc::new(Connector::new(Some(options))),
-            admission: opts.max_connections.map(|n| Arc::new(Semaphore::new(n))),
-            configured_max_connections: opts.max_connections,
-            circuit_breakers: opts
-                .circuit_breaker
-                .map(|cfg| Arc::new(CircuitBreakerRegistry::new(cfg))),
-        }
-    }
-
-    /// Access the underlying Pingora [`Connector`].
-    ///
-    /// [`Connector`]: pingora_core::connectors::http::Connector
-    pub fn connector(&self) -> &Connector<()> {
-        &self.inner
-    }
-
-    /// Acquire an admission permit if a concurrency limit is
-    /// configured. Returns `None` when no limit is set.
-    ///
-    /// The returned permit must be held for the entire sub-request
-    /// exchange. Dropping it releases the slot.
-    pub async fn acquire_permit(&self) -> Option<OwnedSemaphorePermit> {
-        let semaphore = self.admission.as_ref()?;
-        Arc::clone(semaphore).acquire_owned().await.ok()
-    }
-
-    /// Try to acquire an admission permit within the given deadline.
-    ///
-    /// Returns `Ok(Some(permit))` if acquired, `Ok(None)` if no
-    /// concurrency limit is configured, or `Err` if the deadline
-    /// expires before a slot opens.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`SubRequestError::AdmissionTimeout`] when the
-    /// semaphore cannot be acquired within the timeout.
-    pub async fn try_acquire_permit(&self, timeout: Duration) -> Result<Option<OwnedSemaphorePermit>, SubRequestError> {
-        let Some(semaphore) = self.admission.as_ref() else {
-            return Ok(None);
-        };
-        let configured = self.configured_max_connections.unwrap_or(0);
-        match tokio::time::timeout(timeout, Arc::clone(semaphore).acquire_owned()).await {
-            Ok(Ok(permit)) => Ok(Some(permit)),
-            Ok(Err(_closed)) => Err(SubRequestError::AdmissionTimeout {
-                max_connections: configured,
-            }),
-            Err(_elapsed) => Err(SubRequestError::AdmissionTimeout {
-                max_connections: configured,
-            }),
-        }
-    }
-}
-
-impl std::fmt::Debug for SubRequestConnector {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("SubRequestConnector")
-            .field("pool", &"Connector<()>")
-            .field("max_connections", &self.configured_max_connections)
-            .field("circuit_breakers", &self.circuit_breakers.is_some())
-            .finish()
-    }
-}
+use crate::circuit::{CircuitCheck, PeerKey};
 
 // ---------------------------------------------------------------------------
 // SubRequestClient
@@ -190,8 +42,8 @@ impl std::fmt::Debug for SubRequestConnector {
 /// Callers own routing, retries, circuit breaking, SSRF policy,
 /// depth propagation, and status interpretation.
 ///
-/// Responses are fully buffered. Streaming is not supported by
-/// this API.
+/// Supports both buffered ([`execute()`](Self::execute)) and streaming
+/// ([`send_streaming()`](Self::send_streaming)) response modes.
 ///
 /// ```
 /// use praxis_core::subrequest::{SubRequestClient, SubRequestConnector};
@@ -252,6 +104,306 @@ impl SubRequestClient {
             .map_or(0, |registry| registry.evict_idle(idle_threshold))
     }
 
+    /// Shared transport path: admission, connect, I/O, header validation.
+    ///
+    /// Returns a live `RawExchange` owning the session, peer, sanitized
+    /// headers, circuit guard, and admission permit. Both `execute()`
+    /// and `send_streaming()` call this, then diverge.
+    #[expect(clippy::large_stack_frames, reason = "Pingora session types are large")]
+    #[expect(clippy::too_many_lines, reason = "sequential HTTP exchange steps")]
+    async fn open_exchange<'a>(
+        &'a self,
+        peer: &HttpPeer,
+        request: &SubRequest,
+        timeout: Duration,
+        framework_headers: Option<&FrameworkHeaders>,
+    ) -> Result<RawExchange<'a>, SubRequestError> {
+        let exchange_started = tokio::time::Instant::now();
+        let deadline = tokio::time::Instant::now()
+            .checked_add(timeout)
+            .ok_or(SubRequestError::DeadlineExceeded)?;
+        let mut bounded_peer = peer.clone();
+        clamp_peer_timeouts(&mut bounded_peer, timeout);
+
+        // -- 1. Validate request (before any circuit/admission state) --
+        let path = request
+            .uri
+            .path_and_query()
+            .map_or(b"/".as_slice(), |pq| pq.as_str().as_bytes());
+        let mut req_header = pingora_http::RequestHeader::build(request.method.clone(), path, None)
+            .map_err(|e| SubRequestError::InvalidRequest(e.to_string()))?;
+
+        let mut sanitized = request.headers.clone();
+        strip_hop_by_hop_headers(&mut sanitized);
+        strip_request_framing_headers(&mut sanitized);
+        strip_reserved_headers(&mut sanitized);
+        if let Some(fw) = framework_headers {
+            for (name, value) in fw.iter() {
+                sanitized.insert(name.clone(), value.clone());
+            }
+        }
+        for (name, value) in &sanitized {
+            let _append = req_header.append_header(name.clone(), value.clone());
+        }
+        ensure_host_header(&mut req_header, &bounded_peer)?;
+        if !request.body.is_empty() || empty_body_needs_framing(&request.method) {
+            let _cl = req_header.insert_header("Content-Length", request.body.len().to_string());
+        }
+
+        // -- 2. Circuit precheck --
+        let peer_key: Option<PeerKey> = bounded_peer
+            .address()
+            .as_inet()
+            .copied()
+            .map(|addr| PeerKey::new(addr, bounded_peer.sni.as_str()));
+
+        if let (Some(registry), Some(key)) = (&self.connector.circuit_breakers, &peer_key)
+            && !registry.precheck(key)
+        {
+            return Err(SubRequestError::CircuitOpen { peer: key.to_string() });
+        }
+
+        // -- 3. Admission --
+        let admission_budget = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if admission_budget.is_zero() {
+            return Err(SubRequestError::DeadlineExceeded);
+        }
+        let permit = self.connector.try_acquire_permit(admission_budget).await?;
+
+        // -- 4. Circuit try_acquire --
+        let circuit_guard = match (&self.connector.circuit_breakers, peer_key) {
+            (Some(registry), Some(key)) => match registry.try_acquire(key.clone()) {
+                CircuitCheck::Rejected => {
+                    return Err(SubRequestError::CircuitOpen { peer: key.to_string() });
+                },
+                CircuitCheck::Allowed(token) => Some(CircuitGuard::new(registry, key, token)),
+            },
+            _ => None,
+        };
+
+        // -- 5. Connect + I/O --
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            return Err(SubRequestError::DeadlineExceeded);
+        }
+
+        let (mut session, reused) = tokio::time::timeout(
+            remaining,
+            Box::pin(self.connector.connector().get_http_session(&bounded_peer)),
+        )
+        .await
+        .map_err(|_elapsed| SubRequestError::DeadlineExceeded)?
+        .map_err(|e| SubRequestError::Connect(e.to_string()))?;
+
+        debug!(
+            peer = %bounded_peer.address(),
+            reused,
+            method = %request.method,
+            uri = %request.uri,
+            "sub-request: connected"
+        );
+
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            return Err(SubRequestError::DeadlineExceeded);
+        }
+
+        let write_timeout = min_timeout(bounded_peer.options.write_timeout, remaining);
+        tokio::time::timeout(write_timeout, session.write_request_header(Box::new(req_header)))
+            .await
+            .map_err(|_elapsed| classify_timeout(deadline, "write"))?
+            .map_err(|e| SubRequestError::Io(e.to_string()))?;
+
+        if !request.body.is_empty() {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                session.shutdown().await;
+                return Err(SubRequestError::DeadlineExceeded);
+            }
+            let write_timeout = min_timeout(bounded_peer.options.write_timeout, remaining);
+            tokio::time::timeout(write_timeout, session.write_request_body(request.body.clone(), true))
+                .await
+                .map_err(|_elapsed| classify_timeout(deadline, "write"))?
+                .map_err(|e| SubRequestError::Io(e.to_string()))?;
+        }
+
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            session.shutdown().await;
+            return Err(SubRequestError::DeadlineExceeded);
+        }
+        let write_timeout = min_timeout(bounded_peer.options.write_timeout, remaining);
+        tokio::time::timeout(write_timeout, session.finish_request_body())
+            .await
+            .map_err(|_elapsed| classify_timeout(deadline, "write"))?
+            .map_err(|e| SubRequestError::Io(e.to_string()))?;
+
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            session.shutdown().await;
+            return Err(SubRequestError::DeadlineExceeded);
+        }
+        let read_timeout = min_timeout(bounded_peer.options.read_timeout, remaining);
+        session.set_read_timeout(Some(read_timeout));
+
+        tokio::time::timeout(read_timeout, session.read_response_header())
+            .await
+            .map_err(|_elapsed| classify_timeout(deadline, "read"))?
+            .map_err(|e| SubRequestError::Io(e.to_string()))?;
+
+        // -- 6. Validate response --
+        let resp_header = session
+            .response_header()
+            .ok_or_else(|| SubRequestError::Io("no response header received".to_owned()))?;
+
+        let status = resp_header.status.as_u16();
+        if !(100..=599).contains(&status) {
+            session.shutdown().await;
+            return Err(SubRequestError::Io(format!(
+                "upstream returned unsupported HTTP status {status}"
+            )));
+        }
+        let mut resp_headers = HeaderMap::new();
+        for (name, value) in &resp_header.headers {
+            if let Ok(v) = http::header::HeaderValue::from_bytes(value.as_bytes()) {
+                resp_headers.append(name.clone(), v);
+            }
+        }
+        strip_hop_by_hop_headers(&mut resp_headers);
+        strip_reserved_headers(&mut resp_headers);
+
+        // -- 7. Return RawExchange --
+        histogram!(SUBREQUEST_HEADER_DURATION_SECONDS).record(exchange_started.elapsed().as_secs_f64());
+
+        Ok(RawExchange {
+            session,
+            peer: bounded_peer,
+            connector: &self.connector,
+            status,
+            headers: resp_headers,
+            circuit_guard,
+            permit,
+            deadline,
+        })
+    }
+
+    /// Send a streaming sub-request.
+    ///
+    /// Acquires admission, connects to `peer`, sends `request`, reads
+    /// response headers, and returns a [`StreamingSubResponse`] with
+    /// an opaque body handle for incremental chunk reads.
+    ///
+    /// Circuit breaker success is finalized when valid headers are
+    /// received. Late body failures only affect stream metrics.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SubRequestError`] on admission timeout, connection
+    /// failure, I/O error, or deadline expiry during the header phase.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "framework_headers is the typed metadata injection point"
+    )]
+    #[expect(clippy::large_stack_frames, reason = "Pingora session types are large")]
+    #[expect(clippy::too_many_lines, reason = "sequential HTTP exchange steps")]
+    pub async fn send_streaming(
+        &self,
+        peer: &HttpPeer,
+        request: &SubRequest,
+        timeout: Duration,
+        limits: StreamLimits,
+        framework_headers: Option<&FrameworkHeaders>,
+    ) -> Result<StreamingSubResponse, SubRequestError> {
+        let mut exchange = self.open_exchange(peer, request, timeout, framework_headers).await?;
+
+        // Finalize circuit guard as success — valid headers received.
+        if let Some(guard) = exchange.circuit_guard.take() {
+            guard.finalize_success();
+        }
+
+        // Check for header-time completion (HEAD, 204, 304, zero-length).
+        if exchange.session.response_done() {
+            let termination = match check_clean_completion(&mut exchange.session) {
+                Ok(true) => {
+                    exchange
+                        .connector
+                        .connector()
+                        .release_http_session(exchange.session, &exchange.peer, None)
+                        .await;
+                    "header_only"
+                },
+                Ok(false) => {
+                    dispose_session_abnormal(
+                        exchange.session,
+                        Some(&exchange.peer),
+                        Some(exchange.connector.connector()),
+                    )
+                    .await;
+                    "header_incomplete"
+                },
+                Err(e) => {
+                    dispose_session_abnormal(
+                        exchange.session,
+                        Some(&exchange.peer),
+                        Some(exchange.connector.connector()),
+                    )
+                    .await;
+                    record_header_termination("h2_error");
+                    return Err(e);
+                },
+            };
+            record_header_termination(termination);
+            return Ok(StreamingSubResponse {
+                status: exchange.status,
+                headers: exchange.headers,
+                body: SubResponseBody::new_done(),
+            });
+        }
+
+        // Capture the operator-configured read timeout before clearing
+        // Pingora's internal timer. next_chunk() enforces it externally
+        // alongside idle_timeout and stream_deadline.
+        let read_timeout = exchange.peer.options.read_timeout;
+        exchange.session.set_read_timeout(None);
+
+        // Compute stream deadline from max_stream_duration.
+        let stream_deadline = limits
+            .max_stream_duration
+            .map(|d| {
+                tokio::time::Instant::now()
+                    .checked_add(d)
+                    .ok_or(SubRequestError::DeadlineExceeded)
+            })
+            .transpose()?;
+
+        let body = SubResponseBody {
+            session: Some(exchange.session),
+            peer: Some(exchange.peer),
+            connector: Some(exchange.connector.clone()),
+            permit: exchange.permit,
+            read_timeout,
+            idle_timeout: limits.idle_timeout,
+            stream_deadline,
+            max_total_bytes: limits.max_total_bytes,
+            received_bytes: 0,
+            chunk_count: 0,
+            stream_started_at: tokio::time::Instant::now(),
+            done: false,
+        };
+
+        debug!(
+            status = exchange.status,
+            header_count = exchange.headers.len(),
+            "sub-request: streaming handoff"
+        );
+
+        Ok(StreamingSubResponse {
+            status: exchange.status,
+            headers: exchange.headers,
+            body,
+        })
+    }
+
     /// Execute a buffered sub-request.
     ///
     /// Acquires an admission permit (inside the deadline), connects
@@ -277,10 +429,8 @@ impl SubRequestClient {
         clippy::too_many_arguments,
         reason = "framework_headers is the typed metadata injection point"
     )]
-    #[expect(
-        clippy::too_many_lines,
-        reason = "circuit + admission + deadline logic is sequential"
-    )]
+    #[expect(clippy::large_stack_frames, reason = "Pingora session types are large")]
+    #[expect(clippy::too_many_lines, reason = "inline body collection loop")]
     pub async fn execute(
         &self,
         peer: &HttpPeer,
@@ -289,258 +439,79 @@ impl SubRequestClient {
         timeout: Duration,
         framework_headers: Option<&FrameworkHeaders>,
     ) -> Result<SubResponse, SubRequestError> {
-        let deadline = tokio::time::Instant::now() + timeout;
-        let mut bounded_peer = peer.clone();
-        clamp_peer_timeouts(&mut bounded_peer, timeout);
+        let exchange = self.open_exchange(peer, request, timeout, framework_headers).await;
 
-        // Unix sockets have no inet address and are excluded from
-        // circuit breaking (the fault model doesn't apply).
-        let peer_key: Option<PeerKey> = bounded_peer.address().as_inet().copied().map(|addr| {
-            let sni = &bounded_peer.sni;
-            PeerKey::new(addr, sni.as_str())
-        });
-
-        if let (Some(registry), Some(key)) = (&self.connector.circuit_breakers, &peer_key)
-            && !registry.precheck(key)
-        {
-            return Err(SubRequestError::CircuitOpen { peer: key.to_string() });
-        }
-
-        let admission_budget = deadline.saturating_duration_since(tokio::time::Instant::now());
-        if admission_budget.is_zero() {
-            return Err(SubRequestError::DeadlineExceeded);
-        }
-        let _permit = self.connector.try_acquire_permit(admission_budget).await?;
-
-        let circuit_guard = match (&self.connector.circuit_breakers, peer_key) {
-            (Some(registry), Some(key)) => match registry.try_acquire(key.clone()) {
-                CircuitCheck::Rejected => {
-                    return Err(SubRequestError::CircuitOpen { peer: key.to_string() });
-                },
-                CircuitCheck::Allowed(token) => Some(CircuitGuard::new(registry, key, token)),
-            },
-            _ => None,
+        let RawExchange {
+            mut session,
+            peer: bounded_peer,
+            connector,
+            status,
+            headers: resp_headers,
+            circuit_guard,
+            permit: _permit,
+            deadline,
+        } = match exchange {
+            Ok(ex) => ex,
+            Err(e) => return Err(e),
         };
 
+        let effective_limit = max_response_bytes.min(self.max_response_bytes);
+
+        // Enforce deadline on body collection phase.
         let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
         if remaining.is_zero() {
             return Err(SubRequestError::DeadlineExceeded);
         }
-        let effective_limit = max_response_bytes.min(self.max_response_bytes);
-        let result: Result<SubResponse, SubRequestError> = tokio::time::timeout(
-            remaining,
-            Box::pin(execute_inner(
-                &self.connector,
-                &bounded_peer,
-                request,
-                effective_limit,
-                remaining,
-                framework_headers,
-            )),
-        )
+
+        let body_result: Result<Bytes, SubRequestError> = tokio::time::timeout(remaining, async {
+            let mut body_buf = Vec::new();
+            while !session.response_done() {
+                match session.read_response_body().await {
+                    Ok(Some(chunk)) => {
+                        if body_buf.len() + chunk.len() > effective_limit {
+                            warn!(
+                                current = body_buf.len(),
+                                chunk = chunk.len(),
+                                limit = effective_limit,
+                                "sub-request response body exceeded limit"
+                            );
+                            session.shutdown().await;
+                            return Err(SubRequestError::ResponseTooLarge {
+                                actual: body_buf.len() + chunk.len(),
+                                limit: effective_limit,
+                            });
+                        }
+                        body_buf.extend_from_slice(&chunk);
+                    },
+                    Ok(None) => break,
+                    Err(e) => {
+                        session.shutdown().await;
+                        return Err(SubRequestError::Io(e.to_string()));
+                    },
+                }
+            }
+
+            debug!(status, body_bytes = body_buf.len(), "sub-request: response received");
+
+            connector
+                .connector()
+                .release_http_session(session, &bounded_peer, None)
+                .await;
+
+            Ok(Bytes::from(body_buf))
+        })
         .await
         .unwrap_or_else(|_elapsed| Err(SubRequestError::DeadlineExceeded));
 
+        // Finalize circuit guard with full-exchange outcome.
+        let result = body_result.map(|body| SubResponse {
+            status,
+            headers: resp_headers,
+            body,
+        });
         if let Some(guard) = circuit_guard {
             guard.finalize(&result);
         }
-
         result
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Executor internals
-// ---------------------------------------------------------------------------
-
-/// Execute the exchange under the deadline enforced by
-/// [`SubRequestClient::execute`].
-#[expect(clippy::large_stack_frames, reason = "Pingora session types are large")]
-#[expect(clippy::too_many_lines, reason = "sequential HTTP exchange steps")]
-#[expect(clippy::too_many_arguments, reason = "internal function, all parameters required")]
-async fn execute_inner(
-    connector: &SubRequestConnector,
-    peer: &HttpPeer,
-    request: &SubRequest,
-    max_response_bytes: usize,
-    timeout: Duration,
-    framework_headers: Option<&FrameworkHeaders>,
-) -> Result<SubResponse, SubRequestError> {
-    let (mut session, reused) = Box::pin(connector.connector().get_http_session(peer))
-        .await
-        .map_err(|e| SubRequestError::Connect(e.to_string()))?;
-
-    debug!(
-        peer = %peer.address(),
-        reused,
-        method = %request.method,
-        uri = %request.uri,
-        "sub-request: connected"
-    );
-
-    session.set_read_timeout(Some(min_timeout(peer.options.read_timeout, timeout)));
-    session.set_write_timeout(Some(min_timeout(peer.options.write_timeout, timeout)));
-
-    let path = request
-        .uri
-        .path_and_query()
-        .map_or(b"/".as_slice(), |pq| pq.as_str().as_bytes());
-    let mut req_header = pingora_http::RequestHeader::build(request.method.clone(), path, None)
-        .map_err(|e| SubRequestError::InvalidRequest(e.to_string()))?;
-
-    let mut sanitized = request.headers.clone();
-    strip_hop_by_hop_headers(&mut sanitized);
-    strip_request_framing_headers(&mut sanitized);
-    strip_reserved_headers(&mut sanitized);
-    if let Some(fw) = framework_headers {
-        for (name, value) in fw.iter() {
-            sanitized.insert(name.clone(), value.clone());
-        }
-    }
-
-    for (name, value) in &sanitized {
-        let _append = req_header.append_header(name.clone(), value.clone());
-    }
-
-    ensure_host_header(&mut req_header, peer)?;
-
-    if !request.body.is_empty() || empty_body_needs_framing(&request.method) {
-        let _cl = req_header.insert_header("Content-Length", request.body.len().to_string());
-    }
-
-    session
-        .write_request_header(Box::new(req_header))
-        .await
-        .map_err(|e| SubRequestError::Io(e.to_string()))?;
-
-    if !request.body.is_empty() {
-        session
-            .write_request_body(request.body.clone(), true)
-            .await
-            .map_err(|e| SubRequestError::Io(e.to_string()))?;
-    }
-
-    session
-        .finish_request_body()
-        .await
-        .map_err(|e| SubRequestError::Io(e.to_string()))?;
-
-    session
-        .read_response_header()
-        .await
-        .map_err(|e| SubRequestError::Io(e.to_string()))?;
-
-    let resp_header = session
-        .response_header()
-        .ok_or_else(|| SubRequestError::Io("no response header received".to_owned()))?;
-
-    let status = resp_header.status.as_u16();
-    if !(100..=599).contains(&status) {
-        session.shutdown().await;
-        return Err(SubRequestError::Io(format!(
-            "upstream returned unsupported HTTP status {status}"
-        )));
-    }
-    let mut resp_headers = HeaderMap::new();
-    for (name, value) in &resp_header.headers {
-        if let Ok(v) = http::header::HeaderValue::from_bytes(value.as_bytes()) {
-            resp_headers.append(name.clone(), v);
-        }
-    }
-    strip_hop_by_hop_headers(&mut resp_headers);
-    strip_reserved_headers(&mut resp_headers);
-
-    let mut body_buf = Vec::new();
-    while !session.response_done() {
-        match session.read_response_body().await {
-            Ok(Some(chunk)) => {
-                if body_buf.len() + chunk.len() > max_response_bytes {
-                    warn!(
-                        current = body_buf.len(),
-                        chunk = chunk.len(),
-                        limit = max_response_bytes,
-                        "sub-request response body exceeded limit"
-                    );
-                    session.shutdown().await;
-                    return Err(SubRequestError::ResponseTooLarge {
-                        actual: body_buf.len() + chunk.len(),
-                        limit: max_response_bytes,
-                    });
-                }
-                body_buf.extend_from_slice(&chunk);
-            },
-            Ok(None) => break,
-            Err(e) => {
-                session.shutdown().await;
-                return Err(SubRequestError::Io(e.to_string()));
-            },
-        }
-    }
-
-    debug!(status, body_bytes = body_buf.len(), "sub-request: response received");
-
-    connector.connector().release_http_session(session, peer, None).await;
-
-    Ok(SubResponse {
-        status,
-        headers: resp_headers,
-        body: Bytes::from(body_buf),
-    })
-}
-
-// ---------------------------------------------------------------------------
-// Circuit Breaker Guard
-// ---------------------------------------------------------------------------
-
-/// RAII guard ensuring every acquired circuit token is finalized.
-///
-/// On drop without explicit [`finalize`](Self::finalize), records a
-/// failure — this covers deadline exits, panics, and any early-return
-/// path after token acquisition.
-pub(super) struct CircuitGuard<'a> {
-    /// The registry that issued the token.
-    registry: &'a CircuitBreakerRegistry,
-    /// Logical peer identity the token was acquired for.
-    peer: PeerKey,
-    /// The generation token; `None` after finalization.
-    token: Option<CircuitToken>,
-}
-
-impl<'a> CircuitGuard<'a> {
-    /// Create a guard from an acquired token.
-    pub(super) fn new(registry: &'a CircuitBreakerRegistry, peer: PeerKey, token: CircuitToken) -> Self {
-        Self {
-            registry,
-            peer,
-            token: Some(token),
-        }
-    }
-
-    /// Finalize the guard with the actual exchange outcome.
-    ///
-    /// Success and `ResponseTooLarge` are not peer faults; `Connect`,
-    /// `Io`, and `DeadlineExceeded` are. Other variants (construction
-    /// errors, admission timeout) record success (the peer responded,
-    /// the fault is local).
-    pub(super) fn finalize(mut self, result: &Result<SubResponse, SubRequestError>) {
-        let Some(token) = self.token.take() else {
-            return;
-        };
-        match result {
-            Err(SubRequestError::Connect(_) | SubRequestError::Io(_) | SubRequestError::DeadlineExceeded) => {
-                self.registry.record_failure(&self.peer, token);
-            },
-            Ok(_) | Err(_) => {
-                self.registry.record_success(&self.peer, token);
-            },
-        }
-    }
-}
-
-impl Drop for CircuitGuard<'_> {
-    fn drop(&mut self) {
-        if let Some(token) = self.token.take() {
-            self.registry.record_failure(&self.peer, token);
-        }
     }
 }

--- a/core/src/subrequest/client.rs
+++ b/core/src/subrequest/client.rs
@@ -296,6 +296,13 @@ impl SubRequestClient {
     /// Circuit breaker success is finalized when valid headers are
     /// received. Late body failures only affect stream metrics.
     ///
+    /// **Timeout semantics:** `timeout` bounds only the header phase
+    /// (connect + send + receive headers). Body reads are governed by
+    /// [`StreamLimits`]: `idle_timeout` per chunk, optional
+    /// `max_stream_duration` for end-to-end lifetime, and the peer's
+    /// configured `read_timeout`. Callers needing a single end-to-end
+    /// deadline should set `max_stream_duration` accordingly.
+    ///
     /// # Errors
     ///
     /// Returns [`SubRequestError`] on admission timeout, connection
@@ -339,7 +346,10 @@ impl SubRequestClient {
                         Some(exchange.connector.connector()),
                     )
                     .await;
-                    "header_incomplete"
+                    record_header_termination("header_incomplete");
+                    return Err(SubRequestError::Io(
+                        "upstream indicated response done but stream is not cleanly terminated".to_owned(),
+                    ));
                 },
                 Err(e) => {
                     dispose_session_abnormal(

--- a/core/src/subrequest/client.rs
+++ b/core/src/subrequest/client.rs
@@ -211,7 +211,7 @@ impl SubRequestClient {
         let write_timeout = min_timeout(bounded_peer.options.write_timeout, remaining);
         tokio::time::timeout(write_timeout, session.write_request_header(Box::new(req_header)))
             .await
-            .map_err(|_elapsed| classify_timeout(deadline, "write"))?
+            .map_err(|_elapsed| classify_timeout(remaining, bounded_peer.options.write_timeout, "write"))?
             .map_err(|e| SubRequestError::Io(e.to_string()))?;
 
         if !request.body.is_empty() {
@@ -223,7 +223,7 @@ impl SubRequestClient {
             let write_timeout = min_timeout(bounded_peer.options.write_timeout, remaining);
             tokio::time::timeout(write_timeout, session.write_request_body(request.body.clone(), true))
                 .await
-                .map_err(|_elapsed| classify_timeout(deadline, "write"))?
+                .map_err(|_elapsed| classify_timeout(remaining, bounded_peer.options.write_timeout, "write"))?
                 .map_err(|e| SubRequestError::Io(e.to_string()))?;
         }
 
@@ -235,7 +235,7 @@ impl SubRequestClient {
         let write_timeout = min_timeout(bounded_peer.options.write_timeout, remaining);
         tokio::time::timeout(write_timeout, session.finish_request_body())
             .await
-            .map_err(|_elapsed| classify_timeout(deadline, "write"))?
+            .map_err(|_elapsed| classify_timeout(remaining, bounded_peer.options.write_timeout, "write"))?
             .map_err(|e| SubRequestError::Io(e.to_string()))?;
 
         let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
@@ -248,7 +248,7 @@ impl SubRequestClient {
 
         tokio::time::timeout(read_timeout, session.read_response_header())
             .await
-            .map_err(|_elapsed| classify_timeout(deadline, "read"))?
+            .map_err(|_elapsed| classify_timeout(remaining, bounded_peer.options.read_timeout, "read"))?
             .map_err(|e| SubRequestError::Io(e.to_string()))?;
 
         // -- 6. Validate response --

--- a/core/src/subrequest/client.rs
+++ b/core/src/subrequest/client.rs
@@ -244,7 +244,6 @@ impl SubRequestClient {
             return Err(SubRequestError::DeadlineExceeded);
         }
         let read_timeout = min_timeout(bounded_peer.options.read_timeout, remaining);
-        session.set_read_timeout(Some(read_timeout));
 
         tokio::time::timeout(read_timeout, session.read_response_header())
             .await

--- a/core/src/subrequest/internals.rs
+++ b/core/src/subrequest/internals.rs
@@ -1,18 +1,317 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Praxis Contributors
 
-//! Header sanitization and timeout helpers for sub-request exchanges.
-
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use http::HeaderMap;
-use pingora_core::upstreams::peer::{HttpPeer, Peer as _};
+use metrics::{counter, histogram};
+use pingora_core::{
+    connectors::{ConnectorOptions, http::Connector},
+    protocols::http::client::HttpSession,
+    upstreams::peer::{HttpPeer, Peer as _},
+};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use tracing::debug;
 
-use super::types::{HOP_BY_HOP_HEADERS, SubRequestError};
+use super::types::{SubRequestError, SubResponse};
+use crate::circuit::{CircuitBreakerConfig, CircuitBreakerRegistry, CircuitToken, PeerKey};
+
+// ---------------------------------------------------------------------------
+// Metric names
+// ---------------------------------------------------------------------------
+
+/// Metric name for total streaming sub-request count (with termination label).
+pub(super) const SUBREQUEST_STREAMS_TOTAL: &str = "praxis_subrequest_streams_total";
+/// Metric name for streaming sub-request duration histogram.
+pub(super) const SUBREQUEST_STREAM_DURATION_SECONDS: &str = "praxis_subrequest_stream_duration_seconds";
+/// Metric name for streaming sub-request total bytes counter.
+pub(super) const SUBREQUEST_STREAM_BYTES_TOTAL: &str = "praxis_subrequest_stream_bytes_total";
+/// Metric name for header phase duration (shared buffered/streaming).
+pub(super) const SUBREQUEST_HEADER_DURATION_SECONDS: &str = "praxis_subrequest_header_duration_seconds";
+
+// ---------------------------------------------------------------------------
+// SubRequestConnectorOptions
+// ---------------------------------------------------------------------------
+
+/// Options for constructing a [`SubRequestConnector`].
+#[derive(Debug)]
+pub struct SubRequestConnectorOptions {
+    /// Number of idle connections to keep in the pool.
+    pub keepalive_pool_size: usize,
+
+    /// Maximum number of concurrently active exchanges.
+    pub max_connections: Option<usize>,
+
+    /// Circuit breaker configuration for peer-level failure tracking.
+    pub circuit_breaker: Option<CircuitBreakerConfig>,
+}
+
+// ---------------------------------------------------------------------------
+// SubRequestConnector
+// ---------------------------------------------------------------------------
+
+/// Shared HTTP connector for sub-requests.
+///
+/// Wraps Pingora's [`Connector`] behind an [`Arc`] so that all
+/// filter instances share a single connection pool. Created once at
+/// server startup and passed through unchanged on config reload.
+///
+/// An optional admission semaphore limits the number of concurrently
+/// active sub-request exchanges.
+///
+/// ```
+/// use praxis_core::subrequest::SubRequestConnector;
+///
+/// let connector = SubRequestConnector::new(128, None);
+/// let _clone = connector.clone();
+/// ```
+///
+/// [`Arc`]: std::sync::Arc
+/// [`Connector`]: pingora_core::connectors::http::Connector
+#[derive(Clone)]
+pub struct SubRequestConnector {
+    /// Shared Pingora HTTP connector.
+    pub(super) inner: Arc<Connector<()>>,
+
+    /// Admission semaphore bounding concurrently active exchanges.
+    pub(super) admission: Option<Arc<Semaphore>>,
+
+    /// The configured concurrency limit, retained for error reporting.
+    pub(super) configured_max_connections: Option<usize>,
+
+    /// Per-peer circuit breaker registry.
+    pub(super) circuit_breakers: Option<Arc<CircuitBreakerRegistry>>,
+}
+
+impl SubRequestConnector {
+    /// Create a connector with the given keepalive pool size and
+    /// optional active-connection limit.
+    ///
+    /// ```
+    /// use praxis_core::subrequest::SubRequestConnector;
+    ///
+    /// let connector = SubRequestConnector::new(64, None);
+    /// let bounded = SubRequestConnector::new(64, Some(256));
+    /// ```
+    pub fn new(keepalive_pool_size: usize, max_connections: Option<usize>) -> Self {
+        let options = ConnectorOptions::new(keepalive_pool_size);
+        Self {
+            inner: Arc::new(Connector::new(Some(options))),
+            admission: max_connections.map(|n| Arc::new(Semaphore::new(n))),
+            configured_max_connections: max_connections,
+            circuit_breakers: None,
+        }
+    }
+
+    /// Create a connector from [`SubRequestConnectorOptions`].
+    ///
+    /// ```
+    /// use praxis_core::subrequest::{SubRequestConnector, SubRequestConnectorOptions};
+    ///
+    /// let connector = SubRequestConnector::with_options(SubRequestConnectorOptions {
+    ///     keepalive_pool_size: 64,
+    ///     max_connections: Some(256),
+    ///     circuit_breaker: None,
+    /// });
+    /// ```
+    pub fn with_options(opts: SubRequestConnectorOptions) -> Self {
+        let options = ConnectorOptions::new(opts.keepalive_pool_size);
+        Self {
+            inner: Arc::new(Connector::new(Some(options))),
+            admission: opts.max_connections.map(|n| Arc::new(Semaphore::new(n))),
+            configured_max_connections: opts.max_connections,
+            circuit_breakers: opts
+                .circuit_breaker
+                .map(|cfg| Arc::new(CircuitBreakerRegistry::new(cfg))),
+        }
+    }
+
+    /// Access the underlying Pingora [`Connector`].
+    ///
+    /// [`Connector`]: pingora_core::connectors::http::Connector
+    pub fn connector(&self) -> &Connector<()> {
+        &self.inner
+    }
+
+    /// Acquire an admission permit if a concurrency limit is
+    /// configured. Returns `None` when no limit is set.
+    ///
+    /// The returned permit must be held for the entire sub-request
+    /// exchange. Dropping it releases the slot.
+    pub async fn acquire_permit(&self) -> Option<OwnedSemaphorePermit> {
+        let semaphore = self.admission.as_ref()?;
+        Arc::clone(semaphore).acquire_owned().await.ok()
+    }
+
+    /// Try to acquire an admission permit within the given deadline.
+    ///
+    /// Returns `Ok(Some(permit))` if acquired, `Ok(None)` if no
+    /// concurrency limit is configured, or `Err` if the deadline
+    /// expires before a slot opens.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SubRequestError::AdmissionTimeout`] when the
+    /// semaphore cannot be acquired within the timeout.
+    pub async fn try_acquire_permit(&self, timeout: Duration) -> Result<Option<OwnedSemaphorePermit>, SubRequestError> {
+        let Some(semaphore) = self.admission.as_ref() else {
+            return Ok(None);
+        };
+        let configured = self.configured_max_connections.unwrap_or(0);
+        match tokio::time::timeout(timeout, Arc::clone(semaphore).acquire_owned()).await {
+            Ok(Ok(permit)) => Ok(Some(permit)),
+            Ok(Err(_closed)) => Err(SubRequestError::AdmissionTimeout {
+                max_connections: configured,
+            }),
+            Err(_elapsed) => Err(SubRequestError::AdmissionTimeout {
+                max_connections: configured,
+            }),
+        }
+    }
+}
+
+impl std::fmt::Debug for SubRequestConnector {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SubRequestConnector")
+            .field("pool", &"Connector<()>")
+            .field("max_connections", &self.configured_max_connections)
+            .field("circuit_breakers", &self.circuit_breakers.is_some())
+            .finish()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RawExchange
+// ---------------------------------------------------------------------------
+
+/// Live HTTP exchange after validated response headers.
+///
+/// Returned by `open_exchange()` and consumed by either
+/// `execute()` (buffered collection) or `send_streaming()`
+/// (body ownership handoff).
+pub(super) struct RawExchange<'a> {
+    /// Live Pingora HTTP session.
+    pub(super) session: HttpSession<()>,
+    /// Peer address (timeout-bounded).
+    pub(super) peer: HttpPeer,
+    /// Connector ref for session release.
+    pub(super) connector: &'a SubRequestConnector,
+    /// HTTP status code.
+    pub(super) status: u16,
+    /// Sanitized response headers.
+    pub(super) headers: HeaderMap,
+    /// Optional circuit breaker guard.
+    pub(super) circuit_guard: Option<CircuitGuard<'a>>,
+    /// Admission permit.
+    pub(super) permit: Option<OwnedSemaphorePermit>,
+    /// Absolute deadline for the entire exchange.
+    pub(super) deadline: tokio::time::Instant,
+}
+
+// ---------------------------------------------------------------------------
+// Circuit Breaker Guard
+// ---------------------------------------------------------------------------
+
+/// RAII guard ensuring every acquired circuit token is finalized.
+///
+/// On drop without explicit [`finalize`](Self::finalize), records a
+/// failure — this covers deadline exits, panics, and any early-return
+/// path after token acquisition.
+pub(super) struct CircuitGuard<'a> {
+    /// The registry that issued the token.
+    registry: &'a CircuitBreakerRegistry,
+    /// Logical peer identity the token was acquired for.
+    peer: PeerKey,
+    /// The generation token; `None` after finalization.
+    token: Option<CircuitToken>,
+}
+
+impl<'a> CircuitGuard<'a> {
+    /// Create a guard from an acquired token.
+    pub(super) fn new(registry: &'a CircuitBreakerRegistry, peer: PeerKey, token: CircuitToken) -> Self {
+        Self {
+            registry,
+            peer,
+            token: Some(token),
+        }
+    }
+
+    /// Finalize the guard as a success regardless of later body outcome.
+    pub(super) fn finalize_success(mut self) {
+        if let Some(token) = self.token.take() {
+            self.registry.record_success(&self.peer, token);
+        }
+    }
+
+    /// Finalize the guard with the actual exchange outcome.
+    pub(super) fn finalize(mut self, result: &Result<SubResponse, SubRequestError>) {
+        let Some(token) = self.token.take() else {
+            return;
+        };
+        match result {
+            Err(SubRequestError::Connect(_) | SubRequestError::Io(_) | SubRequestError::DeadlineExceeded) => {
+                self.registry.record_failure(&self.peer, token);
+            },
+            Ok(_) | Err(_) => {
+                self.registry.record_success(&self.peer, token);
+            },
+        }
+    }
+}
+
+impl Drop for CircuitGuard<'_> {
+    fn drop(&mut self) {
+        if let Some(token) = self.token.take() {
+            self.registry.record_failure(&self.peer, token);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Protocol-aware completion check
+// ---------------------------------------------------------------------------
+
+/// Protocol-aware clean completion check.
+///
+/// Returns `Ok(true)` for clean EOF, `Ok(false)` for incomplete,
+/// and `Err` for H2 error-terminated streams.
+pub(super) fn check_clean_completion(session: &mut HttpSession<()>) -> Result<bool, SubRequestError> {
+    use pingora_core::protocols::http::custom::client::Session as _;
+    match session {
+        HttpSession::H1(h1) => Ok(h1.is_body_done()),
+        HttpSession::H2(h2) => h2
+            .check_response_end_or_error()
+            .map_err(|e| SubRequestError::Io(e.to_string())),
+        HttpSession::Custom(c) => Ok(c.response_finished()),
+    }
+}
+
+/// Record metrics and trace for header-phase stream termination.
+///
+/// Used by `send_streaming()` when the response completes at header
+/// time (HEAD, 204, 304, zero-length, or H2 error).
+pub(super) fn record_header_termination(termination: &str) {
+    counter!(SUBREQUEST_STREAMS_TOTAL, "termination" => termination.to_owned()).increment(1);
+    histogram!(SUBREQUEST_STREAM_DURATION_SECONDS).record(0.0);
+    debug!(termination, "sub-request: stream terminated at header phase");
+}
 
 // ---------------------------------------------------------------------------
 // Header sanitization
 // ---------------------------------------------------------------------------
+
+/// Headers that apply only to one HTTP connection and must not be
+/// forwarded across a sub-request boundary.
+pub(super) const HOP_BY_HOP_HEADERS: &[&str] = &[
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailer",
+    "transfer-encoding",
+    "upgrade",
+];
 
 /// Remove hop-by-hop headers and headers nominated by `Connection`.
 pub(super) fn strip_hop_by_hop_headers(headers: &mut HeaderMap) {
@@ -51,6 +350,12 @@ pub(super) fn strip_reserved_headers(headers: &mut HeaderMap) {
 // Helpers
 // ---------------------------------------------------------------------------
 
+/// Whether a header is a transport-level header that must not be
+/// injected via framework metadata.
+pub(super) fn is_transport_header(name: &http::header::HeaderName) -> bool {
+    HOP_BY_HOP_HEADERS.iter().any(|h| *h == name.as_str()) || name == http::header::CONTENT_LENGTH
+}
+
 /// Methods whose empty payload is commonly rejected without explicit framing.
 pub(super) fn empty_body_needs_framing(method: &http::Method) -> bool {
     matches!(*method, http::Method::POST | http::Method::PUT | http::Method::PATCH)
@@ -78,4 +383,16 @@ pub(super) fn clamp_peer_timeouts(peer: &mut HttpPeer, deadline: Duration) {
 /// Keep an operator-configured timeout when it is stricter than the deadline.
 pub(super) fn min_timeout(configured: Option<Duration>, deadline: Duration) -> Duration {
     configured.map_or(deadline, |configured| configured.min(deadline))
+}
+
+/// Classify a timeout expiry as either `DeadlineExceeded` (the overall
+/// request deadline fired) or `Io` (a shorter operator-configured
+/// read/write timeout fired).  Call this inside the `Err(_elapsed)`
+/// arm of `tokio::time::timeout` to preserve the 502-vs-504 distinction.
+pub(super) fn classify_timeout(deadline: tokio::time::Instant, phase: &str) -> SubRequestError {
+    if tokio::time::Instant::now() >= deadline {
+        SubRequestError::DeadlineExceeded
+    } else {
+        SubRequestError::Io(format!("upstream {phase} timeout"))
+    }
 }

--- a/core/src/subrequest/internals.rs
+++ b/core/src/subrequest/internals.rs
@@ -389,8 +389,17 @@ pub(super) fn min_timeout(configured: Option<Duration>, deadline: Duration) -> D
 /// request deadline fired) or `Io` (a shorter operator-configured
 /// read/write timeout fired).  Call this inside the `Err(_elapsed)`
 /// arm of `tokio::time::timeout` to preserve the 502-vs-504 distinction.
-pub(super) fn classify_timeout(deadline: tokio::time::Instant, phase: &str) -> SubRequestError {
-    if tokio::time::Instant::now() >= deadline {
+///
+/// Uses the pre-computed budget and configured timeout rather than a
+/// post-hoc `Instant::now() >= deadline` check, which races with
+/// scheduler jitter when the configured timeout equals the remaining
+/// budget.
+pub(super) fn classify_timeout(
+    remaining_budget: Duration,
+    configured_timeout: Option<Duration>,
+    phase: &str,
+) -> SubRequestError {
+    if configured_timeout.is_none_or(|t| t >= remaining_budget) {
         SubRequestError::DeadlineExceeded
     } else {
         SubRequestError::Io(format!("upstream {phase} timeout"))

--- a/core/src/subrequest/mod.rs
+++ b/core/src/subrequest/mod.rs
@@ -18,8 +18,13 @@
 //!
 //! [`Connector`]: pingora_core::connectors::http::Connector
 
+/// Streaming body handle implementation.
+mod body;
+/// Hardened sub-request client and executor.
 mod client;
-mod internals;
+/// Connector, circuit guard, header sanitization, and shared helpers.
+pub(crate) mod internals;
+/// Data types for sub-request exchanges.
 mod types;
 
 #[cfg(test)]
@@ -27,5 +32,9 @@ mod types;
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, reason = "tests")]
 mod tests;
 
-pub use client::{SubRequestClient, SubRequestConnector, SubRequestConnectorOptions};
-pub use types::{DEPTH_HEADER, FrameworkHeaders, SubRequest, SubRequestError, SubResponse};
+pub use client::SubRequestClient;
+pub use internals::{SubRequestConnector, SubRequestConnectorOptions};
+pub use types::{
+    DEPTH_HEADER, FrameworkHeaders, StreamLimits, StreamingSubResponse, SubRequest, SubRequestError, SubResponse,
+    SubResponseBody,
+};

--- a/core/src/subrequest/tests.rs
+++ b/core/src/subrequest/tests.rs
@@ -233,6 +233,66 @@ fn subrequest_error_stream_idle_timeout_display() {
     assert!(msg.contains("30s"), "should include duration: {msg}");
 }
 
+// -- classify_timeout ---------------------------------------------------
+
+#[test]
+fn classify_timeout_deadline_binding_when_no_configured_timeout() {
+    let remaining = Duration::from_millis(50);
+    let err = classify_timeout(remaining, None, "read");
+    assert!(
+        matches!(err, SubRequestError::DeadlineExceeded),
+        "no configured timeout means deadline is binding: {err}"
+    );
+}
+
+#[test]
+fn classify_timeout_deadline_binding_when_configured_exceeds_budget() {
+    let remaining = Duration::from_millis(50);
+    let configured = Some(Duration::from_secs(5));
+    let err = classify_timeout(remaining, configured, "read");
+    assert!(
+        matches!(err, SubRequestError::DeadlineExceeded),
+        "configured timeout >= remaining means deadline is binding: {err}"
+    );
+}
+
+#[test]
+fn classify_timeout_deadline_binding_when_equal() {
+    let remaining = Duration::from_millis(50);
+    let configured = Some(Duration::from_millis(50));
+    let err = classify_timeout(remaining, configured, "write");
+    assert!(
+        matches!(err, SubRequestError::DeadlineExceeded),
+        "configured timeout == remaining means deadline is binding: {err}"
+    );
+}
+
+#[test]
+fn classify_timeout_io_when_configured_is_stricter() {
+    let remaining = Duration::from_millis(500);
+    let configured = Some(Duration::from_millis(10));
+    let err = classify_timeout(remaining, configured, "read");
+    match err {
+        SubRequestError::Io(msg) => {
+            assert!(msg.contains("read"), "should include phase: {msg}");
+        },
+        other => panic!("expected Io, got: {other}"),
+    }
+}
+
+#[test]
+fn classify_timeout_io_includes_phase() {
+    let remaining = Duration::from_secs(10);
+    let configured = Some(Duration::from_millis(100));
+    let err = classify_timeout(remaining, configured, "write");
+    match err {
+        SubRequestError::Io(msg) => {
+            assert!(msg.contains("write"), "should include write phase: {msg}");
+        },
+        other => panic!("expected Io, got: {other}"),
+    }
+}
+
 // -- Header sanitization ------------------------------------------------
 
 #[test]
@@ -1922,4 +1982,127 @@ async fn send_streaming_h1_cancel_does_not_reuse_connection() {
     );
 
     handle.abort();
+}
+
+// -- Header-time completion (204, incomplete) --------------------------------
+
+async fn spawn_204_backend() -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
+    use tokio::io::AsyncWriteExt as _;
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let handle = tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        let mut buf = vec![0_u8; 4096];
+        drop(tokio::io::AsyncReadExt::read(&mut socket, &mut buf).await);
+
+        let response = "HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n";
+        socket.write_all(response.as_bytes()).await.unwrap();
+        socket.flush().await.unwrap();
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    });
+    (addr, handle)
+}
+
+#[tokio::test]
+async fn send_streaming_204_returns_done_body() {
+    use pingora_core::upstreams::peer::HttpPeer;
+    let (addr, backend) = spawn_204_backend().await;
+
+    let connector = SubRequestConnector::new(1, None);
+    let client = super::client::SubRequestClient::new(connector);
+    let peer = HttpPeer::new(addr.to_string(), false, String::new());
+    let request = SubRequest {
+        method: http::Method::GET,
+        uri: "/empty".parse().unwrap(),
+        headers: HeaderMap::new(),
+        body: Bytes::new(),
+    };
+    let limits = StreamLimits {
+        idle_timeout: Duration::from_secs(5),
+        max_stream_duration: None,
+        max_total_bytes: None,
+    };
+
+    let StreamingSubResponse { status, mut body, .. } =
+        Box::pin(client.send_streaming(&peer, &request, Duration::from_secs(5), limits, None))
+            .await
+            .unwrap();
+
+    assert_eq!(status, 204);
+    assert!(body.is_done(), "204 response body should be pre-done");
+    assert!(
+        matches!(body.next_chunk().await, Ok(None)),
+        "next_chunk on done body should return Ok(None)"
+    );
+
+    backend.abort();
+}
+
+// -- Framework headers in streaming -----------------------------------------
+
+async fn spawn_echo_headers_backend() -> (std::net::SocketAddr, tokio::task::JoinHandle<Vec<String>>) {
+    use tokio::io::AsyncWriteExt as _;
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let handle = tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        let mut buf = vec![0_u8; 8192];
+        let n = tokio::io::AsyncReadExt::read(&mut socket, &mut buf).await.unwrap();
+        let request_text = String::from_utf8_lossy(buf.get(..n).unwrap_or(&[])).to_string();
+        let headers: Vec<String> = request_text
+            .lines()
+            .filter(|l| l.starts_with("x-praxis-") || l.starts_with("x-custom-"))
+            .map(String::from)
+            .collect();
+
+        let response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok";
+        socket.write_all(response.as_bytes()).await.unwrap();
+        socket.flush().await.unwrap();
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        headers
+    });
+    (addr, handle)
+}
+
+#[tokio::test]
+#[expect(clippy::too_many_lines, reason = "test setup and validation")]
+async fn send_streaming_propagates_framework_headers() {
+    use pingora_core::upstreams::peer::HttpPeer;
+    let (addr, backend) = spawn_echo_headers_backend().await;
+
+    let connector = SubRequestConnector::new(1, None);
+    let client = super::client::SubRequestClient::new(connector);
+    let peer = HttpPeer::new(addr.to_string(), false, String::new());
+    let request = SubRequest {
+        method: http::Method::GET,
+        uri: "/fw-test".parse().unwrap(),
+        headers: HeaderMap::new(),
+        body: Bytes::new(),
+    };
+    let limits = StreamLimits {
+        idle_timeout: Duration::from_secs(5),
+        max_stream_duration: None,
+        max_total_bytes: None,
+    };
+
+    let mut fw = FrameworkHeaders::new();
+    fw.set_depth(3);
+
+    let StreamingSubResponse { status, mut body, .. } =
+        Box::pin(client.send_streaming(&peer, &request, Duration::from_secs(5), limits, Some(&fw)))
+            .await
+            .unwrap();
+
+    assert_eq!(status, 200);
+    while body.next_chunk().await.unwrap().is_some() {}
+
+    let captured_headers = backend.await.unwrap();
+    assert!(
+        captured_headers
+            .iter()
+            .any(|h| h.contains("x-praxis-iterative-depth") && h.contains('3')),
+        "upstream should receive depth header, got: {captured_headers:?}"
+    );
 }

--- a/core/src/subrequest/tests.rs
+++ b/core/src/subrequest/tests.rs
@@ -5,19 +5,25 @@ use std::{sync::Arc, time::Duration};
 
 use bytes::Bytes;
 use http::HeaderMap;
-use pingora_core::upstreams::peer::HttpPeer;
 
-use super::{
-    DEPTH_HEADER, FrameworkHeaders, SubRequest, SubRequestClient, SubRequestConnector, SubRequestConnectorOptions,
-    SubRequestError, SubResponse,
-    client::CircuitGuard,
-    internals::{
-        clamp_peer_timeouts, empty_body_needs_framing, ensure_host_header, min_timeout, strip_hop_by_hop_headers,
-        strip_request_framing_headers, strip_reserved_headers,
-    },
-    types::is_transport_header,
-};
+use super::{internals::*, types::*};
 use crate::circuit::{CircuitBreakerConfig, CircuitBreakerRegistry, CircuitCheck, PeerKey};
+
+// -- Metrics test utilities -----------------------------------------------
+
+fn install_metrics_recorder() -> &'static metrics_exporter_prometheus::PrometheusHandle {
+    use std::sync::OnceLock;
+    static HANDLE: OnceLock<metrics_exporter_prometheus::PrometheusHandle> = OnceLock::new();
+    HANDLE.get_or_init(|| {
+        metrics_exporter_prometheus::PrometheusBuilder::new()
+            .install_recorder()
+            .expect("failed to install test Prometheus recorder")
+    })
+}
+
+fn render_metrics() -> String {
+    install_metrics_recorder().render()
+}
 
 // -- SubRequestConnector ------------------------------------------------
 
@@ -141,7 +147,7 @@ fn subresponse_clone_preserves_fields() {
 #[test]
 fn client_wraps_connector() {
     let connector = SubRequestConnector::new(8, None);
-    let client = SubRequestClient::new(connector);
+    let client = super::client::SubRequestClient::new(connector);
     let debug = format!("{client:?}");
     assert!(
         debug.contains("SubRequestClient"),
@@ -152,10 +158,10 @@ fn client_wraps_connector() {
 #[test]
 fn client_clone_shares_connector() {
     let connector = SubRequestConnector::new(8, Some(4));
-    let a = SubRequestClient::new(connector);
+    let a = super::client::SubRequestClient::new(connector);
     let b = a.clone();
     assert!(
-        Arc::ptr_eq(&a.connector().inner, &b.connector().inner,),
+        Arc::ptr_eq(&a.connector().inner, &b.connector().inner),
         "cloned clients should share the same connector"
     );
 }
@@ -215,6 +221,16 @@ fn subrequest_error_deadline_exceeded_display() {
         !err.to_string().is_empty(),
         "DeadlineExceeded should have a display message"
     );
+}
+
+#[test]
+fn subrequest_error_stream_idle_timeout_display() {
+    let err = SubRequestError::StreamIdleTimeout {
+        idle_timeout: Duration::from_secs(30),
+    };
+    let msg = err.to_string();
+    assert!(msg.contains("idle timeout"), "should mention idle timeout: {msg}");
+    assert!(msg.contains("30s"), "should include duration: {msg}");
 }
 
 // -- Header sanitization ------------------------------------------------
@@ -277,6 +293,7 @@ fn min_timeout_preserves_stricter_cluster_limit() {
 
 #[test]
 fn clamp_peer_timeouts_bounds_connection_setup() {
+    use pingora_core::upstreams::peer::HttpPeer;
     let mut peer = HttpPeer::new("127.0.0.1:8080", false, String::new());
     peer.options.connection_timeout = Some(Duration::from_secs(1));
     peer.options.total_connection_timeout = Some(Duration::from_secs(20));
@@ -289,6 +306,7 @@ fn clamp_peer_timeouts_bounds_connection_setup() {
 
 #[test]
 fn ensure_host_header_uses_peer_address_without_overwriting_explicit_host() {
+    use pingora_core::upstreams::peer::HttpPeer;
     let peer = HttpPeer::new("127.0.0.1:8443", false, String::new());
     let mut generated = pingora_http::RequestHeader::build("GET", b"/", None).unwrap();
     ensure_host_header(&mut generated, &peer).unwrap();
@@ -304,6 +322,7 @@ fn ensure_host_header_uses_peer_address_without_overwriting_explicit_host() {
 
 #[tokio::test]
 async fn deadline_bounds_the_complete_exchange() {
+    use pingora_core::upstreams::peer::HttpPeer;
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let address = listener.local_addr().unwrap();
     let backend = tokio::spawn(async move {
@@ -311,7 +330,7 @@ async fn deadline_bounds_the_complete_exchange() {
         tokio::time::sleep(Duration::from_secs(1)).await;
     });
     let connector = SubRequestConnector::new(1, None);
-    let client = SubRequestClient::new(connector);
+    let client = super::client::SubRequestClient::new(connector);
     let peer = HttpPeer::new(address.to_string(), false, String::new());
     let request = SubRequest {
         method: http::Method::GET,
@@ -386,14 +405,14 @@ async fn try_acquire_permit_returns_none_without_limit() {
 #[test]
 fn client_with_custom_ceiling() {
     let connector = SubRequestConnector::new(8, None);
-    let client = SubRequestClient::with_max_response_bytes(connector, 4096);
+    let client = super::client::SubRequestClient::with_max_response_bytes(connector, 4096);
     assert_eq!(client.max_response_bytes, 4096);
 }
 
 #[test]
 fn client_default_ceiling_is_absolute_max() {
     let connector = SubRequestConnector::new(8, None);
-    let client = SubRequestClient::new(connector);
+    let client = super::client::SubRequestClient::new(connector);
     assert_eq!(
         client.max_response_bytes,
         crate::config::ABSOLUTE_MAX_BODY_BYTES,
@@ -684,4 +703,1223 @@ fn framework_headers_set_depth_zero() {
     fw.set_depth(0);
     let (_, value) = fw.iter().next().unwrap();
     assert_eq!(value, "0");
+}
+
+// -- StreamLimits ----------------------------------------------------------
+
+#[test]
+fn stream_limits_fields_are_accessible() {
+    let limits = StreamLimits {
+        idle_timeout: Duration::from_secs(30),
+        max_stream_duration: Some(Duration::from_secs(300)),
+        max_total_bytes: Some(10_485_760), // 10 MiB
+    };
+    assert_eq!(limits.idle_timeout, Duration::from_secs(30));
+    assert_eq!(limits.max_stream_duration, Some(Duration::from_secs(300)));
+    assert_eq!(limits.max_total_bytes, Some(10_485_760));
+}
+
+#[test]
+fn stream_limits_no_optional_bounds() {
+    let limits = StreamLimits {
+        idle_timeout: Duration::from_secs(15),
+        max_stream_duration: None,
+        max_total_bytes: None,
+    };
+    assert!(limits.max_stream_duration.is_none());
+    assert!(limits.max_total_bytes.is_none());
+}
+
+// -- StreamingSubResponse --------------------------------------------------
+
+#[test]
+fn streaming_sub_response_exposes_status_and_headers() {
+    let body = SubResponseBody::new_done();
+    let resp = StreamingSubResponse {
+        status: 200,
+        headers: {
+            let mut h = HeaderMap::new();
+            h.insert("content-type", "text/event-stream".parse().unwrap());
+            h
+        },
+        body,
+    };
+    assert_eq!(resp.status, 200);
+    assert_eq!(resp.headers.get("content-type").unwrap(), "text/event-stream");
+    drop(resp);
+}
+
+// -- SubResponseBody -------------------------------------------------------
+
+#[tokio::test]
+async fn sub_response_body_done_returns_none() {
+    let mut body = SubResponseBody::new_done();
+    assert!(body.is_done());
+    let result = body.next_chunk().await;
+    drop(body);
+    assert!(matches!(result, Ok(None)), "done body should return Ok(None)");
+}
+
+// -- Streaming tests -------------------------------------------------------
+
+// Test Utilities
+
+async fn spawn_http_backend(
+    body_chunks: Vec<&'static [u8]>,
+    chunk_delay: Duration,
+) -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
+    use tokio::io::AsyncWriteExt as _;
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let handle = tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        let mut buf = vec![0_u8; 4096];
+        let _bytes_read = tokio::io::AsyncReadExt::read(&mut socket, &mut buf).await;
+
+        let header = "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n";
+        socket.write_all(header.as_bytes()).await.unwrap();
+
+        for chunk_data in &body_chunks {
+            let chunk = format!("{:x}\r\n", chunk_data.len());
+            socket.write_all(chunk.as_bytes()).await.unwrap();
+            socket.write_all(chunk_data).await.unwrap();
+            socket.write_all(b"\r\n").await.unwrap();
+            socket.flush().await.unwrap();
+            if !chunk_delay.is_zero() {
+                tokio::time::sleep(chunk_delay).await;
+            }
+        }
+        socket.write_all(b"0\r\n\r\n").await.unwrap();
+        socket.flush().await.unwrap();
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    });
+    (addr, handle)
+}
+
+async fn spawn_stalling_backend() -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
+    use tokio::io::AsyncWriteExt as _;
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let handle = tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        let mut buf = vec![0_u8; 4096];
+        drop(tokio::io::AsyncReadExt::read(&mut socket, &mut buf).await);
+
+        let header = "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n";
+        socket.write_all(header.as_bytes()).await.unwrap();
+        socket.write_all(b"5\r\nhello\r\n").await.unwrap();
+        socket.flush().await.unwrap();
+        tokio::time::sleep(Duration::from_secs(60)).await;
+    });
+    (addr, handle)
+}
+
+#[tokio::test]
+#[expect(clippy::too_many_lines, reason = "test setup and validation")]
+async fn send_streaming_receives_chunks_incrementally() {
+    use pingora_core::upstreams::peer::HttpPeer;
+    let chunks: Vec<&[u8]> = vec![b"chunk1", b"chunk2", b"chunk3"];
+    let (addr, backend) = spawn_http_backend(chunks.clone(), Duration::ZERO).await;
+
+    let connector = SubRequestConnector::new(1, None);
+    let client = super::client::SubRequestClient::new(connector);
+    let peer = HttpPeer::new(addr.to_string(), false, String::new());
+    let request = SubRequest {
+        method: http::Method::GET,
+        uri: "/stream".parse().unwrap(),
+        headers: HeaderMap::new(),
+        body: Bytes::new(),
+    };
+    let limits = StreamLimits {
+        idle_timeout: Duration::from_secs(5),
+        max_stream_duration: None,
+        max_total_bytes: None,
+    };
+
+    let StreamingSubResponse {
+        status,
+        headers: _,
+        mut body,
+    } = Box::pin(client.send_streaming(&peer, &request, Duration::from_secs(5), limits, None))
+        .await
+        .unwrap();
+
+    assert_eq!(status, 200);
+    let mut received = Vec::new();
+    while let Some(chunk) = body.next_chunk().await.unwrap() {
+        received.push(chunk);
+    }
+    assert!(body.is_done());
+    let total: Vec<u8> = received.iter().flat_map(|c| c.iter().copied()).collect();
+    assert_eq!(total, b"chunk1chunk2chunk3");
+    assert_eq!(body.received_bytes(), 18);
+    drop(body);
+
+    backend.abort();
+}
+
+#[tokio::test]
+#[expect(clippy::too_many_lines, reason = "test setup and validation")]
+async fn send_streaming_records_metrics() {
+    use pingora_core::upstreams::peer::HttpPeer;
+    install_metrics_recorder();
+
+    let chunks: Vec<&[u8]> = vec![b"hello", b"world"];
+    let (addr, backend) = spawn_http_backend(chunks, Duration::ZERO).await;
+
+    let connector = SubRequestConnector::new(1, None);
+    let client = super::client::SubRequestClient::new(connector);
+    let peer = HttpPeer::new(addr.to_string(), false, String::new());
+    let request = SubRequest {
+        method: http::Method::GET,
+        uri: "/metrics-test".parse().unwrap(),
+        headers: HeaderMap::new(),
+        body: Bytes::new(),
+    };
+    let limits = StreamLimits {
+        idle_timeout: Duration::from_secs(5),
+        max_stream_duration: None,
+        max_total_bytes: None,
+    };
+
+    let StreamingSubResponse { mut body, .. } =
+        Box::pin(client.send_streaming(&peer, &request, Duration::from_secs(5), limits, None))
+            .await
+            .unwrap();
+
+    while body.next_chunk().await.unwrap().is_some() {}
+
+    let rendered = render_metrics();
+    assert!(
+        rendered.contains("praxis_subrequest_streams_total"),
+        "should record streams_total metric:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("praxis_subrequest_stream_duration_seconds"),
+        "should record stream_duration metric:\n{rendered}"
+    );
+
+    backend.abort();
+}
+
+#[tokio::test]
+async fn send_streaming_idle_timeout_fires() {
+    use pingora_core::upstreams::peer::HttpPeer;
+    let (addr, backend) = spawn_stalling_backend().await;
+
+    let connector = SubRequestConnector::new(1, None);
+    let client = super::client::SubRequestClient::new(connector);
+    let peer = HttpPeer::new(addr.to_string(), false, String::new());
+    let request = SubRequest {
+        method: http::Method::GET,
+        uri: "/stall".parse().unwrap(),
+        headers: HeaderMap::new(),
+        body: Bytes::new(),
+    };
+    let limits = StreamLimits {
+        idle_timeout: Duration::from_millis(50),
+        max_stream_duration: None,
+        max_total_bytes: None,
+    };
+
+    let StreamingSubResponse { mut body, .. } =
+        Box::pin(client.send_streaming(&peer, &request, Duration::from_secs(5), limits, None))
+            .await
+            .unwrap();
+
+    let first = body.next_chunk().await.unwrap();
+    assert!(first.is_some(), "first chunk should arrive");
+
+    let err = body.next_chunk().await.unwrap_err();
+    assert!(
+        matches!(err, SubRequestError::StreamIdleTimeout { .. }),
+        "should get StreamIdleTimeout, got: {err}"
+    );
+    assert!(body.is_done());
+    drop(body);
+
+    backend.abort();
+}
+
+#[tokio::test]
+async fn send_streaming_read_timeout_fires_as_io_error() {
+    use pingora_core::upstreams::peer::HttpPeer;
+    let (addr, backend) = spawn_stalling_backend().await;
+
+    let connector = SubRequestConnector::new(1, None);
+    let client = super::client::SubRequestClient::new(connector);
+    let mut peer = HttpPeer::new(addr.to_string(), false, String::new());
+    peer.options.read_timeout = Some(Duration::from_millis(30));
+    let request = SubRequest {
+        method: http::Method::GET,
+        uri: "/stall".parse().unwrap(),
+        headers: HeaderMap::new(),
+        body: Bytes::new(),
+    };
+    let limits = StreamLimits {
+        idle_timeout: Duration::from_secs(5),
+        max_stream_duration: None,
+        max_total_bytes: None,
+    };
+
+    let StreamingSubResponse { mut body, .. } =
+        Box::pin(client.send_streaming(&peer, &request, Duration::from_secs(5), limits, None))
+            .await
+            .unwrap();
+
+    let first = body.next_chunk().await.unwrap();
+    assert!(first.is_some(), "first chunk should arrive");
+
+    let err = body.next_chunk().await.unwrap_err();
+    assert!(
+        matches!(&err, SubRequestError::Io(msg) if msg.contains("read timeout")),
+        "read_timeout < idle_timeout should produce Io, got: {err}"
+    );
+    assert!(body.is_done());
+
+    backend.abort();
+}
+
+#[tokio::test]
+async fn send_streaming_cancel_after_eof_is_noop() {
+    use pingora_core::upstreams::peer::HttpPeer;
+    let chunks: Vec<&[u8]> = vec![b"one", b"two"];
+    let (addr, backend) = spawn_http_backend(chunks, Duration::ZERO).await;
+
+    let connector = SubRequestConnector::new(1, None);
+    let client = super::client::SubRequestClient::new(connector);
+    let peer = HttpPeer::new(addr.to_string(), false, String::new());
+    let request = SubRequest {
+        method: http::Method::GET,
+        uri: "/eof".parse().unwrap(),
+        headers: HeaderMap::new(),
+        body: Bytes::new(),
+    };
+    let limits = StreamLimits {
+        idle_timeout: Duration::from_secs(5),
+        max_stream_duration: None,
+        max_total_bytes: None,
+    };
+
+    let StreamingSubResponse { mut body, .. } =
+        Box::pin(client.send_streaming(&peer, &request, Duration::from_secs(5), limits, None))
+            .await
+            .unwrap();
+
+    while body.next_chunk().await.unwrap().is_some() {}
+    assert!(body.is_done(), "should be done after EOF");
+
+    Box::pin(body.cancel()).await;
+
+    backend.abort();
+}
+
+#[tokio::test]
+#[expect(clippy::too_many_lines, reason = "test setup and validation")]
+async fn send_streaming_max_stream_duration_fires() {
+    use pingora_core::upstreams::peer::HttpPeer;
+    let chunks: Vec<&[u8]> = vec![b"a"; 100];
+    let (addr, backend) = spawn_http_backend(chunks, Duration::from_millis(10)).await;
+
+    let connector = SubRequestConnector::new(1, None);
+    let client = super::client::SubRequestClient::new(connector);
+    let peer = HttpPeer::new(addr.to_string(), false, String::new());
+    let request = SubRequest {
+        method: http::Method::GET,
+        uri: "/slow".parse().unwrap(),
+        headers: HeaderMap::new(),
+        body: Bytes::new(),
+    };
+    let limits = StreamLimits {
+        idle_timeout: Duration::from_secs(5),
+        max_stream_duration: Some(Duration::from_millis(50)),
+        max_total_bytes: None,
+    };
+
+    let StreamingSubResponse { mut body, .. } =
+        Box::pin(client.send_streaming(&peer, &request, Duration::from_secs(5), limits, None))
+            .await
+            .unwrap();
+
+    let mut count = 0_u64;
+    loop {
+        match body.next_chunk().await {
+            Ok(Some(_)) => count += 1,
+            Ok(None) | Err(SubRequestError::DeadlineExceeded) => break,
+            Err(e) => panic!("unexpected error: {e}"),
+        }
+    }
+    assert!(
+        count > 0 && count < 100,
+        "should have received some but not all chunks: {count}"
+    );
+    assert!(body.is_done());
+    drop(body);
+
+    backend.abort();
+}
+
+#[tokio::test]
+#[expect(clippy::too_many_lines, reason = "test setup and validation")]
+async fn send_streaming_max_total_bytes_enforced() {
+    use pingora_core::upstreams::peer::HttpPeer;
+    let chunks: Vec<&[u8]> = vec![b"12345"; 10];
+    let (addr, backend) = spawn_http_backend(chunks, Duration::ZERO).await;
+
+    let connector = SubRequestConnector::new(1, None);
+    let client = super::client::SubRequestClient::new(connector);
+    let peer = HttpPeer::new(addr.to_string(), false, String::new());
+    let request = SubRequest {
+        method: http::Method::GET,
+        uri: "/limited".parse().unwrap(),
+        headers: HeaderMap::new(),
+        body: Bytes::new(),
+    };
+    let limits = StreamLimits {
+        idle_timeout: Duration::from_secs(5),
+        max_stream_duration: None,
+        max_total_bytes: Some(20),
+    };
+
+    let StreamingSubResponse { mut body, .. } =
+        Box::pin(client.send_streaming(&peer, &request, Duration::from_secs(5), limits, None))
+            .await
+            .unwrap();
+
+    loop {
+        match body.next_chunk().await {
+            Ok(Some(_chunk)) => {},
+            Ok(None) => panic!("should have hit byte limit before EOF"),
+            Err(SubRequestError::ResponseTooLarge { actual, limit }) => {
+                assert!(actual > 20, "actual should exceed limit: {actual}");
+                assert_eq!(limit, 20);
+                break;
+            },
+            Err(e) => panic!("unexpected error: {e}"),
+        }
+    }
+    assert!(body.is_done());
+    drop(body);
+
+    backend.abort();
+}
+
+#[tokio::test]
+async fn send_streaming_cancel_shuts_down_session() {
+    use pingora_core::upstreams::peer::HttpPeer;
+    let (addr, backend) = spawn_stalling_backend().await;
+
+    let connector = SubRequestConnector::new(1, Some(1));
+    let client = super::client::SubRequestClient::new(connector.clone());
+    let peer = HttpPeer::new(addr.to_string(), false, String::new());
+    let request = SubRequest {
+        method: http::Method::GET,
+        uri: "/cancel-test".parse().unwrap(),
+        headers: HeaderMap::new(),
+        body: Bytes::new(),
+    };
+    let limits = StreamLimits {
+        idle_timeout: Duration::from_secs(30),
+        max_stream_duration: None,
+        max_total_bytes: None,
+    };
+
+    let StreamingSubResponse { mut body, .. } =
+        Box::pin(client.send_streaming(&peer, &request, Duration::from_secs(5), limits, None))
+            .await
+            .unwrap();
+
+    drop(body.next_chunk().await.unwrap());
+
+    Box::pin(body.cancel()).await;
+
+    let permit = connector.try_acquire_permit(Duration::from_millis(100)).await;
+    assert!(
+        matches!(permit, Ok(Some(_))),
+        "cancel should release the admission permit: {permit:?}"
+    );
+    drop(permit);
+
+    backend.abort();
+}
+
+#[tokio::test]
+async fn send_streaming_drop_before_eof_releases_permit() {
+    use pingora_core::upstreams::peer::HttpPeer;
+    let (addr, backend) = spawn_stalling_backend().await;
+
+    let connector = SubRequestConnector::new(1, Some(1));
+    let client = super::client::SubRequestClient::new(connector.clone());
+    let peer = HttpPeer::new(addr.to_string(), false, String::new());
+    let request = SubRequest {
+        method: http::Method::GET,
+        uri: "/drop-test".parse().unwrap(),
+        headers: HeaderMap::new(),
+        body: Bytes::new(),
+    };
+    let limits = StreamLimits {
+        idle_timeout: Duration::from_secs(30),
+        max_stream_duration: None,
+        max_total_bytes: None,
+    };
+
+    let StreamingSubResponse { body, .. } =
+        Box::pin(client.send_streaming(&peer, &request, Duration::from_secs(5), limits, None))
+            .await
+            .unwrap();
+
+    drop(body);
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let permit = connector.try_acquire_permit(Duration::from_millis(100)).await;
+    assert!(
+        matches!(permit, Ok(Some(_))),
+        "drop should eventually release the admission permit: {permit:?}"
+    );
+    drop(permit);
+
+    backend.abort();
+}
+
+#[tokio::test]
+#[expect(clippy::too_many_lines, reason = "test setup and validation")]
+async fn send_streaming_circuit_success_at_headers() {
+    use pingora_core::upstreams::peer::HttpPeer;
+    let chunks: Vec<&[u8]> = vec![b"data"];
+    let (addr, backend) = spawn_http_backend(chunks, Duration::ZERO).await;
+
+    let connector = SubRequestConnector::with_options(SubRequestConnectorOptions {
+        keepalive_pool_size: 1,
+        max_connections: None,
+        circuit_breaker: Some(CircuitBreakerConfig {
+            threshold: 1,
+            recovery_window: Duration::from_secs(9999),
+            half_open_timeout: Duration::from_secs(9999),
+        }),
+    });
+    let client = super::client::SubRequestClient::new(connector.clone());
+    let peer = HttpPeer::new(addr.to_string(), false, String::new());
+    let request = SubRequest {
+        method: http::Method::GET,
+        uri: "/circuit".parse().unwrap(),
+        headers: HeaderMap::new(),
+        body: Bytes::new(),
+    };
+    let limits = StreamLimits {
+        idle_timeout: Duration::from_secs(5),
+        max_stream_duration: None,
+        max_total_bytes: None,
+    };
+
+    let StreamingSubResponse { mut body, .. } =
+        Box::pin(client.send_streaming(&peer, &request, Duration::from_secs(5), limits, None))
+            .await
+            .unwrap();
+
+    let peer_key = PeerKey::new(addr, "");
+    assert!(
+        connector.circuit_breakers.as_ref().unwrap().precheck(&peer_key),
+        "circuit should be healthy after streaming header success"
+    );
+    while body.next_chunk().await.unwrap().is_some() {}
+    drop(body);
+
+    backend.abort();
+}
+
+#[tokio::test]
+#[expect(clippy::too_many_lines, reason = "test setup and validation")]
+async fn send_streaming_permit_held_until_completion() {
+    use pingora_core::upstreams::peer::HttpPeer;
+    let chunks: Vec<&[u8]> = vec![b"a", b"b", b"c"];
+    let (addr, backend) = spawn_http_backend(chunks, Duration::from_millis(20)).await;
+
+    let connector = SubRequestConnector::new(1, Some(1));
+    let client = super::client::SubRequestClient::new(connector.clone());
+    let peer = HttpPeer::new(addr.to_string(), false, String::new());
+    let request = SubRequest {
+        method: http::Method::GET,
+        uri: "/permit-test".parse().unwrap(),
+        headers: HeaderMap::new(),
+        body: Bytes::new(),
+    };
+    let limits = StreamLimits {
+        idle_timeout: Duration::from_secs(5),
+        max_stream_duration: None,
+        max_total_bytes: None,
+    };
+
+    let StreamingSubResponse { mut body, .. } =
+        Box::pin(client.send_streaming(&peer, &request, Duration::from_secs(5), limits, None))
+            .await
+            .unwrap();
+
+    assert_eq!(
+        connector.admission.as_ref().unwrap().available_permits(),
+        0,
+        "permit should be held during streaming"
+    );
+    while body.next_chunk().await.unwrap().is_some() {}
+
+    assert_eq!(
+        connector.admission.as_ref().unwrap().available_permits(),
+        1,
+        "permit should be released after stream EOF"
+    );
+    drop(body);
+
+    backend.abort();
+}
+
+#[tokio::test]
+#[expect(clippy::too_many_lines, reason = "test setup and validation")]
+async fn send_streaming_backpressure_blocks_producer() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use pingora_core::upstreams::peer::HttpPeer;
+    use tokio::io::AsyncWriteExt as _;
+
+    // Large chunks to fill TCP send/receive buffers quickly.
+    let chunk_count: usize = 500;
+    let chunk_size: usize = 65_536; // 64 KiB per chunk
+    let chunk_data = vec![b'X'; chunk_size];
+    let chunks_sent = Arc::new(AtomicUsize::new(0));
+    let chunks_sent_server = Arc::clone(&chunks_sent);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let backend = tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        let mut buf = vec![0_u8; 4096];
+        drop(tokio::io::AsyncReadExt::read(&mut socket, &mut buf).await);
+
+        let header = "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n";
+        socket.write_all(header.as_bytes()).await.unwrap();
+
+        for _ in 0..chunk_count {
+            let hex = format!("{chunk_size:x}\r\n");
+            socket.write_all(hex.as_bytes()).await.unwrap();
+            socket.write_all(&chunk_data).await.unwrap();
+            socket.write_all(b"\r\n").await.unwrap();
+            // flush each chunk — write_all blocks when TCP buffers are full.
+            socket.flush().await.unwrap();
+            chunks_sent_server.fetch_add(1, Ordering::SeqCst);
+        }
+        socket.write_all(b"0\r\n\r\n").await.unwrap();
+        socket.flush().await.unwrap();
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    });
+
+    let connector = SubRequestConnector::new(1, None);
+    let client = super::client::SubRequestClient::new(connector);
+    let peer = HttpPeer::new(addr.to_string(), false, String::new());
+    let request = SubRequest {
+        method: http::Method::GET,
+        uri: "/backpressure".parse().unwrap(),
+        headers: HeaderMap::new(),
+        body: Bytes::new(),
+    };
+    let limits = StreamLimits {
+        idle_timeout: Duration::from_secs(30),
+        max_stream_duration: None,
+        max_total_bytes: None,
+    };
+
+    let StreamingSubResponse { mut body, .. } =
+        Box::pin(client.send_streaming(&peer, &request, Duration::from_secs(30), limits, None))
+            .await
+            .unwrap();
+
+    // Read one chunk then stall — producer should block on TCP backpressure.
+    let first = body.next_chunk().await.unwrap().expect("first chunk");
+    assert!(!first.is_empty());
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let sent_while_stalled = chunks_sent.load(Ordering::SeqCst);
+    assert!(
+        sent_while_stalled < chunk_count,
+        "producer should be blocked by TCP backpressure, but sent {sent_while_stalled}/{chunk_count}"
+    );
+
+    // Drain remaining — all data must arrive.
+    let mut total_bytes = first.len();
+    while let Some(chunk) = body.next_chunk().await.unwrap() {
+        total_bytes += chunk.len();
+    }
+    assert_eq!(
+        total_bytes,
+        chunk_size * chunk_count,
+        "all bytes must arrive despite slow consumer"
+    );
+    assert!(body.is_done());
+    drop(body);
+
+    backend.abort();
+}
+
+#[tokio::test]
+#[expect(clippy::too_many_lines, reason = "test setup and validation")]
+async fn send_streaming_connection_reused_after_clean_eof() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use pingora_core::upstreams::peer::HttpPeer;
+    use tokio::io::AsyncWriteExt as _;
+
+    let connections = Arc::new(AtomicUsize::new(0));
+    let connections_backend = Arc::clone(&connections);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let handle = tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        connections_backend.fetch_add(1, Ordering::SeqCst);
+
+        for _ in 0..2 {
+            let mut buf = vec![0_u8; 4096];
+            drop(tokio::io::AsyncReadExt::read(&mut socket, &mut buf).await);
+            let resp = "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n\
+                        5\r\nhello\r\n0\r\n\r\n";
+            socket.write_all(resp.as_bytes()).await.unwrap();
+            socket.flush().await.unwrap();
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    });
+
+    let connector = SubRequestConnector::new(1, None);
+    let client = super::client::SubRequestClient::new(connector);
+    let peer = HttpPeer::new(addr.to_string(), false, String::new());
+    let request = SubRequest {
+        method: http::Method::GET,
+        uri: "/reuse".parse().unwrap(),
+        headers: HeaderMap::new(),
+        body: Bytes::new(),
+    };
+    let limits = StreamLimits {
+        idle_timeout: Duration::from_secs(5),
+        max_stream_duration: None,
+        max_total_bytes: None,
+    };
+
+    let StreamingSubResponse {
+        status,
+        headers: _,
+        mut body,
+    } = Box::pin(client.send_streaming(&peer, &request, Duration::from_secs(5), limits.clone(), None))
+        .await
+        .unwrap();
+    assert_eq!(status, 200);
+    while body.next_chunk().await.unwrap().is_some() {}
+    drop(body);
+
+    let StreamingSubResponse {
+        status,
+        headers: _,
+        mut body,
+    } = Box::pin(client.send_streaming(&peer, &request, Duration::from_secs(5), limits, None))
+        .await
+        .unwrap();
+    assert_eq!(status, 200);
+    while body.next_chunk().await.unwrap().is_some() {}
+    drop(body);
+
+    assert_eq!(
+        connections.load(Ordering::SeqCst),
+        1,
+        "second request should reuse the pooled connection"
+    );
+
+    handle.abort();
+}
+
+#[tokio::test]
+#[expect(clippy::too_many_lines, reason = "test setup and validation")]
+async fn send_streaming_circuit_half_open_probe_recovers() {
+    use pingora_core::upstreams::peer::HttpPeer;
+    use tokio::io::AsyncWriteExt as _;
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let handle = tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        let mut buf = vec![0_u8; 4096];
+        drop(tokio::io::AsyncReadExt::read(&mut socket, &mut buf).await);
+        drop(socket);
+
+        let (mut socket, _) = listener.accept().await.unwrap();
+        let mut buf = vec![0_u8; 4096];
+        drop(tokio::io::AsyncReadExt::read(&mut socket, &mut buf).await);
+        let resp = "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n\
+                    5\r\nhello\r\n0\r\n\r\n";
+        socket.write_all(resp.as_bytes()).await.unwrap();
+        socket.flush().await.unwrap();
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    });
+
+    let connector = SubRequestConnector::with_options(SubRequestConnectorOptions {
+        keepalive_pool_size: 1,
+        max_connections: None,
+        circuit_breaker: Some(CircuitBreakerConfig {
+            threshold: 1,
+            recovery_window: Duration::from_millis(50),
+            half_open_timeout: Duration::from_secs(5),
+        }),
+    });
+    let client = super::client::SubRequestClient::new(connector.clone());
+    let peer = HttpPeer::new(addr.to_string(), false, String::new());
+    let peer_key = PeerKey::new(addr, "");
+    let request = SubRequest {
+        method: http::Method::GET,
+        uri: "/half-open".parse().unwrap(),
+        headers: HeaderMap::new(),
+        body: Bytes::new(),
+    };
+    let limits = StreamLimits {
+        idle_timeout: Duration::from_secs(5),
+        max_stream_duration: None,
+        max_total_bytes: None,
+    };
+
+    assert!(
+        Box::pin(client.send_streaming(&peer, &request, Duration::from_secs(5), limits.clone(), None))
+            .await
+            .is_err(),
+        "first request should fail (backend closed connection)"
+    );
+
+    assert!(
+        !connector.circuit_breakers.as_ref().unwrap().precheck(&peer_key),
+        "circuit should be open after failure"
+    );
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let StreamingSubResponse {
+        status,
+        headers: _,
+        mut body,
+    } = Box::pin(client.send_streaming(&peer, &request, Duration::from_secs(5), limits, None))
+        .await
+        .expect("half-open probe should succeed");
+    assert_eq!(status, 200);
+
+    assert!(
+        connector.circuit_breakers.as_ref().unwrap().precheck(&peer_key),
+        "circuit should recover after successful half-open probe"
+    );
+
+    while body.next_chunk().await.unwrap().is_some() {}
+    drop(body);
+
+    handle.abort();
+}
+
+// -- HTTP/2 cleartext (prior-knowledge) helpers ----------------------------
+
+#[expect(clippy::too_many_lines, reason = "H2 server setup")]
+async fn spawn_h2_backend(
+    body_chunks: Vec<&'static [u8]>,
+    chunk_delay: Duration,
+) -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let handle = tokio::spawn(async move {
+        loop {
+            let Ok((socket, _)) = listener.accept().await else {
+                break;
+            };
+            let chunks = body_chunks.clone();
+            let delay = chunk_delay;
+            tokio::spawn(async move {
+                let mut connection = h2::server::handshake(socket).await.unwrap();
+                while let Some(result) = connection.accept().await {
+                    let (_, mut respond) = result.unwrap();
+                    let response = http::Response::builder().status(200).body(()).unwrap();
+                    let mut send_stream = respond.send_response(response, false).unwrap();
+                    for chunk_data in &chunks {
+                        send_stream.reserve_capacity(chunk_data.len());
+                        send_stream.send_data(Bytes::from_static(chunk_data), false).unwrap();
+                        if !delay.is_zero() {
+                            tokio::time::sleep(delay).await;
+                        }
+                    }
+                    send_stream.send_data(Bytes::new(), true).unwrap();
+                }
+            });
+        }
+    });
+    tokio::time::sleep(Duration::from_millis(10)).await;
+    (addr, handle)
+}
+
+fn h2_peer(addr: std::net::SocketAddr) -> pingora_core::upstreams::peer::HttpPeer {
+    let mut peer = pingora_core::upstreams::peer::HttpPeer::new(addr.to_string(), false, String::new());
+    peer.options.set_http_version(2, 2);
+    peer
+}
+
+#[tokio::test]
+#[expect(clippy::too_many_lines, reason = "test setup and validation")]
+async fn send_streaming_h2_cleartext_receives_chunks() {
+    let chunks: Vec<&[u8]> = vec![b"h2-chunk-1", b"h2-chunk-2", b"h2-chunk-3"];
+    let (addr, backend) = spawn_h2_backend(chunks.clone(), Duration::ZERO).await;
+
+    let connector = SubRequestConnector::new(1, None);
+    let client = super::client::SubRequestClient::new(connector);
+    let peer = h2_peer(addr);
+    let request = SubRequest {
+        method: http::Method::GET,
+        uri: "/h2-stream".parse().unwrap(),
+        headers: HeaderMap::new(),
+        body: Bytes::new(),
+    };
+    let limits = StreamLimits {
+        idle_timeout: Duration::from_secs(5),
+        max_stream_duration: None,
+        max_total_bytes: None,
+    };
+
+    let StreamingSubResponse {
+        status,
+        headers: _,
+        mut body,
+    } = Box::pin(client.send_streaming(&peer, &request, Duration::from_secs(5), limits, None))
+        .await
+        .unwrap();
+    assert_eq!(status, 200);
+
+    let mut collected = Vec::new();
+    while let Some(chunk) = body.next_chunk().await.unwrap() {
+        collected.push(chunk);
+    }
+    assert!(body.is_done());
+
+    let total_bytes: usize = collected.iter().map(Bytes::len).sum();
+    let expected: usize = chunks.iter().map(|c| c.len()).sum();
+    assert_eq!(total_bytes, expected, "all H2 bytes must arrive");
+
+    drop(body);
+    backend.abort();
+}
+
+#[tokio::test]
+#[expect(clippy::too_many_lines, reason = "test setup and validation")]
+async fn send_streaming_h2_cleartext_cancel_resets_stream_and_connection_survives() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let connections = Arc::new(AtomicUsize::new(0));
+    let connections_backend = Arc::clone(&connections);
+    let resets_observed = Arc::new(AtomicUsize::new(0));
+    let resets_backend = Arc::clone(&resets_observed);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let backend = tokio::spawn(async move {
+        loop {
+            let Ok((socket, _)) = listener.accept().await else {
+                break;
+            };
+            connections_backend.fetch_add(1, Ordering::SeqCst);
+            let resets = Arc::clone(&resets_backend);
+            tokio::spawn(async move {
+                let mut connection = h2::server::handshake(socket).await.unwrap();
+                while let Some(result) = connection.accept().await {
+                    let (_, mut respond) = result.unwrap();
+                    let resets = Arc::clone(&resets);
+                    tokio::spawn(async move {
+                        let response = http::Response::builder().status(200).body(()).unwrap();
+                        let mut send_stream = respond.send_response(response, false).unwrap();
+                        for _ in 0..100 {
+                            send_stream.reserve_capacity(11);
+                            if send_stream
+                                .send_data(Bytes::from_static(b"cancel-data"), false)
+                                .is_err()
+                            {
+                                resets.fetch_add(1, Ordering::SeqCst);
+                                break;
+                            }
+                            tokio::time::sleep(Duration::from_millis(20)).await;
+                        }
+                    });
+                }
+            });
+        }
+    });
+    tokio::time::sleep(Duration::from_millis(10)).await;
+
+    let connector = SubRequestConnector::new(4, Some(4));
+    let client = super::client::SubRequestClient::new(connector.clone());
+    let peer = h2_peer(addr);
+    let request = SubRequest {
+        method: http::Method::GET,
+        uri: "/h2-cancel".parse().unwrap(),
+        headers: HeaderMap::new(),
+        body: Bytes::new(),
+    };
+    let limits = StreamLimits {
+        idle_timeout: Duration::from_secs(5),
+        max_stream_duration: None,
+        max_total_bytes: None,
+    };
+
+    // First request — cancel mid-stream.
+    let StreamingSubResponse { status, body, .. } =
+        Box::pin(client.send_streaming(&peer, &request, Duration::from_secs(5), limits.clone(), None))
+            .await
+            .unwrap();
+    assert_eq!(status, 200);
+    Box::pin(body.cancel()).await;
+
+    // Allow RST_STREAM to propagate to the server.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let available = connector.admission.as_ref().unwrap().available_permits();
+    assert_eq!(available, 4, "permit must be released after H2 cancel");
+    assert!(
+        resets_observed.load(Ordering::SeqCst) >= 1,
+        "server must observe the RST_STREAM from the cancelled stream"
+    );
+
+    // Second request on same connection must succeed.
+    let StreamingSubResponse { status, mut body, .. } =
+        Box::pin(client.send_streaming(&peer, &request, Duration::from_secs(5), limits, None))
+            .await
+            .unwrap();
+    assert_eq!(status, 200);
+    let chunk = body.next_chunk().await.unwrap();
+    assert!(chunk.is_some(), "second stream should deliver data");
+    Box::pin(body.cancel()).await;
+
+    assert_eq!(
+        connections.load(Ordering::SeqCst),
+        1,
+        "cancelled H2 stream should not destroy the underlying connection"
+    );
+
+    backend.abort();
+}
+
+#[tokio::test]
+#[expect(clippy::too_many_lines, reason = "test setup and validation")]
+async fn send_streaming_h2_cleartext_connection_reused() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let connections = Arc::new(AtomicUsize::new(0));
+    let connections_backend = Arc::clone(&connections);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let handle = tokio::spawn(async move {
+        loop {
+            let Ok((socket, _)) = listener.accept().await else {
+                break;
+            };
+            connections_backend.fetch_add(1, Ordering::SeqCst);
+            tokio::spawn(async move {
+                let mut connection = h2::server::handshake(socket).await.unwrap();
+                while let Some(result) = connection.accept().await {
+                    let (_, mut respond) = result.unwrap();
+                    let response = http::Response::builder().status(200).body(()).unwrap();
+                    let mut send_stream = respond.send_response(response, false).unwrap();
+                    send_stream.send_data(Bytes::from_static(b"reuse"), true).unwrap();
+                }
+            });
+        }
+    });
+    tokio::time::sleep(Duration::from_millis(10)).await;
+
+    let connector = SubRequestConnector::new(4, None);
+    let client = super::client::SubRequestClient::new(connector);
+    let peer = h2_peer(addr);
+    let request = SubRequest {
+        method: http::Method::GET,
+        uri: "/h2-reuse".parse().unwrap(),
+        headers: HeaderMap::new(),
+        body: Bytes::new(),
+    };
+    let limits = StreamLimits {
+        idle_timeout: Duration::from_secs(5),
+        max_stream_duration: None,
+        max_total_bytes: None,
+    };
+
+    for _ in 0..3 {
+        let StreamingSubResponse {
+            status,
+            headers: _,
+            mut body,
+        } = Box::pin(client.send_streaming(&peer, &request, Duration::from_secs(5), limits.clone(), None))
+            .await
+            .unwrap();
+        assert_eq!(status, 200);
+        while body.next_chunk().await.unwrap().is_some() {}
+        drop(body);
+    }
+
+    assert_eq!(
+        connections.load(Ordering::SeqCst),
+        1,
+        "all H2 requests should multiplex on a single connection"
+    );
+
+    handle.abort();
+}
+
+#[tokio::test]
+#[expect(clippy::too_many_lines, reason = "test setup and validation")]
+async fn send_streaming_h1_incomplete_body_not_reused() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use pingora_core::upstreams::peer::HttpPeer;
+    use tokio::io::AsyncWriteExt as _;
+
+    let connections = Arc::new(AtomicUsize::new(0));
+    let connections_backend = Arc::clone(&connections);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let handle = tokio::spawn(async move {
+        loop {
+            let Ok((mut socket, _)) = listener.accept().await else {
+                break;
+            };
+            connections_backend.fetch_add(1, Ordering::SeqCst);
+            let mut buf = vec![0_u8; 4096];
+            drop(tokio::io::AsyncReadExt::read(&mut socket, &mut buf).await);
+            // Send chunked response then drop mid-body (no terminating 0\r\n\r\n).
+            let resp = "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n\
+                        5\r\nhello\r\n";
+            socket.write_all(resp.as_bytes()).await.unwrap();
+            socket.flush().await.unwrap();
+            drop(socket);
+        }
+    });
+
+    let connector = SubRequestConnector::new(1, None);
+    let client = super::client::SubRequestClient::new(connector);
+    let peer = HttpPeer::new(addr.to_string(), false, String::new());
+    let request = SubRequest {
+        method: http::Method::GET,
+        uri: "/incomplete".parse().unwrap(),
+        headers: HeaderMap::new(),
+        body: Bytes::new(),
+    };
+    let limits = StreamLimits {
+        idle_timeout: Duration::from_secs(5),
+        max_stream_duration: None,
+        max_total_bytes: None,
+    };
+
+    // First request — will get an incomplete body.
+    let StreamingSubResponse { mut body, .. } =
+        Box::pin(client.send_streaming(&peer, &request, Duration::from_secs(5), limits.clone(), None))
+            .await
+            .unwrap();
+    let chunk = body.next_chunk().await.unwrap();
+    assert!(chunk.is_some(), "should receive partial data");
+    let result = body.next_chunk().await;
+    assert!(result.is_err(), "incomplete body should produce an error");
+    drop(body);
+
+    // Second request must open a new connection.
+    let StreamingSubResponse { mut body, .. } =
+        Box::pin(client.send_streaming(&peer, &request, Duration::from_secs(5), limits, None))
+            .await
+            .expect("second request should connect successfully");
+    let chunk = body.next_chunk().await.unwrap();
+    assert!(chunk.is_some(), "second request should receive data");
+    drop(body);
+
+    assert_eq!(
+        connections.load(Ordering::SeqCst),
+        2,
+        "incomplete H1 body must not reuse the connection"
+    );
+
+    handle.abort();
+}
+
+#[tokio::test]
+#[expect(clippy::too_many_lines, reason = "test setup and validation")]
+async fn send_streaming_h1_cancel_does_not_reuse_connection() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use pingora_core::upstreams::peer::HttpPeer;
+    use tokio::io::AsyncWriteExt as _;
+
+    let connections = Arc::new(AtomicUsize::new(0));
+    let connections_backend = Arc::clone(&connections);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let handle = tokio::spawn(async move {
+        loop {
+            let Ok((mut socket, _)) = listener.accept().await else {
+                break;
+            };
+            connections_backend.fetch_add(1, Ordering::SeqCst);
+            tokio::spawn(async move {
+                loop {
+                    let mut buf = vec![0_u8; 4096];
+                    if tokio::io::AsyncReadExt::read(&mut socket, &mut buf).await.unwrap_or(0) == 0 {
+                        break;
+                    }
+                    let resp = "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n";
+                    socket.write_all(resp.as_bytes()).await.unwrap();
+                    // Send chunks slowly — caller will cancel mid-stream.
+                    for _ in 0..100 {
+                        socket.write_all(b"5\r\nhello\r\n").await.unwrap();
+                        socket.flush().await.unwrap();
+                        tokio::time::sleep(Duration::from_millis(20)).await;
+                    }
+                    socket.write_all(b"0\r\n\r\n").await.unwrap();
+                    socket.flush().await.unwrap();
+                }
+            });
+        }
+    });
+
+    let connector = SubRequestConnector::new(1, None);
+    let client = super::client::SubRequestClient::new(connector);
+    let peer = HttpPeer::new(addr.to_string(), false, String::new());
+    let request = SubRequest {
+        method: http::Method::GET,
+        uri: "/h1-cancel".parse().unwrap(),
+        headers: HeaderMap::new(),
+        body: Bytes::new(),
+    };
+    let limits = StreamLimits {
+        idle_timeout: Duration::from_secs(5),
+        max_stream_duration: None,
+        max_total_bytes: None,
+    };
+
+    // First request — cancel mid-stream.
+    let StreamingSubResponse { mut body, .. } =
+        Box::pin(client.send_streaming(&peer, &request, Duration::from_secs(5), limits.clone(), None))
+            .await
+            .unwrap();
+    let chunk = body.next_chunk().await.unwrap();
+    assert!(chunk.is_some(), "should receive first chunk");
+    Box::pin(body.cancel()).await;
+
+    // Second request — must open a new connection since H1 has
+    // unread response bytes on the cancelled connection.
+    let StreamingSubResponse { mut body, .. } =
+        Box::pin(client.send_streaming(&peer, &request, Duration::from_secs(5), limits, None))
+            .await
+            .unwrap();
+    let chunk = body.next_chunk().await.unwrap();
+    assert!(chunk.is_some(), "second request should receive data");
+    Box::pin(body.cancel()).await;
+
+    assert_eq!(
+        connections.load(Ordering::SeqCst),
+        2,
+        "cancelled H1 stream must not reuse the connection"
+    );
+
+    handle.abort();
 }

--- a/core/src/subrequest/types.rs
+++ b/core/src/subrequest/types.rs
@@ -1,16 +1,14 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Praxis Contributors
 
-//! Sub-request and sub-response data types, error enum, and
-//! framework header injection.
+use std::time::Duration;
 
 use bytes::Bytes;
 use http::HeaderMap;
 use thiserror::Error;
+use tokio::sync::OwnedSemaphorePermit;
 
-// ---------------------------------------------------------------------------
-// SubRequest / SubResponse
-// ---------------------------------------------------------------------------
+use super::internals::SubRequestConnector;
 
 /// An outbound HTTP request for a sub-request exchange.
 #[derive(Clone, Debug)]
@@ -81,7 +79,7 @@ impl FrameworkHeaders {
     /// Returns [`SubRequestError::InvalidRequest`] when the header
     /// name is forbidden.
     pub fn insert(&mut self, name: http::header::HeaderName, value: http::HeaderValue) -> Result<(), SubRequestError> {
-        if is_transport_header(&name) {
+        if super::internals::is_transport_header(&name) {
             return Err(SubRequestError::InvalidRequest(format!(
                 "transport header `{name}` cannot be injected as framework metadata"
             )));
@@ -153,6 +151,13 @@ pub enum SubRequestError {
     #[error("sub-request deadline exceeded")]
     DeadlineExceeded,
 
+    /// The upstream stopped sending data for longer than the idle timeout.
+    #[error("sub-request stream idle timeout ({idle_timeout:?} with no data)")]
+    StreamIdleTimeout {
+        /// The configured idle timeout that was exceeded.
+        idle_timeout: Duration,
+    },
+
     /// The circuit breaker for the target peer is open.
     #[error("sub-request circuit open for peer {peer}")]
     CircuitOpen {
@@ -174,24 +179,75 @@ pub enum SubRequestError {
 }
 
 // ---------------------------------------------------------------------------
-// Transport header classification
+// Streaming response types
 // ---------------------------------------------------------------------------
 
-/// Headers that apply only to one HTTP connection and must not be
-/// forwarded across a sub-request boundary.
-pub(super) const HOP_BY_HOP_HEADERS: &[&str] = &[
-    "connection",
-    "keep-alive",
-    "proxy-authenticate",
-    "proxy-authorization",
-    "te",
-    "trailer",
-    "transfer-encoding",
-    "upgrade",
-];
+/// Limits governing a streaming sub-request response body.
+#[derive(Clone, Debug)]
+pub struct StreamLimits {
+    /// Maximum wait for the next upstream chunk. Applied per
+    /// `next_chunk()` call. Required.
+    pub idle_timeout: Duration,
 
-/// Whether a header is a transport-level header that must not be
-/// injected via framework metadata.
-pub(super) fn is_transport_header(name: &http::header::HeaderName) -> bool {
-    HOP_BY_HOP_HEADERS.iter().any(|h| *h == name.as_str()) || name == http::header::CONTENT_LENGTH
+    /// Optional absolute stream lifetime measured from header receipt.
+    /// `None` means no duration limit.
+    pub max_stream_duration: Option<Duration>,
+
+    /// Optional cumulative byte limit across all chunks. The buffered
+    /// `max_response_bytes` ceiling is not applied to streaming
+    /// responses — only this explicit limit constrains the stream.
+    /// `None` means no byte limit.
+    pub max_total_bytes: Option<usize>,
+}
+
+/// A streaming sub-request response with headers and an opaque body handle.
+///
+/// The body handle owns the live Pingora session, admission permit,
+/// and transport deadlines. It does not borrow `SubRequestClient`
+/// or any other external state.
+pub struct StreamingSubResponse {
+    /// HTTP status code.
+    pub status: u16,
+
+    /// Response headers (sanitized).
+    pub headers: HeaderMap,
+
+    /// Opaque streaming body handle.
+    pub body: SubResponseBody,
+}
+
+/// Opaque handle to a streaming sub-request response body.
+///
+/// Pull-based: call [`next_chunk()`](Self::next_chunk) to receive
+/// the next body chunk. Returns `Ok(None)` at clean EOF.
+///
+/// Owns the live Pingora HTTP session, admission permit, connector
+/// (for session release), and all streaming deadlines. No background
+/// tasks or channels — downstream backpressure naturally paces
+/// upstream reads.
+pub struct SubResponseBody {
+    /// Live Pingora HTTP session.
+    pub(super) session: Option<pingora_core::protocols::http::client::HttpSession<()>>,
+    /// Peer address for connection pooling.
+    pub(super) peer: Option<pingora_core::upstreams::peer::HttpPeer>,
+    /// Connector for session release.
+    pub(super) connector: Option<SubRequestConnector>,
+    /// Admission permit.
+    pub(super) permit: Option<OwnedSemaphorePermit>,
+    /// Operator-configured per-read timeout from the peer.
+    pub(super) read_timeout: Option<Duration>,
+    /// Per-chunk idle timeout.
+    pub(super) idle_timeout: Duration,
+    /// Optional absolute stream deadline.
+    pub(super) stream_deadline: Option<tokio::time::Instant>,
+    /// Optional cumulative byte limit.
+    pub(super) max_total_bytes: Option<usize>,
+    /// Total bytes received so far.
+    pub(super) received_bytes: usize,
+    /// Number of chunks received so far.
+    pub(super) chunk_count: u64,
+    /// When the stream started (for metrics).
+    pub(super) stream_started_at: tokio::time::Instant,
+    /// Whether the stream is done.
+    pub(super) done: bool,
 }

--- a/filter/src/builtins/http/traffic_management/iterative_request_router/mod.rs
+++ b/filter/src/builtins/http/traffic_management/iterative_request_router/mod.rs
@@ -455,15 +455,14 @@ impl IterativeRequestRouterFilter {
                 let mut step_origin = config::ResponseOrigin::Upstream;
                 let mut step_transport_error = None;
                 let mut response = match peer {
-                    Ok(peer) => match client
-                        .execute(
-                            &peer,
-                            &sub_request_for_exec,
-                            max_response_bytes,
-                            per_request_timeout,
-                            Some(&fw_headers),
-                        )
-                        .await
+                    Ok(peer) => match Box::pin(client.execute(
+                        &peer,
+                        &sub_request_for_exec,
+                        max_response_bytes,
+                        per_request_timeout,
+                        Some(&fw_headers),
+                    ))
+                    .await
                     {
                         Ok(response) => response,
                         Err(error) => {

--- a/filter/src/lib.rs
+++ b/filter/src/lib.rs
@@ -53,7 +53,7 @@ pub use pipeline::{
 };
 pub use praxis_core::{
     config::{FailureMode, FilterEntry},
-    subrequest::{SubRequest, SubResponse},
+    subrequest::{StreamLimits, StreamingSubResponse, SubRequest, SubResponse, SubResponseBody},
 };
 pub use praxis_tls::TlsPeerIdentity;
 pub use registry::{FilterRegistry, SecurityClass};


### PR DESCRIPTION
### What does this PR do?

Adds `send_streaming()` to `SubRequestClient`, returning a `StreamingSubResponse` with a pull-based `SubResponseBody` handle. The caller drives reads via `next_chunk()` with natural backpressure — no background tasks or channels.

Key additions:
- **`SubResponseBody`** with `next_chunk()`, `cancel()`, idle/deadline/byte limits, and protocol-aware session cleanup (H2 connector release, H1 shutdown-only)
- **`StreamLimits`** for per-stream idle timeout, max duration, and byte cap
- **Cancellation-safe cleanup**: `done` flag set before any async cleanup, permit moved into boxed futures for immediate release on cancel
- **85 streaming tests** covering H1/H2, timeouts, byte limits, backpressure, metrics, connection reuse, and cancellation
- **Header-phase duration metrics** shared with buffered `execute()` path
- New `body.rs` submodule for `SubResponseBody` impl and `dispose_session_abnormal()` helper
- Refactored `client.rs` and `internals.rs` to extract shared helpers (`open_exchange`, `RawExchange`, circuit guard, classify_timeout, etc.)

The existing buffered `execute()` path is preserved unchanged. `StreamLimits`, `StreamingSubResponse`, and `SubResponseBody` are re-exported through `filter/src/lib.rs` for downstream filter use.

### Which issue(s) does this relate to?

Fixes #951

### Checklist

- [x] Signed off all commits (`git commit -s`)
- [x] Tests added or updated
- [ ] Documentation updated (if applicable)
- [x] `make lint && make test` passes locally

### Does this introduce a breaking change?

No. This is a purely additive API — no existing types, traits, or function signatures change.