### PR TITLE
feat(filter): integrate streaming response transport into IRR

### DIFF
--- a/filter/src/builtins/http/traffic_management/iterative_request_router/mod.rs
+++ b/filter/src/builtins/http/traffic_management/iterative_request_router/mod.rs
@@ -14,12 +14,19 @@
 //! inject its own credentials and required representation headers
 //! (e.g. via a `headers` or `credential_injection` filter).
 //!
-//! # Streaming limitations
+//! # Streaming support
 //!
-//! Intermediate and terminal responses are fully buffered in memory
-//! (bounded by `max_response_bytes`). SSE and long-lived streaming
-//! responses are not supported. The iterative request router is
-//! designed for bounded, buffered workflows.
+//! When a step's filters select [`SubRequestResponseMode::Streaming`],
+//! IRR dispatches via `send_streaming()` instead of the buffered
+//! `execute()` path. Response-header filters run before transition
+//! evaluation; only status, origin, transport error, and default
+//! predicates are available. Once a streaming response is committed
+//! downstream, no failover or replacement response can occur.
+//!
+//! Transitions that depend on filter results (filter/key/value
+//! predicates) or `BodyMode::StreamBuffer` response mode are
+//! rejected at config validation time for streaming-capable pipelines,
+//! with a runtime guard for dynamically registered filters.
 //!
 //! # Position requirement
 //!
@@ -31,6 +38,7 @@
 //! See proposal 00786 for the full design rationale.
 
 mod config;
+mod streaming;
 #[cfg(test)]
 #[expect(clippy::allow_attributes, reason = "blanket test suppressions")]
 #[allow(clippy::unwrap_used, clippy::expect_used, reason = "tests")]
@@ -49,19 +57,41 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use http::HeaderMap;
 use pingora_core::upstreams::peer::HttpPeer;
-use praxis_core::subrequest::FrameworkHeaders;
+use praxis_core::subrequest::{FrameworkHeaders, StreamLimits};
 use tracing::{debug, info, warn};
 
-use self::config::IterativeRequestRouterConfig;
+use self::{
+    config::IterativeRequestRouterConfig,
+    streaming::{IrrStreamingBody, StepResponseContinuation},
+};
 use crate::{
     FilterEntry, FilterError, FilterPipeline, FilterRegistry, IterationState, NextIterationBody, SubRequest,
-    SubResponse,
-    actions::{FilterAction, Rejection, TerminalResponse},
+    SubRequestResponseMode, SubResponse,
+    actions::{FilterAction, Rejection, StreamingTerminalResponse, TerminalResponse},
     factory::parse_filter_config,
     filter::{HttpFilter, HttpFilterContext},
     pipeline::subrequest::DEPTH_HEADER,
     results::RetainedFilterResults,
 };
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Streaming idle timeout (max time between chunks).
+const STREAMING_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+/// Whether transitions depend on response body content (filter result
+/// predicates or body-dependent metadata).
+pub(super) fn has_body_dependent_transitions(transitions: &[config::StepTransition]) -> bool {
+    transitions
+        .iter()
+        .any(|t| t.filter.is_some() || t.key.is_some() || t.value.is_some())
+}
 
 // ---------------------------------------------------------------------------
 // IterativeRequestRouterFilter
@@ -111,7 +141,7 @@ pub struct IterativeRequestRouterFilter {
     step_timeout: Duration,
 
     /// Pre-built sub-pipelines keyed by step name.
-    step_pipelines: HashMap<Arc<str>, FilterPipeline>,
+    step_pipelines: HashMap<Arc<str>, Arc<FilterPipeline>>,
 
     /// Transition rules keyed by step name.
     step_transitions: HashMap<Arc<str>, Vec<config::StepTransition>>,
@@ -177,8 +207,39 @@ impl IterativeRequestRouterFilter {
                 .into());
             }
 
-            step_pipelines.insert(Arc::clone(&name), pipeline);
+            step_pipelines.insert(Arc::clone(&name), Arc::new(pipeline));
             step_transitions.insert(Arc::clone(&name), step.on_result);
+        }
+
+        for (name, pipeline) in &step_pipelines {
+            if !pipeline.may_select_streaming_subrequest_response() {
+                continue;
+            }
+            if let Some(transitions) = step_transitions.get(name) {
+                for (i, t) in transitions.iter().enumerate() {
+                    if t.filter.is_some() || t.key.is_some() || t.value.is_some() {
+                        return Err(format!(
+                            "iterative_request_router: step '{name}' transition {i}: \
+                             filter/key/value predicates are incompatible with \
+                             streaming-capable pipelines (response body is not \
+                             available during transition evaluation)"
+                        )
+                        .into());
+                    }
+                }
+            }
+
+            if matches!(
+                pipeline.body_capabilities().response_body_mode,
+                crate::body::BodyMode::StreamBuffer { .. }
+            ) {
+                return Err(format!(
+                    "iterative_request_router: step '{name}': StreamBuffer \
+                     response body mode is incompatible with streaming-capable \
+                     pipelines"
+                )
+                .into());
+            }
         }
 
         let step_timeout = cfg.step_timeout_ms.map_or(timeout, Duration::from_millis);
@@ -250,6 +311,11 @@ impl IterativeRequestRouterFilter {
     /// Run the complete iterative subrequest lifecycle.
     #[expect(clippy::too_many_lines, reason = "iteration loop is inherently sequential")]
     #[expect(clippy::large_stack_frames, reason = "sub-pipeline execution needs stack space")]
+    #[expect(clippy::large_futures, reason = "streaming and buffered paths require large future")]
+    #[expect(
+        clippy::significant_drop_tightening,
+        reason = "step execution temporaries span iteration loop"
+    )]
     async fn run_iterations(
         &self,
         ctx: &mut HttpFilterContext<'_>,
@@ -452,111 +518,252 @@ impl IterativeRequestRouterFilter {
                 if per_request_timeout.is_zero() {
                     return Ok(StepExecution::Rejected(Rejection::status(504)));
                 }
-                let mut step_origin = config::ResponseOrigin::Upstream;
-                let mut step_transport_error = None;
-                let mut response = match peer {
-                    Ok(peer) => match Box::pin(client.execute(
-                        &peer,
-                        &sub_request_for_exec,
-                        max_response_bytes,
-                        per_request_timeout,
-                        Some(&fw_headers),
-                    ))
-                    .await
-                    {
-                        Ok(response) => response,
-                        Err(error) => {
-                            let (status, kind) = classify_transport_failure(&error);
-                            step_origin = config::ResponseOrigin::Transport;
-                            step_transport_error = Some(kind);
-                            warn!(
-                                step = current_step.as_ref(),
-                                %error,
-                                status,
-                                "iterative_request_router: sub-request transport failure"
-                            );
-                            SubResponse {
-                                status,
-                                headers: HeaderMap::new(),
-                                body: Bytes::new(),
-                            }
-                        },
-                    },
-                    Err(error) => {
-                        step_origin = config::ResponseOrigin::Transport;
-                        step_transport_error = Some(config::TransportErrorKind::Connect);
-                        let status = 502;
-                        warn!(
-                            step = current_step.as_ref(),
-                            %error,
-                            status,
-                            "iterative_request_router: sub-request transport failure"
-                        );
-                        SubResponse {
-                            status,
-                            headers: HeaderMap::new(),
-                            body: Bytes::new(),
+
+                match filter_ctx.subrequest_response_mode {
+                    SubRequestResponseMode::Streaming => {
+                        // Runtime guard: reject if transitions depend on response body
+                        let transitions = self
+                            .step_transitions
+                            .get(&current_step)
+                            .map_or(&[][..], |v| v.as_slice());
+                        if has_body_dependent_transitions(transitions) {
+                            return Err(format!(
+                                "iterative_request_router: step '{current_step}' selected \
+                                     streaming but has body-dependent transitions"
+                            )
+                            .into());
+                        }
+                        if matches!(
+                            pipeline.body_capabilities().response_body_mode,
+                            crate::body::BodyMode::StreamBuffer { .. }
+                        ) {
+                            return Err(format!(
+                                "iterative_request_router: step '{current_step}' selected \
+                                     streaming but has StreamBuffer response body mode"
+                            )
+                            .into());
+                        }
+
+                        let mut step_origin = config::ResponseOrigin::Upstream;
+                        let mut step_transport_error = None;
+
+                        let streaming_result = match peer {
+                            Ok(peer) => {
+                                let limits = StreamLimits {
+                                    idle_timeout: STREAMING_IDLE_TIMEOUT,
+                                    max_stream_duration: None,
+                                    max_total_bytes: None,
+                                };
+                                Box::pin(client.send_streaming(
+                                    &peer,
+                                    &sub_request_for_exec,
+                                    per_request_timeout,
+                                    limits,
+                                    Some(&fw_headers),
+                                ))
+                                .await
+                            },
+                            Err(error) => Err(praxis_core::subrequest::SubRequestError::Connect(error.to_string())),
+                        };
+                        in_transport_inner.store(false, Ordering::Release);
+
+                        match streaming_result {
+                            Ok(streaming_response) => {
+                                let status = streaming_response.status;
+                                let mut response_headers = streaming_response.headers;
+                                sanitize_subresponse_headers(&mut response_headers);
+
+                                response_header.status =
+                                    http::StatusCode::from_u16(status).map_err(|e| -> FilterError {
+                                        format!("iterative_request_router: invalid upstream status: {e}").into()
+                                    })?;
+                                response_header.headers.clone_from(&response_headers);
+                                filter_ctx.response_header = Some(&mut response_header);
+
+                                let action = pipeline.execute_http_response(&mut filter_ctx).await?;
+                                if let FilterAction::Reject(rejection) = action {
+                                    streaming_response.body.cancel().await;
+                                    return Ok(StepExecution::Rejected(rejection));
+                                }
+
+                                // Extract final response metadata from filter context
+                                let (final_status, mut final_headers) =
+                                    if let Some(meta) = filter_ctx.response_header.as_deref() {
+                                        (meta.status, meta.headers.clone())
+                                    } else {
+                                        (
+                                            http::StatusCode::from_u16(status).unwrap_or(http::StatusCode::BAD_GATEWAY),
+                                            response_headers,
+                                        )
+                                    };
+                                sanitize_subresponse_headers(&mut final_headers);
+
+                                let outcome = StepOutcome {
+                                    response: SubResponse {
+                                        status: final_status.as_u16(),
+                                        headers: final_headers.clone(),
+                                        body: Bytes::new(),
+                                    },
+                                    origin: step_origin,
+                                    transport_error: step_transport_error,
+                                };
+
+                                Ok(StepExecution::Streaming {
+                                    outcome,
+                                    body: Box::new(streaming_response.body),
+                                    response_snapshot: crate::Response {
+                                        status: final_status,
+                                        headers: final_headers,
+                                    },
+                                })
+                            },
+                            Err(error) => {
+                                let (status, kind) = classify_transport_failure(&error);
+                                step_origin = config::ResponseOrigin::Transport;
+                                step_transport_error = Some(kind);
+                                warn!(
+                                    step = current_step.as_ref(),
+                                    %error,
+                                    status,
+                                    "iterative_request_router: streaming sub-request transport failure"
+                                );
+                                let response = SubResponse {
+                                    status,
+                                    headers: HeaderMap::new(),
+                                    body: Bytes::new(),
+                                };
+                                // Fall through to buffered transition path with synthetic response
+                                // (transport failures don't have a body to stream)
+
+                                response_header.status =
+                                    http::StatusCode::from_u16(status).map_err(|e| -> FilterError {
+                                        format!("iterative_request_router: invalid status: {e}").into()
+                                    })?;
+                                response_header.headers.clone_from(&response.headers);
+                                filter_ctx.response_header = Some(&mut response_header);
+
+                                let action = pipeline.execute_http_response(&mut filter_ctx).await?;
+                                if let FilterAction::Reject(rejection) = action {
+                                    return Ok(StepExecution::Rejected(rejection));
+                                }
+
+                                Ok(StepExecution::Complete {
+                                    response,
+                                    origin: step_origin,
+                                    transport_error: step_transport_error,
+                                })
+                            },
                         }
                     },
-                };
-                in_transport_inner.store(false, Ordering::Release);
-                sanitize_subresponse_headers(&mut response.headers);
+                    SubRequestResponseMode::Buffered => {
+                        let mut step_origin = config::ResponseOrigin::Upstream;
+                        let mut step_transport_error = None;
+                        let mut response = match peer {
+                            Ok(peer) => match Box::pin(client.execute(
+                                &peer,
+                                &sub_request_for_exec,
+                                max_response_bytes,
+                                per_request_timeout,
+                                Some(&fw_headers),
+                            ))
+                            .await
+                            {
+                                Ok(response) => response,
+                                Err(error) => {
+                                    let (status, kind) = classify_transport_failure(&error);
+                                    step_origin = config::ResponseOrigin::Transport;
+                                    step_transport_error = Some(kind);
+                                    warn!(
+                                        step = current_step.as_ref(),
+                                        %error,
+                                        status,
+                                        "iterative_request_router: sub-request transport failure"
+                                    );
+                                    SubResponse {
+                                        status,
+                                        headers: HeaderMap::new(),
+                                        body: Bytes::new(),
+                                    }
+                                },
+                            },
+                            Err(error) => {
+                                step_origin = config::ResponseOrigin::Transport;
+                                step_transport_error = Some(config::TransportErrorKind::Connect);
+                                let status = 502;
+                                warn!(
+                                    step = current_step.as_ref(),
+                                    %error,
+                                    status,
+                                    "iterative_request_router: sub-request transport failure"
+                                );
+                                SubResponse {
+                                    status,
+                                    headers: HeaderMap::new(),
+                                    body: Bytes::new(),
+                                }
+                            },
+                        };
+                        in_transport_inner.store(false, Ordering::Release);
+                        sanitize_subresponse_headers(&mut response.headers);
 
-                response_header.status = http::StatusCode::from_u16(response.status).map_err(|e| -> FilterError {
-                    format!("iterative_request_router: invalid upstream status: {e}").into()
-                })?;
-                response_header.headers.clone_from(&response.headers);
-                filter_ctx.response_header = Some(&mut response_header);
+                        response_header.status =
+                            http::StatusCode::from_u16(response.status).map_err(|e| -> FilterError {
+                                format!("iterative_request_router: invalid upstream status: {e}").into()
+                            })?;
+                        response_header.headers.clone_from(&response.headers);
+                        filter_ctx.response_header = Some(&mut response_header);
 
-                let action = pipeline.execute_http_response(&mut filter_ctx).await?;
-                if let FilterAction::Reject(rejection) = action {
-                    return Ok(StepExecution::Rejected(rejection));
-                }
-                if iteration_state_exceeds_limit(&filter_ctx, self.max_state_bytes) {
-                    return Ok(StepExecution::Rejected(Rejection::status(413)));
-                }
+                        let action = pipeline.execute_http_response(&mut filter_ctx).await?;
+                        if let FilterAction::Reject(rejection) = action {
+                            return Ok(StepExecution::Rejected(rejection));
+                        }
+                        if iteration_state_exceeds_limit(&filter_ctx, self.max_state_bytes) {
+                            return Ok(StepExecution::Rejected(Rejection::status(413)));
+                        }
 
-                let mut response_body = Some(std::mem::take(&mut response.body));
-                if response_body_exceeds_limits(
-                    pipeline.body_capabilities().response_body_mode,
-                    max_response_bytes,
-                    response_body.as_ref().map_or(0, Bytes::len),
-                ) {
-                    return Err("iterative_request_router: step response exceeds configured body limit"
-                        .to_owned()
-                        .into());
-                }
-                let action = pipeline.execute_http_response_body(&mut filter_ctx, &mut response_body, true)?;
-                if let FilterAction::Reject(rejection) = action {
-                    return Ok(StepExecution::Rejected(rejection));
-                }
-                if iteration_state_exceeds_limit(&filter_ctx, self.max_state_bytes) {
-                    return Ok(StepExecution::Rejected(Rejection::status(413)));
-                }
-                if response_body_exceeds_limits(
-                    pipeline.body_capabilities().response_body_mode,
-                    max_response_bytes,
-                    response_body.as_ref().map_or(0, Bytes::len),
-                ) {
-                    return Err(
-                        "iterative_request_router: transformed step response exceeds configured body limit"
-                            .to_owned()
-                            .into(),
-                    );
-                }
+                        let mut response_body = Some(std::mem::take(&mut response.body));
+                        if response_body_exceeds_limits(
+                            pipeline.body_capabilities().response_body_mode,
+                            max_response_bytes,
+                            response_body.as_ref().map_or(0, Bytes::len),
+                        ) {
+                            return Err("iterative_request_router: step response exceeds configured body limit"
+                                .to_owned()
+                                .into());
+                        }
+                        let action = pipeline.execute_http_response_body(&mut filter_ctx, &mut response_body, true)?;
+                        if let FilterAction::Reject(rejection) = action {
+                            return Ok(StepExecution::Rejected(rejection));
+                        }
+                        if iteration_state_exceeds_limit(&filter_ctx, self.max_state_bytes) {
+                            return Ok(StepExecution::Rejected(Rejection::status(413)));
+                        }
+                        if response_body_exceeds_limits(
+                            pipeline.body_capabilities().response_body_mode,
+                            max_response_bytes,
+                            response_body.as_ref().map_or(0, Bytes::len),
+                        ) {
+                            return Err(
+                                "iterative_request_router: transformed step response exceeds configured body limit"
+                                    .to_owned()
+                                    .into(),
+                            );
+                        }
 
-                if let Some(meta) = filter_ctx.response_header.as_deref() {
-                    response.status = meta.status.as_u16();
-                    response.headers.clone_from(&meta.headers);
-                }
-                response.body = response_body.unwrap_or_default();
-                sanitize_subresponse_headers(&mut response.headers);
+                        if let Some(meta) = filter_ctx.response_header.as_deref() {
+                            response.status = meta.status.as_u16();
+                            response.headers.clone_from(&meta.headers);
+                        }
+                        response.body = response_body.unwrap_or_default();
+                        sanitize_subresponse_headers(&mut response.headers);
 
-                Ok(StepExecution::Complete {
-                    response,
-                    origin: step_origin,
-                    transport_error: step_transport_error,
-                })
+                        Ok(StepExecution::Complete {
+                            response,
+                            origin: step_origin,
+                            transport_error: step_transport_error,
+                        })
+                    },
+                }
             })
             .await
             {
@@ -578,6 +785,100 @@ impl IterativeRequestRouterFilter {
                 },
             };
 
+            // Handle streaming step results before normal post-step processing.
+            // The streaming terminal path takes ownership of filter_ctx.extensions
+            // (which include the parent's extensions swapped in at step start).
+            if let Ok(StepExecution::Streaming {
+                outcome,
+                body: upstream_body,
+                response_snapshot,
+            }) = step_result
+            {
+                // Extract iteration state and filter results for transition evaluation
+                if let Some(updated_state) = filter_ctx.extensions.remove::<IterationState>() {
+                    state = updated_state;
+                }
+                let next_iteration_body = filter_ctx.extensions.remove::<NextIterationBody>();
+                let mut step_filter_results = filter_ctx
+                    .extensions
+                    .remove::<RetainedFilterResults>()
+                    .unwrap_or_default()
+                    .0;
+                step_filter_results.extend(
+                    filter_ctx
+                        .filter_results
+                        .iter()
+                        .map(|(name, results)| (*name, results.clone())),
+                );
+
+                let transitions = self
+                    .step_transitions
+                    .get(&current_step)
+                    .map_or(&[][..], |v| v.as_slice());
+                match evaluate_transitions(transitions, &outcome, &step_filter_results) {
+                    TransitionResult::Done | TransitionResult::NoMatch => {
+                        std::mem::swap(&mut filter_ctx.extensions, &mut ctx.extensions);
+                        let continuation = StepResponseContinuation {
+                            pipeline: Arc::clone(self.step_pipelines.get(&current_step).ok_or_else(
+                                || -> FilterError {
+                                    format!("iterative_request_router: step '{current_step}' not found").into()
+                                },
+                            )?),
+                            request_snapshot: crate::Request {
+                                method: filter_ctx.request.method.clone(),
+                                uri: filter_ctx.request.uri.clone(),
+                                headers: filter_ctx.request.headers.clone(),
+                            },
+                            response_snapshot,
+                            extensions: std::mem::take(&mut filter_ctx.extensions),
+                            filter_state: std::mem::take(&mut filter_ctx.filter_state),
+                            filter_results: std::mem::take(&mut filter_ctx.filter_results),
+                            filter_metadata: std::mem::take(&mut filter_ctx.filter_metadata),
+                            structured_metadata: std::mem::take(&mut filter_ctx.structured_metadata),
+                            executed_filter_indices: std::mem::take(&mut filter_ctx.executed_filter_indices),
+                            body_done_indices: std::mem::take(&mut filter_ctx.body_done_indices),
+                            response_body_bytes: filter_ctx.response_body_bytes,
+                            response_body_mode: filter_ctx.response_body_mode,
+                            completed: false,
+                            client_addr: filter_ctx.client_addr,
+                            downstream_tls: filter_ctx.downstream_tls,
+                            request_start: filter_ctx.request_start,
+                            peer_identity: filter_ctx.peer_identity.clone(),
+                        };
+                        let status = normalize_response_status(outcome.response.status);
+                        let terminal = StreamingTerminalResponse::new(
+                            status,
+                            Box::new(IrrStreamingBody::new(*upstream_body, continuation)),
+                        )
+                        .with_headers(outcome.response.headers);
+                        return Ok(FilterAction::StreamingTerminalResponse(Box::new(terminal)));
+                    },
+                    TransitionResult::Next(next_step) => {
+                        debug!(
+                            from = current_step.as_ref(),
+                            to = next_step.as_ref(),
+                            "streaming failover: cancelling unread body"
+                        );
+                        (*upstream_body).cancel().await;
+                        // Swap extensions back to parent and continue the loop
+                        std::mem::swap(&mut filter_ctx.extensions, &mut ctx.extensions);
+                        state.previous_response = None;
+                        state.iteration += 1;
+                        let next_body = next_iteration_body.map_or_else(|| current_request.body.clone(), |b| b.0);
+                        current_request = SubRequest {
+                            method: current_request.method.clone(),
+                            uri: current_request.uri.clone(),
+                            headers: HeaderMap::new(),
+                            body: next_body,
+                        };
+                        current_step = next_step;
+                        continue;
+                    },
+                }
+            }
+
+            // Existing post-step processing continues unchanged for
+            // Complete/Rejected variants...
             if let Some(updated_state) = filter_ctx.extensions.remove::<IterationState>() {
                 state = updated_state;
             }
@@ -598,7 +899,8 @@ impl IterativeRequestRouterFilter {
             );
             std::mem::swap(&mut filter_ctx.extensions, &mut ctx.extensions);
 
-            let (mut response, origin, transport_error) = match step_result? {
+            let step_result_value = step_result?;
+            let (mut response, origin, transport_error) = match step_result_value {
                 StepExecution::Complete {
                     response,
                     origin,
@@ -615,6 +917,9 @@ impl IterativeRequestRouterFilter {
                         config::ResponseOrigin::Local,
                         None,
                     )
+                },
+                StepExecution::Streaming { .. } => {
+                    unreachable!("streaming step results are handled before this point")
                 },
             };
             sanitize_subresponse_headers(&mut response.headers);
@@ -699,6 +1004,16 @@ enum StepExecution {
         origin: config::ResponseOrigin,
         /// Transport error classification, if any.
         transport_error: Option<config::TransportErrorKind>,
+    },
+
+    /// The step uses streaming mode; response-header filters ran.
+    Streaming {
+        /// Step outcome with header-only response snapshot.
+        outcome: StepOutcome,
+        /// Upstream streaming body handle.
+        body: Box<praxis_core::subrequest::SubResponseBody>,
+        /// Snapshot of response headers for continuation.
+        response_snapshot: crate::Response,
     },
 }
 
@@ -1078,7 +1393,7 @@ fn build_sub_filter_context<'a>(
         selected_endpoint_index: None,
         structured_metadata: HashMap::new(),
         subrequest_client: runtime.subrequest_client,
-        subrequest_response_mode: crate::SubRequestResponseMode::Buffered,
+        subrequest_response_mode: SubRequestResponseMode::Buffered,
         time_source: runtime.time_source,
         upstream: None,
     }

--- a/filter/src/builtins/http/traffic_management/iterative_request_router/streaming.rs
+++ b/filter/src/builtins/http/traffic_management/iterative_request_router/streaming.rs
@@ -1,0 +1,269 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Streaming response lifecycle types for the iterative request router.
+//!
+//! The iterative request router runs step pipelines across multiple
+//! sub-requests. When a step's pipeline selects streaming mode,
+//! `on_request()` returns a terminal streaming response whose body
+//! is owned by [`IrrStreamingBody`].
+//!
+//! [`IrrStreamingBody`] pulls upstream chunks through the step's
+//! response-body filters until the stream ends, then runs the step's
+//! completion lifecycle exactly once (owned `end_of_stream` hook).
+//!
+//! [`StepResponseContinuation`] holds all state needed to run body
+//! filters after `on_request()` returns: the step pipeline, request
+//! and response snapshots, filter extensions, filter state, metadata,
+//! and a completion guard. The continuation owns an `Arc<FilterPipeline>`
+//! so the pipeline outlives the router filter.
+
+use std::{any::Any, collections::HashMap};
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use praxis_core::subrequest::SubResponseBody;
+
+use crate::{
+    FilterError, FilterPipeline, actions::StreamingResponseBody, extensions::RequestExtensions,
+    results::FilterResultSet,
+};
+
+/// State continuation for streaming a step's response body.
+///
+/// Owns the step pipeline, request/response snapshots, and all
+/// per-filter state needed to run response-body filters after
+/// `on_request()` returns. The `Arc<FilterPipeline>` outlives
+/// the router filter, enabling body hooks to execute while the
+/// router's `on_request` has already completed.
+pub(super) struct StepResponseContinuation {
+    /// Arc-wrapped step pipeline for executing response-body filters.
+    pub(super) pipeline: std::sync::Arc<FilterPipeline>,
+    /// Snapshot of the step's request for filter context reconstruction.
+    pub(super) request_snapshot: crate::Request,
+    /// Snapshot of the step's response headers for filter context reconstruction.
+    pub(super) response_snapshot: crate::Response,
+    /// Request extensions that persist across body chunks.
+    pub(super) extensions: RequestExtensions,
+    /// Per-filter state that persists across body chunks.
+    pub(super) filter_state: HashMap<usize, Box<dyn Any + Send + Sync>>,
+    /// Filter results that persist across body chunks.
+    pub(super) filter_results: HashMap<&'static str, FilterResultSet>,
+    /// Filter metadata that persists across body chunks.
+    pub(super) filter_metadata: HashMap<String, String>,
+    /// Structured metadata that persists across body chunks.
+    pub(super) structured_metadata: HashMap<String, serde_json::Value>,
+    /// Tracks which filters executed during request phase.
+    pub(super) executed_filter_indices: Vec<bool>,
+    /// Tracks which filters completed their body hooks.
+    pub(super) body_done_indices: Vec<bool>,
+    /// Accumulated response body bytes seen so far.
+    pub(super) response_body_bytes: u64,
+    /// Response body mode from pipeline capabilities.
+    pub(super) response_body_mode: crate::body::BodyMode,
+    /// Whether the completion lifecycle has run.
+    pub(super) completed: bool,
+    /// Original downstream client address for body filter context.
+    pub(super) client_addr: Option<std::net::IpAddr>,
+    /// Whether the original downstream connection uses TLS.
+    pub(super) downstream_tls: bool,
+    /// Start time of the containing client request.
+    pub(super) request_start: std::time::Instant,
+    /// Verified downstream mTLS identity.
+    pub(super) peer_identity: Option<praxis_tls::TlsPeerIdentity>,
+}
+
+/// Streaming body implementation for iterative request router steps.
+///
+/// Pulls upstream chunks through the step's response-body filters,
+/// accumulates state in the owned [`StepResponseContinuation`],
+/// and runs the step's completion lifecycle exactly once after
+/// upstream EOF.
+///
+/// The `upstream` field is `Option<SubResponseBody>` because
+/// `SubResponseBody::cancel()` consumes `self`. Standard Rust
+/// pattern: `.take()` to move it out for cancellation.
+pub(super) struct IrrStreamingBody {
+    /// Upstream streaming body handle. `None` after cancellation.
+    upstream: Option<SubResponseBody>,
+    /// Owned state for running step response-body filters.
+    continuation: StepResponseContinuation,
+    /// Whether the stream has finished (EOF or error).
+    finished: bool,
+}
+
+impl IrrStreamingBody {
+    /// Create a new streaming body for a step's response.
+    pub(super) fn new(upstream: SubResponseBody, continuation: StepResponseContinuation) -> Self {
+        Self {
+            upstream: Some(upstream),
+            continuation,
+            finished: false,
+        }
+    }
+
+    /// Run the step's response-body filters on a single chunk.
+    ///
+    /// Reconstructs a temporary `HttpFilterContext` from the
+    /// continuation's owned state, runs the pipeline's body
+    /// execution, then writes state changes back to the
+    /// continuation for the next chunk.
+    #[expect(clippy::too_many_lines, reason = "context reconstruction requires many fields")]
+    fn run_step_body_filters(&mut self, body: &mut Option<Bytes>, end_of_stream: bool) -> Result<(), FilterError> {
+        let cont = &mut self.continuation;
+        let mut ctx = crate::filter::HttpFilterContext {
+            buffered_request_body: None,
+            body_done_indices: std::mem::take(&mut cont.body_done_indices),
+            branch_iterations: HashMap::new(),
+            client_addr: cont.client_addr,
+            cluster: None,
+            current_filter_id: None,
+            downstream_tls: cont.downstream_tls,
+            extensions: std::mem::take(&mut cont.extensions),
+            executed_filter_indices: std::mem::take(&mut cont.executed_filter_indices),
+            extra_request_headers: Vec::new(),
+            filter_metadata: std::mem::take(&mut cont.filter_metadata),
+            filter_results: std::mem::take(&mut cont.filter_results),
+            filter_state: std::mem::take(&mut cont.filter_state),
+            health_registry: None,
+            id_generator: cont.pipeline.id_generator(),
+            kv_stores: None,
+            metrics_route: None,
+            peer_identity: cont.peer_identity.clone(),
+            pre_read_mutations: Vec::new(),
+            request: &cont.request_snapshot,
+            request_body_bytes: 0,
+            request_body_mode: cont.pipeline.body_capabilities().request_body_mode,
+            request_headers_to_remove: Vec::new(),
+            request_headers_to_set: Vec::new(),
+            request_start: cont.request_start,
+            response_body_bytes: cont.response_body_bytes,
+            response_body_mode: cont.response_body_mode,
+            response_header: None,
+            response_headers_modified: false,
+            rewritten_path: None,
+            selected_endpoint_index: None,
+            structured_metadata: std::mem::take(&mut cont.structured_metadata),
+            subrequest_client: None,
+            subrequest_response_mode: crate::context::SubRequestResponseMode::Buffered,
+            time_source: cont.pipeline.time_source(),
+            upstream: None,
+        };
+
+        let result = cont.pipeline.execute_http_response_body_with_response_header(
+            &mut ctx,
+            body,
+            end_of_stream,
+            Some(&cont.response_snapshot),
+        );
+
+        cont.body_done_indices = ctx.body_done_indices;
+        cont.executed_filter_indices = ctx.executed_filter_indices;
+        cont.extensions = ctx.extensions;
+        cont.filter_metadata = ctx.filter_metadata;
+        cont.filter_results = ctx.filter_results;
+        cont.filter_state = ctx.filter_state;
+        cont.response_body_bytes = ctx.response_body_bytes;
+        cont.structured_metadata = ctx.structured_metadata;
+
+        match result? {
+            crate::actions::FilterAction::Reject(_) => {
+                Err("iterative_request_router: step body filter rejected during stream"
+                    .to_owned()
+                    .into())
+            },
+            _ => Ok(()),
+        }
+    }
+
+    /// Run the step's completion lifecycle exactly once.
+    ///
+    /// Called after upstream EOF. Runs body filters with
+    /// `end_of_stream: true` to let them emit any buffered
+    /// completion chunk (e.g. a closing SSE comment or JSON
+    /// array bracket).
+    fn complete_step(&mut self) -> Result<Option<Bytes>, FilterError> {
+        if self.continuation.completed {
+            return Ok(None);
+        }
+        self.continuation.completed = true;
+        let mut body: Option<Bytes> = None;
+        self.run_step_body_filters(&mut body, true)?;
+        Ok(body)
+    }
+
+    /// Handle a chunk received from the upstream.
+    fn handle_upstream_chunk(&mut self, chunk: Bytes) -> Result<Option<Bytes>, FilterError> {
+        let mut body = Some(chunk);
+        self.run_step_body_filters(&mut body, false)?;
+        Ok(body)
+    }
+
+    /// Handle upstream EOF.
+    fn handle_upstream_eof(&mut self) -> Result<Option<Bytes>, FilterError> {
+        let completion = self.complete_step()?;
+        self.finished = true;
+        if completion.as_ref().is_some_and(|b| !b.is_empty()) {
+            Ok(completion)
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Handle an upstream error.
+    async fn handle_upstream_error(
+        &mut self,
+        e: praxis_core::subrequest::SubRequestError,
+    ) -> Result<Option<Bytes>, FilterError> {
+        self.finished = true;
+        if let Some(upstream_body) = self.upstream.take() {
+            upstream_body.cancel().await;
+        }
+        Err(format!("iterative_request_router: upstream stream error: {e}").into())
+    }
+}
+
+#[async_trait]
+impl StreamingResponseBody for IrrStreamingBody {
+    async fn next_chunk(&mut self) -> Result<Option<Bytes>, FilterError> {
+        if self.finished {
+            return Ok(None);
+        }
+
+        loop {
+            let upstream = self.upstream.as_mut().ok_or_else(|| -> FilterError {
+                "iterative_request_router: upstream already consumed".to_owned().into()
+            })?;
+
+            match upstream.next_chunk().await {
+                Ok(Some(chunk)) => {
+                    if let Some(bytes) = self.handle_upstream_chunk(chunk)? {
+                        return Ok(Some(bytes));
+                    }
+                },
+                Ok(None) => return self.handle_upstream_eof(),
+                Err(e) => return Box::pin(self.handle_upstream_error(e)).await,
+            }
+        }
+    }
+
+    async fn suppress(&mut self) -> Result<(), FilterError> {
+        if !self.finished {
+            self.finished = true;
+            if let Some(upstream_body) = self.upstream.take() {
+                upstream_body.cancel().await;
+            }
+            self.complete_step()?;
+        }
+        Ok(())
+    }
+
+    async fn cancel(&mut self) {
+        if !self.finished {
+            self.finished = true;
+            if let Some(upstream_body) = self.upstream.take() {
+                upstream_body.cancel().await;
+            }
+        }
+    }
+}

--- a/filter/src/builtins/http/traffic_management/iterative_request_router/tests.rs
+++ b/filter/src/builtins/http/traffic_management/iterative_request_router/tests.rs
@@ -779,8 +779,152 @@ fn classify_invalid_request_falls_through_to_io() {
 }
 
 // ---------------------------------------------------------------------------
+// Streaming Validation
+// ---------------------------------------------------------------------------
+
+#[test]
+#[expect(clippy::too_many_lines, reason = "YAML config literal")]
+fn rejects_filter_result_transition_on_streaming_capable_step() {
+    let mut registry = crate::FilterRegistry::with_builtins();
+    registry
+        .register(
+            "test_streaming_selector",
+            crate::FilterFactory::Http(std::sync::Arc::new(|_| Ok(Box::new(StreamingSelectorFilter)))),
+        )
+        .unwrap();
+
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        "
+initial_step: s
+steps:
+  - name: s
+    filters:
+      - filter: test_streaming_selector
+      - filter: static_response
+        status: 200
+    on_result:
+      - filter: test_streaming_selector
+        key: action
+        value: loop
+        next: s
+      - default: true
+        done: true
+",
+    )
+    .unwrap();
+    let result = super::IterativeRequestRouterFilter::from_config_with_registry(&yaml, &registry);
+    assert!(
+        result.is_err(),
+        "filter/key/value transition should be rejected for streaming step"
+    );
+    if let Err(err) = result {
+        let msg = err.to_string();
+        assert!(
+            msg.contains("streaming") && msg.contains("filter"),
+            "error should mention streaming and filter: {msg}"
+        );
+    }
+}
+
+#[test]
+fn accepts_status_only_transition_on_streaming_capable_step() {
+    let mut registry = crate::FilterRegistry::with_builtins();
+    registry
+        .register(
+            "test_streaming_selector",
+            crate::FilterFactory::Http(std::sync::Arc::new(|_| Ok(Box::new(StreamingSelectorFilter)))),
+        )
+        .unwrap();
+
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        "
+initial_step: s
+steps:
+  - name: s
+    filters:
+      - filter: test_streaming_selector
+      - filter: static_response
+        status: 200
+    on_result:
+      - status: [502, 503]
+        next: s
+      - default: true
+        done: true
+",
+    )
+    .unwrap();
+    let result = super::IterativeRequestRouterFilter::from_config_with_registry(&yaml, &registry);
+    assert!(result.is_ok(), "status-only transition should be accepted");
+}
+
+#[test]
+fn streaming_runtime_guard_rejects_body_dependent_transitions() {
+    assert!(
+        super::has_body_dependent_transitions(&[config::StepTransition {
+            default: false,
+            done: false,
+            filter: Some("f".to_owned()),
+            key: Some("k".to_owned()),
+            next: Some("n".to_owned()),
+            origin: None,
+            status: None,
+            transport_error: None,
+            value: Some("v".to_owned()),
+        }]),
+        "filter/key/value transition should be body-dependent"
+    );
+}
+
+#[test]
+fn streaming_runtime_guard_accepts_status_transition() {
+    assert!(
+        !super::has_body_dependent_transitions(&[config::StepTransition {
+            default: false,
+            done: false,
+            filter: None,
+            key: None,
+            next: Some("n".to_owned()),
+            origin: None,
+            status: Some(vec![502]),
+            transport_error: None,
+            value: None,
+        }]),
+        "status-only transition should not be body-dependent"
+    );
+}
+
+#[test]
+fn streaming_runtime_guard_accepts_default_transition() {
+    assert!(
+        !super::has_body_dependent_transitions(&[make_default_done()]),
+        "default transition should not be body-dependent"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Test Utilities
 // ---------------------------------------------------------------------------
+
+struct StreamingSelectorFilter;
+
+#[async_trait::async_trait]
+impl crate::HttpFilter for StreamingSelectorFilter {
+    fn name(&self) -> &'static str {
+        "test_streaming_selector"
+    }
+
+    fn may_select_streaming_subrequest_response(&self) -> bool {
+        true
+    }
+
+    async fn on_request(
+        &self,
+        ctx: &mut crate::HttpFilterContext<'_>,
+    ) -> Result<crate::FilterAction, crate::FilterError> {
+        ctx.set_subrequest_response_mode(crate::SubRequestResponseMode::Streaming);
+        Ok(crate::FilterAction::Continue)
+    }
+}
 
 /// Build a default-done transition.
 fn make_default_done() -> config::StepTransition {

--- a/tests/integration/tests/suite/iterative_request_router.rs
+++ b/tests/integration/tests/suite/iterative_request_router.rs
@@ -1874,6 +1874,200 @@ fn http_get_raw(path: &str) -> String {
 }
 
 // ---------------------------------------------------------------------------
+// Streaming Tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn streaming_sse_first_chunk_arrives_before_upstream_completion() {
+    let chunks = vec![
+        "data: chunk1\n\n".to_owned(),
+        "data: chunk2\n\n".to_owned(),
+        "data: chunk3\n\n".to_owned(),
+    ];
+    let backend = Backend::chunked(chunks)
+        .header("content-type", "text/event-stream")
+        .start_with_shutdown();
+    let proxy_port = free_port();
+    let registry = streaming_registry();
+    let config = Config::from_yaml(&irr_yaml(
+        proxy_port,
+        &format!(
+            r#"
+initial_step: stream
+steps:
+  - name: stream
+    filters:
+      - filter: test_streaming_selector
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: sse
+      - filter: load_balancer
+        clusters:
+          - name: sse
+            endpoints: ["127.0.0.1:{}"]
+    on_result:
+      - default: true
+        done: true
+"#,
+            backend.port()
+        ),
+    ))
+    .unwrap();
+    let proxy = start_full_proxy_with_registry(&config, &registry);
+
+    let raw = http_send(
+        proxy.addr(),
+        "GET / HTTP/1.1\r\nHost: localhost\r\nx-stream-response: true\r\nConnection: close\r\n\r\n",
+    );
+
+    let status = parse_status(&raw);
+    assert_eq!(status, 200, "streaming SSE should return 200");
+    let body = parse_body(&raw);
+    assert!(body.contains("data: chunk1"), "first chunk should arrive: {body}");
+    assert!(body.contains("data: chunk3"), "last chunk should arrive: {body}");
+}
+
+#[test]
+fn streaming_header_failover_cancels_unread_body() {
+    let failing = Backend::status(503, "fail").start_with_shutdown();
+    let fallback = Backend::fixed("fallback-ok").start_with_shutdown();
+    let proxy_port = free_port();
+    let registry = streaming_registry();
+    let config = Config::from_yaml(&irr_yaml(
+        proxy_port,
+        &format!(
+            r#"
+initial_step: primary
+steps:
+  - name: primary
+    filters:
+      - filter: test_streaming_selector
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: primary
+      - filter: load_balancer
+        clusters:
+          - name: primary
+            endpoints: ["127.0.0.1:{}"]
+    on_result:
+      - status: [502, 503, 504]
+        next: fallback
+      - default: true
+        done: true
+  - name: fallback
+    filters:
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: fallback
+      - filter: load_balancer
+        clusters:
+          - name: fallback
+            endpoints: ["127.0.0.1:{}"]
+    on_result:
+      - default: true
+        done: true
+"#,
+            failing.port(),
+            fallback.port()
+        ),
+    ))
+    .unwrap();
+    let proxy = start_full_proxy_with_registry(&config, &registry);
+
+    let raw = http_send(
+        proxy.addr(),
+        "GET / HTTP/1.1\r\nHost: localhost\r\nx-stream-response: true\r\nConnection: close\r\n\r\n",
+    );
+
+    let status = parse_status(&raw);
+    assert_eq!(status, 200, "failover should reach fallback");
+    let body = parse_body(&raw);
+    assert_eq!(body, "fallback-ok", "should get fallback response");
+}
+
+#[test]
+fn streaming_selector_present_but_buffered_when_header_absent() {
+    let backend_port = start_backend("buffered-ok");
+    let proxy_port = free_port();
+    let registry = streaming_registry();
+    let config = Config::from_yaml(&irr_yaml(
+        proxy_port,
+        &format!(
+            r#"
+initial_step: step
+steps:
+  - name: step
+    filters:
+      - filter: test_streaming_selector
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: backend
+      - filter: load_balancer
+        clusters:
+          - name: backend
+            endpoints: ["127.0.0.1:{backend_port}"]
+    on_result:
+      - default: true
+        done: true
+"#
+        ),
+    ))
+    .unwrap();
+    let proxy = start_full_proxy_with_registry(&config, &registry);
+
+    let (status, body) = http_get(proxy.addr(), "/", None);
+    assert_eq!(status, 200);
+    assert_eq!(
+        body, "buffered-ok",
+        "without x-stream-response header, buffered path should be used"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test-Only Streaming Selector Filter
+// ---------------------------------------------------------------------------
+
+struct IntegrationStreamingSelectorFilter;
+
+#[async_trait::async_trait]
+impl HttpFilter for IntegrationStreamingSelectorFilter {
+    fn name(&self) -> &'static str {
+        "test_streaming_selector"
+    }
+
+    fn may_select_streaming_subrequest_response(&self) -> bool {
+        true
+    }
+
+    async fn on_request(&self, ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
+        if ctx
+            .request
+            .headers
+            .get("x-stream-response")
+            .is_some_and(|v| v == "true")
+        {
+            ctx.set_subrequest_response_mode(praxis_filter::SubRequestResponseMode::Streaming);
+        }
+        Ok(FilterAction::Continue)
+    }
+}
+
+fn streaming_registry() -> FilterRegistry {
+    let mut registry = FilterRegistry::with_builtins();
+    registry
+        .register(
+            "test_streaming_selector",
+            FilterFactory::Http(Arc::new(|_| Ok(Box::new(IntegrationStreamingSelectorFilter)))),
+        )
+        .unwrap();
+    registry
+}
+
+// ---------------------------------------------------------------------------
 // Test Utilities
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
### What does this PR do?

Adds streaming response support to the Iterative Request Router (IRR). When a step's filters select `SubRequestResponseMode::Streaming`, IRR dispatches via `send_streaming()` instead of the buffered `execute()` path, enabling real-time chunk delivery for SSE and long-lived streaming responses. Response-header filters run before transition evaluation so header-based failover still works. The existing buffered path is unchanged.

This PR is stacked on #979 (streaming terminal response lifecycle) and #951 (streaming SubRequestClient transport).

### Which issue(s) does this relate to?

Fixes #953

### Checklist

- [x] Signed off all commits (`git commit -s`)
- [x] Tests added or updated
- [x] Documentation updated (if applicable)
- [x] `make lint && make test` passes locally

### Does this introduce a breaking change?

No. Streaming is opt-in via filter selection; the default buffered path is unchanged.