### PR TITLE
chore(deps): bump h2 to 0.4.16 (RUSTSEC-2026-0258)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,17 +10,6 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom 0.2.17",
- "once_cell",
- "version_check",
-]
-
-[[package]]
-name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
@@ -1387,7 +1376,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf5efcf77a4da27927d3ab0509dec5b0954bb3bc59da5a1de9e52642ebd4cdf9"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "num_cpus",
  "parking_lot",
  "seize",
@@ -1595,9 +1584,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1634,9 +1623,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash 0.7.8",
-]
 
 [[package]]
 name = "hashbrown"
@@ -3594,7 +3580,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a820a1a3e59644b38bc03606b638b41f1c5a474215efcec37f94b15871a7e1c"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "async-trait",
  "blake2",
  "bstr",
@@ -3629,7 +3615,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7d6d9e04414ba6819c51ec210eddf17865c505431a492c86c6356338c2b4f60"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "async-trait",
  "brotli",
  "bstr",
@@ -3717,7 +3703,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec55d3bcbd56e52b3424bc62739a237d43c14df8ed04aaf294ae187b60da348a"
 dependencies = [
  "arrayvec 0.7.8",
- "hashbrown 0.12.3",
+ "hashbrown 0.17.1",
  "parking_lot",
  "rand 0.8.7",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ clap = { version = "4.6.6", features = ["derive"] }
 criterion = { version = "0.8.2", features = ["async_tokio"] }
 dashmap = "6.2.1"
 futures = "0.3.34"
-h2 = "0.4.15"
+h2 = "0.4.16"
 http = "1.5.0"
 metrics = "0.24.6"
 metrics-exporter-prometheus = { version = "0.18.3", default-features = false }

--- a/tests/conformance/tests/suite/rfcs/test_utils.rs
+++ b/tests/conformance/tests/suite/rfcs/test_utils.rs
@@ -21,42 +21,46 @@ pub(super) fn h2c_get(addr: &str, path: &str) -> (http::Response<()>, String) {
         .build()
         .expect("tokio runtime");
 
-    rt.block_on(async {
-        let tcp = tokio::net::TcpStream::connect(addr).await.expect("TCP connect for h2c");
+    rt.block_on(h2c_get_async(addr, path))
+}
 
-        let (mut client, h2_conn) = h2::client::handshake(tcp).await.expect("h2c handshake");
-        tokio::spawn(async move {
-            if let Err(e) = h2_conn.await {
-                eprintln!("h2c connection closed: {e}");
-            }
-        });
+/// Perform the h2c GET request asynchronously.
+#[expect(clippy::large_stack_frames, reason = "test helper with H2 handshake structs")]
+async fn h2c_get_async(addr: &str, path: &str) -> (http::Response<()>, String) {
+    let tcp = tokio::net::TcpStream::connect(addr).await.expect("TCP connect for h2c");
 
-        let request = http::Request::get(path)
-            .header("host", "localhost")
-            .body(())
-            .expect("build h2c request");
-
-        let (response_fut, _) = client.send_request(request, true).expect("send h2c request");
-        let response = response_fut.await.expect("h2c response");
-        let status = response.status();
-        let headers = response.headers().clone();
-        let mut body_stream = response.into_body();
-
-        let mut body = Vec::new();
-        while let Some(chunk) = body_stream.data().await {
-            let data = chunk.expect("h2c body chunk");
-            body.extend_from_slice(&data);
-            drop(body_stream.flow_control().release_capacity(data.len()));
+    let (mut client, h2_conn) = h2::client::handshake(tcp).await.expect("h2c handshake");
+    tokio::spawn(async move {
+        if let Err(e) = h2_conn.await {
+            eprintln!("h2c connection closed: {e}");
         }
+    });
 
-        let mut resp_builder = http::Response::builder().status(status);
-        for (key, value) in &headers {
-            resp_builder = resp_builder.header(key, value);
-        }
-        let resp = resp_builder.body(()).expect("rebuild response");
+    let request = http::Request::get(path)
+        .header("host", "localhost")
+        .body(())
+        .expect("build h2c request");
 
-        (resp, String::from_utf8_lossy(&body).into_owned())
-    })
+    let (response_fut, _) = client.send_request(request, true).expect("send h2c request");
+    let response = response_fut.await.expect("h2c response");
+    let status = response.status();
+    let headers = response.headers().clone();
+    let mut body_stream = response.into_body();
+
+    let mut body = Vec::new();
+    while let Some(chunk) = body_stream.data().await {
+        let data = chunk.expect("h2c body chunk");
+        body.extend_from_slice(&data);
+        drop(body_stream.flow_control().release_capacity(data.len()));
+    }
+
+    let mut resp_builder = http::Response::builder().status(status);
+    for (key, value) in &headers {
+        resp_builder = resp_builder.header(key, value);
+    }
+    let resp = resp_builder.body(()).expect("rebuild response");
+
+    (resp, String::from_utf8_lossy(&body).into_owned())
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Bump workspace `h2` from 0.4.15 to 0.4.16
- Refresh `Cargo.lock`

Fixes [RUSTSEC-2026-0258](https://rustsec.org/advisories/RUSTSEC-2026-0258) (unbounded empty HTTP/2 DATA frames), which was failing the `audit` CI job.

Closes #992

Same class of fix as [opendatahub-io/praxis-extproc#45](https://github.com/opendatahub-io/praxis-extproc/pull/45).

## Test plan
- [x] `make audit`
- [x] `cargo deny check`