### PR TITLE
feat: multi-service credential gateway (Phase 1)

### DIFF
--- a/configs/mitzo-gateway.yaml
+++ b/configs/mitzo-gateway.yaml
@@ -1,0 +1,215 @@
+# Praxis Credential Gateway — Phase 1
+#
+# Credential-injecting reverse proxy for the local tool stack.
+# Services call localhost:9090/<prefix> with no auth headers.
+# Praxis strips the prefix, injects real credentials, proxies upstream over TLS.
+#
+# Credential sources (consolidated by start.sh):
+#   VERTEX_ACCESS_TOKEN      — GCP OAuth2 token (rotated by start.sh via gcloud)
+#   OPENAI_API_KEY           — OpenAI API
+#   GITHUB_TOKEN             — GitHub API (PAT)
+#   JIRA_API_TOKEN_B64       — Atlassian (base64 of email:token)
+#   ORG_PULSE_API_TOKEN      — Org Pulse team tracker
+#   NTFY_AUTH_TOKEN           — ntfy.sh push notifications
+#
+# Usage:
+#   ./scripts/start.sh                  # launchd entry point
+#   ./target/release/praxis -c configs/mitzo-gateway.yaml   # manual
+#
+# Test:
+#   curl http://127.0.0.1:9090/anthropic/v1/messages \
+#     -H "Content-Type: application/json" \
+#     -H "anthropic-version: 2023-06-01" \
+#     -d '{"model":"claude-sonnet-4-20250514","max_tokens":50,
+#          "messages":[{"role":"user","content":"Say hi"}]}'
+#
+#   curl http://127.0.0.1:9090/github/repos/dimakis/mgmt/pulls
+#   curl http://127.0.0.1:9090/jira/rest/api/3/myself
+
+listeners:
+  - name: credential-gateway
+    address: "127.0.0.1:9090"
+    filter_chains: [main]
+
+filter_chains:
+  - name: main
+    filters:
+      # ── Set Host headers for upstream TLS ──
+      # Must run before router (conditions check original path).
+      - filter: headers
+        request_set:
+          - name: Host
+            value: "us-east5-aiplatform.googleapis.com"
+        conditions:
+          - when:
+              path_prefix: "/anthropic/"
+
+      - filter: headers
+        request_set:
+          - name: Host
+            value: "api.openai.com"
+        conditions:
+          - when:
+              path_prefix: "/openai/"
+
+      - filter: headers
+        request_set:
+          - name: Host
+            value: "api.github.com"
+        conditions:
+          - when:
+              path_prefix: "/github/"
+
+      - filter: headers
+        request_set:
+          - name: Host
+            value: "redhat.atlassian.net"
+        conditions:
+          - when:
+              path_prefix: "/jira/"
+
+      # ── Routing (matches on original path, selects cluster) ──
+      - filter: router
+        routes:
+          - path_prefix: "/anthropic/"
+            cluster: anthropic
+          - path_prefix: "/openai/"
+            cluster: openai
+          - path_prefix: "/github/"
+            cluster: github
+          - path_prefix: "/jira/"
+            cluster: jira
+          - path_prefix: "/org-pulse/"
+            cluster: org-pulse
+          - path_prefix: "/ntfy/"
+            cluster: ntfy
+
+      # ── Strip routing prefix (after router, before upstream) ──
+      # Only one fires per request (conditions are mutually exclusive).
+      # allow_rewrite_override needed because pipeline has multiple path_rewrite instances.
+      - filter: path_rewrite
+        replace:
+          pattern: "^/anthropic/"
+          replacement: "/"
+        conditions:
+          - when:
+              path_prefix: "/anthropic/"
+
+      - filter: path_rewrite
+        allow_rewrite_override: true
+        replace:
+          pattern: "^/openai/"
+          replacement: "/"
+        conditions:
+          - when:
+              path_prefix: "/openai/"
+
+      - filter: path_rewrite
+        allow_rewrite_override: true
+        replace:
+          pattern: "^/github/"
+          replacement: "/"
+        conditions:
+          - when:
+              path_prefix: "/github/"
+
+      - filter: path_rewrite
+        allow_rewrite_override: true
+        replace:
+          pattern: "^/jira/"
+          replacement: "/"
+        conditions:
+          - when:
+              path_prefix: "/jira/"
+
+      - filter: path_rewrite
+        allow_rewrite_override: true
+        replace:
+          pattern: "^/org-pulse/"
+          replacement: "/"
+        conditions:
+          - when:
+              path_prefix: "/org-pulse/"
+
+      - filter: path_rewrite
+        allow_rewrite_override: true
+        replace:
+          pattern: "^/ntfy/"
+          replacement: "/"
+        conditions:
+          - when:
+              path_prefix: "/ntfy/"
+
+      # ── Upstreams ──
+      - filter: load_balancer
+        clusters:
+          - name: anthropic
+            endpoints:
+              - "us-east5-aiplatform.googleapis.com:443"
+            tls:
+              sni: "us-east5-aiplatform.googleapis.com"
+
+          - name: openai
+            endpoints:
+              - "api.openai.com:443"
+            tls:
+              sni: "api.openai.com"
+
+          - name: github
+            endpoints:
+              - "api.github.com:443"
+            tls:
+              sni: "api.github.com"
+
+          - name: jira
+            endpoints:
+              - "redhat.atlassian.net:443"
+            tls:
+              sni: "redhat.atlassian.net"
+
+          - name: org-pulse
+            endpoints:
+              - "api-team-tracker.apps.int.spoke.prod.us-west-2.aws.paas.redhat.com:443"
+            tls:
+              sni: "api-team-tracker.apps.int.spoke.prod.us-west-2.aws.paas.redhat.com"
+
+          - name: ntfy
+            endpoints:
+              - "ntfy.sh:443"
+            tls:
+              sni: "ntfy.sh"
+
+      # ── Credential injection ──
+      # Each cluster gets its credential injected server-side.
+      # Client-provided auth headers are stripped and replaced.
+      - filter: credential_injection
+        clusters:
+          - name: anthropic
+            header: Authorization
+            env_var: VERTEX_ACCESS_TOKEN
+            header_prefix: "Bearer "
+
+          - name: openai
+            header: Authorization
+            env_var: OPENAI_API_KEY
+            header_prefix: "Bearer "
+
+          - name: github
+            header: Authorization
+            env_var: GITHUB_TOKEN
+            header_prefix: "Bearer "
+
+          - name: jira
+            header: Authorization
+            env_var: JIRA_API_TOKEN_B64
+            header_prefix: "Basic "
+
+          - name: org-pulse
+            header: Authorization
+            env_var: ORG_PULSE_API_TOKEN
+            header_prefix: "Bearer "
+
+          - name: ntfy
+            header: Authorization
+            env_var: NTFY_AUTH_TOKEN
+            header_prefix: "Bearer "

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# Start praxis credential gateway
+# Sourced by launchd via com.praxis.gateway.plist
+#
+# Consolidates credentials from across the tool stack into env vars,
+# then starts praxis. GCP Vertex token is refreshed at startup.
+
+set -euo pipefail
+
+PRAXIS_DIR="$HOME/redhat/praxis"
+BINARY="$PRAXIS_DIR/target/release/praxis"
+CONFIG="$PRAXIS_DIR/configs/mitzo-gateway.yaml"
+
+if [[ ! -x "$BINARY" ]]; then
+  echo "ERROR: praxis binary not found at $BINARY" >&2
+  exit 1
+fi
+
+if [[ ! -f "$CONFIG" ]]; then
+  echo "ERROR: config not found at $CONFIG" >&2
+  exit 1
+fi
+
+# --- Load credentials from scattered .env files ---
+
+load_env_var() {
+  local file="$1" var="$2"
+  if [[ -f "$file" ]]; then
+    local val
+    val=$(grep "^${var}=" "$file" 2>/dev/null | head -1 | cut -d'=' -f2-)
+    if [[ -n "$val" ]]; then
+      export "$var=$val"
+    fi
+  fi
+}
+
+# OpenAI (zshenv has it, but also check centaur .env as fallback)
+[[ -f "$HOME/.zshenv" ]] && source "$HOME/.zshenv"
+load_env_var "$HOME/projects/centaur/.env" "OPENAI_API_KEY"
+
+# GitHub PAT
+load_env_var "$HOME/projects/centaur/.env" "GITHUB_TOKEN"
+
+# Jira — needs base64 encoding of email:token
+load_env_var "$HOME/redhat/mgmt/.env" "JIRA_API_TOKEN"
+JIRA_EMAIL="dsaridak@redhat.com"
+if [[ -n "${JIRA_API_TOKEN:-}" ]]; then
+  export JIRA_API_TOKEN_B64
+  JIRA_API_TOKEN_B64=$(printf '%s:%s' "$JIRA_EMAIL" "$JIRA_API_TOKEN" | base64)
+fi
+
+# Org Pulse
+load_env_var "$HOME/redhat/mgmt/.env" "ORG_PULSE_API_TOKEN"
+
+# ntfy
+load_env_var "$HOME/projects/centaur/.env" "NTFY_AUTH_TOKEN"
+
+# --- GCP Vertex AI token (short-lived, refresh at startup) ---
+if command -v gcloud &>/dev/null; then
+  VERTEX_ACCESS_TOKEN=$(gcloud auth print-access-token 2>/dev/null || true)
+  if [[ -n "$VERTEX_ACCESS_TOKEN" ]]; then
+    export VERTEX_ACCESS_TOKEN
+  else
+    echo "WARN: gcloud auth print-access-token failed, Anthropic/Vertex route will 401" >&2
+  fi
+else
+  echo "WARN: gcloud not found, Anthropic/Vertex route will 401" >&2
+fi
+
+# --- Validate all credentials are present ---
+MISSING=()
+check_var() { eval "val=\${$1:-}"; [[ -z "$val" ]] && MISSING+=("$1"); }
+check_var OPENAI_API_KEY
+check_var GITHUB_TOKEN
+check_var JIRA_API_TOKEN_B64
+check_var ORG_PULSE_API_TOKEN
+check_var NTFY_AUTH_TOKEN
+check_var VERTEX_ACCESS_TOKEN
+
+if [[ ${#MISSING[@]} -gt 0 ]]; then
+  echo "WARN: missing credentials: ${MISSING[*]}" >&2
+  echo "WARN: routes for missing credentials will return upstream 401/403" >&2
+fi
+
+echo "Praxis credential gateway starting on :9090"
+echo "  Loaded: $(( 6 - ${#MISSING[@]} ))/6 credentials"
+exec "$BINARY" -c "$CONFIG"


### PR DESCRIPTION
## Summary

- Multi-service credential-injecting reverse proxy config for the local tool stack
- Routes 6 upstreams (Anthropic/Vertex, OpenAI, GitHub, Jira, Org Pulse, ntfy) through `localhost:9090` with path-prefix routing
- Consolidated `start.sh` loads credentials from scattered `.env` files across mgmt, centaur, and zshenv
- Tested: GitHub rate_limit (200) and Jira /myself (200) confirmed working through proxy

## Known Limitation

Vertex AI OAuth2 tokens expire after ~1 hour. The `credential_injection` filter reads env vars at construction time with no refresh mechanism. Follow-up PR against praxis upstream will add `file`-based credential source with TTL (using existing ArcSwap pattern from TLS cert hot-reload).

## Test plan

- [x] Config validates clean (`praxis -t`)
- [x] GitHub route: `curl localhost:9090/github/rate_limit` returns authenticated response
- [x] Jira route: `curl localhost:9090/jira/rest/api/3/myself` returns user profile
- [ ] OpenAI route verification
- [ ] Vertex/Anthropic route (blocked on token refresh)
- [ ] launchd service starts cleanly
- [ ] ntfy and Org Pulse route verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)