### PR TITLE
chore(OCI): openssl not needed for build... yet

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -6,9 +6,7 @@
 
 FROM rust:1.96-alpine AS builder
 
-ENV OPENSSL_STATIC=1
-
-RUN apk add --no-cache musl-dev openssl-dev openssl-libs-static pkgconf cmake make g++
+RUN apk add --no-cache musl-dev pkgconf cmake make g++
 
 WORKDIR /src
 


### PR DESCRIPTION
### What does this PR do?

This 🔥 openssl as a dependency when building. afaict it was never required. 
This is also prep work, as when introducing support for openssl, it won't be statically linked, but will be dynamic dependency.
