### PR TITLE
WIP: Openssl support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3386,6 +3386,7 @@ version = "0.5.2"
 dependencies = [
  "arc-swap",
  "notify",
+ "openssl",
  "rcgen",
  "rustls",
  "rustls-pemfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1401,6 +1401,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2680,6 +2695,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2690,6 +2730,28 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-src"
+version = "300.6.1+3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "openssl-src",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "opentelemetry"
@@ -3238,6 +3300,7 @@ dependencies = [
  "http",
  "metrics",
  "metrics-exporter-prometheus",
+ "openssl",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
@@ -3666,6 +3729,7 @@ dependencies = [
  "percent-encoding",
  "quixotic-plecostomus-error",
  "quixotic-plecostomus-http",
+ "quixotic-plecostomus-openssl",
  "quixotic-plecostomus-pool",
  "quixotic-plecostomus-runtime",
  "quixotic-plecostomus-rustls",
@@ -3730,6 +3794,19 @@ dependencies = [
  "hashbrown 0.17.1",
  "parking_lot",
  "rand 0.8.7",
+]
+
+[[package]]
+name = "quixotic-plecostomus-openssl"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b1fee3c7367d3092980b0b3c6a18da77a0239d24a7410f5b91795978160e318"
+dependencies = [
+ "foreign-types",
+ "libc",
+ "openssl",
+ "openssl-sys",
+ "tokio-openssl",
 ]
 
 [[package]]
@@ -4990,6 +5067,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-openssl"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59df6849caa43bb7567f9a36f863c447d95a11d5903c9cc334ba32576a27eadd"
+dependencies = [
+ "openssl",
+ "openssl-sys",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5387,6 +5475,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,9 +61,11 @@ opentelemetry = { version = "0.32.0", default-features = false, features = ["tra
 opentelemetry_sdk = { version = "0.32.1", default-features = false, features = ["trace", "rt-tokio"] }
 opentelemetry-otlp = { version = "0.32.0", default-features = false, features = ["grpc-tonic", "trace"] }
 # Temporary fork: https://github.com/praxis-proxy/pingora
-pingora-core = { version = "0.8.2", package = "quixotic-plecostomus-core", features = ["rustls"] }
+# TLS backend (rustls or openssl) is selected via feature flags so the two
+# remain mutually exclusive. Do not add features here; gate them in each crate.
+pingora-core = { version = "0.8.2", package = "quixotic-plecostomus-core" }
 pingora-http = { version = "0.8.2", package = "quixotic-plecostomus-http" }
-pingora-proxy = { version = "0.8.2", package = "quixotic-plecostomus-proxy", features = ["rustls"] }
+pingora-proxy = { version = "0.8.2", package = "quixotic-plecostomus-proxy" }
 percent-encoding = "2.3.2"
 rand = "0.10.2"
 plotters = { version = "0.3.7", default-features = false, features = ["svg_backend", "line_series"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,6 +17,8 @@ name = "praxis_core"
 workspace = true
 
 [features]
+rustls = ["pingora-core/rustls"]
+openssl = ["pingora-core/openssl", "dep:openssl"]
 otel = [
     "dep:opentelemetry",
     "dep:opentelemetry_sdk",
@@ -33,6 +35,7 @@ metrics = { workspace = true }
 opentelemetry = { workspace = true, optional = true }
 opentelemetry_sdk = { workspace = true, optional = true }
 opentelemetry-otlp = { workspace = true, optional = true }
+openssl = { version = "0.10", optional = true }
 pingora-core = { workspace = true }
 pingora-http = { workspace = true }
 praxis-tls = { workspace = true }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,8 +17,8 @@ name = "praxis_core"
 workspace = true
 
 [features]
-rustls = ["pingora-core/rustls"]
-openssl = ["pingora-core/openssl", "dep:openssl"]
+rustls = ["pingora-core/rustls", "praxis-tls/rustls"]
+openssl = ["pingora-core/openssl", "dep:openssl", "praxis-tls/openssl"]
 otel = [
     "dep:opentelemetry",
     "dep:opentelemetry_sdk",

--- a/core/src/connectivity/peer.rs
+++ b/core/src/connectivity/peer.rs
@@ -199,17 +199,25 @@ pub fn apply_cached_tls(peer: &mut HttpPeer, tls: &praxis_tls::CachedClusterTls,
     }
 
     if let Some(ca) = tls.ca() {
-        peer.options.ca = Some(Arc::from(ca_from_cached(ca)));
+        #[cfg(feature = "rustls")]
+        {
+            peer.options.ca = Some(Arc::from(ca_from_cached(ca)));
+        }
+        #[cfg(feature = "openssl")]
+        {
+            peer.options.ca = Some(Arc::new(ca_from_cached(ca).into_boxed_slice()));
+        }
     }
 
     if let Some(client) = tls.client_cert() {
-        peer.client_cert_key = Some(Arc::new(client_cert_from_cached(client)));
+        if let Some(cert_key) = client_cert_from_cached(client) {
+            peer.client_cert_key = Some(Arc::new(cert_key));
+        }
     }
 }
 
-/// Convert cached CA DER bytes into [`WrappedX509`] values.
-///
-/// [`WrappedX509`]: pingora_core::utils::tls::WrappedX509
+/// Convert cached CA DER bytes into values for the active TLS backend.
+#[cfg(feature = "rustls")]
 pub fn ca_from_cached(cached: &praxis_tls::CachedCaCerts) -> Vec<pingora_core::utils::tls::WrappedX509> {
     cached
         .der_certs()
@@ -222,11 +230,55 @@ pub fn ca_from_cached(cached: &praxis_tls::CachedCaCerts) -> Vec<pingora_core::u
         .collect()
 }
 
+/// Convert cached CA DER bytes into values for the active TLS backend.
+#[cfg(feature = "openssl")]
+pub fn ca_from_cached(cached: &praxis_tls::CachedCaCerts) -> Vec<openssl::x509::X509> {
+    cached
+        .der_certs()
+        .iter()
+        .filter_map(|der| {
+            openssl::x509::X509::from_der(der)
+                .inspect_err(|e| tracing::warn!("failed to parse cached CA cert: {e}"))
+                .ok()
+        })
+        .collect()
+}
+
 /// Convert cached client cert/key DER bytes into a [`CertKey`].
 ///
+/// Returns `None` and logs a warning if the bytes cannot be parsed.
+///
 /// [`CertKey`]: pingora_core::utils::tls::CertKey
-pub fn client_cert_from_cached(cached: &praxis_tls::CachedClientCert) -> pingora_core::utils::tls::CertKey {
-    pingora_core::utils::tls::CertKey::new(cached.cert_der().to_vec(), cached.key_der().to_vec())
+#[cfg(feature = "rustls")]
+pub fn client_cert_from_cached(
+    cached: &praxis_tls::CachedClientCert,
+) -> Option<pingora_core::utils::tls::CertKey> {
+    Some(pingora_core::utils::tls::CertKey::new(
+        cached.cert_der().to_vec(),
+        cached.key_der().to_vec(),
+    ))
+}
+
+/// Convert cached client cert/key DER bytes into a [`CertKey`].
+///
+/// Returns `None` and logs a warning if the bytes cannot be parsed.
+///
+/// [`CertKey`]: pingora_core::utils::tls::CertKey
+#[cfg(feature = "openssl")]
+pub fn client_cert_from_cached(
+    cached: &praxis_tls::CachedClientCert,
+) -> Option<pingora_core::utils::tls::CertKey> {
+    let certs = cached
+        .cert_der()
+        .iter()
+        .map(|der| openssl::x509::X509::from_der(der))
+        .collect::<Result<Vec<_>, _>>()
+        .inspect_err(|e| tracing::warn!("failed to parse cached client cert: {e}"))
+        .ok()?;
+    let key = openssl::pkey::PKey::private_key_from_der(cached.key_der())
+        .inspect_err(|e| tracing::warn!("failed to parse cached client key: {e}"))
+        .ok()?;
+    Some(pingora_core::utils::tls::CertKey::new(certs, key))
 }
 
 // ---------------------------------------------------------------------------

--- a/filter/Cargo.toml
+++ b/filter/Cargo.toml
@@ -15,6 +15,8 @@ name = "praxis_filter"
 
 [features]
 default = []
+rustls = ["pingora-core/rustls"]
+openssl = ["pingora-core/openssl"]
 policy-engine = [
     "dep:ppe",
 ]

--- a/filter/Cargo.toml
+++ b/filter/Cargo.toml
@@ -15,8 +15,8 @@ name = "praxis_filter"
 
 [features]
 default = []
-rustls = ["pingora-core/rustls"]
-openssl = ["pingora-core/openssl"]
+rustls = ["pingora-core/rustls", "praxis-tls/rustls"]
+openssl = ["pingora-core/openssl", "praxis-tls/openssl"]
 policy-engine = [
     "dep:ppe",
 ]

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -15,6 +15,8 @@ name = "praxis_protocol"
 
 [features]
 default = []
+rustls = ["pingora-core/rustls", "pingora-proxy/rustls"]
+openssl = ["pingora-core/openssl", "pingora-proxy/openssl"]
 
 [lints]
 workspace = true

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -15,8 +15,8 @@ name = "praxis_protocol"
 
 [features]
 default = []
-rustls = ["pingora-core/rustls", "pingora-proxy/rustls"]
-openssl = ["pingora-core/openssl", "pingora-proxy/openssl"]
+rustls = ["pingora-core/rustls", "pingora-proxy/rustls", "praxis-tls/rustls"]
+openssl = ["pingora-core/openssl", "pingora-proxy/openssl", "praxis-tls/openssl"]
 
 [lints]
 workspace = true

--- a/protocol/src/tls_setup.rs
+++ b/protocol/src/tls_setup.rs
@@ -29,6 +29,7 @@ use tokio::sync::watch;
 /// [`build_server_config`]: praxis_tls::setup::build_server_config
 /// [`ReloadableCertResolver`]: praxis_tls::reload::ReloadableCertResolver
 /// [`CertWatcher`]: praxis_tls::watcher::CertWatcher
+#[cfg(feature = "rustls")]
 #[expect(clippy::too_many_lines, reason = "hot-reload vs static TLS branching")]
 pub(crate) fn build_tls_settings(
     tls: &ListenerTls,
@@ -74,4 +75,20 @@ pub(crate) fn build_tls_settings(
     let server_config = praxis_tls::setup::build_server_config(tls).map_err(|e| tls_err!(e))?;
     let settings = TlsSettings::with_server_config(server_config).map_err(|e| tls_err!(e))?;
     Ok((settings, None))
+}
+
+/// Listener-side TLS is not yet implemented for the openssl backend.
+///
+/// The inbound TLS path requires porting `praxis-tls` to use OpenSSL's
+/// `TlsSettings` API, which differs substantially from the rustls one.
+/// Tracked as follow-up work.
+#[cfg(feature = "openssl")]
+pub(crate) fn build_tls_settings(
+    _tls: &ListenerTls,
+    address: &str,
+    _context_label: &str,
+) -> Result<(TlsSettings, Option<watch::Sender<bool>>), ProxyError> {
+    Err(ProxyError::Config(format!(
+        "TLS for {address}: listener TLS is not yet supported with the openssl feature"
+    )))
 }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -44,7 +44,9 @@ tempfile = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 [features]
-default = []
+default = ["rustls"]
+rustls = ["praxis-core/rustls", "praxis-filter/rustls", "praxis-protocol/rustls"]
+openssl = ["praxis-core/openssl", "praxis-filter/openssl", "praxis-protocol/openssl"]
 dev = ["basic-auth-filter"]
 basic-auth-filter = ["praxis-filter/basic-auth-filter", "experimental"]
 policy-engine = ["praxis-filter/policy-engine"]

--- a/tests/utils/Cargo.toml
+++ b/tests/utils/Cargo.toml
@@ -34,3 +34,6 @@ tokio-rustls = { workspace = true }
 tokio-tungstenite = { workspace = true }
 
 [features]
+default = ["rustls"]
+rustls = ["praxis/rustls", "praxis-core/rustls", "praxis-filter/rustls", "praxis-protocol/rustls", "pingora-core/rustls"]
+openssl = ["praxis/openssl", "praxis-core/openssl", "praxis-filter/openssl", "praxis-protocol/openssl", "pingora-core/openssl"]

--- a/tls/Cargo.toml
+++ b/tls/Cargo.toml
@@ -17,13 +17,16 @@ name = "praxis_tls"
 workspace = true
 
 [features]
+rustls = ["dep:rustls", "dep:rustls-pemfile"]
+openssl = ["dep:openssl"]
 hot-reload = ["dep:arc-swap", "dep:notify", "dep:tokio"]
 
 [dependencies]
 arc-swap = { workspace = true, optional = true }
 notify = { workspace = true, optional = true }
-rustls = { workspace = true }
-rustls-pemfile = { workspace = true }
+openssl = { version = "0.10", optional = true }
+rustls = { workspace = true, optional = true }
+rustls-pemfile = { workspace = true, optional = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync", "time", "rt"], optional = true }

--- a/tls/src/cached.rs
+++ b/tls/src/cached.rs
@@ -272,6 +272,7 @@ fn load_and_validate_certs(path: &str, context: &str) -> Result<Vec<Vec<u8>>, Tl
 }
 
 /// Read a PEM certificate file and return DER-encoded certificate bytes.
+#[cfg(feature = "rustls")]
 fn parse_cert_pem(cert_path: &str) -> Result<Vec<Vec<u8>>, TlsError> {
     let pem = read_pem_file(cert_path)?;
     rustls_pemfile::certs(&mut &pem[..])
@@ -283,7 +284,27 @@ fn parse_cert_pem(cert_path: &str) -> Result<Vec<Vec<u8>>, TlsError> {
         .map(|certs| certs.into_iter().map(|c| c.to_vec()).collect())
 }
 
+/// Read a PEM certificate file and return DER-encoded certificate bytes.
+#[cfg(feature = "openssl")]
+fn parse_cert_pem(cert_path: &str) -> Result<Vec<Vec<u8>>, TlsError> {
+    let pem = read_pem_file(cert_path)?;
+    openssl::x509::X509::stack_from_pem(&pem)
+        .map_err(|e| TlsError::FileLoadError {
+            path: cert_path.to_owned(),
+            detail: e.to_string(),
+        })?
+        .iter()
+        .map(|cert| {
+            cert.to_der().map_err(|e| TlsError::FileLoadError {
+                path: cert_path.to_owned(),
+                detail: e.to_string(),
+            })
+        })
+        .collect()
+}
+
 /// Read a PEM private key file and return the DER-encoded key bytes.
+#[cfg(feature = "rustls")]
 fn parse_key_pem(key_path: &str) -> Result<Zeroizing<Vec<u8>>, TlsError> {
     let pem = read_pem_file(key_path)?;
     rustls_pemfile::private_key(&mut &pem[..])
@@ -296,6 +317,24 @@ fn parse_key_pem(key_path: &str) -> Result<Zeroizing<Vec<u8>>, TlsError> {
             detail: "no private key found".to_owned(),
         })
         .map(|k| Zeroizing::new(k.secret_der().to_vec()))
+}
+
+/// Read a PEM private key file and return the DER-encoded key bytes.
+#[cfg(feature = "openssl")]
+fn parse_key_pem(key_path: &str) -> Result<Zeroizing<Vec<u8>>, TlsError> {
+    let pem = read_pem_file(key_path)?;
+    openssl::pkey::PKey::private_key_from_pem(&pem)
+        .map_err(|e| TlsError::FileLoadError {
+            path: key_path.to_owned(),
+            detail: e.to_string(),
+        })
+        .and_then(|key| {
+            key.private_key_to_der().map_err(|e| TlsError::FileLoadError {
+                path: key_path.to_owned(),
+                detail: e.to_string(),
+            })
+        })
+        .map(Zeroizing::new)
 }
 
 /// Read a file into a zeroizing byte vector, mapping I/O errors

--- a/tls/src/config/cipher_suite.rs
+++ b/tls/src/config/cipher_suite.rs
@@ -3,6 +3,7 @@
 
 //! Cipher suite identifiers for restricting accepted TLS cipher suites.
 
+#[cfg(feature = "rustls")]
 use rustls::{SupportedCipherSuite, crypto::aws_lc_rs::cipher_suite};
 use serde::{Deserialize, Serialize};
 
@@ -72,20 +73,10 @@ pub enum CipherSuiteId {
 }
 
 impl CipherSuiteId {
-    /// Convert to the corresponding rustls [`SupportedCipherSuite`].
+    /// Convert to the corresponding rustls `SupportedCipherSuite`.
     ///
-    /// ```
-    /// use praxis_tls::CipherSuiteId;
-    ///
-    /// let suite = CipherSuiteId::Tls13Aes256GcmSha384;
-    /// let rustls_suite = suite.to_rustls();
-    /// assert_eq!(
-    ///     format!("{:?}", rustls_suite.suite()),
-    ///     "TLS13_AES_256_GCM_SHA384"
-    /// );
-    /// ```
-    ///
-    /// [`SupportedCipherSuite`]: rustls::SupportedCipherSuite
+    /// Only available when the `rustls` feature is enabled.
+    #[cfg(feature = "rustls")]
     pub fn to_rustls(&self) -> SupportedCipherSuite {
         match self {
             Self::Tls13Aes128GcmSha256 => cipher_suite::TLS13_AES_128_GCM_SHA256,

--- a/tls/src/config/listener.rs
+++ b/tls/src/config/listener.rs
@@ -819,6 +819,7 @@ certificates:
     }
 
     #[test]
+    #[cfg(feature = "rustls")]
     fn cipher_suite_id_to_rustls_all_variants() {
         let expected = [
             (CipherSuiteId::Tls13Aes128GcmSha256, "TLS13_AES_128_GCM_SHA256"),

--- a/tls/src/lib.rs
+++ b/tls/src/lib.rs
@@ -14,13 +14,15 @@
 //! TLS configuration types for the Praxis proxy.
 
 mod cached;
+#[cfg(feature = "rustls")]
 mod client_auth;
 mod config;
 pub mod dns;
 mod error;
 mod identity;
-#[cfg(feature = "hot-reload")]
+#[cfg(all(feature = "hot-reload", feature = "rustls"))]
 pub mod reload;
+#[cfg(feature = "rustls")]
 pub mod setup;
 pub mod sni;
 pub mod sni_name;
@@ -28,7 +30,7 @@ pub mod sni_name;
 #[expect(clippy::allow_attributes, reason = "blanket test suppressions")]
 #[allow(clippy::unwrap_used, clippy::expect_used, reason = "test utilities")]
 mod test_utils;
-#[cfg(feature = "hot-reload")]
+#[cfg(all(feature = "hot-reload", feature = "rustls"))]
 pub mod watcher;
 
 pub use cached::{CachedCaCerts, CachedClientCert, CachedClusterTls};

--- a/tls/src/test_utils.rs
+++ b/tls/src/test_utils.rs
@@ -17,8 +17,7 @@ use rcgen::{CertificateParams, DnType, IsCa, Issuer, KeyPair};
 /// features, rustls cannot auto-detect a provider. This function
 /// installs one explicitly. It is idempotent: if a provider is
 /// already installed the call is a no-op.
-///
-/// [`CryptoProvider`]: rustls::crypto::CryptoProvider
+#[cfg(feature = "rustls")]
 pub(crate) fn ensure_crypto_provider() {
     drop(rustls::crypto::aws_lc_rs::default_provider().install_default());
 }


### PR DESCRIPTION
See #1014 

# Dependency verification:

```shell
cargo tree --no-default-features --features openssl -p praxis-proxy --invert rustls
```

```shell
cargo tree --no-default-features --features openssl -p praxis-proxy --invert ring
```

```shell
cargo tree --no-default-features --features openssl -p praxis-proxy --invert aws-lc-rs
```

None should resolve.

<details>

Using this to test:

```dockerfile
# syntax=docker/dockerfile:1

# ------------------------------------------------------------------------------
# Stage 1: Build
# ------------------------------------------------------------------------------

FROM registry.access.redhat.com/ubi9/ubi AS builder

ARG CARGO_PROFILE=release

RUN dnf install -y rust-toolset openssl-devel gcc gcc-c++ cmake make \
    && dnf clean all

ENV OPENSSL_NO_VENDOR=1

WORKDIR /src

# ------------------------------------------------------------------------------
# Cache Build
# ------------------------------------------------------------------------------

# Cache dependency builds: copy only manifests first, then
# create stub source files so `cargo build` resolves and
# compiles all dependencies without the real source code.
# See: https://shaneutt.com/blog/rust-fast-small-docker-image-builds/

COPY Cargo.toml Cargo.lock ./
COPY core/Cargo.toml core/Cargo.toml
COPY filter/Cargo.toml filter/Cargo.toml
COPY protocol/Cargo.toml protocol/Cargo.toml
COPY tls/Cargo.toml tls/Cargo.toml
COPY server/Cargo.toml server/Cargo.toml

# The server crate has a build.rs that discovers external filter
# crates via cargo metadata for build-time auto-registration.
COPY server/build.rs server/build.rs

# Strip workspace members not needed for the praxis binary
# so we don't need their Cargo.toml files.
RUN sed -i '/xtask/d; /benchmarks/d; /tests\//d' Cargo.toml
RUN mkdir -p core/src \
    filter/src \
    protocol/src \
    tls/src \
    server/src \
    && echo '//! stub' > core/src/lib.rs \
    && echo '//! stub' > filter/src/lib.rs \
    && echo '//! stub' > protocol/src/lib.rs \
    && echo '//! stub' > tls/src/lib.rs \
    && echo '//! stub' > server/src/lib.rs \
    && printf '//! stub\nfn main() {}\n' > server/src/main.rs

RUN --mount=type=cache,target=/usr/local/cargo/registry \
    --mount=type=cache,target=/src/target \
    cargo build --ignore-rust-version --no-default-features --features openssl --release -p praxis-proxy

# ------------------------------------------------------------------------------
# Cache Tricks
# ------------------------------------------------------------------------------

# Replace stubs with real source, then rebuild. Only the
# project crates recompile; all dependencies are cached.
COPY core/src core/src
COPY filter/src filter/src
COPY protocol/src protocol/src
COPY tls/src tls/src
COPY server/src server/src
COPY examples examples

# Touch the lib/main files so cargo sees them as newer than
# the cached stub artifacts.
RUN find core/src filter/src \
    protocol/src tls/src server/src \
    -name '*.rs' -exec touch {} +

# ------------------------------------------------------------------------------
# Build
# ------------------------------------------------------------------------------

RUN --mount=type=cache,target=/usr/local/cargo/registry \
    --mount=type=cache,target=/src/target \
    cargo build --ignore-rust-version --no-default-features --features openssl --release -p praxis-proxy \
    && cp target/release/praxis /usr/local/bin/praxis

# ------------------------------------------------------------------------------
# Stage 2: Runtime
# ------------------------------------------------------------------------------

FROM registry.access.redhat.com/ubi9/ubi-minimal

LABEL org.opencontainers.image.source="https://github.com/praxis-proxy/praxis" \
    org.opencontainers.image.description="Praxis proxy server" \
    org.opencontainers.image.licenses="MIT"

RUN microdnf install -y openssl-libs \
    && microdnf clean all

COPY --from=builder --chown=root:root --chmod=0555 \
    /usr/local/bin/praxis /usr/local/bin/praxis

COPY examples/configs/operations/container-default.yaml \
    /etc/praxis/config.yaml

USER 1001

EXPOSE 50051 50052 9090

ENTRYPOINT ["praxis-extproc"]
CMD ["-c", "/etc/praxis/extproc.yaml"]
```

</details>