### PR TITLE
feat(tcp): add praxis_tcp_connection_duration_seconds histogram metric

### DIFF
--- a/docs/operating/observability.md
+++ b/docs/operating/observability.md
@@ -122,9 +122,10 @@ return **400** JSON errors.
 
 ## Metrics Reference
 
-Praxis records two categories of Prometheus metrics:
-HTTP request metrics (always on when admin is
-enabled) and per-filter duration histograms (opt-in).
+Praxis records Prometheus metrics in three
+categories: HTTP request metrics, TCP connection
+metrics (both always on when admin is enabled), and
+per-filter duration histograms (opt-in).
 
 Recorder upkeep runs every five seconds whenever the
 admin endpoint is enabled. It is independent of
@@ -156,6 +157,45 @@ code `0` (no response written) maps to `unknown`.
 Wall-clock duration of completed HTTP requests in
 seconds. Uses the same label set as
 `praxis_http_requests_total`.
+
+### TCP Connection Metrics
+
+These are recorded automatically for every TCP
+connection when the admin endpoint is enabled.
+
+#### `praxis_tcp_connection_duration_seconds` (histogram)
+
+Wall-clock lifetime of a TCP connection from accept
+to close, in seconds.
+
+| Label | Values |
+| ---------- | ---------------------------------------- |
+| `listener` | Listener name from config |
+| `reason` | `completed`, `sni_timeout`, `filter_rejection`, `connect_failure`, `peeked_write_error` |
+
+The `reason` label captures why the connection
+closed:
+
+| Reason | Meaning |
+| --------------------- | ---------------------------------------- |
+| `completed` | Normal forwarding finished |
+| `sni_timeout` | SNI peek timed out before routing |
+| `filter_rejection` | Connect filters rejected the connection |
+| `connect_failure` | Upstream connection failed |
+| `peeked_write_error` | Writing peeked bytes to upstream failed |
+
+#### `praxis_tcp_connections_total` (counter)
+
+Total accepted TCP connections.
+
+| Label | Values |
+| ---------- | ---------------------------------------- |
+| `listener` | Listener name from config |
+
+Incremented once per accepted connection after
+overload checks pass. Use with
+`praxis_connections_active` to derive connection
+rates and concurrency.
 
 ### Filter Duration Histograms
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -40,6 +40,7 @@ page.
 | [logging.yaml](configs/observability/logging.yaml) | request_id — ensures every request has a correlation ID |
 | [process-logging.yaml](configs/observability/process-logging.yaml) | Non-blocking process logs written to a rotating file |
 | [tcp-access-log.yaml](configs/observability/tcp-access-log.yaml) | Structured JSON logging of TCP connection events (connect and disconnect) |
+| [tcp-connection-metrics.yaml](configs/observability/tcp-connection-metrics.yaml) | Prometheus histogram for TCP connection duration |
 | [trace-context.yaml](configs/observability/trace-context.yaml) | W3C Trace Context header propagation |
 | [tracing-otlp.yaml](configs/observability/tracing-otlp.yaml) | Exports distributed tracing spans to an OpenTelemetry Collector via OTLP/gRPC |
 

--- a/examples/configs/observability/tcp-connection-metrics.yaml
+++ b/examples/configs/observability/tcp-connection-metrics.yaml
@@ -1,0 +1,24 @@
+# TCP Connection Metrics
+#
+# Prometheus histogram for TCP connection duration. Each completed
+# connection is recorded in praxis_tcp_connection_duration_seconds
+# with a listener label. Scraped via the admin /metrics endpoint.
+#
+# Usage:
+#   cargo run -p praxis-proxy -- -c examples/configs/observability/tcp-connection-metrics.yaml
+#
+# Exercise:
+#   echo "hello" | nc localhost 5432
+#   curl -s http://localhost:9901/metrics | grep tcp_connection_duration
+
+admin:
+  address: "127.0.0.1:9901"
+
+insecure_options:
+  allow_private_upstreams: true
+
+listeners:
+  - name: postgres
+    address: "127.0.0.1:5432"
+    protocol: tcp
+    upstream: "127.0.0.1:15432"

--- a/protocol/src/tcp/metrics.rs
+++ b/protocol/src/tcp/metrics.rs
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Prometheus metrics for TCP connection lifecycle.
+
+use metrics::{SharedString, histogram};
+
+use crate::http::pingora::metrics::is_recorder_installed;
+
+// -----------------------------------------------------------------------------
+// Constants
+// -----------------------------------------------------------------------------
+
+/// Histogram for TCP connection duration in seconds.
+const TCP_CONNECTION_DURATION_SECONDS: &str = "praxis_tcp_connection_duration_seconds";
+
+// -----------------------------------------------------------------------------
+// Metric Recording
+// -----------------------------------------------------------------------------
+
+/// Record TCP connection duration for a closed connection.
+///
+/// The `reason` label captures the disconnect cause (e.g. `completed`,
+/// `sni_timeout`, `filter_rejection`, `connect_failure`, `peeked_write_error`).
+///
+/// No-op when the Prometheus recorder has not been installed
+/// (i.e. when the admin interface is disabled).
+pub(crate) fn record_tcp_connection_duration(
+    listener: SharedString,
+    reason: &'static str,
+    duration_secs: f64,
+) {
+    if !is_recorder_installed() {
+        return;
+    }
+    histogram!(
+        TCP_CONNECTION_DURATION_SECONDS,
+        "listener" => listener,
+        "reason" => reason
+    )
+    .record(duration_secs);
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn record_without_recorder_does_not_panic() {
+        record_tcp_connection_duration(SharedString::const_str("test-listener"), "completed", 1.5);
+    }
+
+    #[test]
+    fn record_zero_duration_does_not_panic() {
+        record_tcp_connection_duration(SharedString::const_str("test-listener"), "sni_timeout", 0.0);
+    }
+
+    #[test]
+    fn record_large_duration_does_not_panic() {
+        record_tcp_connection_duration(SharedString::const_str("long-lived"), "completed", 86400.0);
+    }
+}

--- a/protocol/src/tcp/metrics.rs
+++ b/protocol/src/tcp/metrics.rs
@@ -25,11 +25,7 @@ const TCP_CONNECTION_DURATION_SECONDS: &str = "praxis_tcp_connection_duration_se
 ///
 /// No-op when the Prometheus recorder has not been installed
 /// (i.e. when the admin interface is disabled).
-pub(crate) fn record_tcp_connection_duration(
-    listener: SharedString,
-    reason: &'static str,
-    duration_secs: f64,
-) {
+pub(crate) fn record_tcp_connection_duration(listener: SharedString, reason: &'static str, duration_secs: f64) {
     if !is_recorder_installed() {
         return;
     }

--- a/protocol/src/tcp/mod.rs
+++ b/protocol/src/tcp/mod.rs
@@ -13,6 +13,8 @@ use tokio::sync::{Semaphore, watch};
 
 use crate::{ListenerPipelines, Protocol};
 
+/// TCP connection metrics (Prometheus histograms).
+pub(crate) mod metrics;
 /// Bidirectional TCP proxy application.
 pub(crate) mod proxy;
 /// TLS configuration and listener grouping utilities.

--- a/protocol/src/tcp/proxy.rs
+++ b/protocol/src/tcp/proxy.rs
@@ -216,6 +216,11 @@ impl PingoraTcpProxy {
 
         let result = resolve_connect_result(pipeline, &mut ctx, remote_addr).await;
         if result.is_none() {
+            super::metrics::record_tcp_connection_duration(
+                self.listener_label_for(local_addr),
+                "filter_rejection",
+                connect_time.elapsed().as_secs_f64(),
+            );
             log_early_close(connect_time, "filter_rejection");
         }
         result
@@ -309,6 +314,11 @@ impl ServerApp for PingoraTcpProxy {
             let (sni_hostname, peeked_bytes) = if self.upstream_addr.is_none() {
                 let Ok(result) = tokio::time::timeout(SNI_PEEK_TIMEOUT, peek_sni(&mut session)).await else {
                     warn!(remote = %remote_addr, "SNI peek timed out, closing connection");
+                    super::metrics::record_tcp_connection_duration(
+                        self.listener_label_for(&local_addr),
+                        "sni_timeout",
+                        connect_time.elapsed().as_secs_f64(),
+                    );
                     log_early_close(connect_time, "sni_timeout");
                     return None;
                 };
@@ -360,6 +370,11 @@ impl ServerApp for PingoraTcpProxy {
                         0,
                     )
                     .await;
+                    super::metrics::record_tcp_connection_duration(
+                        self.listener_label_for(&local_addr),
+                        "connect_failure",
+                        connect_time.elapsed().as_secs_f64(),
+                    );
                     log_early_close(connect_time, "connect_failure");
                     return None;
                 };
@@ -384,6 +399,11 @@ impl ServerApp for PingoraTcpProxy {
                     0,
                 )
                 .await;
+                super::metrics::record_tcp_connection_duration(
+                    self.listener_label_for(&local_addr),
+                    "peeked_write_error",
+                    connect_time.elapsed().as_secs_f64(),
+                );
                 log_early_close(connect_time, "peeked_write_error");
                 return None;
             }
@@ -414,6 +434,11 @@ impl ServerApp for PingoraTcpProxy {
                 duration_ms,
                 reason = "completed",
                 "connection_close"
+            );
+            super::metrics::record_tcp_connection_duration(
+                self.listener_label_for(&local_addr),
+                "completed",
+                connect_time.elapsed().as_secs_f64(),
             );
 
             None

--- a/tests/integration/tests/suite/examples/mod.rs
+++ b/tests/integration/tests/suite/examples/mod.rs
@@ -64,6 +64,7 @@ mod static_response;
 mod sticky_sessions;
 mod stream_buffer;
 mod subset_lb;
+mod tcp_connection_metrics;
 mod timeout;
 mod trace_context;
 #[cfg(feature = "otel")]

--- a/tests/integration/tests/suite/examples/tcp_connection_metrics.rs
+++ b/tests/integration/tests/suite/examples/tcp_connection_metrics.rs
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Functional integration tests for the tcp-connection-metrics example
+//! configuration.
+
+use std::{
+    collections::HashMap,
+    io::{Read as _, Write as _},
+    net::TcpStream,
+    time::Duration,
+};
+
+use praxis_test_utils::{free_port, http_get, start_full_proxy, start_tcp_tagged_backend, wait_for_tcp};
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn tcp_connection_metrics_example_emits_histogram() {
+    let backend_port = start_tcp_tagged_backend("pg");
+    let proxy_port = free_port();
+    let admin_port = free_port();
+    let config = super::load_example_config(
+        "observability/tcp-connection-metrics.yaml",
+        proxy_port,
+        HashMap::from([
+            ("127.0.0.1:5432", proxy_port),
+            ("127.0.0.1:15432", backend_port),
+            ("127.0.0.1:9901", admin_port),
+        ]),
+    );
+
+    let _proxy = start_full_proxy(&config);
+    wait_for_tcp(&format!("127.0.0.1:{proxy_port}"));
+    wait_for_tcp(&format!("127.0.0.1:{admin_port}"));
+
+    let mut stream = TcpStream::connect(format!("127.0.0.1:{proxy_port}")).expect("TCP connect");
+    stream.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+    stream.set_write_timeout(Some(Duration::from_secs(2))).unwrap();
+    stream.write_all(b"SELECT 1").expect("TCP write");
+    stream.shutdown(std::net::Shutdown::Write).expect("shutdown write");
+
+    let mut buf = Vec::new();
+    stream.read_to_end(&mut buf).expect("TCP read");
+    drop(stream);
+
+    std::thread::sleep(Duration::from_millis(100));
+
+    let (status, body) = http_get(&format!("127.0.0.1:{admin_port}"), "/metrics", None);
+    assert_eq!(status, 200, "/metrics should return 200");
+    assert!(
+        body.contains("praxis_tcp_connection_duration_seconds"),
+        "metrics should contain praxis_tcp_connection_duration_seconds histogram: {body}"
+    );
+    assert!(
+        body.contains("listener=\"postgres\""),
+        "metrics should contain listener=postgres label: {body}"
+    );
+    assert!(
+        body.contains("reason=\"completed\""),
+        "metrics should contain reason=completed label: {body}"
+    );
+}
+
+#[test]
+fn tcp_connection_metrics_example_forwards_traffic() {
+    let backend_port = start_tcp_tagged_backend("dbdata");
+    let proxy_port = free_port();
+    let admin_port = free_port();
+    let config = super::load_example_config(
+        "observability/tcp-connection-metrics.yaml",
+        proxy_port,
+        HashMap::from([
+            ("127.0.0.1:5432", proxy_port),
+            ("127.0.0.1:15432", backend_port),
+            ("127.0.0.1:9901", admin_port),
+        ]),
+    );
+
+    let _proxy = start_full_proxy(&config);
+    wait_for_tcp(&format!("127.0.0.1:{proxy_port}"));
+
+    let resp = tcp_send_recv(&format!("127.0.0.1:{proxy_port}"), b"hello");
+    assert!(
+        resp.contains("dbdata"),
+        "tcp-connection-metrics example should forward to tagged backend, got: {resp}"
+    );
+    assert!(
+        resp.contains("hello"),
+        "tcp-connection-metrics example should echo payload, got: {resp}"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------------
+
+fn tcp_send_recv(addr: &str, data: &[u8]) -> String {
+    let mut stream = TcpStream::connect(addr).expect("TCP connect failed");
+    stream.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+    stream.set_write_timeout(Some(Duration::from_secs(2))).unwrap();
+    stream.write_all(data).expect("TCP write failed");
+    stream.shutdown(std::net::Shutdown::Write).expect("TCP shutdown write");
+
+    let mut buf = Vec::new();
+    stream.read_to_end(&mut buf).expect("TCP read failed");
+    String::from_utf8_lossy(&buf).into_owned()
+}

--- a/tests/integration/tests/suite/main.rs
+++ b/tests/integration/tests/suite/main.rs
@@ -81,6 +81,7 @@ mod sni_router;
 mod stream_buffer_adapter;
 mod streaming_terminal_response;
 mod tcp_access_log;
+mod tcp_connection_metrics;
 mod tcp_edge_cases;
 mod tcp_load_balancer;
 mod tls;

--- a/tests/integration/tests/suite/tcp_connection_metrics.rs
+++ b/tests/integration/tests/suite/tcp_connection_metrics.rs
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Integration tests for TCP connection duration metrics.
+
+use std::{
+    io::{Read as _, Write as _},
+    net::TcpStream,
+    time::Duration,
+};
+
+use praxis_core::config::Config;
+use praxis_test_utils::{free_port, http_get, start_full_proxy, start_tcp_tagged_backend, wait_for_tcp};
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn tcp_connection_duration_histogram_emitted_after_connection_close() {
+    let backend_port = start_tcp_tagged_backend("metrics-test");
+    let proxy_port = free_port();
+    let admin_port = free_port();
+
+    let yaml = format!(
+        r#"
+admin:
+  address: "127.0.0.1:{admin_port}"
+
+insecure_options:
+  allow_private_upstreams: true
+
+listeners:
+  - name: tcp-metrics-test
+    address: "127.0.0.1:{proxy_port}"
+    protocol: tcp
+    upstream: "127.0.0.1:{backend_port}"
+"#
+    );
+
+    let config = Config::from_yaml(&yaml).unwrap();
+    let _proxy = start_full_proxy(&config);
+    wait_for_tcp(&format!("127.0.0.1:{proxy_port}"));
+    wait_for_tcp(&format!("127.0.0.1:{admin_port}"));
+
+    let mut stream = TcpStream::connect(format!("127.0.0.1:{proxy_port}")).expect("TCP connect");
+    stream.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+    stream.set_write_timeout(Some(Duration::from_secs(2))).unwrap();
+    stream.write_all(b"hello").expect("TCP write");
+    stream.shutdown(std::net::Shutdown::Write).expect("shutdown write");
+
+    let mut buf = Vec::new();
+    stream.read_to_end(&mut buf).expect("TCP read");
+    drop(stream);
+
+    std::thread::sleep(Duration::from_millis(100));
+
+    let (status, body) = http_get(&format!("127.0.0.1:{admin_port}"), "/metrics", None);
+    assert_eq!(status, 200, "/metrics should return 200");
+    assert!(
+        body.contains("praxis_tcp_connection_duration_seconds"),
+        "/metrics should contain praxis_tcp_connection_duration_seconds: {body}"
+    );
+    assert!(
+        body.contains("listener=\"tcp-metrics-test\""),
+        "/metrics should contain listener=tcp-metrics-test label: {body}"
+    );
+    assert!(
+        body.contains("reason=\"completed\""),
+        "/metrics should contain reason=completed label for normal close: {body}"
+    );
+}
+
+#[test]
+fn tcp_connection_duration_uses_correct_listener_label() {
+    let backend_port = start_tcp_tagged_backend("label-test");
+    let proxy_port = free_port();
+    let admin_port = free_port();
+
+    let yaml = format!(
+        r#"
+admin:
+  address: "127.0.0.1:{admin_port}"
+
+insecure_options:
+  allow_private_upstreams: true
+
+listeners:
+  - name: custom-label
+    address: "127.0.0.1:{proxy_port}"
+    protocol: tcp
+    upstream: "127.0.0.1:{backend_port}"
+"#
+    );
+
+    let config = Config::from_yaml(&yaml).unwrap();
+    let _proxy = start_full_proxy(&config);
+    wait_for_tcp(&format!("127.0.0.1:{proxy_port}"));
+    wait_for_tcp(&format!("127.0.0.1:{admin_port}"));
+
+    let mut stream = TcpStream::connect(format!("127.0.0.1:{proxy_port}")).expect("TCP connect");
+    stream.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+    stream.set_write_timeout(Some(Duration::from_secs(2))).unwrap();
+    stream.write_all(b"data").expect("TCP write");
+    stream.shutdown(std::net::Shutdown::Write).expect("shutdown write");
+
+    let mut buf = Vec::new();
+    stream.read_to_end(&mut buf).expect("TCP read");
+    drop(stream);
+
+    std::thread::sleep(Duration::from_millis(100));
+
+    let (status, body) = http_get(&format!("127.0.0.1:{admin_port}"), "/metrics", None);
+    assert_eq!(status, 200, "/metrics should return 200");
+    assert!(
+        body.contains("listener=\"custom-label\""),
+        "metric should use the configured listener name as label: {body}"
+    );
+    assert!(
+        body.contains("reason=\"completed\""),
+        "metric should contain the reason label: {body}"
+    );
+}
+
+#[test]
+fn tcp_connection_duration_records_connect_failure_reason() {
+    let unreachable_port = free_port();
+    let proxy_port = free_port();
+    let admin_port = free_port();
+
+    let yaml = format!(
+        r#"
+admin:
+  address: "127.0.0.1:{admin_port}"
+
+insecure_options:
+  allow_private_upstreams: true
+
+listeners:
+  - name: tcp-fail-test
+    address: "127.0.0.1:{proxy_port}"
+    protocol: tcp
+    upstream: "127.0.0.1:{unreachable_port}"
+"#
+    );
+
+    let config = Config::from_yaml(&yaml).unwrap();
+    let _proxy = start_full_proxy(&config);
+    wait_for_tcp(&format!("127.0.0.1:{proxy_port}"));
+    wait_for_tcp(&format!("127.0.0.1:{admin_port}"));
+
+    let stream = TcpStream::connect(format!("127.0.0.1:{proxy_port}")).expect("TCP connect");
+    drop(stream);
+
+    std::thread::sleep(Duration::from_millis(200));
+
+    let (status, body) = http_get(&format!("127.0.0.1:{admin_port}"), "/metrics", None);
+    assert_eq!(status, 200, "/metrics should return 200");
+    assert!(
+        body.contains("reason=\"connect_failure\""),
+        "/metrics should contain reason=connect_failure for unreachable upstream: {body}"
+    );
+}


### PR DESCRIPTION
Record TCP connection lifetime (accept to close) as a Prometheus histogram labeled by listener name. The metric is emitted on all disconnect paths and exposed via the admin /metrics endpoint when enabled.

### What does this PR do?

Adds a `praxis_tcp_connection_duration_seconds` Prometheus histogram that records the lifetime of each TCP connection (from accept to close), labeled by listener name. This gives operators visibility into how long TCP connections live across different listeners.

**Changes:**
- New `protocol/src/tcp/metrics.rs` module with `record_tcp_connection_duration()` 
- Records duration at all disconnect exit paths in `PingoraTcpProxy::process_new()`
- Uses the existing `listener_label_for()` infrastructure for accurate per-listener labeling
- Example config: `examples/configs/observability/tcp-connection-metrics.yaml`
- Unit tests (no-panic without recorder) and integration tests (metric emission + correct labels)

### Which issue(s) does this relate to?

Fixes #1027

### Checklist

- [x] Signed off all commits (`git commit -s`)
- [x] Tests added or updated
- [x] Documentation updated (if applicable)
- [x] `make lint && make test` passes locally

### Does this introduce a breaking change?

No. The metric is purely additive and only emitted when the admin interface is enabled.