### PR TITLE
POC: content-aware routing filter using llm-d-sc (discussion #1017)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,7 +286,7 @@ checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -586,9 +586,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.4.3"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -781,7 +781,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -900,9 +900,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
 dependencies = [
  "cfg-if",
 ]
@@ -1017,7 +1017,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70def8d72740e44d9f676d8dab2c933a236663d86dd24319b57a2bed4d694774"
 dependencies = [
- "petgraph",
+ "petgraph 0.7.1",
 ]
 
 [[package]]
@@ -1226,7 +1226,7 @@ checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1250,14 +1250,14 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "either"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "embedded-io"
@@ -1297,7 +1297,7 @@ checksum = "a65863d15a4ce2888bd2f0f543cc963d3879c3a022c8ee43f6141d479a3ac815"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1396,6 +1396,12 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
@@ -1480,7 +1486,7 @@ checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1590,9 +1596,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1638,13 +1644,22 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1655,7 +1670,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1904,9 +1919,9 @@ checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92a7ed671a6aad807a8651a2e1782a6598fda9ce5185dd8158549e95a91c6428"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -2182,7 +2197,7 @@ dependencies = [
  "ena",
  "itertools 0.14.0",
  "lalrpop-util",
- "petgraph",
+ "petgraph 0.7.1",
  "pico-args",
  "regex",
  "regex-syntax",
@@ -2273,6 +2288,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
+name = "llm-d-sc-praxis-filter"
+version = "0.1.0"
+source = "git+https://github.com/cnuland/llm-d-sc-praxis-filter?branch=main#458562e84cdf2766c3522e9e493ea647b5302735"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "metrics",
+ "praxis-proxy-core",
+ "praxis-proxy-filter",
+ "prost",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tonic",
+ "tonic-prost",
+ "tonic-prost-build",
+ "tracing",
+ "yaml_serde",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2283,9 +2320,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "logos"
@@ -2490,6 +2527,12 @@ checksum = "29e871a9861f3664f18b7e04e9301d4edd55090c2dadb4b1c602e26ab32b1f5b"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "murmur3"
@@ -2844,6 +2887,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
+ "indexmap 2.14.0",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
  "indexmap 2.14.0",
 ]
 
@@ -3213,6 +3267,7 @@ version = "0.5.3"
 dependencies = [
  "cargo_metadata",
  "clap",
+ "llm-d-sc-praxis-filter",
  "nix",
  "notify",
  "praxis-proxy-core",
@@ -3465,6 +3520,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3516,6 +3581,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-build"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
+dependencies = [
+ "heck 0.5.0",
+ "itertools 0.14.0",
+ "log",
+ "multimap",
+ "petgraph 0.8.3",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "pulldown-cmark",
+ "pulldown-cmark-to-cmark",
+ "regex",
+ "syn 2.0.119",
+ "tempfile",
+]
+
+[[package]]
 name = "prost-derive"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3545,6 +3631,26 @@ checksum = "4dcd034599e63b970727f70d79e02d62390a4a84f7c6b827c27c46d5ac3fa622"
 dependencies = [
  "ar_archive_writer",
  "cc",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
+dependencies = [
+ "bitflags 2.13.1",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-to-cmark"
+version = "22.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab1ad36992cead65f02aa399a373a42730922f1525d988172634fdefdecb8a60"
+dependencies = [
+ "pulldown-cmark",
 ]
 
 [[package]]
@@ -4072,7 +4178,7 @@ checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -4312,9 +4418,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.14"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -4489,7 +4595,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -4815,9 +4921,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4903,7 +5009,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -5033,7 +5139,7 @@ checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -5125,6 +5231,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic-build"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c68f61875ac5293cf72e6c8cf0158086428c82c37229e98c840878f1706b0322"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "tonic-prost"
 version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5133,6 +5251,22 @@ dependencies = [
  "bytes",
  "prost",
  "tonic",
+]
+
+[[package]]
+name = "tonic-prost-build"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "prost-types",
+ "quote",
+ "syn 2.0.119",
+ "tempfile",
+ "tonic-build",
 ]
 
 [[package]]
@@ -5424,9 +5558,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.24.1"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
+checksum = "f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -5895,7 +6029,7 @@ dependencies = [
  "praxis-proxy-core",
  "quote",
  "serde_json",
- "syn 3.0.3",
+ "syn 3.0.4",
  "tempfile",
  "tokio",
  "tracing",
@@ -6046,13 +6180,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f212a141d820099d57ffafb9569be9617a6f27d3dc881fbee8fb56642f917a9"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -402,3 +402,12 @@ bare_urls = "deny"
 invalid_html_tags = "deny"
 missing_crate_level_docs = "deny"
 private_doc_tests = "allow"
+
+[patch."https://github.com/praxis-proxy/praxis"]
+# Redirects the git dependency that llm-d-sc-praxis-filter declares on
+# praxis-proxy-filter/praxis-proxy-core back onto THIS checkout's own
+# workspace members, so the whole graph resolves to exactly one instance of
+# each type instead of two (this repo's `filter/` and a fresh git clone of
+# the same repo) that Cargo would otherwise refuse to unify.
+praxis-proxy-filter = { path = "filter" }
+praxis-proxy-core = { path = "core" }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -25,6 +25,10 @@ clap = { workspace = true }
 notify = { workspace = true }
 praxis-core = { workspace = true }
 praxis-filter = { workspace = true }
+# POC: auto-discovered external filter crate (see docs/filters/extensions.md).
+# This is the entire Praxis-side change for the llm-d-sc content-aware routing
+# integration proposed in discussion #1017.
+llm-d-sc-praxis-filter = { git = "https://github.com/cnuland/llm-d-sc-praxis-filter", branch = "main" }
 praxis-protocol = { workspace = true }
 serde = { workspace = true }
 serde_yaml = { workspace = true }


### PR DESCRIPTION
## Summary

Proof of concept answering the three questions raised in #1017: an
`llm_d_sc` HTTP filter that classifies request prompts via
[llm-d-sc](https://github.com/llm-d-incubation/llm-d-semantic-classifier)
(used **unmodified**, over its existing gRPC contract) and selects
`ctx.cluster` from the returned ranked label. llm-d-sc never sees or
returns a route — that decision stays entirely in Praxis, from Praxis
config.

**This diff is the entire Praxis-side change**: one dependency added to
`server/Cargo.toml` via the auto-discovery mechanism already documented in
`docs/filters/extensions.md`, plus a `[patch]` entry so the filter crate's
git dependency on `praxis-proxy-filter`/`praxis-proxy-core` unifies with
this workspace's own path members. No Praxis source file is modified.
Verified against this repo's real, current `main` — not a stale snapshot.

The filter crate itself, full findings (`FINDINGS.md`), and an alternative
**in-tree, feature-gated** implementation (24 files, opt-in
`llm-d-sc-filter` cargo feature, off by default) live at:
**https://github.com/cnuland/llm-d-sc-praxis-filter**

## Praxis's own results — the part this PR is actually about

Everything below is Praxis-side and independent of which classifier sits
behind the filter:

- Filter registers via `cargo metadata` auto-discovery; built and verified
  clean against upstream `main` (not a snapshot).
- `check_conflicting_cluster_selectors` correctly rejects `router` +
  `llm_d_sc` sharing a chain (verified against the real binary) — a real
  limitation worth documenting for anyone wanting both path-based and
  content-based routing together.
- Fail-open measured, not asserted: a refused classifier connection costs
  ~0.19ms added latency, 100% HTTP 200 via `default_cluster`; a slow
  classifier costs exactly its configured `timeout_ms` and no more; a
  saturated classifier queue degrades to `default_cluster` rather than
  failing the request.
- Filter overhead measured locally (stub upstream, isolates the filter from
  backend variance): cache-hit +0.06–0.29ms p50, cache-miss +14–59ms p50
  depending on concurrency.
- 10/10 Kubernetes verification against two real llama.cpp backends in a
  homelab cluster (a 27B and a 284B model), with the built-in
  `credential_injection` filter composing cleanly for the backend requiring
  a bearer token — keyed on `ctx.cluster`, zero Praxis changes needed.
- **Ground-truth, per-request-isolated end-to-end latency** (llama.cpp
  metrics snapshotted before/after every request, reconciled against that
  request's own response `usage` — proof, not inference, of an uncontended
  measurement): `always-large` p50 8.40s, `always-small` p50 8.04s,
  `classified` p50 **7.13s** — beating both pure strategies on median,
  plausibly from natural early-stopping on easy prompts. n=40 per arm, real
  p99s. Full methodology in `FINDINGS.md` F-8.

## The classifier finding — disclosed in full, not softened

This POC surfaced a genuine, reproducible characteristic of llm-d-sc's
bundled `complexity` classifier: it scores 97.5% on its own published
held-out set (reproduced exactly here) but 68.6–78.6% on an
independently-authored 128-prompt set with zero anchor overlap. Root cause
(`FINDINGS.md` F-7): the classifier generalizes across *domain* but not
across *task framing* — all of its COMPLEX/REASONING anchors are framed as
technical system-design or formal-proof tasks, so equally hard prompts
framed as planning or creative documents land nearer the MEDIUM anchors.

**We didn't stop at the label-agreement number.** A follow-up experiment
(`FINDINGS.md` F-9, full writeup in the linked repo's
`bench/affinity/ANALYSIS.md`) sent every prompt to both real backends,
judged both answers blind, and measured **actual model-selection accuracy**
— does the cheap model really succeed, independent of what any human called
the prompt. Result: 78.6% (n=118), landing almost exactly on the
label-agreement figure — the fuzzy human labels turn out to predict real
outcomes about as well as they predict the classifier's own label. On real
outcomes rather than labels, a safety-biased `MEDIUM→large` mapping still
cuts quality risk from 11.9% to 1.7% at a disclosed cost in wasted capacity
— the same conclusion F-7 reached from label data, now confirmed
independently.

This is not "Praxis doesn't work with llm-d-sc" — the integration is
faithful (128/128 agreement between requests routed through Praxis and the
same prompts classified directly, no proxy involved) and the runtime
numbers above stand on their own. It's a finding *about the bundled
classifier's anchor coverage*, disclosed because the whole point of this
POC is to give the community a real, reproducible number rather than
another flattering one.

## Why draft

Offered for discussion, not immediate merge, given the classifier finding
above deserves community input on next steps (custom anchors is the
lowest-cost fix, per F-7 — no retraining required).

## Non-goals (v0.1 scope, stated not hidden)

Single signal per llm-d-sc instance, no TLS to llm-d-sc, no filter-side
cache (llm-d-sc already has a revision-keyed one), no response-phase
classification.

Full spec, all benchmarks, and the model-affinity experiment:
https://github.com/cnuland/llm-d-sc-praxis-filter/blob/main/FINDINGS.md