### PR TITLE
refactor(filter): extract reusable FilteredSubrequestExecutor from IRR

### DIFF
--- a/crates/filter/src/builtins/http/traffic_management/iterative_request_router/mod.rs
+++ b/crates/filter/src/builtins/http/traffic_management/iterative_request_router/mod.rs
@@ -16,7 +16,7 @@
 //!
 //! # Streaming support
 //!
-//! When a step's filters select [`SubRequestResponseMode::Streaming`],
+//! When a step's filters select [`SubRequestResponseMode::Streaming`](crate::SubRequestResponseMode::Streaming),
 //! IRR dispatches via `send_streaming()` instead of the buffered
 //! `execute()` path. Header-safe failover transitions run before that
 //! step exposes bytes. After clean EOF and response-body completion,
@@ -60,29 +60,22 @@ use std::{
 use async_trait::async_trait;
 use bytes::Bytes;
 use http::HeaderMap;
-use pingora_core::upstreams::peer::HttpPeer;
 use tracing::{debug, info, warn};
 
 use self::{
     config::IterativeRequestRouterConfig,
-    runner::{IrrStepRunner, OpenedStepKind, StepRuntime},
-    streaming::{IrrStreamingBody, IrrStreamingSession, ensure_combined_retained_limit},
+    runner::{IrrStepRunner, OpenedStepKind},
+    streaming::{IrrStreamingSession, ensure_combined_retained_limit, step_completion_from},
 };
 use crate::{
-    FilterEntry, FilterError, FilterPipeline, FilterRegistry, IterationState, StreamTermination, SubRequest,
-    SubRequestResponseMode, SubResponse,
+    FilterEntry, FilterError, FilterPipeline, FilterRegistry, IterationState, NextIterationBody, RequestExtensions,
+    StreamTermination, SubRequest, SubResponse,
     actions::{FilterAction, Rejection, StreamingResponseBody as _, StreamingTerminalResponse, TerminalResponse},
     factory::parse_filter_config,
     filter::{HttpFilter, HttpFilterContext},
+    filtered_subrequest::{FilteredStreamingBody, SubrequestRuntime, normalize_response_status},
     pipeline::subrequest::DEPTH_HEADER,
 };
-
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-/// Streaming idle timeout (max time between chunks).
-const STREAMING_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
 
 // ---------------------------------------------------------------------------
 // Utilities
@@ -117,6 +110,20 @@ pub(super) fn streaming_transition_order_is_valid(transitions: &[config::StepTra
             true
         }
     })
+}
+
+/// Strip the router-owned iteration extensions before handing state back to the
+/// parent request context.
+///
+/// The generic executor already removes its own transient mechanisms; the
+/// router additionally injects [`IterationState`] and [`NextIterationBody`],
+/// which must not leak into the parent pipeline. Applying this to the executor's
+/// parent-facing extensions restores the exact end state of the pre-extraction
+/// router.
+pub(super) fn strip_iteration_extensions(mut extensions: RequestExtensions) -> RequestExtensions {
+    extensions.remove::<IterationState>();
+    extensions.remove::<NextIterationBody>();
+    extensions
 }
 
 // ---------------------------------------------------------------------------
@@ -428,7 +435,7 @@ impl IterativeRequestRouterFilter {
             depth,
             max_response_bytes,
             self.max_state_bytes,
-            StepRuntime {
+            SubrequestRuntime {
                 client_addr: ctx.client_addr,
                 downstream_tls: ctx.downstream_tls,
                 peer_identity: ctx.peer_identity.clone(),
@@ -482,7 +489,7 @@ impl IterativeRequestRouterFilter {
                     let transitions = self.step_transitions.get(&current_step).map_or(&[][..], Vec::as_slice);
                     if !streaming_transition_order_is_valid(transitions) {
                         (*body).cancel().await;
-                        ctx.extensions = continuation.into_parent_extensions();
+                        ctx.extensions = strip_iteration_extensions(continuation.into_parent_extensions());
                         return Err(format!(
                             "iterative_request_router: step '{current_step}' selected streaming with interleaved transition phases"
                         )
@@ -495,19 +502,21 @@ impl IterativeRequestRouterFilter {
                                 to = next_step.as_ref(),
                                 "streaming header failover before response commitment"
                             );
-                            let mut skipped = IrrStreamingBody::new(body, continuation);
+                            let mut skipped = FilteredStreamingBody::new(body, continuation);
                             if let Err(error) = skipped.suppress().await {
-                                ctx.extensions = skipped.into_continuation().into_parent_extensions();
+                                ctx.extensions =
+                                    strip_iteration_extensions(skipped.into_continuation().into_parent_extensions());
                                 return Err(error);
                             }
-                            let mut completion = match skipped.into_continuation().into_completion() {
-                                Ok(completion) => completion,
-                                Err(error) => {
-                                    let (error, restored_extensions) = error.into_parts();
-                                    ctx.extensions = restored_extensions;
-                                    return Err(error);
-                                },
-                            };
+                            let mut completion =
+                                match step_completion_from(skipped.into_continuation().into_completion()) {
+                                    Ok(completion) => completion,
+                                    Err(error) => {
+                                        let (error, restored_extensions) = error.into_parts();
+                                        ctx.extensions = restored_extensions;
+                                        return Err(error);
+                                    },
+                                };
                             completion.state.previous_response = None;
                             completion.state.iteration += 1;
                             if completion.state.retained_bytes() > self.max_state_bytes {
@@ -528,9 +537,9 @@ impl IterativeRequestRouterFilter {
                             current_step = next_step;
                         },
                         TransitionResult::Done | TransitionResult::NoMatch => {
-                            let Some(active_state) = continuation.extensions.get::<IterationState>() else {
+                            let Some(active_state) = continuation.extensions().get::<IterationState>() else {
                                 (*body).cancel().await;
-                                ctx.extensions = continuation.into_parent_extensions();
+                                ctx.extensions = strip_iteration_extensions(continuation.into_parent_extensions());
                                 return Err(
                                     "iterative_request_router: iteration state missing before stream handoff"
                                         .to_owned()
@@ -545,7 +554,7 @@ impl IterativeRequestRouterFilter {
                             .is_err()
                             {
                                 (*body).cancel().await;
-                                let completion = match continuation.into_completion() {
+                                let completion = match step_completion_from(continuation.into_completion()) {
                                     Ok(completion) => completion,
                                     Err(error) => {
                                         let (error, restored_extensions) = error.into_parts();
@@ -579,7 +588,7 @@ impl IterativeRequestRouterFilter {
                     }
                 },
                 OpenedStepKind::Complete(mut outcome) => {
-                    let completion = match continuation.into_completion() {
+                    let completion = match step_completion_from(continuation.into_completion()) {
                         Ok(completion) => completion,
                         Err(error) => {
                             let (error, restored_extensions) = error.into_parts();
@@ -744,54 +753,6 @@ pub(super) enum TransitionResult {
     NoMatch,
 }
 
-/// Convert transport failures into a gateway status and error classification.
-pub(super) fn classify_transport_failure(
-    error: &praxis_core::subrequest::SubRequestError,
-) -> (u16, config::TransportErrorKind) {
-    use praxis_core::subrequest::SubRequestError;
-    match error {
-        SubRequestError::AdmissionTimeout { .. } => (503, config::TransportErrorKind::AdmissionTimeout),
-        SubRequestError::CircuitOpen { .. } => (503, config::TransportErrorKind::CircuitOpen),
-        SubRequestError::Connect(_) => (502, config::TransportErrorKind::Connect),
-        SubRequestError::DeadlineExceeded => (504, config::TransportErrorKind::DeadlineExceeded),
-        SubRequestError::ResponseTooLarge { .. } => (502, config::TransportErrorKind::ResponseTooLarge),
-        _ => (502, config::TransportErrorKind::Io),
-    }
-}
-
-/// Convert a nested filter's local response into transition input.
-fn subresponse_from_rejection(rejection: Rejection) -> SubResponse {
-    let status = normalize_response_status(rejection.status);
-    let mut headers = HeaderMap::new();
-    for (name, value) in rejection.headers {
-        let Ok(name) = http::HeaderName::try_from(name) else {
-            continue;
-        };
-        let Ok(value) = http::HeaderValue::try_from(value) else {
-            continue;
-        };
-        headers.append(name, value);
-    }
-    if let Some(header_map) = rejection.header_map {
-        for (name, value) in header_map.iter() {
-            headers.append(name.clone(), value.clone());
-        }
-    }
-    let mut response = SubResponse {
-        status,
-        headers,
-        body: rejection.body.unwrap_or_default(),
-    };
-    sanitize_subresponse_headers(&mut response.headers);
-    response
-}
-
-/// Keep final locally generated statuses inside the terminal response range.
-/// Informational, invalid upstream, or invalid custom-filter values become 502.
-fn normalize_response_status(status: u16) -> u16 {
-    if (200..=599).contains(&status) { status } else { 502 }
-}
-
 /// Evaluate transition rules against a step outcome.
 pub(super) fn evaluate_transitions(
     transitions: &[config::StepTransition],
@@ -877,156 +838,6 @@ fn parse_depth(request: &crate::Request) -> u8 {
         .unwrap_or(0)
 }
 
-/// Strip all reserved internal headers from sub-request headers
-/// so the core executor re-injects depth via
-/// [`FrameworkHeaders`](praxis_core::subrequest::FrameworkHeaders).
-///
-/// The depth header uses a reserved `x-praxis-*` prefix, so it
-/// is covered by the [`is_reserved`] check.
-///
-/// [`is_reserved`]: praxis_core::reserved_headers::is_reserved
-fn strip_reserved_headers(headers: &mut HeaderMap) {
-    let to_remove: Vec<http::header::HeaderName> = headers
-        .keys()
-        .filter(|name| praxis_core::reserved_headers::is_reserved(name.as_str()))
-        .cloned()
-        .collect();
-    for name in to_remove {
-        headers.remove(&name);
-    }
-}
-
-/// Apply request mutations emitted across the step's header and body
-/// filter phases before dispatching its upstream request.
-fn apply_request_header_mutations(headers: &mut HeaderMap, ctx: &HttpFilterContext<'_>) {
-    for name in &ctx.request_headers_to_remove {
-        headers.remove(name);
-    }
-    for (name, value) in &ctx.request_headers_to_set {
-        headers.insert(name.clone(), value.clone());
-    }
-    for (name, value) in &ctx.extra_request_headers {
-        if let (Ok(name), Ok(value)) = (
-            http::header::HeaderName::from_bytes(name.as_bytes()),
-            http::HeaderValue::from_str(value),
-        ) {
-            headers.insert(name, value);
-        }
-    }
-}
-
-/// Apply body pre-read mutations to the request snapshot that header
-/// filters use for classification and routing.
-fn apply_pre_read_header_mutations(headers: &mut HeaderMap, ctx: &HttpFilterContext<'_>) {
-    if ctx.pre_read_mutations.is_empty() {
-        apply_request_header_mutations(headers, ctx);
-        return;
-    }
-
-    for mutation in &ctx.pre_read_mutations {
-        match mutation {
-            crate::TrustedHeaderMutation::Remove(name) => {
-                headers.remove(name);
-            },
-            crate::TrustedHeaderMutation::Set(name, value) => {
-                headers.insert(name.clone(), value.clone());
-            },
-            crate::TrustedHeaderMutation::Add(name, value) => {
-                if let Ok(value) = http::HeaderValue::from_str(value) {
-                    headers.append(name.clone(), value);
-                }
-            },
-        }
-    }
-}
-
-/// Remove inbound message-framing headers after request-body filters
-/// have potentially changed the payload. The subrequest executor adds
-/// the correct `Content-Length` for non-empty bodies.
-fn strip_request_framing_headers(headers: &mut HeaderMap) {
-    headers.remove(http::header::CONTENT_LENGTH);
-    headers.remove(http::header::TRANSFER_ENCODING);
-}
-
-/// Headers that apply only to one HTTP connection and must not cross it.
-const REQUEST_HOP_BY_HOP: &[&str] = &[
-    "connection",
-    "keep-alive",
-    "proxy-authenticate",
-    "proxy-authorization",
-    "te",
-    "trailer",
-    "transfer-encoding",
-    "upgrade",
-];
-
-/// Response-side hop-by-hop headers.
-const RESPONSE_HOP_BY_HOP: &[&str] = &[
-    "connection",
-    "keep-alive",
-    "proxy-authenticate",
-    "te",
-    "trailer",
-    "transfer-encoding",
-    "upgrade",
-];
-
-/// Apply the same forwarding boundary as the normal upstream path.
-fn sanitize_subrequest_headers(headers: &mut HeaderMap) {
-    strip_hop_by_hop_headers(headers, REQUEST_HOP_BY_HOP);
-    strip_reserved_headers(headers);
-    strip_request_framing_headers(headers);
-}
-
-/// Supply the selected upstream authority without carrying a prior step's Host.
-fn ensure_destination_host(headers: &mut HeaderMap, address: &str) -> Result<(), FilterError> {
-    if !headers.contains_key(http::header::HOST) {
-        let value = http::HeaderValue::from_str(address).map_err(|error| -> FilterError {
-            format!("iterative_request_router: invalid upstream Host: {error}").into()
-        })?;
-        headers.insert(http::header::HOST, value);
-    }
-    Ok(())
-}
-
-/// Remove connection-scoped and proxy-internal response metadata.
-fn sanitize_subresponse_headers(headers: &mut HeaderMap) {
-    strip_hop_by_hop_headers(headers, RESPONSE_HOP_BY_HOP);
-    strip_reserved_headers(headers);
-}
-
-/// Remove the static hop-by-hop set and headers named by `Connection`.
-fn strip_hop_by_hop_headers(headers: &mut HeaderMap, static_headers: &[&str]) {
-    let connection_values: Vec<_> = headers.get_all(http::header::CONNECTION).iter().cloned().collect();
-    for name in static_headers {
-        headers.remove(*name);
-    }
-    for value in connection_values {
-        let Ok(value) = value.to_str() else { continue };
-        for token in value.split(',').map(str::trim).filter(|token| !token.is_empty()) {
-            headers.remove(token);
-        }
-    }
-}
-
-/// Whether a fully buffered nested body exceeds its pipeline mode's
-/// configured ceiling.
-fn body_exceeds_limit(mode: crate::body::BodyMode, body_len: usize) -> bool {
-    match mode {
-        crate::body::BodyMode::SizeLimit { max_bytes }
-        | crate::body::BodyMode::StreamBuffer {
-            max_bytes: Some(max_bytes),
-        } => body_len > max_bytes,
-        crate::body::BodyMode::Stream | crate::body::BodyMode::StreamBuffer { max_bytes: None } => false,
-    }
-}
-
-/// Whether a response exceeds either the iterative router's global
-/// per-step ceiling or the nested pipeline's body-mode ceiling.
-fn response_body_exceeds_limits(mode: crate::body::BodyMode, max_response_bytes: usize, body_len: usize) -> bool {
-    body_len > max_response_bytes || body_exceeds_limit(mode, body_len)
-}
-
 /// Clamp the router-specific response cap to the listener's global body mode.
 fn effective_response_limit(configured: usize, parent_mode: crate::body::BodyMode) -> usize {
     match parent_mode {
@@ -1036,151 +847,6 @@ fn effective_response_limit(configured: usize, parent_mode: crate::body::BodyMod
         } => configured.min(max_bytes),
         crate::body::BodyMode::Stream | crate::body::BodyMode::StreamBuffer { max_bytes: None } => configured,
     }
-}
-
-/// Extract only the listener-level streaming ceiling from a nested pipeline.
-///
-/// The IRR `max_response_bytes` setting is intentionally buffered-only. A
-/// nested `SizeLimit` is produced by listener body-limit propagation and must
-/// still constrain the live transport.
-fn streaming_transport_limit(mode: crate::body::BodyMode) -> Option<usize> {
-    match mode {
-        crate::body::BodyMode::SizeLimit { max_bytes } => Some(max_bytes),
-        crate::body::BodyMode::Stream | crate::body::BodyMode::StreamBuffer { .. } => None,
-    }
-}
-
-/// Whether a step filter grew the shared iteration state past its ceiling.
-fn iteration_state_exceeds_limit(ctx: &HttpFilterContext<'_>, max_state_bytes: usize) -> bool {
-    ctx.extensions
-        .get::<IterationState>()
-        .is_some_and(|state| state.retained_bytes() > max_state_bytes)
-}
-
-/// Runtime resources inherited from the pipeline that contains the
-/// iterative router.
-#[derive(Clone, Copy)]
-struct SubPipelineRuntimeResources<'a> {
-    /// Original downstream client address.
-    client_addr: Option<std::net::IpAddr>,
-
-    /// Whether the original downstream connection uses TLS.
-    downstream_tls: bool,
-
-    /// Shared endpoint-health state.
-    health_registry: Option<&'a praxis_core::health::HealthRegistry>,
-
-    /// Shared request ID generator.
-    id_generator: &'a praxis_core::id::IdGenerator,
-
-    /// Named runtime key-value stores.
-    kv_stores: Option<&'a praxis_core::kv::KvStoreRegistry>,
-
-    /// Verified downstream mTLS identity.
-    peer_identity: Option<&'a Arc<praxis_tls::TlsPeerIdentity>>,
-
-    /// Start time of the containing client request.
-    request_start: Instant,
-
-    /// Shared client used for recursive subrequests.
-    subrequest_client: Option<&'a praxis_core::subrequest::SubRequestClient>,
-
-    /// Server-provided wall-clock source.
-    time_source: &'a dyn praxis_core::time::TimeSource,
-}
-
-/// Build a [`HttpFilterContext`] for running a step's sub-pipeline,
-/// inheriting server-injected resources from the containing request.
-#[expect(clippy::too_many_lines, reason = "all fields must be initialized")]
-fn build_sub_filter_context<'a>(
-    pipeline: &'a FilterPipeline,
-    request: &'a crate::Request,
-    runtime: SubPipelineRuntimeResources<'a>,
-) -> HttpFilterContext<'a> {
-    HttpFilterContext {
-        buffered_request_body: None,
-        body_done_indices: Vec::new(),
-        branch_iterations: HashMap::new(),
-        client_addr: runtime.client_addr,
-        cluster: None,
-        current_filter_id: None,
-        downstream_tls: runtime.downstream_tls,
-        extensions: crate::extensions::RequestExtensions::default(),
-        executed_filter_indices: Vec::new(),
-        extra_request_headers: Vec::new(),
-        filter_metadata: HashMap::new(),
-        filter_results: HashMap::new(),
-        filter_state: HashMap::new(),
-        health_registry: runtime.health_registry,
-        id_generator: runtime.id_generator,
-        kv_stores: runtime.kv_stores,
-        session_stores: None,
-        metrics_route: None,
-        peer_identity: runtime.peer_identity.cloned(),
-        prior_pre_read_mutations: Vec::new(),
-        pre_read_mutations: Vec::new(),
-        request,
-        request_body_bytes: 0,
-        request_body_mode: pipeline.body_capabilities().request_body_mode,
-        request_headers_to_remove: Vec::new(),
-        request_headers_to_set: Vec::new(),
-        request_start: runtime.request_start,
-        response_body_bytes: 0,
-        response_body_mode: pipeline.body_capabilities().response_body_mode,
-        response_header: None,
-        response_headers_modified: false,
-        rewritten_path: None,
-        selected_endpoint_index: None,
-        attempted_endpoints: Vec::new(),
-        retry_policy: None,
-        route_retry_policy: None,
-        cluster_retry_state: None,
-        cluster_retry_state_released: false,
-        endpoint_reselector: None,
-        pinned_endpoint_address: None,
-        structured_metadata: HashMap::new(),
-        subrequest_client: runtime.subrequest_client,
-        subrequest_response_mode: SubRequestResponseMode::Buffered,
-        time_source: runtime.time_source,
-        upstream: None,
-    }
-}
-
-/// Convert a Praxis [`Upstream`] to a Pingora [`HttpPeer`].
-///
-/// Applies TLS settings (CA, client cert, verify toggle) and
-/// connection options (timeouts) from the upstream config. Derives
-/// SNI from the address hostname when not explicitly configured.
-///
-/// [`Upstream`]: praxis_core::connectivity::Upstream
-async fn build_peer(
-    upstream: &praxis_core::connectivity::Upstream,
-) -> Result<HttpPeer, praxis_core::connectivity::peer::AddressResolutionError> {
-    use praxis_core::connectivity::peer as peer_utils;
-
-    let addr: &str = &upstream.address;
-    let socket_addr = peer_utils::resolve_address(addr).await?;
-    let tls_enabled = upstream.tls.is_some();
-    let sni = upstream
-        .tls
-        .as_ref()
-        .and_then(|t| t.sni().map(str::to_owned))
-        .unwrap_or_else(|| {
-            if tls_enabled {
-                peer_utils::derive_sni(addr)
-            } else {
-                String::new()
-            }
-        });
-
-    let mut peer = HttpPeer::new(socket_addr, tls_enabled, sni);
-    peer_utils::apply_connection_options(&mut peer, &upstream.connection);
-
-    if let Some(tls) = &upstream.tls {
-        peer_utils::apply_cached_tls(&mut peer, tls, addr);
-    }
-
-    Ok(peer)
 }
 
 /// Build a [`TerminalResponse`] carrying the sub-request response.

--- a/crates/filter/src/builtins/http/traffic_management/iterative_request_router/runner.rs
+++ b/crates/filter/src/builtins/http/traffic_management/iterative_request_router/runner.rs
@@ -1,72 +1,53 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 Praxis Contributors
 
-//! One-step execution for the iterative request router.
+//! Thin adapter running one IRR step through the generic subrequest executor.
+//!
+//! [`IrrStepRunner`] owns a [`FilteredSubrequestExecutor`] and the router's
+//! named step pipelines. [`open_step`](IrrStepRunner::open_step) looks up the
+//! selected step pipeline, injects the router's [`IterationState`] into the
+//! request extensions, and delegates the filter and transport lifecycle to the
+//! executor. The executor's continuation types are mapped back onto the
+//! router's [`OpenedStep`] and [`StepOutcome`] vocabulary so the rest of the
+//! router is unchanged.
 
 use std::{
     collections::HashMap,
-    sync::{
-        Arc,
-        atomic::{AtomicBool, Ordering},
-    },
+    sync::Arc,
     time::{Duration, Instant},
 };
 
-use bytes::Bytes;
-use http::HeaderMap;
-use praxis_core::subrequest::{FrameworkHeaders, StreamLimits};
-use tracing::{Instrument as _, warn};
+use praxis_core::subrequest::{SubRequestClient, SubResponseBody};
 
-use super::{
-    StepOutcome, SubPipelineRuntimeResources, apply_pre_read_header_mutations, apply_request_header_mutations,
-    body_exceeds_limit, build_peer, build_sub_filter_context, classify_transport_failure, config,
-    ensure_destination_host, iteration_state_exceeds_limit, response_body_exceeds_limits, sanitize_subrequest_headers,
-    sanitize_subresponse_headers, streaming::StepResponseContinuation, streaming_transport_limit,
-    strip_reserved_headers, subresponse_from_rejection,
-};
+use super::{StepOutcome, config, strip_iteration_extensions};
 use crate::{
-    FilterAction, FilterError, FilterPipeline, IterationState, NextIterationBody, RequestExtensions, StreamTermination,
-    StreamTerminationCause, SubRequest, SubRequestResponseMode, SubResponse, actions::Rejection,
-    context::PendingStreamChunks, results::RetainedFilterResults,
+    FilterError, FilterPipeline, IterationState, RequestExtensions, SubRequest,
+    filtered_subrequest::{
+        FilteredSubrequestContinuation, FilteredSubrequestExecutor, FilteredSubrequestInput, OpenedResponse,
+        OpenedSubrequest, ResponseOrigin, RetainedStateAccounting, SubrequestOutcome, SubrequestRuntime,
+        TransportFailure,
+    },
 };
-
-/// Owned request attributes needed after the outer request hook returns.
-#[derive(Clone)]
-pub(super) struct StepRuntime {
-    /// Original downstream client address.
-    pub(super) client_addr: Option<std::net::IpAddr>,
-    /// Whether the original downstream uses TLS.
-    pub(super) downstream_tls: bool,
-    /// Verified downstream peer identity.
-    pub(super) peer_identity: Option<Arc<praxis_tls::TlsPeerIdentity>>,
-    /// Start time of the logical client request.
-    pub(super) request_start: Instant,
-}
-
-/// Executes exactly one IRR step and returns owned continuation state.
-pub(super) struct IrrStepRunner {
-    /// Shared transport client.
-    client: praxis_core::subrequest::SubRequestClient,
-    /// Nested IRR depth forwarded to subrequests.
-    depth: u8,
-    /// Per-step buffered response ceiling.
-    max_response_bytes: usize,
-    /// Retained iteration-state and pending-output ceiling.
-    max_state_bytes: usize,
-    /// Owned downstream request attributes.
-    runtime: StepRuntime,
-    /// Named, pre-built step pipelines.
-    step_pipelines: HashMap<Arc<str>, Arc<FilterPipeline>>,
-    /// Per-step duration ceiling.
-    step_timeout: Duration,
-}
 
 /// One opened step, including state needed for body/completion processing.
 pub(super) struct OpenedStep {
     /// Owned filter lifecycle state.
-    pub(super) continuation: StepResponseContinuation,
+    pub(super) continuation: FilteredSubrequestContinuation,
     /// Buffered or pull-based response source.
     pub(super) kind: OpenedStepKind,
+}
+
+/// Transport/body shape selected by the step filters.
+pub(super) enum OpenedStepKind {
+    /// The complete response was collected and filtered.
+    Complete(StepOutcome),
+    /// Response headers are filtered; body remains pull-based.
+    Streaming {
+        /// Live upstream response body.
+        body: Box<SubResponseBody>,
+        /// Header-time transition metadata.
+        outcome: StepOutcome,
+    },
 }
 
 /// A step error together with the parent request extensions it borrowed.
@@ -78,19 +59,9 @@ pub(super) struct OpenStepError {
 }
 
 impl OpenStepError {
-    /// Build an error before a nested filter context exists.
+    /// Build an error carrying the parent extensions to restore.
     fn new(error: FilterError, extensions: RequestExtensions) -> Self {
         Self { error, extensions }
-    }
-
-    /// Recover only the parent-owned extensions from a failed nested context.
-    fn capture(error: FilterError, ctx: &mut crate::HttpFilterContext<'_>) -> Self {
-        ctx.extensions.remove::<IterationState>();
-        ctx.extensions.remove::<NextIterationBody>();
-        ctx.extensions.remove::<PendingStreamChunks>();
-        ctx.extensions.remove::<RetainedFilterResults>();
-        ctx.extensions.remove::<StreamTermination>();
-        Self::new(error, std::mem::take(&mut ctx.extensions))
     }
 
     /// Split the error from the extensions its caller must restore.
@@ -99,66 +70,117 @@ impl OpenStepError {
     }
 }
 
-/// Transport/body shape selected by the step filters.
-pub(super) enum OpenedStepKind {
-    /// The complete response was collected and filtered.
-    Complete(StepOutcome),
-    /// Response headers are filtered; body remains pull-based.
-    Streaming {
-        /// Live upstream response body.
-        body: Box<praxis_core::subrequest::SubResponseBody>,
-        /// Header-time transition metadata.
-        outcome: StepOutcome,
-    },
+/// Reports whether the router's retained iteration state exceeds its ceiling.
+///
+/// The generic executor enforces the ceiling at every phase boundary through
+/// this hook without knowing the router's [`IterationState`] layout.
+struct IterationAccounting {
+    /// Retained-state raw byte ceiling.
+    max_state_bytes: usize,
 }
 
-/// Internal result before owned continuation state is captured.
-enum RawStepKind {
-    /// Complete buffered or synthetic response.
-    Complete(StepOutcome),
-    /// Local filter rejection.
-    Rejected(Rejection),
-    /// Open pull-based upstream response.
-    Streaming {
-        /// Live upstream response body.
-        body: Box<praxis_core::subrequest::SubResponseBody>,
-        /// Header-time transition metadata.
-        outcome: StepOutcome,
-    },
+impl RetainedStateAccounting for IterationAccounting {
+    fn exceeds_limit(&self, extensions: &RequestExtensions) -> bool {
+        extensions
+            .get::<IterationState>()
+            .is_some_and(|state| state.retained_bytes() > self.max_state_bytes)
+    }
+}
+
+impl From<ResponseOrigin> for config::ResponseOrigin {
+    fn from(origin: ResponseOrigin) -> Self {
+        match origin {
+            ResponseOrigin::Upstream => config::ResponseOrigin::Upstream,
+            ResponseOrigin::Local => config::ResponseOrigin::Local,
+            ResponseOrigin::Transport => config::ResponseOrigin::Transport,
+        }
+    }
+}
+
+impl From<TransportFailure> for config::TransportErrorKind {
+    fn from(failure: TransportFailure) -> Self {
+        match failure {
+            TransportFailure::AdmissionTimeout => config::TransportErrorKind::AdmissionTimeout,
+            TransportFailure::CircuitOpen => config::TransportErrorKind::CircuitOpen,
+            TransportFailure::Connect => config::TransportErrorKind::Connect,
+            TransportFailure::Io => config::TransportErrorKind::Io,
+            TransportFailure::DeadlineExceeded => config::TransportErrorKind::DeadlineExceeded,
+            TransportFailure::ResponseTooLarge => config::TransportErrorKind::ResponseTooLarge,
+        }
+    }
+}
+
+/// Map a generic executor outcome onto the router's transition vocabulary.
+fn step_outcome_from(outcome: SubrequestOutcome) -> StepOutcome {
+    StepOutcome {
+        response: outcome.response,
+        origin: outcome.origin.into(),
+        transport_error: outcome.transport_error.map(Into::into),
+    }
+}
+
+impl OpenedStep {
+    /// Adapt the generic opened sub-request into the router's step vocabulary.
+    fn from_executor(opened: OpenedSubrequest) -> Self {
+        let OpenedSubrequest { continuation, kind } = opened;
+        let kind = match kind {
+            OpenedResponse::Complete(outcome) => OpenedStepKind::Complete(step_outcome_from(outcome)),
+            OpenedResponse::Streaming { body, outcome } => OpenedStepKind::Streaming {
+                body,
+                outcome: step_outcome_from(outcome),
+            },
+        };
+        Self { continuation, kind }
+    }
+}
+
+/// Executes exactly one IRR step by delegating to the generic executor.
+pub(super) struct IrrStepRunner {
+    /// Generic filtered sub-request executor.
+    executor: FilteredSubrequestExecutor,
+    /// Named, pre-built step pipelines.
+    step_pipelines: HashMap<Arc<str>, Arc<FilterPipeline>>,
 }
 
 impl IrrStepRunner {
     /// Build an owned runner for one logical IRR request.
     #[expect(clippy::too_many_arguments, reason = "runner owns explicit IRR limits and resources")]
     pub(super) fn new(
-        client: praxis_core::subrequest::SubRequestClient,
+        client: SubRequestClient,
         depth: u8,
         max_response_bytes: usize,
         max_state_bytes: usize,
-        runtime: StepRuntime,
+        downstream: SubrequestRuntime,
         step_pipelines: HashMap<Arc<str>, Arc<FilterPipeline>>,
         step_timeout: Duration,
     ) -> Self {
-        Self {
+        let executor = FilteredSubrequestExecutor::new(
+            Box::new(IterationAccounting { max_state_bytes }),
             client,
             depth,
+            downstream,
             max_response_bytes,
             max_state_bytes,
-            runtime,
-            step_pipelines,
             step_timeout,
+        );
+        Self {
+            executor,
+            step_pipelines,
         }
     }
 
     /// Open one named step under the remaining overall deadline.
+    ///
+    /// The deadline and step-existence checks run before the router's iteration
+    /// state is injected, preserving the router's error precedence; the filter
+    /// and transport lifecycle is then delegated to the executor.
     #[expect(
         clippy::too_many_lines,
-        reason = "one step owns the complete filter and transport lifecycle"
+        reason = "adapter keeps the router's step-open error precedence in one place"
     )]
-    #[expect(clippy::large_futures, reason = "step execution spans filter and transport futures")]
     #[expect(
         clippy::large_stack_frames,
-        reason = "step execution reconstructs a full filter context"
+        reason = "constructs the executor's full step future before boxing it"
     )]
     pub(super) async fn open_step(
         &self,
@@ -183,421 +205,21 @@ impl IrrStepRunner {
                 extensions,
             ));
         };
-
-        let mut sub_headers = current_request.headers.clone();
-        strip_reserved_headers(&mut sub_headers);
-        let sub_req = crate::Request {
-            method: current_request.method.clone(),
-            uri: current_request.uri.clone(),
-            headers: sub_headers.clone(),
+        extensions.insert(state.clone());
+        let input = FilteredSubrequestInput {
+            pipeline,
+            request: current_request,
+            label: current_step.as_ref(),
+            iteration: state.iteration,
+            deadline: state.deadline(),
+            extensions,
         };
-        let mut routed_req = sub_req.clone();
-        let mut response_header = crate::Response {
-            headers: HeaderMap::new(),
-            status: http::StatusCode::OK,
-        };
-        let resources = SubPipelineRuntimeResources {
-            client_addr: self.runtime.client_addr,
-            downstream_tls: self.runtime.downstream_tls,
-            health_registry: pipeline.health_registry(),
-            id_generator: pipeline.id_generator(),
-            kv_stores: pipeline.kv_stores(),
-            peer_identity: self.runtime.peer_identity.as_ref(),
-            request_start: self.runtime.request_start,
-            subrequest_client: Some(&self.client),
-            time_source: pipeline.time_source(),
-        };
-        let mut filter_ctx = build_sub_filter_context(pipeline, &sub_req, resources);
-        filter_ctx.extensions = std::mem::take(&mut extensions);
-        filter_ctx.extensions.insert(state.clone());
-        filter_ctx.extensions.insert(RetainedFilterResults::default());
-        filter_ctx.enable_stream_chunk_emission(self.max_state_bytes);
-
-        let step_budget = remaining.min(self.step_timeout);
-        let step_started = Instant::now();
-        let step_deadline = step_started
-            .checked_add(step_budget)
-            .unwrap_or_else(|| state.deadline());
-        let in_transport = Arc::new(AtomicBool::new(false));
-        let in_transport_inner = Arc::clone(&in_transport);
-
-        let step_span = tracing::info_span!(
-            "iterative_subrequest",
-            step = current_step.as_ref(),
-            iteration = state.iteration,
-        );
-
-        let timed: Result<Result<RawStepKind, FilterError>, tokio::time::error::Elapsed> =
-            tokio::time::timeout(step_budget, async {
-            let mut request_body = Some(current_request.body.clone());
-            if body_exceeds_limit(
-                pipeline.body_capabilities().request_body_mode,
-                request_body.as_ref().map_or(0, Bytes::len),
-            ) {
-                return Ok(RawStepKind::Rejected(Rejection::status(413)));
-            }
-
-            let pre_read_body = matches!(
-                pipeline.body_capabilities().request_body_mode,
-                crate::BodyMode::StreamBuffer { .. }
-            );
-            if pre_read_body {
-                let action = pipeline
-                    .execute_http_request_body(&mut filter_ctx, &mut request_body, true)
-                    .await?;
-                if let FilterAction::Reject(rejection) = action {
-                    return Ok(RawStepKind::Rejected(rejection));
-                }
-                if iteration_state_exceeds_limit(&filter_ctx, self.max_state_bytes) {
-                    return Ok(RawStepKind::Rejected(Rejection::status(413)));
-                }
-                apply_pre_read_header_mutations(&mut routed_req.headers, &filter_ctx);
-                filter_ctx.extra_request_headers.clear();
-                filter_ctx.request_headers_to_remove.clear();
-                filter_ctx.request_headers_to_set.clear();
-                filter_ctx.pre_read_mutations.clear();
-                sub_headers.clone_from(&routed_req.headers);
-                filter_ctx.request = &routed_req;
-            }
-
-            let action = pipeline.execute_http_request(&mut filter_ctx).await?;
-            if let FilterAction::Reject(rejection) = action {
-                return Ok(RawStepKind::Rejected(rejection));
-            }
-            if iteration_state_exceeds_limit(&filter_ctx, self.max_state_bytes) {
-                return Ok(RawStepKind::Rejected(Rejection::status(413)));
-            }
-            if !pre_read_body {
-                let action = pipeline
-                    .execute_http_request_body(&mut filter_ctx, &mut request_body, true)
-                    .await?;
-                if let FilterAction::Reject(rejection) = action {
-                    return Ok(RawStepKind::Rejected(rejection));
-                }
-                if iteration_state_exceeds_limit(&filter_ctx, self.max_state_bytes) {
-                    return Ok(RawStepKind::Rejected(Rejection::status(413)));
-                }
-            }
-
-            let upstream = filter_ctx.upstream.as_ref().ok_or_else(|| -> FilterError {
-                format!("iterative_request_router: step '{current_step}' did not resolve an upstream").into()
-            })?;
-            in_transport_inner.store(true, Ordering::Release);
-            let peer = build_peer(upstream).await;
-            apply_request_header_mutations(&mut sub_headers, &filter_ctx);
-            ensure_destination_host(&mut sub_headers, &upstream.address)?;
-            sanitize_subrequest_headers(&mut sub_headers);
-            let request = SubRequest {
-                method: current_request.method.clone(),
-                uri: filter_ctx.rewritten_path.as_ref().map_or_else(
-                    || current_request.uri.clone(),
-                    |path| http::Uri::try_from(path.as_str()).unwrap_or_else(|_| current_request.uri.clone()),
-                ),
-                headers: sub_headers,
-                body: request_body.unwrap_or_default(),
-            };
-            let mut framework_headers = FrameworkHeaders::new();
-            framework_headers.set_depth(self.depth + 1);
-            let transport_budget = step_budget
-                .checked_sub(step_started.elapsed())
-                .unwrap_or(Duration::ZERO);
-            if transport_budget.is_zero() {
-                return Ok(RawStepKind::Rejected(Rejection::status(504)));
-            }
-
-            match filter_ctx.subrequest_response_mode {
-                SubRequestResponseMode::Streaming => {
-                    if matches!(
-                        pipeline.body_capabilities().response_body_mode,
-                        crate::BodyMode::StreamBuffer { .. }
-                    ) {
-                        return Err(format!(
-                            "iterative_request_router: step '{current_step}' selected streaming with StreamBuffer response mode"
-                        )
-                        .into());
-                    }
-                    let limits = StreamLimits {
-                        idle_timeout: super::STREAMING_IDLE_TIMEOUT,
-                        // IrrStreamingBody enforces the original absolute step
-                        // deadline so header time cannot be granted twice.
-                        max_stream_duration: None,
-                        max_total_bytes: streaming_transport_limit(
-                            pipeline.body_capabilities().response_body_mode,
-                        ),
-                    };
-                    let response = match peer {
-                        Ok(peer) => self
-                            .client
-                            .send_streaming(&peer, &request, transport_budget, limits, Some(&framework_headers))
-                            .await,
-                        Err(error) => Err(praxis_core::subrequest::SubRequestError::Connect(error.to_string())),
-                    };
-                    in_transport_inner.store(false, Ordering::Release);
-                    match response {
-                        Ok(response) => {
-                            let status = response.status;
-                            let mut headers = response.headers;
-                            sanitize_subresponse_headers(&mut headers);
-                            response_header.status = http::StatusCode::from_u16(status)
-                                .map_err(|error| -> FilterError { format!("invalid upstream status: {error}").into() })?;
-                            response_header.headers.clone_from(&headers);
-                            filter_ctx.response_header = Some(&mut response_header);
-                            let response_action = pipeline.execute_http_response(&mut filter_ctx).await?;
-                            if let FilterAction::Reject(rejection) = response_action {
-                                response.body.cancel().await;
-                                return Ok(RawStepKind::Rejected(rejection));
-                            }
-                            if iteration_state_exceeds_limit(&filter_ctx, self.max_state_bytes) {
-                                response.body.cancel().await;
-                                return Ok(RawStepKind::Rejected(Rejection::status(413)));
-                            }
-                            let metadata = filter_ctx.response_header.as_deref().ok_or_else(|| -> FilterError {
-                                "iterative_request_router: response metadata missing after header filters"
-                                    .to_owned()
-                                    .into()
-                            })?;
-                            let status = metadata.status;
-                            let mut headers = metadata.headers.clone();
-                            sanitize_subresponse_headers(&mut headers);
-                            Ok(RawStepKind::Streaming {
-                                body: Box::new(response.body),
-                                outcome: StepOutcome {
-                                    response: SubResponse { status: status.as_u16(), headers, body: Bytes::new() },
-                                    origin: config::ResponseOrigin::Upstream,
-                                    transport_error: None,
-                                },
-                            })
-                        },
-                        Err(error) => {
-                            let (status, kind) = classify_transport_failure(&error);
-                            warn!(step = current_step.as_ref(), %error, status, "IRR streaming transport failure");
-                            let response = SubResponse { status, headers: HeaderMap::new(), body: Bytes::new() };
-                            response_header.status = http::StatusCode::from_u16(status)
-                                .map_err(|source| -> FilterError { source.into() })?;
-                            filter_ctx.response_header = Some(&mut response_header);
-                            let response_action = pipeline.execute_http_response(&mut filter_ctx).await?;
-                            if let FilterAction::Reject(rejection) = response_action {
-                                return Ok(RawStepKind::Rejected(rejection));
-                            }
-                            if iteration_state_exceeds_limit(&filter_ctx, self.max_state_bytes) {
-                                return Ok(RawStepKind::Rejected(Rejection::status(413)));
-                            }
-                            let metadata = filter_ctx.response_header.as_deref().ok_or_else(|| -> FilterError {
-                                "iterative_request_router: response metadata missing after header filters"
-                                    .to_owned()
-                                    .into()
-                            })?;
-                            let mut headers = metadata.headers.clone();
-                            sanitize_subresponse_headers(&mut headers);
-                            Ok(RawStepKind::Complete(StepOutcome {
-                                response: SubResponse {
-                                    status: metadata.status.as_u16(),
-                                    headers,
-                                    body: response.body,
-                                },
-                                origin: config::ResponseOrigin::Transport,
-                                transport_error: Some(kind),
-                            }))
-                        },
-                    }
-                },
-                SubRequestResponseMode::Buffered => {
-                    let (mut response, origin, transport_error) = match peer {
-                        Ok(peer) => match self
-                            .client
-                            .execute(&peer, &request, self.max_response_bytes, transport_budget, Some(&framework_headers))
-                            .await
-                        {
-                            Ok(response) => (response, config::ResponseOrigin::Upstream, None),
-                            Err(error) => {
-                                let (status, kind) = classify_transport_failure(&error);
-                                warn!(step = current_step.as_ref(), %error, status, "IRR buffered transport failure");
-                                (
-                                    SubResponse { status, headers: HeaderMap::new(), body: Bytes::new() },
-                                    config::ResponseOrigin::Transport,
-                                    Some(kind),
-                                )
-                            },
-                        },
-                        Err(error) => {
-                            warn!(step = current_step.as_ref(), %error, status = 502_u16, "IRR buffered transport failure");
-                            (
-                                SubResponse { status: 502, headers: HeaderMap::new(), body: Bytes::new() },
-                                config::ResponseOrigin::Transport,
-                                Some(config::TransportErrorKind::Connect),
-                            )
-                        },
-                    };
-                    in_transport_inner.store(false, Ordering::Release);
-                    sanitize_subresponse_headers(&mut response.headers);
-                    response_header.status = http::StatusCode::from_u16(response.status)
-                        .map_err(|error| -> FilterError { error.into() })?;
-                    response_header.headers.clone_from(&response.headers);
-                    filter_ctx.response_header = Some(&mut response_header);
-                    let response_action = pipeline.execute_http_response(&mut filter_ctx).await?;
-                    if let FilterAction::Reject(rejection) = response_action {
-                        return Ok(RawStepKind::Rejected(rejection));
-                    }
-                    if iteration_state_exceeds_limit(&filter_ctx, self.max_state_bytes) {
-                        return Ok(RawStepKind::Rejected(Rejection::status(413)));
-                    }
-                    let mut body = Some(std::mem::take(&mut response.body));
-                    if response_body_exceeds_limits(
-                        pipeline.body_capabilities().response_body_mode,
-                        self.max_response_bytes,
-                        body.as_ref().map_or(0, Bytes::len),
-                    ) {
-                        return Err("iterative_request_router: step response exceeds configured body limit".into());
-                    }
-                    let body_action = pipeline.execute_http_response_body(&mut filter_ctx, &mut body, true)?;
-                    if let FilterAction::Reject(rejection) = body_action {
-                        return Ok(RawStepKind::Rejected(rejection));
-                    }
-                    if iteration_state_exceeds_limit(&filter_ctx, self.max_state_bytes) {
-                        return Ok(RawStepKind::Rejected(Rejection::status(413)));
-                    }
-                    if response_body_exceeds_limits(
-                        pipeline.body_capabilities().response_body_mode,
-                        self.max_response_bytes,
-                        body.as_ref().map_or(0, Bytes::len),
-                    ) {
-                        return Err(
-                            "iterative_request_router: transformed step response exceeds configured body limit"
-                                .into(),
-                        );
-                    }
-                    response.body = body.unwrap_or_default();
-                    if let Some(metadata) = filter_ctx.response_header.as_deref() {
-                        response.status = metadata.status.as_u16();
-                        response.headers.clone_from(&metadata.headers);
-                    }
-                    sanitize_subresponse_headers(&mut response.headers);
-                    Ok(RawStepKind::Complete(StepOutcome { response, origin, transport_error }))
-                },
-            }
-            }
-            .instrument(step_span))
-            .await;
-
-        let mut raw = match timed {
-            Ok(Ok(raw)) => raw,
-            Ok(Err(error)) => return Err(OpenStepError::capture(error, &mut filter_ctx)),
-            Err(_) if in_transport.load(Ordering::Acquire) => RawStepKind::Complete(StepOutcome {
-                response: SubResponse {
-                    status: 504,
-                    headers: HeaderMap::new(),
-                    body: Bytes::new(),
-                },
-                origin: config::ResponseOrigin::Transport,
-                transport_error: Some(config::TransportErrorKind::DeadlineExceeded),
-            }),
-            Err(_) => RawStepKind::Rejected(Rejection::status(504)),
-        };
-
-        filter_ctx.response_header = None;
-        if filter_ctx.subrequest_response_mode == SubRequestResponseMode::Streaming
-            && let RawStepKind::Complete(outcome) = &mut raw
-            && outcome.origin == config::ResponseOrigin::Transport
-        {
-            let cause = outcome
-                .transport_error
-                .map_or(StreamTerminationCause::Io, stream_termination_cause);
-            filter_ctx.extensions.insert(StreamTermination::new(cause));
-            let response_snapshot = crate::Response {
-                status: http::StatusCode::from_u16(outcome.response.status).unwrap_or(http::StatusCode::BAD_GATEWAY),
-                headers: outcome.response.headers.clone(),
-            };
-            let mut completion_body = None;
-            let completion_action = pipeline
-                .execute_http_response_body_with_response_header(
-                    &mut filter_ctx,
-                    &mut completion_body,
-                    true,
-                    Some(&response_snapshot),
-                )
-                .map_err(|error| OpenStepError::capture(error, &mut filter_ctx))?;
-            if let FilterAction::Reject(_) = completion_action {
-                let error = "iterative_request_router: step completion filter rejected an abnormal stream"
-                    .to_owned()
-                    .into();
-                return Err(OpenStepError::capture(error, &mut filter_ctx));
-            }
-            if iteration_state_exceeds_limit(&filter_ctx, self.max_state_bytes) {
-                let error = "iterative_request_router: retained state limit exceeded during stream completion"
-                    .to_owned()
-                    .into();
-                return Err(OpenStepError::capture(error, &mut filter_ctx));
-            }
-            if completion_body
-                .as_ref()
-                .is_some_and(|body| body.len() > self.max_response_bytes)
-            {
-                let error = "iterative_request_router: abnormal completion exceeds response body limit"
-                    .to_owned()
-                    .into();
-                return Err(OpenStepError::capture(error, &mut filter_ctx));
-            }
-            outcome.response.body = completion_body.unwrap_or_default();
+        match Box::pin(self.executor.execute(input)).await {
+            Ok(opened) => Ok(OpenedStep::from_executor(opened)),
+            Err(error) => {
+                let (error, extensions) = error.into_parts();
+                Err(OpenStepError::new(error, strip_iteration_extensions(extensions)))
+            },
         }
-        let (kind, response_snapshot, completed) = match raw {
-            RawStepKind::Complete(outcome) => {
-                let snapshot = crate::Response {
-                    status: http::StatusCode::from_u16(outcome.response.status)
-                        .unwrap_or(http::StatusCode::BAD_GATEWAY),
-                    headers: outcome.response.headers.clone(),
-                };
-                (OpenedStepKind::Complete(outcome), snapshot, true)
-            },
-            RawStepKind::Rejected(rejection) => {
-                let response = subresponse_from_rejection(rejection);
-                let snapshot = crate::Response {
-                    status: http::StatusCode::from_u16(response.status).unwrap_or(http::StatusCode::BAD_GATEWAY),
-                    headers: response.headers.clone(),
-                };
-                (
-                    OpenedStepKind::Complete(StepOutcome {
-                        response,
-                        origin: config::ResponseOrigin::Local,
-                        transport_error: None,
-                    }),
-                    snapshot,
-                    true,
-                )
-            },
-            RawStepKind::Streaming { body, outcome } => {
-                let snapshot = crate::Response {
-                    status: http::StatusCode::from_u16(outcome.response.status)
-                        .unwrap_or(http::StatusCode::BAD_GATEWAY),
-                    headers: outcome.response.headers.clone(),
-                };
-                (OpenedStepKind::Streaming { body, outcome }, snapshot, false)
-            },
-        };
-        let request_snapshot = crate::Request {
-            method: filter_ctx.request.method.clone(),
-            uri: filter_ctx.request.uri.clone(),
-            headers: filter_ctx.request.headers.clone(),
-        };
-        let continuation = StepResponseContinuation::capture(
-            Arc::clone(pipeline),
-            request_snapshot,
-            response_snapshot,
-            &mut filter_ctx,
-            completed,
-            step_deadline,
-        );
-        Ok(OpenedStep { continuation, kind })
-    }
-}
-
-/// Convert transition-level transport metadata into completion-hook metadata.
-fn stream_termination_cause(kind: config::TransportErrorKind) -> StreamTerminationCause {
-    match kind {
-        config::TransportErrorKind::AdmissionTimeout => StreamTerminationCause::AdmissionTimeout,
-        config::TransportErrorKind::CircuitOpen => StreamTerminationCause::CircuitOpen,
-        config::TransportErrorKind::Connect => StreamTerminationCause::Connect,
-        config::TransportErrorKind::Io => StreamTerminationCause::Io,
-        config::TransportErrorKind::DeadlineExceeded => StreamTerminationCause::DeadlineExceeded,
-        config::TransportErrorKind::ResponseTooLarge => StreamTerminationCause::ResponseTooLarge,
     }
 }

--- a/crates/filter/src/builtins/http/traffic_management/iterative_request_router/streaming.rs
+++ b/crates/filter/src/builtins/http/traffic_management/iterative_request_router/streaming.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 Praxis Contributors
 
-//! Streaming response lifecycle types for the iterative request router.
+//! Streaming response lifecycle for the iterative request router.
 //!
 //! The iterative request router runs step pipelines across multiple
 //! sub-requests. When a step's pipeline selects streaming mode,
@@ -9,19 +9,17 @@
 //! is owned by [`IrrStreamingSession`].
 //!
 //! [`IrrStreamingSession`] pulls upstream chunks through each step's
-//! response-body filters until the stream ends, then runs the step's
-//! completion lifecycle exactly once and evaluates the next transition.
-//! A matching `next` opens another step without recommitting downstream
-//! response headers.
+//! response-body filters — via the generic [`FilteredStreamingBody`] — until
+//! the stream ends, then runs the step's completion lifecycle exactly once
+//! and evaluates the next transition. A matching `next` opens another step
+//! without recommitting downstream response headers.
 //!
-//! [`StepResponseContinuation`] holds all state needed to run body
-//! filters after `on_request()` returns: the step pipeline, request
-//! and response snapshots, filter extensions, filter state, metadata,
-//! and a completion guard. The continuation owns an `Arc<FilterPipeline>`
-//! so the pipeline outlives the router filter.
+//! [`step_completion_from`] adapts the executor's caller-agnostic
+//! [`SubrequestCompletion`] into the router's [`StepCompletion`], recovering
+//! the router's [`IterationState`] and [`NextIterationBody`] from the returned
+//! extensions.
 
 use std::{
-    any::Any,
     collections::{HashMap, VecDeque},
     sync::Arc,
 };
@@ -29,14 +27,13 @@ use std::{
 use async_trait::async_trait;
 use bytes::Bytes;
 use praxis_core::subrequest::SubResponseBody;
-use tracing::warn;
 
 use crate::{
-    FilterError, FilterPipeline, IterationState, NextIterationBody, StreamTermination, StreamTerminationCause,
+    FilterError, IterationState, NextIterationBody, StreamTermination,
     actions::StreamingResponseBody,
-    context::PendingStreamChunks,
     extensions::RequestExtensions,
-    results::{FilterResultSet, RetainedFilterResults},
+    filtered_subrequest::{FilteredStreamingBody, FilteredSubrequestContinuation, SubrequestCompletion},
+    results::FilterResultSet,
 };
 
 /// State made available after a step's completion hook has run.
@@ -70,432 +67,44 @@ impl StepCompletionError {
     }
 }
 
-/// State continuation for streaming a step's response body.
+/// Adapt the executor's generic completion into the router's step vocabulary.
 ///
-/// Owns the step pipeline, request/response snapshots, and all
-/// per-filter state needed to run response-body filters after
-/// `on_request()` returns. The `Arc<FilterPipeline>` outlives
-/// the router filter, enabling body hooks to execute while the
-/// router's `on_request` has already completed.
-pub(super) struct StepResponseContinuation {
-    /// Arc-wrapped step pipeline for executing response-body filters.
-    pub(super) pipeline: Arc<FilterPipeline>,
-    /// Snapshot of the step's request for filter context reconstruction.
-    pub(super) request_snapshot: crate::Request,
-    /// Snapshot of the step's response headers for filter context reconstruction.
-    pub(super) response_snapshot: crate::Response,
-    /// Request extensions that persist across body chunks.
-    pub(super) extensions: RequestExtensions,
-    /// Per-filter state that persists across body chunks.
-    pub(super) filter_state: HashMap<usize, Box<dyn Any + Send + Sync>>,
-    /// Filter results that persist across body chunks.
-    pub(super) filter_results: HashMap<&'static str, FilterResultSet>,
-    /// Filter metadata that persists across body chunks.
-    pub(super) filter_metadata: HashMap<String, String>,
-    /// Structured metadata that persists across body chunks.
-    pub(super) structured_metadata: HashMap<String, serde_json::Value>,
-    /// Tracks which filters executed during request phase.
-    pub(super) executed_filter_indices: Vec<bool>,
-    /// Tracks which filters completed their body hooks.
-    pub(super) body_done_indices: Vec<bool>,
-    /// Accumulated response body bytes seen so far.
-    pub(super) response_body_bytes: u64,
-    /// Response body mode from pipeline capabilities.
-    pub(super) response_body_mode: crate::body::BodyMode,
-    /// Whether the completion lifecycle has run.
-    pub(super) completed: bool,
-    /// Original downstream client address for body filter context.
-    pub(super) client_addr: Option<std::net::IpAddr>,
-    /// Whether the original downstream connection uses TLS.
-    pub(super) downstream_tls: bool,
-    /// Start time of the containing client request.
-    pub(super) request_start: std::time::Instant,
-    /// Absolute deadline shared by header and body processing for this step.
-    pub(super) step_deadline: std::time::Instant,
-    /// Verified downstream mTLS identity.
-    pub(super) peer_identity: Option<Arc<praxis_tls::TlsPeerIdentity>>,
-}
-
-impl StepResponseContinuation {
-    /// Capture all owned step context after response headers have run.
-    #[expect(
-        clippy::too_many_arguments,
-        reason = "capture owns the complete response continuation boundary"
-    )]
-    pub(super) fn capture(
-        pipeline: Arc<FilterPipeline>,
-        request_snapshot: crate::Request,
-        response_snapshot: crate::Response,
-        ctx: &mut crate::filter::HttpFilterContext<'_>,
-        completed: bool,
-        step_deadline: std::time::Instant,
-    ) -> Self {
-        Self {
-            pipeline,
-            request_snapshot,
-            response_snapshot,
-            extensions: std::mem::take(&mut ctx.extensions),
-            filter_state: std::mem::take(&mut ctx.filter_state),
-            filter_results: std::mem::take(&mut ctx.filter_results),
-            filter_metadata: std::mem::take(&mut ctx.filter_metadata),
-            structured_metadata: std::mem::take(&mut ctx.structured_metadata),
-            executed_filter_indices: std::mem::take(&mut ctx.executed_filter_indices),
-            body_done_indices: std::mem::take(&mut ctx.body_done_indices),
-            response_body_bytes: ctx.response_body_bytes,
-            response_body_mode: ctx.response_body_mode,
-            completed,
-            client_addr: ctx.client_addr,
-            downstream_tls: ctx.downstream_tls,
-            request_start: ctx.request_start,
-            step_deadline,
-            peer_identity: ctx.peer_identity.clone(),
-        }
-    }
-
-    /// Recover only caller-owned extensions when an internal invariant fails.
-    pub(super) fn into_parent_extensions(mut self) -> RequestExtensions {
-        self.extensions.remove::<IterationState>();
-        self.extensions.remove::<NextIterationBody>();
-        self.extensions.remove::<PendingStreamChunks>();
-        self.extensions.remove::<RetainedFilterResults>();
-        self.extensions.remove::<StreamTermination>();
-        self.extensions
-    }
-
-    /// Consume the completed continuation into transition inputs.
-    pub(super) fn into_completion(mut self) -> Result<StepCompletion, StepCompletionError> {
-        let Some(state) = self.extensions.remove::<IterationState>() else {
-            return Err(StepCompletionError {
-                error: "iterative_request_router: iteration state missing after step completion"
-                    .to_owned()
-                    .into(),
-                extensions: self.into_parent_extensions(),
-            });
-        };
-        let next_iteration_body = self.extensions.remove::<NextIterationBody>().map(|body| body.0);
-        let pending_chunks = self
-            .extensions
-            .remove::<PendingStreamChunks>()
-            .map_or_else(VecDeque::new, PendingStreamChunks::into_chunks);
-        let termination = self.extensions.remove::<StreamTermination>();
-        let mut filter_results = self.extensions.remove::<RetainedFilterResults>().unwrap_or_default().0;
-        filter_results.extend(self.filter_results);
-        Ok(StepCompletion {
-            extensions: self.extensions,
-            filter_results,
-            next_iteration_body,
-            pending_chunks,
-            state,
-            termination,
-        })
-    }
-}
-
-/// Streaming body implementation for iterative request router steps.
-///
-/// Pulls upstream chunks through the step's response-body filters,
-/// accumulates state in the owned [`StepResponseContinuation`],
-/// and runs the step's completion lifecycle exactly once after
-/// upstream EOF.
-///
-/// The `upstream` field is `Option<SubResponseBody>` because
-/// `SubResponseBody::cancel()` consumes `self`. Standard Rust
-/// pattern: `.take()` to move it out for cancellation.
-pub(super) struct IrrStreamingBody {
-    /// Upstream streaming body handle. `None` after cancellation.
-    upstream: Option<Box<SubResponseBody>>,
-    /// Owned state for running step response-body filters.
-    continuation: StepResponseContinuation,
-    /// Whether the stream has finished (EOF or error).
-    finished: bool,
-    /// Completion-hook body output held until IRR selects a transition.
-    deferred_completion_output: Option<Bytes>,
-    /// Per-callback local output waiting to be pulled downstream.
-    pending_chunks: VecDeque<Bytes>,
-}
-
-impl IrrStreamingBody {
-    /// Create a new streaming body for a step's response.
-    pub(super) fn new(upstream: Box<SubResponseBody>, continuation: StepResponseContinuation) -> Self {
-        Self {
-            upstream: Some(upstream),
-            continuation,
-            finished: false,
-            deferred_completion_output: None,
-            pending_chunks: VecDeque::new(),
-        }
-    }
-
-    /// Consume the body wrapper after EOF and recover its owned step state.
-    pub(super) fn into_continuation(self) -> StepResponseContinuation {
-        self.continuation
-    }
-
-    /// Consume a finished body into its continuation and deferred output.
-    fn into_finished_parts(self) -> (StepResponseContinuation, Option<Bytes>) {
-        (self.continuation, self.deferred_completion_output)
-    }
-
-    /// Exchange extensions with the outer protocol lifecycle.
-    fn exchange_extensions(&mut self, extensions: &mut RequestExtensions) {
-        std::mem::swap(&mut self.continuation.extensions, extensions);
-    }
-
-    /// Run the step's response-body filters on a single chunk.
-    ///
-    /// Reconstructs a temporary `HttpFilterContext` from the
-    /// continuation's owned state, runs the pipeline's body
-    /// execution, then writes state changes back to the
-    /// continuation for the next chunk.
-    #[expect(clippy::too_many_lines, reason = "context reconstruction requires many fields")]
-    fn run_step_body_filters(&mut self, body: &mut Option<Bytes>, end_of_stream: bool) -> Result<(), FilterError> {
-        let cont = &mut self.continuation;
-        let mut ctx = crate::filter::HttpFilterContext {
-            buffered_request_body: None,
-            body_done_indices: std::mem::take(&mut cont.body_done_indices),
-            branch_iterations: HashMap::new(),
-            client_addr: cont.client_addr,
-            cluster: None,
-            current_filter_id: None,
-            downstream_tls: cont.downstream_tls,
-            extensions: std::mem::take(&mut cont.extensions),
-            executed_filter_indices: std::mem::take(&mut cont.executed_filter_indices),
-            extra_request_headers: Vec::new(),
-            filter_metadata: std::mem::take(&mut cont.filter_metadata),
-            filter_results: std::mem::take(&mut cont.filter_results),
-            filter_state: std::mem::take(&mut cont.filter_state),
-            health_registry: cont.pipeline.health_registry(),
-            id_generator: cont.pipeline.id_generator(),
-            kv_stores: cont.pipeline.kv_stores(),
-            metrics_route: None,
-            peer_identity: cont.peer_identity.clone(),
-            prior_pre_read_mutations: Vec::new(),
-            pre_read_mutations: Vec::new(),
-            request: &cont.request_snapshot,
-            request_body_bytes: 0,
-            request_body_mode: cont.pipeline.body_capabilities().request_body_mode,
-            request_headers_to_remove: Vec::new(),
-            request_headers_to_set: Vec::new(),
-            request_start: cont.request_start,
-            response_body_bytes: cont.response_body_bytes,
-            response_body_mode: cont.response_body_mode,
-            response_header: None,
-            response_headers_modified: false,
-            rewritten_path: None,
-            selected_endpoint_index: None,
-            attempted_endpoints: Vec::new(),
-            retry_policy: None,
-            route_retry_policy: None,
-            cluster_retry_state: None,
-            cluster_retry_state_released: false,
-            endpoint_reselector: None,
-            pinned_endpoint_address: None,
-            session_stores: None,
-            structured_metadata: std::mem::take(&mut cont.structured_metadata),
-            subrequest_client: cont.pipeline.subrequest_client(),
-            subrequest_response_mode: crate::context::SubRequestResponseMode::Streaming,
-            time_source: cont.pipeline.time_source(),
-            upstream: None,
-        };
-
-        let result = cont.pipeline.execute_http_response_body_with_response_header(
-            &mut ctx,
-            body,
-            end_of_stream,
-            Some(&cont.response_snapshot),
-        );
-
-        cont.body_done_indices = ctx.body_done_indices;
-        cont.executed_filter_indices = ctx.executed_filter_indices;
-        cont.extensions = ctx.extensions;
-        cont.filter_metadata = ctx.filter_metadata;
-        cont.filter_results = ctx.filter_results;
-        cont.filter_state = ctx.filter_state;
-        cont.response_body_bytes = ctx.response_body_bytes;
-        cont.structured_metadata = ctx.structured_metadata;
-
-        match result? {
-            crate::actions::FilterAction::Reject(_) => {
-                Err("iterative_request_router: step body filter rejected during stream"
-                    .to_owned()
-                    .into())
-            },
-            _ => Ok(()),
-        }
-    }
-
-    /// Run the step's completion lifecycle exactly once.
-    ///
-    /// Called after upstream EOF. Runs body filters with
-    /// `end_of_stream: true` to let them emit any buffered
-    /// completion chunk (e.g. a closing SSE comment or JSON
-    /// array bracket).
-    fn complete_step(&mut self) -> Result<Option<Bytes>, FilterError> {
-        if self.continuation.completed {
-            return Ok(None);
-        }
-        self.continuation.completed = true;
-        let mut body: Option<Bytes> = None;
-        self.run_step_body_filters(&mut body, true)?;
-        Ok(body)
-    }
-
-    /// Handle a chunk received from the upstream.
-    fn handle_upstream_chunk(&mut self, chunk: Bytes) -> Result<Option<Bytes>, FilterError> {
-        let mut body = Some(chunk);
-        self.run_step_body_filters(&mut body, false)?;
-        let emitted = self
-            .continuation
-            .extensions
-            .get_mut::<PendingStreamChunks>()
-            .map_or_else(VecDeque::new, PendingStreamChunks::drain_chunks);
-        self.pending_chunks.extend(emitted);
-        self.pending_chunks.extend(body.filter(|bytes| !bytes.is_empty()));
-        Ok(self.pending_chunks.pop_front())
-    }
-
-    /// Complete the step after a response-body filter failure.
-    async fn handle_filter_error(&mut self, error: FilterError) -> Result<Option<Bytes>, FilterError> {
-        warn!("iterative_request_router: response body filter failed: {error}");
-        if let Some(upstream_body) = self.upstream.take() {
-            (*upstream_body).cancel().await;
-        }
-        self.continuation
-            .extensions
-            .insert(StreamTermination::new(StreamTerminationCause::Filter));
-        let completion = self.complete_step().map_err(|completion_error| -> FilterError {
-            format!(
-                "iterative_request_router: response filter failed ({error}); completion also failed ({completion_error})"
-            )
-            .into()
-        })?;
-        self.finished = true;
-        self.deferred_completion_output = self.handled_completion_output(completion);
-        Ok(None)
-    }
-
-    /// Handle upstream EOF.
-    fn handle_upstream_eof(&mut self) -> Result<Option<Bytes>, FilterError> {
-        let completion = self.complete_step()?;
-        self.finished = true;
-        self.deferred_completion_output = completion.filter(|bytes| !bytes.is_empty());
-        Ok(None)
-    }
-
-    /// Handle an upstream error.
-    async fn handle_upstream_error(
-        &mut self,
-        e: praxis_core::subrequest::SubRequestError,
-    ) -> Result<Option<Bytes>, FilterError> {
-        if let Some(upstream_body) = self.upstream.take() {
-            (*upstream_body).cancel().await;
-        }
-        self.continuation
-            .extensions
-            .insert(StreamTermination::new(termination_cause(&e)));
-        let completion = self.complete_step()?;
-        self.finished = true;
-        self.deferred_completion_output = self.handled_completion_output(completion);
-        Ok(None)
-    }
-
-    /// Expose an abnormal completion body only when a filter explicitly
-    /// converted the failure into a valid terminal sequence.
-    fn handled_completion_output(&self, completion: Option<Bytes>) -> Option<Bytes> {
-        self.continuation
-            .extensions
-            .get::<StreamTermination>()
-            .is_some_and(StreamTermination::is_handled)
-            .then_some(completion)
-            .flatten()
-            .filter(|bytes| !bytes.is_empty())
-    }
-}
-
-/// Map transport detail to the provider-neutral completion classification.
-fn termination_cause(error: &praxis_core::subrequest::SubRequestError) -> StreamTerminationCause {
-    use praxis_core::subrequest::SubRequestError;
-    match error {
-        SubRequestError::AdmissionTimeout { .. } => StreamTerminationCause::AdmissionTimeout,
-        SubRequestError::CircuitOpen { .. } => StreamTerminationCause::CircuitOpen,
-        SubRequestError::Connect(_) => StreamTerminationCause::Connect,
-        SubRequestError::DeadlineExceeded => StreamTerminationCause::DeadlineExceeded,
-        SubRequestError::StreamIdleTimeout { .. } => StreamTerminationCause::IdleTimeout,
-        SubRequestError::ResponseTooLarge { .. } => StreamTerminationCause::ResponseTooLarge,
-        _ => StreamTerminationCause::Io,
-    }
-}
-
-#[async_trait]
-impl StreamingResponseBody for IrrStreamingBody {
-    #[expect(clippy::too_many_lines, reason = "pull loop applies deadlines and completion state")]
-    async fn next_chunk(&mut self) -> Result<Option<Bytes>, FilterError> {
-        if let Some(chunk) = self.pending_chunks.pop_front() {
-            return Ok(Some(chunk));
-        }
-        if self.finished {
-            return Ok(None);
-        }
-
-        loop {
-            let upstream = self.upstream.as_mut().ok_or_else(|| -> FilterError {
-                "iterative_request_router: upstream already consumed".to_owned().into()
-            })?;
-
-            let remaining = self
-                .continuation
-                .step_deadline
-                .checked_duration_since(std::time::Instant::now())
-                .unwrap_or_default();
-            let next = if remaining.is_zero() {
-                Err(praxis_core::subrequest::SubRequestError::DeadlineExceeded)
-            } else {
-                tokio::time::timeout(remaining, upstream.next_chunk())
-                    .await
-                    .unwrap_or(Err(praxis_core::subrequest::SubRequestError::DeadlineExceeded))
-            };
-
-            match next {
-                Ok(Some(chunk)) => match self.handle_upstream_chunk(chunk) {
-                    Ok(Some(bytes)) => return Ok(Some(bytes)),
-                    Ok(None) => {},
-                    Err(error) => return Box::pin(self.handle_filter_error(error)).await,
-                },
-                Ok(None) => return self.handle_upstream_eof(),
-                Err(e) => return Box::pin(self.handle_upstream_error(e)).await,
-            }
-        }
-    }
-
-    async fn suppress(&mut self) -> Result<(), FilterError> {
-        if !self.finished {
-            self.finished = true;
-            if let Some(upstream_body) = self.upstream.take() {
-                (*upstream_body).cancel().await;
-            }
-            self.complete_step()?;
-        }
-        Ok(())
-    }
-
-    async fn cancel(&mut self) {
-        if !self.finished {
-            self.finished = true;
-            if let Some(upstream_body) = self.upstream.take() {
-                (*upstream_body).cancel().await;
-            }
-        }
-    }
-
-    fn swap_extensions(&mut self, extensions: &mut RequestExtensions) {
-        self.exchange_extensions(extensions);
-    }
+/// The generic [`SubrequestCompletion`] already lifted the executor-owned
+/// mechanisms into typed fields and left caller-injected types in its
+/// extensions. This recovers the router's [`IterationState`] and
+/// [`NextIterationBody`]; a missing iteration state is a lifecycle error whose
+/// recoverable extensions have both router-owned types stripped, matching the
+/// parent-facing end state of every other exit path.
+pub(super) fn step_completion_from(completion: SubrequestCompletion) -> Result<StepCompletion, StepCompletionError> {
+    let SubrequestCompletion {
+        mut extensions,
+        filter_results,
+        pending_chunks,
+        termination,
+    } = completion;
+    let Some(state) = extensions.remove::<IterationState>() else {
+        return Err(StepCompletionError {
+            error: "iterative_request_router: iteration state missing after step completion"
+                .to_owned()
+                .into(),
+            extensions: super::strip_iteration_extensions(extensions),
+        });
+    };
+    let next_iteration_body = extensions.remove::<NextIterationBody>().map(|body| body.0);
+    Ok(StepCompletion {
+        extensions,
+        filter_results,
+        next_iteration_body,
+        pending_chunks,
+        state,
+        termination,
+    })
 }
 
 /// A committed logical response that can span multiple IRR steps.
 pub(super) struct IrrStreamingSession {
     /// Active step body, when a streamed step is being consumed.
-    current: Option<IrrStreamingBody>,
+    current: Option<FilteredStreamingBody>,
     /// Outcome corresponding to `current`.
     current_outcome: Option<super::StepOutcome>,
     /// Request inherited or replaced for the current step.
@@ -540,14 +149,14 @@ impl IrrStreamingSession {
         current_request: crate::SubRequest,
         outcome: super::StepOutcome,
         body: Box<SubResponseBody>,
-        continuation: StepResponseContinuation,
+        continuation: FilteredSubrequestContinuation,
         pending_chunks: VecDeque<Bytes>,
         step_transitions: HashMap<Arc<str>, Vec<super::config::StepTransition>>,
         max_state_bytes: usize,
         max_stream_response_bytes: Option<usize>,
     ) -> Self {
         Self {
-            current: Some(IrrStreamingBody::new(body, continuation)),
+            current: Some(FilteredStreamingBody::new(body, continuation)),
             current_outcome: Some(outcome),
             current_request,
             current_step,
@@ -692,7 +301,7 @@ impl IrrStreamingSession {
             .take()
             .ok_or_else(|| -> FilterError { "iterative_request_router: current stream missing at EOF".into() })?;
         let (continuation, completion_output) = current.into_finished_parts();
-        let completion = match continuation.into_completion() {
+        let completion = match step_completion_from(continuation.into_completion()) {
             Ok(completion) => completion,
             Err(error) => {
                 let (error, restored_extensions) = error.into_parts();
@@ -750,7 +359,7 @@ impl IrrStreamingSession {
             super::runner::OpenedStepKind::Streaming { body, outcome } => {
                 if !super::streaming_transition_order_is_valid(self.transitions()) {
                     (*body).cancel().await;
-                    self.extensions = Some(continuation.into_parent_extensions());
+                    self.extensions = Some(super::strip_iteration_extensions(continuation.into_parent_extensions()));
                     self.state = Some(state);
                     return Err(format!(
                         "iterative_request_router: step '{}' selected streaming with interleaved transition phases",
@@ -760,13 +369,15 @@ impl IrrStreamingSession {
                 }
                 match super::evaluate_header_transitions(self.transitions(), &outcome) {
                     super::TransitionResult::Next(next) => {
-                        let mut skipped = IrrStreamingBody::new(body, continuation);
+                        let mut skipped = FilteredStreamingBody::new(body, continuation);
                         if let Err(error) = skipped.suppress().await {
-                            self.extensions = Some(skipped.into_continuation().into_parent_extensions());
+                            self.extensions = Some(super::strip_iteration_extensions(
+                                skipped.into_continuation().into_parent_extensions(),
+                            ));
                             self.state = Some(state);
                             return Err(error);
                         }
-                        let mut completion = match skipped.into_continuation().into_completion() {
+                        let mut completion = match step_completion_from(skipped.into_continuation().into_completion()) {
                             Ok(completion) => completion,
                             Err(error) => {
                                 let (error, restored_extensions) = error.into_parts();
@@ -799,13 +410,13 @@ impl IrrStreamingSession {
                         self.next_step = Some(next);
                     },
                     super::TransitionResult::Done | super::TransitionResult::NoMatch => {
-                        self.current = Some(IrrStreamingBody::new(body, continuation));
+                        self.current = Some(FilteredStreamingBody::new(body, continuation));
                         self.current_outcome = Some(outcome);
                     },
                 }
             },
             super::runner::OpenedStepKind::Complete(outcome) => {
-                let completion = match continuation.into_completion() {
+                let completion = match step_completion_from(continuation.into_completion()) {
                     Ok(completion) => completion,
                     Err(error) => {
                         let (error, restored_extensions) = error.into_parts();

--- a/crates/filter/src/builtins/http/traffic_management/iterative_request_router/tests.rs
+++ b/crates/filter/src/builtins/http/traffic_management/iterative_request_router/tests.rs
@@ -733,28 +733,6 @@ fn build_terminal_normalizes_informational_status() {
 }
 
 #[test]
-fn local_rejection_becomes_transition_response() {
-    let mut rejection = crate::Rejection::status(503)
-        .with_header("Retry-After", "1")
-        .with_header("Connection", "x-private")
-        .with_header("x-private", "secret")
-        .with_header("x-praxis-private", "secret")
-        .with_body(bytes::Bytes::from_static(b"unavailable"));
-    rejection
-        .header_map
-        .get_or_insert_with(Default::default)
-        .append("x-opaque", http::HeaderValue::from_bytes(&[0x80]).unwrap());
-    let response = super::subresponse_from_rejection(rejection);
-    assert_eq!(response.status, 503);
-    assert_eq!(response.headers.get("retry-after").unwrap(), "1");
-    assert!(!response.headers.contains_key("connection"));
-    assert!(!response.headers.contains_key("x-private"));
-    assert!(!response.headers.contains_key("x-praxis-private"));
-    assert_eq!(response.headers.get("x-opaque").unwrap().as_bytes(), &[0x80]);
-    assert_eq!(response.body, bytes::Bytes::from_static(b"unavailable"));
-}
-
-#[test]
 fn build_terminal_preserves_body() {
     use crate::SubResponse;
 
@@ -793,61 +771,6 @@ fn build_terminal_preserves_headers() {
         "application/json",
         "terminal should preserve content-type header"
     );
-}
-
-// ---------------------------------------------------------------------------
-// classify_transport_failure
-// ---------------------------------------------------------------------------
-
-#[test]
-fn classify_admission_timeout_returns_503() {
-    let error = praxis_core::subrequest::SubRequestError::AdmissionTimeout { max_connections: 64 };
-    let (status, kind) = super::classify_transport_failure(&error);
-    assert_eq!(status, 503, "AdmissionTimeout should return 503");
-    assert_eq!(kind, config::TransportErrorKind::AdmissionTimeout);
-}
-
-#[test]
-fn classify_connect_returns_502() {
-    let error = praxis_core::subrequest::SubRequestError::Connect("refused".to_owned());
-    let (status, kind) = super::classify_transport_failure(&error);
-    assert_eq!(status, 502, "Connect should return 502");
-    assert_eq!(kind, config::TransportErrorKind::Connect);
-}
-
-#[test]
-fn classify_deadline_exceeded_returns_504() {
-    let error = praxis_core::subrequest::SubRequestError::DeadlineExceeded;
-    let (status, kind) = super::classify_transport_failure(&error);
-    assert_eq!(status, 504, "DeadlineExceeded should return 504");
-    assert_eq!(kind, config::TransportErrorKind::DeadlineExceeded);
-}
-
-#[test]
-fn classify_response_too_large_returns_502() {
-    let error = praxis_core::subrequest::SubRequestError::ResponseTooLarge {
-        actual: 200,
-        limit: 100,
-    };
-    let (status, kind) = super::classify_transport_failure(&error);
-    assert_eq!(status, 502, "ResponseTooLarge should return 502");
-    assert_eq!(kind, config::TransportErrorKind::ResponseTooLarge);
-}
-
-#[test]
-fn classify_io_returns_502() {
-    let error = praxis_core::subrequest::SubRequestError::Io("broken pipe".to_owned());
-    let (status, kind) = super::classify_transport_failure(&error);
-    assert_eq!(status, 502, "Io should return 502");
-    assert_eq!(kind, config::TransportErrorKind::Io);
-}
-
-#[test]
-fn classify_invalid_request_falls_through_to_io() {
-    let error = praxis_core::subrequest::SubRequestError::InvalidRequest("bad uri".to_owned());
-    let (status, kind) = super::classify_transport_failure(&error);
-    assert_eq!(status, 502, "InvalidRequest wildcard should return 502");
-    assert_eq!(kind, config::TransportErrorKind::Io);
 }
 
 // ---------------------------------------------------------------------------
@@ -1269,75 +1192,6 @@ fn parse_depth_empty_string() {
     let mut req = crate::test_utils::make_request(http::Method::GET, "/");
     req.headers.insert(DEPTH_HEADER, http::HeaderValue::from_static(""));
     assert_eq!(super::parse_depth(&req), 0, "empty should return 0");
-}
-
-// ---------------------------------------------------------------------------
-// strip_reserved_headers
-// ---------------------------------------------------------------------------
-
-#[test]
-fn strip_reserved_empty_map() {
-    let mut headers = HeaderMap::new();
-    super::strip_reserved_headers(&mut headers);
-    assert!(headers.is_empty(), "empty map should stay empty");
-}
-
-#[test]
-fn strip_reserved_praxis_prefix() {
-    let mut headers = HeaderMap::new();
-    headers.insert("x-praxis-foo", "bar".parse().unwrap());
-    super::strip_reserved_headers(&mut headers);
-    assert!(headers.is_empty(), "x-praxis-* should be removed");
-}
-
-#[test]
-fn strip_reserved_ext_protocol_prefix() {
-    let mut headers = HeaderMap::new();
-    headers.insert("x-ext-protocol-route", "value".parse().unwrap());
-    super::strip_reserved_headers(&mut headers);
-    assert!(headers.is_empty(), "x-ext-protocol-* should be removed");
-}
-
-#[test]
-fn strip_reserved_ext_agent_prefix() {
-    let mut headers = HeaderMap::new();
-    headers.insert("x-ext-agent-task", "value".parse().unwrap());
-    super::strip_reserved_headers(&mut headers);
-    assert!(headers.is_empty(), "x-ext-agent-* should be removed");
-}
-
-#[test]
-fn strip_reserved_preserves_non_reserved() {
-    let mut headers = HeaderMap::new();
-    headers.insert("authorization", "Bearer token".parse().unwrap());
-    headers.insert("content-type", "application/json".parse().unwrap());
-    super::strip_reserved_headers(&mut headers);
-    assert_eq!(headers.len(), 2, "non-reserved headers should be preserved");
-}
-
-#[test]
-fn strip_reserved_mixed() {
-    let mut headers = HeaderMap::new();
-    headers.insert("authorization", "Bearer token".parse().unwrap());
-    headers.insert("x-praxis-internal", "secret".parse().unwrap());
-    headers.insert("x-ext-agent-id", "agent1".parse().unwrap());
-    headers.insert("x-custom", "value".parse().unwrap());
-    super::strip_reserved_headers(&mut headers);
-    assert_eq!(headers.len(), 2, "only reserved should be removed");
-    assert!(headers.contains_key("authorization"));
-    assert!(headers.contains_key("x-custom"));
-}
-
-#[test]
-fn strip_reserved_no_dash_not_removed() {
-    let mut headers = HeaderMap::new();
-    headers.insert("x-praxisfoo", "value".parse().unwrap());
-    super::strip_reserved_headers(&mut headers);
-    assert_eq!(
-        headers.len(),
-        1,
-        "x-praxisfoo (no dash after prefix) should NOT be removed"
-    );
 }
 
 // ---------------------------------------------------------------------------
@@ -2441,6 +2295,38 @@ fn transition_transport_origin_matches_any_transport_error() {
 }
 
 // ---------------------------------------------------------------------------
+// Transport Failure -> Config Kind Bridge
+// ---------------------------------------------------------------------------
+
+#[test]
+fn transport_failure_maps_to_matching_config_kind() {
+    use crate::filtered_subrequest::TransportFailure;
+    // Each executor-internal failure must map to the config kind that a
+    // `transport_error` transition branch matches on. A mis-mapping here would
+    // leave classify + transition tests green while breaking branch selection.
+    let cases = [
+        (
+            TransportFailure::AdmissionTimeout,
+            config::TransportErrorKind::AdmissionTimeout,
+        ),
+        (TransportFailure::CircuitOpen, config::TransportErrorKind::CircuitOpen),
+        (TransportFailure::Connect, config::TransportErrorKind::Connect),
+        (TransportFailure::Io, config::TransportErrorKind::Io),
+        (
+            TransportFailure::DeadlineExceeded,
+            config::TransportErrorKind::DeadlineExceeded,
+        ),
+        (
+            TransportFailure::ResponseTooLarge,
+            config::TransportErrorKind::ResponseTooLarge,
+        ),
+    ];
+    for (failure, expected) in cases {
+        assert_eq!(config::TransportErrorKind::from(failure), expected);
+    }
+}
+
+// ---------------------------------------------------------------------------
 // build_terminal_response - Additional
 // ---------------------------------------------------------------------------
 
@@ -2538,34 +2424,6 @@ fn build_terminal_preserves_opaque_header_bytes() {
 }
 
 #[test]
-fn nested_body_limit_detects_oversized_buffer() {
-    assert!(super::body_exceeds_limit(
-        crate::BodyMode::StreamBuffer { max_bytes: Some(4) },
-        5
-    ));
-    assert!(!super::body_exceeds_limit(
-        crate::BodyMode::SizeLimit { max_bytes: 5 },
-        5
-    ));
-    assert!(!super::body_exceeds_limit(crate::BodyMode::Stream, usize::MAX));
-}
-
-#[test]
-fn transformed_response_must_remain_within_all_limits() {
-    assert!(super::response_body_exceeds_limits(crate::BodyMode::Stream, 4, 5));
-    assert!(super::response_body_exceeds_limits(
-        crate::BodyMode::StreamBuffer { max_bytes: Some(3) },
-        4,
-        4,
-    ));
-    assert!(!super::response_body_exceeds_limits(
-        crate::BodyMode::StreamBuffer { max_bytes: Some(4) },
-        4,
-        4,
-    ));
-}
-
-#[test]
 fn listener_response_limit_clamps_router_limit() {
     assert_eq!(
         super::effective_response_limit(
@@ -2575,102 +2433,6 @@ fn listener_response_limit_clamps_router_limit() {
         4
     );
     assert_eq!(super::effective_response_limit(4, crate::BodyMode::Stream), 4);
-}
-
-#[test]
-fn streaming_transport_uses_only_listener_limit() {
-    assert_eq!(
-        super::streaming_transport_limit(crate::BodyMode::SizeLimit { max_bytes: 4 }),
-        Some(4)
-    );
-    assert_eq!(super::streaming_transport_limit(crate::BodyMode::Stream), None);
-}
-
-#[test]
-fn strip_request_framing_headers_removes_stale_lengths() {
-    let mut headers = HeaderMap::new();
-    headers.insert(http::header::CONTENT_LENGTH, "100".parse().unwrap());
-    headers.insert(http::header::TRANSFER_ENCODING, "chunked".parse().unwrap());
-    headers.insert(http::header::CONTENT_TYPE, "application/json".parse().unwrap());
-
-    super::strip_request_framing_headers(&mut headers);
-
-    assert!(!headers.contains_key(http::header::CONTENT_LENGTH));
-    assert!(!headers.contains_key(http::header::TRANSFER_ENCODING));
-    assert!(headers.contains_key(http::header::CONTENT_TYPE));
-}
-
-#[test]
-fn request_sanitization_strips_all_reserved_headers_including_depth() {
-    let mut headers = HeaderMap::new();
-    headers.insert(http::header::CONNECTION, "x-remove, keep-alive".parse().unwrap());
-    headers.insert("x-remove", "secret".parse().unwrap());
-    headers.insert("keep-alive", "timeout=5".parse().unwrap());
-    headers.insert("x-praxis-route", "internal".parse().unwrap());
-    headers.insert(DEPTH_HEADER, "1".parse().unwrap());
-    headers.insert(http::header::AUTHORIZATION, "Bearer step-token".parse().unwrap());
-    headers.insert(http::header::CONTENT_LENGTH, "99".parse().unwrap());
-
-    super::sanitize_subrequest_headers(&mut headers);
-
-    assert!(!headers.contains_key(http::header::CONNECTION));
-    assert!(!headers.contains_key("x-remove"));
-    assert!(!headers.contains_key("keep-alive"));
-    assert!(!headers.contains_key("x-praxis-route"));
-    assert!(!headers.contains_key(http::header::CONTENT_LENGTH));
-    assert!(
-        !headers.contains_key(DEPTH_HEADER),
-        "sanitize must strip depth; core executor re-injects via framework_headers"
-    );
-    assert_eq!(headers.get(http::header::AUTHORIZATION).unwrap(), "Bearer step-token");
-}
-
-#[test]
-fn sanitize_strips_depth_header_for_framework_reinsertion() {
-    let mut headers = HeaderMap::new();
-    headers.insert(DEPTH_HEADER, "spoofed".parse().unwrap());
-    headers.insert("x-praxis-route", "internal".parse().unwrap());
-    headers.insert(http::header::AUTHORIZATION, "Bearer token".parse().unwrap());
-
-    super::sanitize_subrequest_headers(&mut headers);
-
-    assert!(
-        !headers.contains_key(DEPTH_HEADER),
-        "sanitize must strip depth so core executor can re-inject via framework_headers"
-    );
-    assert!(!headers.contains_key("x-praxis-route"));
-    assert_eq!(headers.get(http::header::AUTHORIZATION).unwrap(), "Bearer token");
-}
-
-#[test]
-fn response_sanitization_strips_hop_by_hop_and_internal_headers() {
-    let mut headers = HeaderMap::new();
-    headers.insert(http::header::CONNECTION, "x-remove".parse().unwrap());
-    headers.insert("x-remove", "secret".parse().unwrap());
-    headers.insert("upgrade", "h2c".parse().unwrap());
-    headers.insert("x-ext-agent-task", "internal".parse().unwrap());
-    headers.append(http::header::SET_COOKIE, "first=1".parse().unwrap());
-    headers.append(http::header::SET_COOKIE, "second=2".parse().unwrap());
-
-    super::sanitize_subresponse_headers(&mut headers);
-
-    assert!(!headers.contains_key(http::header::CONNECTION));
-    assert!(!headers.contains_key("x-remove"));
-    assert!(!headers.contains_key("upgrade"));
-    assert!(!headers.contains_key("x-ext-agent-task"));
-    assert_eq!(headers.get_all(http::header::SET_COOKIE).iter().count(), 2);
-}
-
-#[test]
-fn destination_host_is_synthesized_without_overwriting_step_override() {
-    let mut generated = HeaderMap::new();
-    super::ensure_destination_host(&mut generated, "model.example:443").unwrap();
-    assert_eq!(generated.get(http::header::HOST).unwrap(), "model.example:443");
-
-    let mut explicit = HeaderMap::new();
-    explicit.insert(http::header::HOST, "override.example".parse().unwrap());
-    super::ensure_destination_host(&mut explicit, "model.example:443").unwrap();
-    assert_eq!(explicit.get(http::header::HOST).unwrap(), "override.example");
 }
 
 #[test]
@@ -2697,63 +2459,6 @@ steps:
         .expect("open security filter must fail nested validation");
 
     assert!(error.to_string().contains("failure_mode: open"));
-}
-
-#[test]
-#[expect(
-    clippy::too_many_lines,
-    reason = "resource identity assertions are intentionally explicit"
-)]
-fn sub_filter_context_inherits_parent_runtime_resources() {
-    use std::{collections::HashMap, sync::Arc, time::Duration};
-
-    use praxis_core::{
-        health::HealthRegistry,
-        id::IdGenerator,
-        kv::KvStoreRegistry,
-        subrequest::{SubRequestClient, SubRequestConnector},
-        time::FixedTimeSource,
-    };
-
-    let registry = crate::FilterRegistry::with_builtins();
-    let pipeline = crate::FilterPipeline::build(&mut [], &registry).unwrap();
-    let request = crate::Request {
-        headers: HeaderMap::new(),
-        method: http::Method::POST,
-        uri: http::Uri::from_static("/v1/responses"),
-    };
-    let health_registry: HealthRegistry = Arc::new(HashMap::new());
-    let id_generator = IdGenerator::with_seed(42);
-    let kv_stores = KvStoreRegistry::new();
-    let client = SubRequestClient::new(SubRequestConnector::new(1, None));
-    let time_source = FixedTimeSource::new(Duration::from_secs(123));
-
-    let ctx = super::build_sub_filter_context(
-        &pipeline,
-        &request,
-        super::SubPipelineRuntimeResources {
-            client_addr: Some(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)),
-            downstream_tls: true,
-            health_registry: Some(&health_registry),
-            id_generator: &id_generator,
-            kv_stores: Some(&kv_stores),
-            peer_identity: None,
-            request_start: std::time::Instant::now(),
-            subrequest_client: Some(&client),
-            time_source: &time_source,
-        },
-    );
-
-    assert!(std::ptr::eq(ctx.health_registry.unwrap(), &health_registry));
-    assert!(std::ptr::eq(ctx.id_generator, &id_generator));
-    assert!(std::ptr::eq(ctx.kv_stores.unwrap(), &kv_stores));
-    assert!(std::ptr::eq(ctx.subrequest_client.unwrap(), &client));
-    assert_eq!(
-        ctx.client_addr,
-        Some(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST))
-    );
-    assert!(ctx.downstream_tls);
-    assert_eq!(ctx.time_source.now(), Duration::from_secs(123));
 }
 
 // ---------------------------------------------------------------------------
@@ -3592,116 +3297,6 @@ steps:
         err.to_string().contains("invalid step"),
         "error must mention the invalid step: {err}"
     );
-}
-
-// ---------------------------------------------------------------------------
-// Header Mutation Helpers
-// ---------------------------------------------------------------------------
-
-#[test]
-fn request_header_mutations_remove_set_and_add() {
-    let req = crate::test_utils::make_request(http::Method::GET, "/");
-    let mut ctx = crate::test_utils::make_filter_context(&req);
-    ctx.request_headers_to_remove.push("x-old".parse().unwrap());
-    ctx.request_headers_to_set
-        .push(("x-set".parse().unwrap(), http::HeaderValue::from_static("set")));
-    ctx.extra_request_headers
-        .push((std::borrow::Cow::Borrowed("x-extra"), "extra".to_owned()));
-    ctx.extra_request_headers
-        .push((std::borrow::Cow::Borrowed("bad name"), "dropped".to_owned()));
-
-    let mut headers = HeaderMap::new();
-    headers.insert("x-old", http::HeaderValue::from_static("stale"));
-    super::apply_request_header_mutations(&mut headers, &ctx);
-
-    assert!(headers.get("x-old").is_none(), "removed headers must be gone");
-    assert_eq!(
-        headers.get("x-set").map(http::HeaderValue::as_bytes),
-        Some(b"set".as_slice()),
-        "set headers must be applied"
-    );
-    assert_eq!(
-        headers.get("x-extra").map(http::HeaderValue::as_bytes),
-        Some(b"extra".as_slice()),
-        "extra headers must be applied"
-    );
-    assert!(
-        headers.get("bad name").is_none(),
-        "invalid extra header names must be dropped"
-    );
-}
-
-#[test]
-fn pre_read_mutations_apply_remove_set_and_add() {
-    let req = crate::test_utils::make_request(http::Method::GET, "/");
-    let mut ctx = crate::test_utils::make_filter_context(&req);
-    ctx.pre_read_mutations = vec![
-        crate::TrustedHeaderMutation::Remove("x-gone".parse().unwrap()),
-        crate::TrustedHeaderMutation::Set("x-set".parse().unwrap(), http::HeaderValue::from_static("set")),
-        crate::TrustedHeaderMutation::Add("x-add".parse().unwrap(), "added".to_owned()),
-        crate::TrustedHeaderMutation::Add("x-bad".parse().unwrap(), "bad\nvalue".to_owned()),
-    ];
-
-    let mut headers = HeaderMap::new();
-    headers.insert("x-gone", http::HeaderValue::from_static("stale"));
-    super::apply_pre_read_header_mutations(&mut headers, &ctx);
-
-    assert!(headers.get("x-gone").is_none(), "Remove mutations must apply");
-    assert_eq!(
-        headers.get("x-set").map(http::HeaderValue::as_bytes),
-        Some(b"set".as_slice()),
-        "Set mutations must apply"
-    );
-    assert_eq!(
-        headers.get("x-add").map(http::HeaderValue::as_bytes),
-        Some(b"added".as_slice()),
-        "Add mutations must apply"
-    );
-    assert!(
-        headers.get("x-bad").is_none(),
-        "Add mutations with invalid values must be dropped"
-    );
-}
-
-#[test]
-fn destination_host_rejects_unencodable_address() {
-    let mut headers = HeaderMap::new();
-    let result = super::ensure_destination_host(&mut headers, "bad\nhost:80");
-    assert!(result.is_err(), "control characters in the Host value must error");
-}
-
-// ---------------------------------------------------------------------------
-// Peer Construction
-// ---------------------------------------------------------------------------
-
-#[tokio::test]
-async fn build_peer_applies_tls_with_explicit_sni() {
-    let tls: praxis_tls::ClusterTls = serde_yaml::from_str("sni: backend.example\nverify: true").unwrap();
-    let cached = praxis_tls::CachedClusterTls::try_from_config(&tls).unwrap();
-    let upstream = praxis_core::connectivity::Upstream {
-        address: std::sync::Arc::from("127.0.0.1:9443"),
-        connection: std::sync::Arc::new(praxis_core::connectivity::ConnectionOptions::default()),
-        tls: Some(cached),
-        authority: None,
-    };
-
-    let peer = super::build_peer(&upstream).await.unwrap();
-    assert_eq!(peer.sni, "backend.example", "the configured SNI must be applied");
-}
-
-#[tokio::test]
-async fn build_peer_derives_sni_from_hostname_address() {
-    let tls: praxis_tls::ClusterTls = serde_yaml::from_str("verify: false").unwrap();
-    let cached = praxis_tls::CachedClusterTls::try_from_config(&tls).unwrap();
-    let upstream = praxis_core::connectivity::Upstream {
-        address: std::sync::Arc::from("localhost:9443"),
-        connection: std::sync::Arc::new(praxis_core::connectivity::ConnectionOptions::default()),
-        tls: Some(cached),
-        authority: None,
-    };
-
-    let peer = super::build_peer(&upstream).await.unwrap();
-    assert_eq!(peer.sni, "localhost", "the SNI must derive from the address hostname");
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/filter/src/filtered_subrequest/context.rs
+++ b/crates/filter/src/filtered_subrequest/context.rs
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Praxis Contributors
+
+//! Nested filter-context construction for a filtered sub-request.
+
+use std::{collections::HashMap, sync::Arc, time::Instant};
+
+use crate::{FilterPipeline, HttpFilterContext, SubRequestResponseMode};
+
+/// Runtime resources inherited from the pipeline that owns the executor.
+///
+/// These mirror the server-injected resources on the outer request so a
+/// nested step pipeline observes the same identity, health, and timing
+/// context as the request that spawned it.
+#[derive(Clone, Copy)]
+pub(super) struct SubrequestRuntimeResources<'a> {
+    /// Original downstream client address.
+    pub(super) client_addr: Option<std::net::IpAddr>,
+
+    /// Whether the original downstream connection uses TLS.
+    pub(super) downstream_tls: bool,
+
+    /// Shared endpoint-health state.
+    pub(super) health_registry: Option<&'a praxis_core::health::HealthRegistry>,
+
+    /// Shared request ID generator.
+    pub(super) id_generator: &'a praxis_core::id::IdGenerator,
+
+    /// Named runtime key-value stores.
+    pub(super) kv_stores: Option<&'a praxis_core::kv::KvStoreRegistry>,
+
+    /// Verified downstream mTLS identity.
+    pub(super) peer_identity: Option<&'a Arc<praxis_tls::TlsPeerIdentity>>,
+
+    /// Start time of the containing client request.
+    pub(super) request_start: Instant,
+
+    /// Shared client used for recursive subrequests.
+    pub(super) subrequest_client: Option<&'a praxis_core::subrequest::SubRequestClient>,
+
+    /// Server-provided wall-clock source.
+    pub(super) time_source: &'a dyn praxis_core::time::TimeSource,
+}
+
+/// Build a [`HttpFilterContext`] for running a sub-request's pipeline,
+/// inheriting server-injected resources from the containing request.
+#[expect(clippy::too_many_lines, reason = "all fields must be initialized")]
+pub(super) fn build_sub_filter_context<'a>(
+    pipeline: &'a FilterPipeline,
+    request: &'a crate::Request,
+    runtime: SubrequestRuntimeResources<'a>,
+) -> HttpFilterContext<'a> {
+    HttpFilterContext {
+        buffered_request_body: None,
+        body_done_indices: Vec::new(),
+        branch_iterations: HashMap::new(),
+        client_addr: runtime.client_addr,
+        cluster: None,
+        current_filter_id: None,
+        downstream_tls: runtime.downstream_tls,
+        extensions: crate::extensions::RequestExtensions::default(),
+        executed_filter_indices: Vec::new(),
+        extra_request_headers: Vec::new(),
+        filter_metadata: HashMap::new(),
+        filter_results: HashMap::new(),
+        filter_state: HashMap::new(),
+        health_registry: runtime.health_registry,
+        id_generator: runtime.id_generator,
+        kv_stores: runtime.kv_stores,
+        session_stores: None,
+        metrics_route: None,
+        peer_identity: runtime.peer_identity.cloned(),
+        prior_pre_read_mutations: Vec::new(),
+        pre_read_mutations: Vec::new(),
+        request,
+        request_body_bytes: 0,
+        request_body_mode: pipeline.body_capabilities().request_body_mode,
+        request_headers_to_remove: Vec::new(),
+        request_headers_to_set: Vec::new(),
+        request_start: runtime.request_start,
+        response_body_bytes: 0,
+        response_body_mode: pipeline.body_capabilities().response_body_mode,
+        response_header: None,
+        response_headers_modified: false,
+        rewritten_path: None,
+        selected_endpoint_index: None,
+        attempted_endpoints: Vec::new(),
+        retry_policy: None,
+        route_retry_policy: None,
+        cluster_retry_state: None,
+        cluster_retry_state_released: false,
+        endpoint_reselector: None,
+        pinned_endpoint_address: None,
+        structured_metadata: HashMap::new(),
+        subrequest_client: runtime.subrequest_client,
+        subrequest_response_mode: SubRequestResponseMode::Buffered,
+        time_source: runtime.time_source,
+        upstream: None,
+    }
+}

--- a/crates/filter/src/filtered_subrequest/continuation.rs
+++ b/crates/filter/src/filtered_subrequest/continuation.rs
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Praxis Contributors
+
+//! Owned response-lifecycle continuation for a filtered sub-request.
+//!
+//! [`FilteredSubrequestContinuation`] holds all state needed to run
+//! response-body filters after the executor's `execute()` returns: the
+//! step pipeline, request and response snapshots, filter extensions,
+//! filter state, metadata, and a completion guard. The continuation owns
+//! an `Arc<FilterPipeline>` so the pipeline outlives the executor's caller.
+
+use std::{
+    any::Any,
+    collections::{HashMap, VecDeque},
+    sync::Arc,
+};
+
+use bytes::Bytes;
+
+use crate::{
+    FilterPipeline, StreamTermination,
+    context::PendingStreamChunks,
+    extensions::RequestExtensions,
+    results::{FilterResultSet, RetainedFilterResults},
+};
+
+/// Generic state made available after a sub-request's completion hook has run.
+///
+/// The executor extracts only the executor-owned mechanisms
+/// (`RetainedFilterResults`, `PendingStreamChunks`, `StreamTermination`) into
+/// typed fields. Any caller-injected extension types remain inside
+/// [`extensions`](Self::extensions) for the caller to recover.
+pub(crate) struct SubrequestCompletion {
+    /// Request extensions after completion, still holding caller-owned types.
+    pub(crate) extensions: RequestExtensions,
+    /// Results retained across all sub-request phases.
+    pub(crate) filter_results: HashMap<&'static str, FilterResultSet>,
+    /// Bounded locally emitted chunks.
+    pub(crate) pending_chunks: VecDeque<Bytes>,
+    /// Typed abnormal source termination, when present.
+    pub(crate) termination: Option<StreamTermination>,
+}
+
+/// State continuation for streaming a sub-request's response body.
+///
+/// Owns the step pipeline, request/response snapshots, and all per-filter
+/// state needed to run response-body filters after `execute()` returns. The
+/// `Arc<FilterPipeline>` outlives the executor's caller, enabling body hooks
+/// to run while the caller's request-phase hook has already completed.
+pub(crate) struct FilteredSubrequestContinuation {
+    /// Arc-wrapped step pipeline for executing response-body filters.
+    pub(super) pipeline: Arc<FilterPipeline>,
+    /// Snapshot of the request for filter context reconstruction.
+    pub(super) request_snapshot: crate::Request,
+    /// Snapshot of the response headers for filter context reconstruction.
+    pub(super) response_snapshot: crate::Response,
+    /// Request extensions that persist across body chunks.
+    pub(super) extensions: RequestExtensions,
+    /// Per-filter state that persists across body chunks.
+    pub(super) filter_state: HashMap<usize, Box<dyn Any + Send + Sync>>,
+    /// Filter results that persist across body chunks.
+    pub(super) filter_results: HashMap<&'static str, FilterResultSet>,
+    /// Filter metadata that persists across body chunks.
+    pub(super) filter_metadata: HashMap<String, String>,
+    /// Structured metadata that persists across body chunks.
+    pub(super) structured_metadata: HashMap<String, serde_json::Value>,
+    /// Tracks which filters executed during request phase.
+    pub(super) executed_filter_indices: Vec<bool>,
+    /// Tracks which filters completed their body hooks.
+    pub(super) body_done_indices: Vec<bool>,
+    /// Accumulated response body bytes seen so far.
+    pub(super) response_body_bytes: u64,
+    /// Response body mode from pipeline capabilities.
+    pub(super) response_body_mode: crate::body::BodyMode,
+    /// Whether the completion lifecycle has run.
+    pub(super) completed: bool,
+    /// Original downstream client address for body filter context.
+    pub(super) client_addr: Option<std::net::IpAddr>,
+    /// Whether the original downstream connection uses TLS.
+    pub(super) downstream_tls: bool,
+    /// Start time of the containing client request.
+    pub(super) request_start: std::time::Instant,
+    /// Absolute deadline shared by header and body processing for this step.
+    pub(super) step_deadline: std::time::Instant,
+    /// Verified downstream mTLS identity.
+    pub(super) peer_identity: Option<Arc<praxis_tls::TlsPeerIdentity>>,
+}
+
+impl FilteredSubrequestContinuation {
+    /// Capture all owned step context after response headers have run.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "capture owns the complete response continuation boundary"
+    )]
+    pub(super) fn capture(
+        pipeline: Arc<FilterPipeline>,
+        request_snapshot: crate::Request,
+        response_snapshot: crate::Response,
+        ctx: &mut crate::filter::HttpFilterContext<'_>,
+        completed: bool,
+        step_deadline: std::time::Instant,
+    ) -> Self {
+        Self {
+            pipeline,
+            request_snapshot,
+            response_snapshot,
+            extensions: std::mem::take(&mut ctx.extensions),
+            filter_state: std::mem::take(&mut ctx.filter_state),
+            filter_results: std::mem::take(&mut ctx.filter_results),
+            filter_metadata: std::mem::take(&mut ctx.filter_metadata),
+            structured_metadata: std::mem::take(&mut ctx.structured_metadata),
+            executed_filter_indices: std::mem::take(&mut ctx.executed_filter_indices),
+            body_done_indices: std::mem::take(&mut ctx.body_done_indices),
+            response_body_bytes: ctx.response_body_bytes,
+            response_body_mode: ctx.response_body_mode,
+            completed,
+            client_addr: ctx.client_addr,
+            downstream_tls: ctx.downstream_tls,
+            request_start: ctx.request_start,
+            step_deadline,
+            peer_identity: ctx.peer_identity.clone(),
+        }
+    }
+
+    /// Recover caller-owned extensions, dropping executor-owned mechanisms.
+    ///
+    /// Removes the executor's own transient extension types
+    /// (`RetainedFilterResults`, `PendingStreamChunks`, `StreamTermination`).
+    /// Caller-injected extension types remain for the caller to strip before
+    /// returning them to the parent request context.
+    pub(crate) fn into_parent_extensions(mut self) -> RequestExtensions {
+        self.extensions.remove::<PendingStreamChunks>();
+        self.extensions.remove::<RetainedFilterResults>();
+        self.extensions.remove::<StreamTermination>();
+        self.extensions
+    }
+
+    /// Consume the completed continuation into generic completion state.
+    ///
+    /// Executor-owned mechanisms are lifted into typed fields; caller-injected
+    /// extension types remain inside [`SubrequestCompletion::extensions`].
+    pub(crate) fn into_completion(mut self) -> SubrequestCompletion {
+        let pending_chunks = self
+            .extensions
+            .remove::<PendingStreamChunks>()
+            .map_or_else(VecDeque::new, PendingStreamChunks::into_chunks);
+        let termination = self.extensions.remove::<StreamTermination>();
+        let mut filter_results = self.extensions.remove::<RetainedFilterResults>().unwrap_or_default().0;
+        filter_results.extend(self.filter_results);
+        SubrequestCompletion {
+            extensions: self.extensions,
+            filter_results,
+            pending_chunks,
+            termination,
+        }
+    }
+
+    /// Borrow the retained request extensions.
+    ///
+    /// The caller reads its own injected extension types (for example an
+    /// iteration-state marker) without consuming the continuation.
+    pub(crate) fn extensions(&self) -> &RequestExtensions {
+        &self.extensions
+    }
+}

--- a/crates/filter/src/filtered_subrequest/mod.rs
+++ b/crates/filter/src/filtered_subrequest/mod.rs
@@ -1,0 +1,702 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Praxis Contributors
+
+//! Reusable execution of a filtered HTTP sub-request.
+//!
+//! [`FilteredSubrequestExecutor`] runs a single named filter pipeline against a
+//! sub-request and returns owned continuation state: it reconstructs a nested
+//! [`HttpFilterContext`](crate::HttpFilterContext), runs the request, request-body,
+//! response, and (for buffered responses) response-body phases, applies the same
+//! forwarding boundary as the normal upstream path, dispatches the transport in
+//! either buffered or streaming mode, and captures a
+//! [`FilteredSubrequestContinuation`] the caller drives to completion.
+//!
+//! The executor is caller-agnostic. It owns three transient extension
+//! mechanisms end-to-end — [`RetainedFilterResults`], [`PendingStreamChunks`],
+//! and [`StreamTermination`] — and never inspects caller-injected extension
+//! types. Callers that stash their own state in the request extensions recover
+//! it from [`FilteredSubrequestError::into_parts`],
+//! [`FilteredSubrequestContinuation::into_parent_extensions`], or
+//! [`FilteredSubrequestContinuation::into_completion`], and strip it themselves.
+//!
+//! Retained-state accounting is delegated to the caller through the
+//! [`RetainedStateAccounting`] hook so the executor stays independent of any
+//! particular caller's state layout while still enforcing a ceiling at every
+//! phase boundary.
+
+mod context;
+mod continuation;
+mod sanitize;
+mod streaming;
+#[cfg(test)]
+#[expect(clippy::allow_attributes, reason = "blanket test suppressions")]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::too_many_lines,
+    reason = "tests"
+)]
+mod tests;
+mod transport;
+
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::{Duration, Instant},
+};
+
+use bytes::Bytes;
+use http::HeaderMap;
+use praxis_core::subrequest::{FrameworkHeaders, StreamLimits, SubResponseBody};
+use tracing::{Instrument as _, warn};
+
+use self::{
+    context::{SubrequestRuntimeResources, build_sub_filter_context},
+    sanitize::{
+        apply_pre_read_header_mutations, apply_request_header_mutations, body_exceeds_limit, ensure_destination_host,
+        response_body_exceeds_limits, sanitize_subrequest_headers, sanitize_subresponse_headers,
+        streaming_transport_limit, strip_reserved_headers, subresponse_from_rejection,
+    },
+    transport::{build_peer, classify_transport_failure, stream_termination_cause},
+};
+pub(crate) use self::{
+    continuation::{FilteredSubrequestContinuation, SubrequestCompletion},
+    sanitize::normalize_response_status,
+    streaming::FilteredStreamingBody,
+};
+use crate::{
+    FilterAction, FilterError, FilterPipeline, StreamTermination, StreamTerminationCause, SubRequest,
+    SubRequestResponseMode, SubResponse, actions::Rejection, context::PendingStreamChunks,
+    extensions::RequestExtensions, results::RetainedFilterResults,
+};
+
+/// Idle timeout applied to a streaming sub-request transport.
+///
+/// The absolute per-step deadline still bounds total duration; this only
+/// caps the gap between upstream chunks so a stalled source is abandoned.
+pub(crate) const STREAMING_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Caller-supplied accounting for retained sub-request state.
+///
+/// The executor enforces a ceiling on caller-owned retained state at every
+/// phase boundary without knowing how that state is represented. Callers
+/// implement this to report, from the live request extensions, whether their
+/// retained footprint currently exceeds the limit.
+pub(crate) trait RetainedStateAccounting {
+    /// Whether the caller-owned retained state currently exceeds its ceiling.
+    fn exceeds_limit(&self, extensions: &RequestExtensions) -> bool;
+}
+
+/// Where a captured sub-response originated.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ResponseOrigin {
+    /// A real upstream produced the response.
+    Upstream,
+    /// A nested filter produced the response locally.
+    Local,
+    /// A transport failure was synthesized into a response.
+    Transport,
+}
+
+/// Transport failure classification used to synthesize a gateway response.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum TransportFailure {
+    /// Admission control timed out before dispatch.
+    AdmissionTimeout,
+    /// The circuit breaker was open.
+    CircuitOpen,
+    /// The connection could not be established.
+    Connect,
+    /// A generic I/O failure occurred.
+    Io,
+    /// The transport deadline was exceeded.
+    DeadlineExceeded,
+    /// The response exceeded the configured size limit.
+    ResponseTooLarge,
+}
+
+/// Owned downstream request attributes needed after the outer hook returns.
+#[derive(Clone)]
+pub(crate) struct SubrequestRuntime {
+    /// Original downstream client address.
+    pub(crate) client_addr: Option<std::net::IpAddr>,
+    /// Whether the original downstream uses TLS.
+    pub(crate) downstream_tls: bool,
+    /// Verified downstream peer identity.
+    pub(crate) peer_identity: Option<Arc<praxis_tls::TlsPeerIdentity>>,
+    /// Start time of the logical client request.
+    pub(crate) request_start: Instant,
+}
+
+/// A captured sub-response together with its origin classification.
+pub(crate) struct SubrequestOutcome {
+    /// The buffered or header-only response.
+    pub(crate) response: SubResponse,
+    /// Where the response came from.
+    pub(crate) origin: ResponseOrigin,
+    /// Transport failure detail, when the response was synthesized.
+    pub(crate) transport_error: Option<TransportFailure>,
+}
+
+/// Transport/body shape selected by the sub-request's filters.
+pub(crate) enum OpenedResponse {
+    /// The complete response was collected and filtered.
+    Complete(SubrequestOutcome),
+    /// Response headers are filtered; body remains pull-based.
+    Streaming {
+        /// Live upstream response body.
+        body: Box<SubResponseBody>,
+        /// Header-time transition metadata.
+        outcome: SubrequestOutcome,
+    },
+}
+
+/// One opened sub-request, including state needed for body/completion processing.
+pub(crate) struct OpenedSubrequest {
+    /// Owned filter lifecycle state.
+    pub(crate) continuation: FilteredSubrequestContinuation,
+    /// Buffered or pull-based response source.
+    pub(crate) kind: OpenedResponse,
+}
+
+/// A sub-request error together with the caller extensions it borrowed.
+pub(crate) struct FilteredSubrequestError {
+    /// Underlying filter or lifecycle error.
+    error: FilterError,
+    /// Caller-owned extensions recovered from the nested filter context.
+    extensions: RequestExtensions,
+}
+
+impl FilteredSubrequestError {
+    /// Build an error before a nested filter context exists.
+    fn new(error: FilterError, extensions: RequestExtensions) -> Self {
+        Self { error, extensions }
+    }
+
+    /// Recover caller-owned extensions from a failed nested context.
+    ///
+    /// Only the executor-owned mechanisms are stripped; caller-injected
+    /// extension types remain for the caller to remove before returning them
+    /// to the parent request context.
+    fn capture(error: FilterError, ctx: &mut crate::HttpFilterContext<'_>) -> Self {
+        ctx.extensions.remove::<PendingStreamChunks>();
+        ctx.extensions.remove::<RetainedFilterResults>();
+        ctx.extensions.remove::<StreamTermination>();
+        Self::new(error, std::mem::take(&mut ctx.extensions))
+    }
+
+    /// Split the error from the extensions its caller must restore.
+    pub(crate) fn into_parts(self) -> (FilterError, RequestExtensions) {
+        (self.error, self.extensions)
+    }
+}
+
+/// Internal result before owned continuation state is captured.
+enum RawResponse {
+    /// Complete buffered or synthetic response.
+    Complete(SubrequestOutcome),
+    /// Local filter rejection.
+    Rejected(Rejection),
+    /// Open pull-based upstream response.
+    Streaming {
+        /// Live upstream response body.
+        body: Box<SubResponseBody>,
+        /// Header-time transition metadata.
+        outcome: SubrequestOutcome,
+    },
+}
+
+/// One sub-request to execute against a named step pipeline.
+pub(crate) struct FilteredSubrequestInput<'a> {
+    /// Pre-built pipeline for this step.
+    pub(crate) pipeline: &'a Arc<FilterPipeline>,
+    /// The sub-request to dispatch.
+    pub(crate) request: &'a SubRequest,
+    /// Human-readable step label for tracing and error messages.
+    pub(crate) label: &'a str,
+    /// Zero-based iteration index for tracing.
+    pub(crate) iteration: u32,
+    /// Absolute overall deadline shared across the logical request.
+    pub(crate) deadline: Instant,
+    /// Caller-provided request extensions, moved into the nested context.
+    pub(crate) extensions: RequestExtensions,
+}
+
+/// Executes exactly one filtered sub-request and returns owned continuation state.
+pub(crate) struct FilteredSubrequestExecutor {
+    /// Caller-supplied retained-state ceiling accounting.
+    accounting: Box<dyn RetainedStateAccounting + Send + Sync>,
+    /// Shared transport client.
+    client: praxis_core::subrequest::SubRequestClient,
+    /// Nested depth forwarded to sub-requests.
+    depth: u8,
+    /// Owned downstream request attributes.
+    downstream: SubrequestRuntime,
+    /// Per-step buffered response ceiling.
+    max_response_bytes: usize,
+    /// Retained-state raw byte ceiling for stream chunk emission.
+    max_state_bytes: usize,
+    /// Per-step duration ceiling.
+    step_timeout: Duration,
+}
+
+impl FilteredSubrequestExecutor {
+    /// Build an executor for one logical filtered-sub-request sequence.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "executor owns explicit subrequest limits and resources"
+    )]
+    pub(crate) fn new(
+        accounting: Box<dyn RetainedStateAccounting + Send + Sync>,
+        client: praxis_core::subrequest::SubRequestClient,
+        depth: u8,
+        downstream: SubrequestRuntime,
+        max_response_bytes: usize,
+        max_state_bytes: usize,
+        step_timeout: Duration,
+    ) -> Self {
+        Self {
+            accounting,
+            client,
+            depth,
+            downstream,
+            max_response_bytes,
+            max_state_bytes,
+            step_timeout,
+        }
+    }
+
+    /// Execute one sub-request under the remaining overall deadline.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "one sub-request owns the complete filter and transport lifecycle"
+    )]
+    #[expect(clippy::large_futures, reason = "step execution spans filter and transport futures")]
+    #[expect(
+        clippy::large_stack_frames,
+        reason = "step execution reconstructs a full filter context"
+    )]
+    pub(crate) async fn execute(
+        &self,
+        input: FilteredSubrequestInput<'_>,
+    ) -> Result<OpenedSubrequest, FilteredSubrequestError> {
+        let FilteredSubrequestInput {
+            pipeline,
+            request: current_request,
+            label,
+            iteration,
+            deadline,
+            mut extensions,
+        } = input;
+
+        let remaining = deadline
+            .checked_duration_since(Instant::now())
+            .unwrap_or(Duration::ZERO);
+        if remaining.is_zero() {
+            return Err(FilteredSubrequestError::new(
+                "iterative_request_router: overall deadline exceeded".to_owned().into(),
+                extensions,
+            ));
+        }
+
+        let mut sub_headers = current_request.headers.clone();
+        strip_reserved_headers(&mut sub_headers);
+        let sub_req = crate::Request {
+            method: current_request.method.clone(),
+            uri: current_request.uri.clone(),
+            headers: sub_headers.clone(),
+        };
+        let mut routed_req = sub_req.clone();
+        let mut response_header = crate::Response {
+            headers: HeaderMap::new(),
+            status: http::StatusCode::OK,
+        };
+        let resources = SubrequestRuntimeResources {
+            client_addr: self.downstream.client_addr,
+            downstream_tls: self.downstream.downstream_tls,
+            health_registry: pipeline.health_registry(),
+            id_generator: pipeline.id_generator(),
+            kv_stores: pipeline.kv_stores(),
+            peer_identity: self.downstream.peer_identity.as_ref(),
+            request_start: self.downstream.request_start,
+            subrequest_client: Some(&self.client),
+            time_source: pipeline.time_source(),
+        };
+        let mut filter_ctx = build_sub_filter_context(pipeline, &sub_req, resources);
+        filter_ctx.extensions = std::mem::take(&mut extensions);
+        filter_ctx.extensions.insert(RetainedFilterResults::default());
+        filter_ctx.enable_stream_chunk_emission(self.max_state_bytes);
+
+        let step_budget = remaining.min(self.step_timeout);
+        let step_started = Instant::now();
+        let step_deadline = step_started.checked_add(step_budget).unwrap_or(deadline);
+        let in_transport = Arc::new(AtomicBool::new(false));
+        let in_transport_inner = Arc::clone(&in_transport);
+
+        let step_span = tracing::info_span!("iterative_subrequest", step = label, iteration = iteration);
+
+        let timed: Result<Result<RawResponse, FilterError>, tokio::time::error::Elapsed> =
+            tokio::time::timeout(step_budget, async {
+            let mut request_body = Some(current_request.body.clone());
+            if body_exceeds_limit(
+                pipeline.body_capabilities().request_body_mode,
+                request_body.as_ref().map_or(0, Bytes::len),
+            ) {
+                return Ok(RawResponse::Rejected(Rejection::status(413)));
+            }
+
+            let pre_read_body = matches!(
+                pipeline.body_capabilities().request_body_mode,
+                crate::BodyMode::StreamBuffer { .. }
+            );
+            if pre_read_body {
+                let action = pipeline
+                    .execute_http_request_body(&mut filter_ctx, &mut request_body, true)
+                    .await?;
+                if let FilterAction::Reject(rejection) = action {
+                    return Ok(RawResponse::Rejected(rejection));
+                }
+                if self.accounting.exceeds_limit(&filter_ctx.extensions) {
+                    return Ok(RawResponse::Rejected(Rejection::status(413)));
+                }
+                apply_pre_read_header_mutations(&mut routed_req.headers, &filter_ctx);
+                filter_ctx.extra_request_headers.clear();
+                filter_ctx.request_headers_to_remove.clear();
+                filter_ctx.request_headers_to_set.clear();
+                filter_ctx.pre_read_mutations.clear();
+                sub_headers.clone_from(&routed_req.headers);
+                filter_ctx.request = &routed_req;
+            }
+
+            let action = pipeline.execute_http_request(&mut filter_ctx).await?;
+            if let FilterAction::Reject(rejection) = action {
+                return Ok(RawResponse::Rejected(rejection));
+            }
+            if self.accounting.exceeds_limit(&filter_ctx.extensions) {
+                return Ok(RawResponse::Rejected(Rejection::status(413)));
+            }
+            if !pre_read_body {
+                let action = pipeline
+                    .execute_http_request_body(&mut filter_ctx, &mut request_body, true)
+                    .await?;
+                if let FilterAction::Reject(rejection) = action {
+                    return Ok(RawResponse::Rejected(rejection));
+                }
+                if self.accounting.exceeds_limit(&filter_ctx.extensions) {
+                    return Ok(RawResponse::Rejected(Rejection::status(413)));
+                }
+            }
+
+            let upstream = filter_ctx.upstream.as_ref().ok_or_else(|| -> FilterError {
+                format!("iterative_request_router: step '{label}' did not resolve an upstream").into()
+            })?;
+            in_transport_inner.store(true, Ordering::Release);
+            let peer = build_peer(upstream).await;
+            apply_request_header_mutations(&mut sub_headers, &filter_ctx);
+            ensure_destination_host(&mut sub_headers, &upstream.address)?;
+            sanitize_subrequest_headers(&mut sub_headers);
+            let request = SubRequest {
+                method: current_request.method.clone(),
+                uri: filter_ctx.rewritten_path.as_ref().map_or_else(
+                    || current_request.uri.clone(),
+                    |path| http::Uri::try_from(path.as_str()).unwrap_or_else(|_| current_request.uri.clone()),
+                ),
+                headers: sub_headers,
+                body: request_body.unwrap_or_default(),
+            };
+            let mut framework_headers = FrameworkHeaders::new();
+            framework_headers.set_depth(self.depth + 1);
+            let transport_budget = step_budget
+                .checked_sub(step_started.elapsed())
+                .unwrap_or(Duration::ZERO);
+            if transport_budget.is_zero() {
+                return Ok(RawResponse::Rejected(Rejection::status(504)));
+            }
+
+            match filter_ctx.subrequest_response_mode {
+                SubRequestResponseMode::Streaming => {
+                    if matches!(
+                        pipeline.body_capabilities().response_body_mode,
+                        crate::BodyMode::StreamBuffer { .. }
+                    ) {
+                        return Err(format!(
+                            "iterative_request_router: step '{label}' selected streaming with StreamBuffer response mode"
+                        )
+                        .into());
+                    }
+                    let limits = StreamLimits {
+                        idle_timeout: STREAMING_IDLE_TIMEOUT,
+                        // FilteredStreamingBody enforces the original absolute step
+                        // deadline so header time cannot be granted twice.
+                        max_stream_duration: None,
+                        max_total_bytes: streaming_transport_limit(
+                            pipeline.body_capabilities().response_body_mode,
+                        ),
+                    };
+                    let response = match peer {
+                        Ok(peer) => self
+                            .client
+                            .send_streaming(&peer, &request, transport_budget, limits, Some(&framework_headers))
+                            .await,
+                        Err(error) => Err(praxis_core::subrequest::SubRequestError::Connect(error.to_string())),
+                    };
+                    in_transport_inner.store(false, Ordering::Release);
+                    match response {
+                        Ok(response) => {
+                            let status = response.status;
+                            let mut headers = response.headers;
+                            sanitize_subresponse_headers(&mut headers);
+                            response_header.status = http::StatusCode::from_u16(status)
+                                .map_err(|error| -> FilterError { format!("invalid upstream status: {error}").into() })?;
+                            response_header.headers.clone_from(&headers);
+                            filter_ctx.response_header = Some(&mut response_header);
+                            let response_action = pipeline.execute_http_response(&mut filter_ctx).await?;
+                            if let FilterAction::Reject(rejection) = response_action {
+                                response.body.cancel().await;
+                                return Ok(RawResponse::Rejected(rejection));
+                            }
+                            if self.accounting.exceeds_limit(&filter_ctx.extensions) {
+                                response.body.cancel().await;
+                                return Ok(RawResponse::Rejected(Rejection::status(413)));
+                            }
+                            let metadata = filter_ctx.response_header.as_deref().ok_or_else(|| -> FilterError {
+                                "iterative_request_router: response metadata missing after header filters"
+                                    .to_owned()
+                                    .into()
+                            })?;
+                            let status = metadata.status;
+                            let mut headers = metadata.headers.clone();
+                            sanitize_subresponse_headers(&mut headers);
+                            Ok(RawResponse::Streaming {
+                                body: Box::new(response.body),
+                                outcome: SubrequestOutcome {
+                                    response: SubResponse { status: status.as_u16(), headers, body: Bytes::new() },
+                                    origin: ResponseOrigin::Upstream,
+                                    transport_error: None,
+                                },
+                            })
+                        },
+                        Err(error) => {
+                            let (status, kind) = classify_transport_failure(&error);
+                            warn!(step = label, %error, status, "IRR streaming transport failure");
+                            let response = SubResponse { status, headers: HeaderMap::new(), body: Bytes::new() };
+                            response_header.status = http::StatusCode::from_u16(status)
+                                .map_err(|source| -> FilterError { source.into() })?;
+                            filter_ctx.response_header = Some(&mut response_header);
+                            let response_action = pipeline.execute_http_response(&mut filter_ctx).await?;
+                            if let FilterAction::Reject(rejection) = response_action {
+                                return Ok(RawResponse::Rejected(rejection));
+                            }
+                            if self.accounting.exceeds_limit(&filter_ctx.extensions) {
+                                return Ok(RawResponse::Rejected(Rejection::status(413)));
+                            }
+                            let metadata = filter_ctx.response_header.as_deref().ok_or_else(|| -> FilterError {
+                                "iterative_request_router: response metadata missing after header filters"
+                                    .to_owned()
+                                    .into()
+                            })?;
+                            let mut headers = metadata.headers.clone();
+                            sanitize_subresponse_headers(&mut headers);
+                            Ok(RawResponse::Complete(SubrequestOutcome {
+                                response: SubResponse {
+                                    status: metadata.status.as_u16(),
+                                    headers,
+                                    body: response.body,
+                                },
+                                origin: ResponseOrigin::Transport,
+                                transport_error: Some(kind),
+                            }))
+                        },
+                    }
+                },
+                SubRequestResponseMode::Buffered => {
+                    let (mut response, origin, transport_error) = match peer {
+                        Ok(peer) => match self
+                            .client
+                            .execute(&peer, &request, self.max_response_bytes, transport_budget, Some(&framework_headers))
+                            .await
+                        {
+                            Ok(response) => (response, ResponseOrigin::Upstream, None),
+                            Err(error) => {
+                                let (status, kind) = classify_transport_failure(&error);
+                                warn!(step = label, %error, status, "IRR buffered transport failure");
+                                (
+                                    SubResponse { status, headers: HeaderMap::new(), body: Bytes::new() },
+                                    ResponseOrigin::Transport,
+                                    Some(kind),
+                                )
+                            },
+                        },
+                        Err(error) => {
+                            warn!(step = label, %error, status = 502_u16, "IRR buffered transport failure");
+                            (
+                                SubResponse { status: 502, headers: HeaderMap::new(), body: Bytes::new() },
+                                ResponseOrigin::Transport,
+                                Some(TransportFailure::Connect),
+                            )
+                        },
+                    };
+                    in_transport_inner.store(false, Ordering::Release);
+                    sanitize_subresponse_headers(&mut response.headers);
+                    response_header.status = http::StatusCode::from_u16(response.status)
+                        .map_err(|error| -> FilterError { error.into() })?;
+                    response_header.headers.clone_from(&response.headers);
+                    filter_ctx.response_header = Some(&mut response_header);
+                    let response_action = pipeline.execute_http_response(&mut filter_ctx).await?;
+                    if let FilterAction::Reject(rejection) = response_action {
+                        return Ok(RawResponse::Rejected(rejection));
+                    }
+                    if self.accounting.exceeds_limit(&filter_ctx.extensions) {
+                        return Ok(RawResponse::Rejected(Rejection::status(413)));
+                    }
+                    let mut body = Some(std::mem::take(&mut response.body));
+                    if response_body_exceeds_limits(
+                        pipeline.body_capabilities().response_body_mode,
+                        self.max_response_bytes,
+                        body.as_ref().map_or(0, Bytes::len),
+                    ) {
+                        return Err("iterative_request_router: step response exceeds configured body limit".into());
+                    }
+                    let body_action = pipeline.execute_http_response_body(&mut filter_ctx, &mut body, true)?;
+                    if let FilterAction::Reject(rejection) = body_action {
+                        return Ok(RawResponse::Rejected(rejection));
+                    }
+                    if self.accounting.exceeds_limit(&filter_ctx.extensions) {
+                        return Ok(RawResponse::Rejected(Rejection::status(413)));
+                    }
+                    if response_body_exceeds_limits(
+                        pipeline.body_capabilities().response_body_mode,
+                        self.max_response_bytes,
+                        body.as_ref().map_or(0, Bytes::len),
+                    ) {
+                        return Err(
+                            "iterative_request_router: transformed step response exceeds configured body limit"
+                                .into(),
+                        );
+                    }
+                    response.body = body.unwrap_or_default();
+                    if let Some(metadata) = filter_ctx.response_header.as_deref() {
+                        response.status = metadata.status.as_u16();
+                        response.headers.clone_from(&metadata.headers);
+                    }
+                    sanitize_subresponse_headers(&mut response.headers);
+                    Ok(RawResponse::Complete(SubrequestOutcome { response, origin, transport_error }))
+                },
+            }
+            }
+            .instrument(step_span))
+            .await;
+
+        let mut raw = match timed {
+            Ok(Ok(raw)) => raw,
+            Ok(Err(error)) => return Err(FilteredSubrequestError::capture(error, &mut filter_ctx)),
+            Err(_) if in_transport.load(Ordering::Acquire) => RawResponse::Complete(SubrequestOutcome {
+                response: SubResponse {
+                    status: 504,
+                    headers: HeaderMap::new(),
+                    body: Bytes::new(),
+                },
+                origin: ResponseOrigin::Transport,
+                transport_error: Some(TransportFailure::DeadlineExceeded),
+            }),
+            Err(_) => RawResponse::Rejected(Rejection::status(504)),
+        };
+
+        filter_ctx.response_header = None;
+        if filter_ctx.subrequest_response_mode == SubRequestResponseMode::Streaming
+            && let RawResponse::Complete(outcome) = &mut raw
+            && outcome.origin == ResponseOrigin::Transport
+        {
+            let cause = outcome
+                .transport_error
+                .map_or(StreamTerminationCause::Io, stream_termination_cause);
+            filter_ctx.extensions.insert(StreamTermination::new(cause));
+            let response_snapshot = crate::Response {
+                status: http::StatusCode::from_u16(outcome.response.status).unwrap_or(http::StatusCode::BAD_GATEWAY),
+                headers: outcome.response.headers.clone(),
+            };
+            let mut completion_body = None;
+            let completion_action = pipeline
+                .execute_http_response_body_with_response_header(
+                    &mut filter_ctx,
+                    &mut completion_body,
+                    true,
+                    Some(&response_snapshot),
+                )
+                .map_err(|error| FilteredSubrequestError::capture(error, &mut filter_ctx))?;
+            if let FilterAction::Reject(_) = completion_action {
+                let error = "iterative_request_router: step completion filter rejected an abnormal stream"
+                    .to_owned()
+                    .into();
+                return Err(FilteredSubrequestError::capture(error, &mut filter_ctx));
+            }
+            if self.accounting.exceeds_limit(&filter_ctx.extensions) {
+                let error = "iterative_request_router: retained state limit exceeded during stream completion"
+                    .to_owned()
+                    .into();
+                return Err(FilteredSubrequestError::capture(error, &mut filter_ctx));
+            }
+            if completion_body
+                .as_ref()
+                .is_some_and(|body| body.len() > self.max_response_bytes)
+            {
+                let error = "iterative_request_router: abnormal completion exceeds response body limit"
+                    .to_owned()
+                    .into();
+                return Err(FilteredSubrequestError::capture(error, &mut filter_ctx));
+            }
+            outcome.response.body = completion_body.unwrap_or_default();
+        }
+        let (kind, response_snapshot, completed) = match raw {
+            RawResponse::Complete(outcome) => {
+                let snapshot = crate::Response {
+                    status: http::StatusCode::from_u16(outcome.response.status)
+                        .unwrap_or(http::StatusCode::BAD_GATEWAY),
+                    headers: outcome.response.headers.clone(),
+                };
+                (OpenedResponse::Complete(outcome), snapshot, true)
+            },
+            RawResponse::Rejected(rejection) => {
+                let response = subresponse_from_rejection(rejection);
+                let snapshot = crate::Response {
+                    status: http::StatusCode::from_u16(response.status).unwrap_or(http::StatusCode::BAD_GATEWAY),
+                    headers: response.headers.clone(),
+                };
+                (
+                    OpenedResponse::Complete(SubrequestOutcome {
+                        response,
+                        origin: ResponseOrigin::Local,
+                        transport_error: None,
+                    }),
+                    snapshot,
+                    true,
+                )
+            },
+            RawResponse::Streaming { body, outcome } => {
+                let snapshot = crate::Response {
+                    status: http::StatusCode::from_u16(outcome.response.status)
+                        .unwrap_or(http::StatusCode::BAD_GATEWAY),
+                    headers: outcome.response.headers.clone(),
+                };
+                (OpenedResponse::Streaming { body, outcome }, snapshot, false)
+            },
+        };
+        let request_snapshot = crate::Request {
+            method: filter_ctx.request.method.clone(),
+            uri: filter_ctx.request.uri.clone(),
+            headers: filter_ctx.request.headers.clone(),
+        };
+        let continuation = FilteredSubrequestContinuation::capture(
+            Arc::clone(pipeline),
+            request_snapshot,
+            response_snapshot,
+            &mut filter_ctx,
+            completed,
+            step_deadline,
+        );
+        Ok(OpenedSubrequest { continuation, kind })
+    }
+}

--- a/crates/filter/src/filtered_subrequest/mod.rs
+++ b/crates/filter/src/filtered_subrequest/mod.rs
@@ -297,7 +297,7 @@ impl FilteredSubrequestExecutor {
             .unwrap_or(Duration::ZERO);
         if remaining.is_zero() {
             return Err(FilteredSubrequestError::new(
-                "iterative_request_router: overall deadline exceeded".to_owned().into(),
+                "filtered_subrequest: overall deadline exceeded".to_owned().into(),
                 extensions,
             ));
         }
@@ -391,7 +391,7 @@ impl FilteredSubrequestExecutor {
             }
 
             let upstream = filter_ctx.upstream.as_ref().ok_or_else(|| -> FilterError {
-                format!("iterative_request_router: step '{label}' did not resolve an upstream").into()
+                format!("filtered_subrequest: step '{label}' did not resolve an upstream").into()
             })?;
             in_transport_inner.store(true, Ordering::Release);
             let peer = build_peer(upstream).await;
@@ -423,7 +423,7 @@ impl FilteredSubrequestExecutor {
                         crate::BodyMode::StreamBuffer { .. }
                     ) {
                         return Err(format!(
-                            "iterative_request_router: step '{label}' selected streaming with StreamBuffer response mode"
+                            "filtered_subrequest: step '{label}' selected streaming despite a StreamBuffer response mode"
                         )
                         .into());
                     }
@@ -463,7 +463,7 @@ impl FilteredSubrequestExecutor {
                                 return Ok(RawResponse::Rejected(Rejection::status(413)));
                             }
                             let metadata = filter_ctx.response_header.as_deref().ok_or_else(|| -> FilterError {
-                                "iterative_request_router: response metadata missing after header filters"
+                                "filtered_subrequest: response metadata missing after header filters"
                                     .to_owned()
                                     .into()
                             })?;
@@ -494,7 +494,7 @@ impl FilteredSubrequestExecutor {
                                 return Ok(RawResponse::Rejected(Rejection::status(413)));
                             }
                             let metadata = filter_ctx.response_header.as_deref().ok_or_else(|| -> FilterError {
-                                "iterative_request_router: response metadata missing after header filters"
+                                "filtered_subrequest: response metadata missing after header filters"
                                     .to_owned()
                                     .into()
                             })?;
@@ -558,7 +558,7 @@ impl FilteredSubrequestExecutor {
                         self.max_response_bytes,
                         body.as_ref().map_or(0, Bytes::len),
                     ) {
-                        return Err("iterative_request_router: step response exceeds configured body limit".into());
+                        return Err("filtered_subrequest: step response exceeds configured body limit".into());
                     }
                     let body_action = pipeline.execute_http_response_body(&mut filter_ctx, &mut body, true)?;
                     if let FilterAction::Reject(rejection) = body_action {
@@ -573,7 +573,7 @@ impl FilteredSubrequestExecutor {
                         body.as_ref().map_or(0, Bytes::len),
                     ) {
                         return Err(
-                            "iterative_request_router: transformed step response exceeds configured body limit"
+                            "filtered_subrequest: transformed step response exceeds configured body limit"
                                 .into(),
                         );
                     }
@@ -628,13 +628,13 @@ impl FilteredSubrequestExecutor {
                 )
                 .map_err(|error| FilteredSubrequestError::capture(error, &mut filter_ctx))?;
             if let FilterAction::Reject(_) = completion_action {
-                let error = "iterative_request_router: step completion filter rejected an abnormal stream"
+                let error = "filtered_subrequest: step completion filter rejected an abnormal stream"
                     .to_owned()
                     .into();
                 return Err(FilteredSubrequestError::capture(error, &mut filter_ctx));
             }
             if self.accounting.exceeds_limit(&filter_ctx.extensions) {
-                let error = "iterative_request_router: retained state limit exceeded during stream completion"
+                let error = "filtered_subrequest: retained state limit exceeded during stream completion"
                     .to_owned()
                     .into();
                 return Err(FilteredSubrequestError::capture(error, &mut filter_ctx));
@@ -643,7 +643,7 @@ impl FilteredSubrequestExecutor {
                 .as_ref()
                 .is_some_and(|body| body.len() > self.max_response_bytes)
             {
-                let error = "iterative_request_router: abnormal completion exceeds response body limit"
+                let error = "filtered_subrequest: abnormal completion exceeds response body limit"
                     .to_owned()
                     .into();
                 return Err(FilteredSubrequestError::capture(error, &mut filter_ctx));

--- a/crates/filter/src/filtered_subrequest/sanitize.rs
+++ b/crates/filter/src/filtered_subrequest/sanitize.rs
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Praxis Contributors
+
+//! Header and body forwarding-boundary helpers for filtered sub-requests.
+//!
+//! These enforce the same hop-by-hop, reserved-header, and message-framing
+//! boundary as the normal upstream path, and translate filter rejections
+//! into transition-visible responses.
+
+use http::HeaderMap;
+
+use crate::{FilterError, HttpFilterContext, SubResponse, actions::Rejection};
+
+/// Headers that apply only to one HTTP connection and must not cross it.
+const REQUEST_HOP_BY_HOP: &[&str] = &[
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailer",
+    "transfer-encoding",
+    "upgrade",
+];
+
+/// Response-side hop-by-hop headers.
+const RESPONSE_HOP_BY_HOP: &[&str] = &[
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "te",
+    "trailer",
+    "transfer-encoding",
+    "upgrade",
+];
+
+/// Strip all reserved internal headers from sub-request headers
+/// so the core executor re-injects depth via
+/// [`FrameworkHeaders`](praxis_core::subrequest::FrameworkHeaders).
+///
+/// The depth header uses a reserved `x-praxis-*` prefix, so it
+/// is covered by the [`is_reserved`] check.
+///
+/// [`is_reserved`]: praxis_core::reserved_headers::is_reserved
+pub(crate) fn strip_reserved_headers(headers: &mut HeaderMap) {
+    let to_remove: Vec<http::header::HeaderName> = headers
+        .keys()
+        .filter(|name| praxis_core::reserved_headers::is_reserved(name.as_str()))
+        .cloned()
+        .collect();
+    for name in to_remove {
+        headers.remove(&name);
+    }
+}
+
+/// Apply request mutations emitted across the header and body filter
+/// phases before dispatching the upstream request.
+pub(super) fn apply_request_header_mutations(headers: &mut HeaderMap, ctx: &HttpFilterContext<'_>) {
+    for name in &ctx.request_headers_to_remove {
+        headers.remove(name);
+    }
+    for (name, value) in &ctx.request_headers_to_set {
+        headers.insert(name.clone(), value.clone());
+    }
+    for (name, value) in &ctx.extra_request_headers {
+        if let (Ok(name), Ok(value)) = (
+            http::header::HeaderName::from_bytes(name.as_bytes()),
+            http::HeaderValue::from_str(value),
+        ) {
+            headers.insert(name, value);
+        }
+    }
+}
+
+/// Apply body pre-read mutations to the request snapshot that header
+/// filters use for classification and routing.
+pub(super) fn apply_pre_read_header_mutations(headers: &mut HeaderMap, ctx: &HttpFilterContext<'_>) {
+    if ctx.pre_read_mutations.is_empty() {
+        apply_request_header_mutations(headers, ctx);
+        return;
+    }
+
+    for mutation in &ctx.pre_read_mutations {
+        match mutation {
+            crate::TrustedHeaderMutation::Remove(name) => {
+                headers.remove(name);
+            },
+            crate::TrustedHeaderMutation::Set(name, value) => {
+                headers.insert(name.clone(), value.clone());
+            },
+            crate::TrustedHeaderMutation::Add(name, value) => {
+                if let Ok(value) = http::HeaderValue::from_str(value) {
+                    headers.append(name.clone(), value);
+                }
+            },
+        }
+    }
+}
+
+/// Remove inbound message-framing headers after request-body filters
+/// have potentially changed the payload. The subrequest executor adds
+/// the correct `Content-Length` for non-empty bodies.
+pub(super) fn strip_request_framing_headers(headers: &mut HeaderMap) {
+    headers.remove(http::header::CONTENT_LENGTH);
+    headers.remove(http::header::TRANSFER_ENCODING);
+}
+
+/// Apply the same forwarding boundary as the normal upstream path.
+pub(super) fn sanitize_subrequest_headers(headers: &mut HeaderMap) {
+    strip_hop_by_hop_headers(headers, REQUEST_HOP_BY_HOP);
+    strip_reserved_headers(headers);
+    strip_request_framing_headers(headers);
+}
+
+/// Supply the selected upstream authority without carrying a prior step's Host.
+pub(super) fn ensure_destination_host(headers: &mut HeaderMap, address: &str) -> Result<(), FilterError> {
+    if !headers.contains_key(http::header::HOST) {
+        let value = http::HeaderValue::from_str(address).map_err(|error| -> FilterError {
+            format!("iterative_request_router: invalid upstream Host: {error}").into()
+        })?;
+        headers.insert(http::header::HOST, value);
+    }
+    Ok(())
+}
+
+/// Remove connection-scoped and proxy-internal response metadata.
+pub(super) fn sanitize_subresponse_headers(headers: &mut HeaderMap) {
+    strip_hop_by_hop_headers(headers, RESPONSE_HOP_BY_HOP);
+    strip_reserved_headers(headers);
+}
+
+/// Remove the static hop-by-hop set and headers named by `Connection`.
+fn strip_hop_by_hop_headers(headers: &mut HeaderMap, static_headers: &[&str]) {
+    let connection_values: Vec<_> = headers.get_all(http::header::CONNECTION).iter().cloned().collect();
+    for name in static_headers {
+        headers.remove(*name);
+    }
+    for value in connection_values {
+        let Ok(value) = value.to_str() else { continue };
+        for token in value.split(',').map(str::trim).filter(|token| !token.is_empty()) {
+            headers.remove(token);
+        }
+    }
+}
+
+/// Whether a fully buffered nested body exceeds its pipeline mode's
+/// configured ceiling.
+pub(super) fn body_exceeds_limit(mode: crate::body::BodyMode, body_len: usize) -> bool {
+    match mode {
+        crate::body::BodyMode::SizeLimit { max_bytes }
+        | crate::body::BodyMode::StreamBuffer {
+            max_bytes: Some(max_bytes),
+        } => body_len > max_bytes,
+        crate::body::BodyMode::Stream | crate::body::BodyMode::StreamBuffer { max_bytes: None } => false,
+    }
+}
+
+/// Whether a response exceeds either the executor's global per-step ceiling
+/// or the nested pipeline's body-mode ceiling.
+pub(super) fn response_body_exceeds_limits(
+    mode: crate::body::BodyMode,
+    max_response_bytes: usize,
+    body_len: usize,
+) -> bool {
+    body_len > max_response_bytes || body_exceeds_limit(mode, body_len)
+}
+
+/// Extract only the listener-level streaming ceiling from a nested pipeline.
+///
+/// The executor's buffered `max_response_bytes` setting is intentionally
+/// buffered-only. A nested `SizeLimit` is produced by listener body-limit
+/// propagation and must still constrain the live transport.
+pub(super) fn streaming_transport_limit(mode: crate::body::BodyMode) -> Option<usize> {
+    match mode {
+        crate::body::BodyMode::SizeLimit { max_bytes } => Some(max_bytes),
+        crate::body::BodyMode::Stream | crate::body::BodyMode::StreamBuffer { .. } => None,
+    }
+}
+
+/// Keep final locally generated statuses inside the terminal response range.
+/// Informational, invalid upstream, or invalid custom-filter values become 502.
+pub(crate) fn normalize_response_status(status: u16) -> u16 {
+    if (200..=599).contains(&status) { status } else { 502 }
+}
+
+/// Convert a nested filter's local response into transition input.
+pub(crate) fn subresponse_from_rejection(rejection: Rejection) -> SubResponse {
+    let status = normalize_response_status(rejection.status);
+    let mut headers = HeaderMap::new();
+    for (name, value) in rejection.headers {
+        let Ok(name) = http::HeaderName::try_from(name) else {
+            continue;
+        };
+        let Ok(value) = http::HeaderValue::try_from(value) else {
+            continue;
+        };
+        headers.append(name, value);
+    }
+    if let Some(header_map) = rejection.header_map {
+        for (name, value) in header_map.iter() {
+            headers.append(name.clone(), value.clone());
+        }
+    }
+    let mut response = SubResponse {
+        status,
+        headers,
+        body: rejection.body.unwrap_or_default(),
+    };
+    sanitize_subresponse_headers(&mut response.headers);
+    response
+}

--- a/crates/filter/src/filtered_subrequest/streaming.rs
+++ b/crates/filter/src/filtered_subrequest/streaming.rs
@@ -1,0 +1,303 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Praxis Contributors
+
+//! Pull-based streaming body for a filtered sub-request's response.
+//!
+//! Pulls upstream chunks through the sub-request pipeline's response-body
+//! filters, accumulates state in the owned [`FilteredSubrequestContinuation`],
+//! and runs the completion lifecycle exactly once after upstream EOF.
+
+use std::collections::{HashMap, VecDeque};
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use praxis_core::subrequest::SubResponseBody;
+use tracing::warn;
+
+use super::{continuation::FilteredSubrequestContinuation, transport::termination_cause};
+use crate::{
+    FilterError, StreamTermination, StreamTerminationCause, actions::StreamingResponseBody,
+    context::PendingStreamChunks, extensions::RequestExtensions,
+};
+
+/// Streaming body implementation for a filtered sub-request's response.
+///
+/// The `upstream` field is `Option<SubResponseBody>` because
+/// `SubResponseBody::cancel()` consumes `self`. Standard Rust
+/// pattern: `.take()` to move it out for cancellation.
+pub(crate) struct FilteredStreamingBody {
+    /// Upstream streaming body handle. `None` after cancellation.
+    upstream: Option<Box<SubResponseBody>>,
+    /// Owned state for running the sub-request's response-body filters.
+    continuation: FilteredSubrequestContinuation,
+    /// Whether the stream has finished (EOF or error).
+    finished: bool,
+    /// Completion-hook body output held until the caller selects a transition.
+    deferred_completion_output: Option<Bytes>,
+    /// Per-callback local output waiting to be pulled downstream.
+    pending_chunks: VecDeque<Bytes>,
+}
+
+impl FilteredStreamingBody {
+    /// Create a new streaming body for a sub-request's response.
+    pub(crate) fn new(upstream: Box<SubResponseBody>, continuation: FilteredSubrequestContinuation) -> Self {
+        Self {
+            upstream: Some(upstream),
+            continuation,
+            finished: false,
+            deferred_completion_output: None,
+            pending_chunks: VecDeque::new(),
+        }
+    }
+
+    /// Consume the body wrapper after EOF and recover its owned step state.
+    pub(crate) fn into_continuation(self) -> FilteredSubrequestContinuation {
+        self.continuation
+    }
+
+    /// Consume a finished body into its continuation and deferred output.
+    pub(crate) fn into_finished_parts(self) -> (FilteredSubrequestContinuation, Option<Bytes>) {
+        (self.continuation, self.deferred_completion_output)
+    }
+
+    /// Exchange extensions with the outer protocol lifecycle.
+    fn exchange_extensions(&mut self, extensions: &mut RequestExtensions) {
+        std::mem::swap(&mut self.continuation.extensions, extensions);
+    }
+
+    /// Run the sub-request's response-body filters on a single chunk.
+    ///
+    /// Reconstructs a temporary `HttpFilterContext` from the
+    /// continuation's owned state, runs the pipeline's body
+    /// execution, then writes state changes back to the
+    /// continuation for the next chunk.
+    #[expect(clippy::too_many_lines, reason = "context reconstruction requires many fields")]
+    fn run_step_body_filters(&mut self, body: &mut Option<Bytes>, end_of_stream: bool) -> Result<(), FilterError> {
+        let cont = &mut self.continuation;
+        let mut ctx = crate::filter::HttpFilterContext {
+            buffered_request_body: None,
+            body_done_indices: std::mem::take(&mut cont.body_done_indices),
+            branch_iterations: HashMap::new(),
+            client_addr: cont.client_addr,
+            cluster: None,
+            current_filter_id: None,
+            downstream_tls: cont.downstream_tls,
+            extensions: std::mem::take(&mut cont.extensions),
+            executed_filter_indices: std::mem::take(&mut cont.executed_filter_indices),
+            extra_request_headers: Vec::new(),
+            filter_metadata: std::mem::take(&mut cont.filter_metadata),
+            filter_results: std::mem::take(&mut cont.filter_results),
+            filter_state: std::mem::take(&mut cont.filter_state),
+            health_registry: cont.pipeline.health_registry(),
+            id_generator: cont.pipeline.id_generator(),
+            kv_stores: cont.pipeline.kv_stores(),
+            metrics_route: None,
+            peer_identity: cont.peer_identity.clone(),
+            prior_pre_read_mutations: Vec::new(),
+            pre_read_mutations: Vec::new(),
+            request: &cont.request_snapshot,
+            request_body_bytes: 0,
+            request_body_mode: cont.pipeline.body_capabilities().request_body_mode,
+            request_headers_to_remove: Vec::new(),
+            request_headers_to_set: Vec::new(),
+            request_start: cont.request_start,
+            response_body_bytes: cont.response_body_bytes,
+            response_body_mode: cont.response_body_mode,
+            response_header: None,
+            response_headers_modified: false,
+            rewritten_path: None,
+            selected_endpoint_index: None,
+            attempted_endpoints: Vec::new(),
+            retry_policy: None,
+            route_retry_policy: None,
+            cluster_retry_state: None,
+            cluster_retry_state_released: false,
+            endpoint_reselector: None,
+            pinned_endpoint_address: None,
+            session_stores: None,
+            structured_metadata: std::mem::take(&mut cont.structured_metadata),
+            subrequest_client: cont.pipeline.subrequest_client(),
+            subrequest_response_mode: crate::context::SubRequestResponseMode::Streaming,
+            time_source: cont.pipeline.time_source(),
+            upstream: None,
+        };
+
+        let result = cont.pipeline.execute_http_response_body_with_response_header(
+            &mut ctx,
+            body,
+            end_of_stream,
+            Some(&cont.response_snapshot),
+        );
+
+        cont.body_done_indices = ctx.body_done_indices;
+        cont.executed_filter_indices = ctx.executed_filter_indices;
+        cont.extensions = ctx.extensions;
+        cont.filter_metadata = ctx.filter_metadata;
+        cont.filter_results = ctx.filter_results;
+        cont.filter_state = ctx.filter_state;
+        cont.response_body_bytes = ctx.response_body_bytes;
+        cont.structured_metadata = ctx.structured_metadata;
+
+        match result? {
+            crate::actions::FilterAction::Reject(_) => {
+                Err("iterative_request_router: step body filter rejected during stream"
+                    .to_owned()
+                    .into())
+            },
+            _ => Ok(()),
+        }
+    }
+
+    /// Run the sub-request's completion lifecycle exactly once.
+    ///
+    /// Called after upstream EOF. Runs body filters with
+    /// `end_of_stream: true` to let them emit any buffered
+    /// completion chunk (e.g. a closing SSE comment or JSON
+    /// array bracket).
+    fn complete_step(&mut self) -> Result<Option<Bytes>, FilterError> {
+        if self.continuation.completed {
+            return Ok(None);
+        }
+        self.continuation.completed = true;
+        let mut body: Option<Bytes> = None;
+        self.run_step_body_filters(&mut body, true)?;
+        Ok(body)
+    }
+
+    /// Handle a chunk received from the upstream.
+    fn handle_upstream_chunk(&mut self, chunk: Bytes) -> Result<Option<Bytes>, FilterError> {
+        let mut body = Some(chunk);
+        self.run_step_body_filters(&mut body, false)?;
+        let emitted = self
+            .continuation
+            .extensions
+            .get_mut::<PendingStreamChunks>()
+            .map_or_else(VecDeque::new, PendingStreamChunks::drain_chunks);
+        self.pending_chunks.extend(emitted);
+        self.pending_chunks.extend(body.filter(|bytes| !bytes.is_empty()));
+        Ok(self.pending_chunks.pop_front())
+    }
+
+    /// Complete the step after a response-body filter failure.
+    async fn handle_filter_error(&mut self, error: FilterError) -> Result<Option<Bytes>, FilterError> {
+        warn!("iterative_request_router: response body filter failed: {error}");
+        if let Some(upstream_body) = self.upstream.take() {
+            (*upstream_body).cancel().await;
+        }
+        self.continuation
+            .extensions
+            .insert(StreamTermination::new(StreamTerminationCause::Filter));
+        let completion = self.complete_step().map_err(|completion_error| -> FilterError {
+            format!(
+                "iterative_request_router: response filter failed ({error}); completion also failed ({completion_error})"
+            )
+            .into()
+        })?;
+        self.finished = true;
+        self.deferred_completion_output = self.handled_completion_output(completion);
+        Ok(None)
+    }
+
+    /// Handle upstream EOF.
+    fn handle_upstream_eof(&mut self) -> Result<Option<Bytes>, FilterError> {
+        let completion = self.complete_step()?;
+        self.finished = true;
+        self.deferred_completion_output = completion.filter(|bytes| !bytes.is_empty());
+        Ok(None)
+    }
+
+    /// Handle an upstream error.
+    async fn handle_upstream_error(
+        &mut self,
+        e: praxis_core::subrequest::SubRequestError,
+    ) -> Result<Option<Bytes>, FilterError> {
+        if let Some(upstream_body) = self.upstream.take() {
+            (*upstream_body).cancel().await;
+        }
+        self.continuation
+            .extensions
+            .insert(StreamTermination::new(termination_cause(&e)));
+        let completion = self.complete_step()?;
+        self.finished = true;
+        self.deferred_completion_output = self.handled_completion_output(completion);
+        Ok(None)
+    }
+
+    /// Expose an abnormal completion body only when a filter explicitly
+    /// converted the failure into a valid terminal sequence.
+    fn handled_completion_output(&self, completion: Option<Bytes>) -> Option<Bytes> {
+        self.continuation
+            .extensions
+            .get::<StreamTermination>()
+            .is_some_and(StreamTermination::is_handled)
+            .then_some(completion)
+            .flatten()
+            .filter(|bytes| !bytes.is_empty())
+    }
+}
+
+#[async_trait]
+impl StreamingResponseBody for FilteredStreamingBody {
+    #[expect(clippy::too_many_lines, reason = "pull loop applies deadlines and completion state")]
+    async fn next_chunk(&mut self) -> Result<Option<Bytes>, FilterError> {
+        if let Some(chunk) = self.pending_chunks.pop_front() {
+            return Ok(Some(chunk));
+        }
+        if self.finished {
+            return Ok(None);
+        }
+
+        loop {
+            let upstream = self.upstream.as_mut().ok_or_else(|| -> FilterError {
+                "iterative_request_router: upstream already consumed".to_owned().into()
+            })?;
+
+            let remaining = self
+                .continuation
+                .step_deadline
+                .checked_duration_since(std::time::Instant::now())
+                .unwrap_or_default();
+            let next = if remaining.is_zero() {
+                Err(praxis_core::subrequest::SubRequestError::DeadlineExceeded)
+            } else {
+                tokio::time::timeout(remaining, upstream.next_chunk())
+                    .await
+                    .unwrap_or(Err(praxis_core::subrequest::SubRequestError::DeadlineExceeded))
+            };
+
+            match next {
+                Ok(Some(chunk)) => match self.handle_upstream_chunk(chunk) {
+                    Ok(Some(bytes)) => return Ok(Some(bytes)),
+                    Ok(None) => {},
+                    Err(error) => return Box::pin(self.handle_filter_error(error)).await,
+                },
+                Ok(None) => return self.handle_upstream_eof(),
+                Err(e) => return Box::pin(self.handle_upstream_error(e)).await,
+            }
+        }
+    }
+
+    async fn suppress(&mut self) -> Result<(), FilterError> {
+        if !self.finished {
+            self.finished = true;
+            if let Some(upstream_body) = self.upstream.take() {
+                (*upstream_body).cancel().await;
+            }
+            self.complete_step()?;
+        }
+        Ok(())
+    }
+
+    async fn cancel(&mut self) {
+        if !self.finished {
+            self.finished = true;
+            if let Some(upstream_body) = self.upstream.take() {
+                (*upstream_body).cancel().await;
+            }
+        }
+    }
+
+    fn swap_extensions(&mut self, extensions: &mut RequestExtensions) {
+        self.exchange_extensions(extensions);
+    }
+}

--- a/crates/filter/src/filtered_subrequest/streaming.rs
+++ b/crates/filter/src/filtered_subrequest/streaming.rs
@@ -140,7 +140,7 @@ impl FilteredStreamingBody {
 
         match result? {
             crate::actions::FilterAction::Reject(_) => {
-                Err("iterative_request_router: step body filter rejected during stream"
+                Err("filtered_subrequest: step body filter rejected during stream"
                     .to_owned()
                     .into())
             },
@@ -180,7 +180,7 @@ impl FilteredStreamingBody {
 
     /// Complete the step after a response-body filter failure.
     async fn handle_filter_error(&mut self, error: FilterError) -> Result<Option<Bytes>, FilterError> {
-        warn!("iterative_request_router: response body filter failed: {error}");
+        warn!("filtered_subrequest: response body filter failed: {error}");
         if let Some(upstream_body) = self.upstream.take() {
             (*upstream_body).cancel().await;
         }
@@ -189,7 +189,7 @@ impl FilteredStreamingBody {
             .insert(StreamTermination::new(StreamTerminationCause::Filter));
         let completion = self.complete_step().map_err(|completion_error| -> FilterError {
             format!(
-                "iterative_request_router: response filter failed ({error}); completion also failed ({completion_error})"
+                "filtered_subrequest: response filter failed ({error}); completion also failed ({completion_error})"
             )
             .into()
         })?;
@@ -248,9 +248,10 @@ impl StreamingResponseBody for FilteredStreamingBody {
         }
 
         loop {
-            let upstream = self.upstream.as_mut().ok_or_else(|| -> FilterError {
-                "iterative_request_router: upstream already consumed".to_owned().into()
-            })?;
+            let upstream = self
+                .upstream
+                .as_mut()
+                .ok_or_else(|| -> FilterError { "filtered_subrequest: upstream already consumed".to_owned().into() })?;
 
             let remaining = self
                 .continuation

--- a/crates/filter/src/filtered_subrequest/tests.rs
+++ b/crates/filter/src/filtered_subrequest/tests.rs
@@ -1,0 +1,473 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Praxis Contributors
+
+//! Tests for the reusable filtered sub-request executor helpers.
+//!
+//! These exercise the transport, sanitization, header-mutation, and
+//! nested-context helpers the executor owns, independent of any particular
+//! caller (the iterative request router is the only caller today).
+
+use http::HeaderMap;
+
+// ---------------------------------------------------------------------------
+// Rejection Conversion
+// ---------------------------------------------------------------------------
+
+#[test]
+fn local_rejection_becomes_transition_response() {
+    let mut rejection = crate::Rejection::status(503)
+        .with_header("Retry-After", "1")
+        .with_header("Connection", "x-private")
+        .with_header("x-private", "secret")
+        .with_header("x-praxis-private", "secret")
+        .with_body(bytes::Bytes::from_static(b"unavailable"));
+    rejection
+        .header_map
+        .get_or_insert_with(Default::default)
+        .append("x-opaque", http::HeaderValue::from_bytes(&[0x80]).unwrap());
+    let response = super::sanitize::subresponse_from_rejection(rejection);
+    assert_eq!(response.status, 503);
+    assert_eq!(response.headers.get("retry-after").unwrap(), "1");
+    assert!(!response.headers.contains_key("connection"));
+    assert!(!response.headers.contains_key("x-private"));
+    assert!(!response.headers.contains_key("x-praxis-private"));
+    assert_eq!(response.headers.get("x-opaque").unwrap().as_bytes(), &[0x80]);
+    assert_eq!(response.body, bytes::Bytes::from_static(b"unavailable"));
+}
+
+// ---------------------------------------------------------------------------
+// classify_transport_failure
+// ---------------------------------------------------------------------------
+
+#[test]
+fn classify_admission_timeout_returns_503() {
+    let error = praxis_core::subrequest::SubRequestError::AdmissionTimeout { max_connections: 64 };
+    let (status, kind) = super::transport::classify_transport_failure(&error);
+    assert_eq!(status, 503, "AdmissionTimeout should return 503");
+    assert_eq!(kind, super::TransportFailure::AdmissionTimeout);
+}
+
+#[test]
+fn classify_connect_returns_502() {
+    let error = praxis_core::subrequest::SubRequestError::Connect("refused".to_owned());
+    let (status, kind) = super::transport::classify_transport_failure(&error);
+    assert_eq!(status, 502, "Connect should return 502");
+    assert_eq!(kind, super::TransportFailure::Connect);
+}
+
+#[test]
+fn classify_deadline_exceeded_returns_504() {
+    let error = praxis_core::subrequest::SubRequestError::DeadlineExceeded;
+    let (status, kind) = super::transport::classify_transport_failure(&error);
+    assert_eq!(status, 504, "DeadlineExceeded should return 504");
+    assert_eq!(kind, super::TransportFailure::DeadlineExceeded);
+}
+
+#[test]
+fn classify_response_too_large_returns_502() {
+    let error = praxis_core::subrequest::SubRequestError::ResponseTooLarge {
+        actual: 200,
+        limit: 100,
+    };
+    let (status, kind) = super::transport::classify_transport_failure(&error);
+    assert_eq!(status, 502, "ResponseTooLarge should return 502");
+    assert_eq!(kind, super::TransportFailure::ResponseTooLarge);
+}
+
+#[test]
+fn classify_io_returns_502() {
+    let error = praxis_core::subrequest::SubRequestError::Io("broken pipe".to_owned());
+    let (status, kind) = super::transport::classify_transport_failure(&error);
+    assert_eq!(status, 502, "Io should return 502");
+    assert_eq!(kind, super::TransportFailure::Io);
+}
+
+#[test]
+fn classify_invalid_request_falls_through_to_io() {
+    let error = praxis_core::subrequest::SubRequestError::InvalidRequest("bad uri".to_owned());
+    let (status, kind) = super::transport::classify_transport_failure(&error);
+    assert_eq!(status, 502, "InvalidRequest wildcard should return 502");
+    assert_eq!(kind, super::TransportFailure::Io);
+}
+
+// ---------------------------------------------------------------------------
+// strip_reserved_headers
+// ---------------------------------------------------------------------------
+
+#[test]
+fn strip_reserved_empty_map() {
+    let mut headers = HeaderMap::new();
+    super::sanitize::strip_reserved_headers(&mut headers);
+    assert!(headers.is_empty(), "empty map should stay empty");
+}
+
+#[test]
+fn strip_reserved_praxis_prefix() {
+    let mut headers = HeaderMap::new();
+    headers.insert("x-praxis-foo", "bar".parse().unwrap());
+    super::sanitize::strip_reserved_headers(&mut headers);
+    assert!(headers.is_empty(), "x-praxis-* should be removed");
+}
+
+#[test]
+fn strip_reserved_ext_protocol_prefix() {
+    let mut headers = HeaderMap::new();
+    headers.insert("x-ext-protocol-route", "value".parse().unwrap());
+    super::sanitize::strip_reserved_headers(&mut headers);
+    assert!(headers.is_empty(), "x-ext-protocol-* should be removed");
+}
+
+#[test]
+fn strip_reserved_ext_agent_prefix() {
+    let mut headers = HeaderMap::new();
+    headers.insert("x-ext-agent-task", "value".parse().unwrap());
+    super::sanitize::strip_reserved_headers(&mut headers);
+    assert!(headers.is_empty(), "x-ext-agent-* should be removed");
+}
+
+#[test]
+fn strip_reserved_preserves_non_reserved() {
+    let mut headers = HeaderMap::new();
+    headers.insert("authorization", "Bearer token".parse().unwrap());
+    headers.insert("content-type", "application/json".parse().unwrap());
+    super::sanitize::strip_reserved_headers(&mut headers);
+    assert_eq!(headers.len(), 2, "non-reserved headers should be preserved");
+}
+
+#[test]
+fn strip_reserved_mixed() {
+    let mut headers = HeaderMap::new();
+    headers.insert("authorization", "Bearer token".parse().unwrap());
+    headers.insert("x-praxis-internal", "secret".parse().unwrap());
+    headers.insert("x-ext-agent-id", "agent1".parse().unwrap());
+    headers.insert("x-custom", "value".parse().unwrap());
+    super::sanitize::strip_reserved_headers(&mut headers);
+    assert_eq!(headers.len(), 2, "only reserved should be removed");
+    assert!(headers.contains_key("authorization"));
+    assert!(headers.contains_key("x-custom"));
+}
+
+#[test]
+fn strip_reserved_no_dash_not_removed() {
+    let mut headers = HeaderMap::new();
+    headers.insert("x-praxisfoo", "value".parse().unwrap());
+    super::sanitize::strip_reserved_headers(&mut headers);
+    assert_eq!(
+        headers.len(),
+        1,
+        "x-praxisfoo (no dash after prefix) should NOT be removed"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Body Limits
+// ---------------------------------------------------------------------------
+
+#[test]
+fn nested_body_limit_detects_oversized_buffer() {
+    assert!(super::sanitize::body_exceeds_limit(
+        crate::BodyMode::StreamBuffer { max_bytes: Some(4) },
+        5
+    ));
+    assert!(!super::sanitize::body_exceeds_limit(
+        crate::BodyMode::SizeLimit { max_bytes: 5 },
+        5
+    ));
+    assert!(!super::sanitize::body_exceeds_limit(
+        crate::BodyMode::Stream,
+        usize::MAX
+    ));
+}
+
+#[test]
+fn transformed_response_must_remain_within_all_limits() {
+    assert!(super::sanitize::response_body_exceeds_limits(
+        crate::BodyMode::Stream,
+        4,
+        5
+    ));
+    assert!(super::sanitize::response_body_exceeds_limits(
+        crate::BodyMode::StreamBuffer { max_bytes: Some(3) },
+        4,
+        4,
+    ));
+    assert!(!super::sanitize::response_body_exceeds_limits(
+        crate::BodyMode::StreamBuffer { max_bytes: Some(4) },
+        4,
+        4,
+    ));
+}
+
+#[test]
+fn streaming_transport_uses_only_listener_limit() {
+    assert_eq!(
+        super::sanitize::streaming_transport_limit(crate::BodyMode::SizeLimit { max_bytes: 4 }),
+        Some(4)
+    );
+    assert_eq!(
+        super::sanitize::streaming_transport_limit(crate::BodyMode::Stream),
+        None
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Header Sanitization
+// ---------------------------------------------------------------------------
+
+#[test]
+fn strip_request_framing_headers_removes_stale_lengths() {
+    let mut headers = HeaderMap::new();
+    headers.insert(http::header::CONTENT_LENGTH, "100".parse().unwrap());
+    headers.insert(http::header::TRANSFER_ENCODING, "chunked".parse().unwrap());
+    headers.insert(http::header::CONTENT_TYPE, "application/json".parse().unwrap());
+
+    super::sanitize::strip_request_framing_headers(&mut headers);
+
+    assert!(!headers.contains_key(http::header::CONTENT_LENGTH));
+    assert!(!headers.contains_key(http::header::TRANSFER_ENCODING));
+    assert!(headers.contains_key(http::header::CONTENT_TYPE));
+}
+
+#[test]
+fn request_sanitization_strips_all_reserved_headers_including_depth() {
+    let mut headers = HeaderMap::new();
+    headers.insert(http::header::CONNECTION, "x-remove, keep-alive".parse().unwrap());
+    headers.insert("x-remove", "secret".parse().unwrap());
+    headers.insert("keep-alive", "timeout=5".parse().unwrap());
+    headers.insert("x-praxis-route", "internal".parse().unwrap());
+    headers.insert(praxis_core::subrequest::DEPTH_HEADER, "1".parse().unwrap());
+    headers.insert(http::header::AUTHORIZATION, "Bearer step-token".parse().unwrap());
+    headers.insert(http::header::CONTENT_LENGTH, "99".parse().unwrap());
+
+    super::sanitize::sanitize_subrequest_headers(&mut headers);
+
+    assert!(!headers.contains_key(http::header::CONNECTION));
+    assert!(!headers.contains_key("x-remove"));
+    assert!(!headers.contains_key("keep-alive"));
+    assert!(!headers.contains_key("x-praxis-route"));
+    assert!(!headers.contains_key(http::header::CONTENT_LENGTH));
+    assert!(
+        !headers.contains_key(praxis_core::subrequest::DEPTH_HEADER),
+        "sanitize must strip depth; core executor re-injects via framework_headers"
+    );
+    assert_eq!(headers.get(http::header::AUTHORIZATION).unwrap(), "Bearer step-token");
+}
+
+#[test]
+fn sanitize_strips_depth_header_for_framework_reinsertion() {
+    let mut headers = HeaderMap::new();
+    headers.insert(praxis_core::subrequest::DEPTH_HEADER, "spoofed".parse().unwrap());
+    headers.insert("x-praxis-route", "internal".parse().unwrap());
+    headers.insert(http::header::AUTHORIZATION, "Bearer token".parse().unwrap());
+
+    super::sanitize::sanitize_subrequest_headers(&mut headers);
+
+    assert!(
+        !headers.contains_key(praxis_core::subrequest::DEPTH_HEADER),
+        "sanitize must strip depth so core executor can re-inject via framework_headers"
+    );
+    assert!(!headers.contains_key("x-praxis-route"));
+    assert_eq!(headers.get(http::header::AUTHORIZATION).unwrap(), "Bearer token");
+}
+
+#[test]
+fn response_sanitization_strips_hop_by_hop_and_internal_headers() {
+    let mut headers = HeaderMap::new();
+    headers.insert(http::header::CONNECTION, "x-remove".parse().unwrap());
+    headers.insert("x-remove", "secret".parse().unwrap());
+    headers.insert("upgrade", "h2c".parse().unwrap());
+    headers.insert("x-ext-agent-task", "internal".parse().unwrap());
+    headers.append(http::header::SET_COOKIE, "first=1".parse().unwrap());
+    headers.append(http::header::SET_COOKIE, "second=2".parse().unwrap());
+
+    super::sanitize::sanitize_subresponse_headers(&mut headers);
+
+    assert!(!headers.contains_key(http::header::CONNECTION));
+    assert!(!headers.contains_key("x-remove"));
+    assert!(!headers.contains_key("upgrade"));
+    assert!(!headers.contains_key("x-ext-agent-task"));
+    assert_eq!(headers.get_all(http::header::SET_COOKIE).iter().count(), 2);
+}
+
+#[test]
+fn destination_host_is_synthesized_without_overwriting_step_override() {
+    let mut generated = HeaderMap::new();
+    super::sanitize::ensure_destination_host(&mut generated, "model.example:443").unwrap();
+    assert_eq!(generated.get(http::header::HOST).unwrap(), "model.example:443");
+
+    let mut explicit = HeaderMap::new();
+    explicit.insert(http::header::HOST, "override.example".parse().unwrap());
+    super::sanitize::ensure_destination_host(&mut explicit, "model.example:443").unwrap();
+    assert_eq!(explicit.get(http::header::HOST).unwrap(), "override.example");
+}
+
+#[test]
+fn destination_host_rejects_unencodable_address() {
+    let mut headers = HeaderMap::new();
+    let result = super::sanitize::ensure_destination_host(&mut headers, "bad\nhost:80");
+    assert!(result.is_err(), "control characters in the Host value must error");
+}
+
+// ---------------------------------------------------------------------------
+// Header Mutation Helpers
+// ---------------------------------------------------------------------------
+
+#[test]
+fn request_header_mutations_remove_set_and_add() {
+    let req = crate::test_utils::make_request(http::Method::GET, "/");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.request_headers_to_remove.push("x-old".parse().unwrap());
+    ctx.request_headers_to_set
+        .push(("x-set".parse().unwrap(), http::HeaderValue::from_static("set")));
+    ctx.extra_request_headers
+        .push((std::borrow::Cow::Borrowed("x-extra"), "extra".to_owned()));
+    ctx.extra_request_headers
+        .push((std::borrow::Cow::Borrowed("bad name"), "dropped".to_owned()));
+
+    let mut headers = HeaderMap::new();
+    headers.insert("x-old", http::HeaderValue::from_static("stale"));
+    super::sanitize::apply_request_header_mutations(&mut headers, &ctx);
+
+    assert!(headers.get("x-old").is_none(), "removed headers must be gone");
+    assert_eq!(
+        headers.get("x-set").map(http::HeaderValue::as_bytes),
+        Some(b"set".as_slice()),
+        "set headers must be applied"
+    );
+    assert_eq!(
+        headers.get("x-extra").map(http::HeaderValue::as_bytes),
+        Some(b"extra".as_slice()),
+        "extra headers must be applied"
+    );
+    assert!(
+        headers.get("bad name").is_none(),
+        "invalid extra header names must be dropped"
+    );
+}
+
+#[test]
+fn pre_read_mutations_apply_remove_set_and_add() {
+    let req = crate::test_utils::make_request(http::Method::GET, "/");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.pre_read_mutations = vec![
+        crate::TrustedHeaderMutation::Remove("x-gone".parse().unwrap()),
+        crate::TrustedHeaderMutation::Set("x-set".parse().unwrap(), http::HeaderValue::from_static("set")),
+        crate::TrustedHeaderMutation::Add("x-add".parse().unwrap(), "added".to_owned()),
+        crate::TrustedHeaderMutation::Add("x-bad".parse().unwrap(), "bad\nvalue".to_owned()),
+    ];
+
+    let mut headers = HeaderMap::new();
+    headers.insert("x-gone", http::HeaderValue::from_static("stale"));
+    super::sanitize::apply_pre_read_header_mutations(&mut headers, &ctx);
+
+    assert!(headers.get("x-gone").is_none(), "Remove mutations must apply");
+    assert_eq!(
+        headers.get("x-set").map(http::HeaderValue::as_bytes),
+        Some(b"set".as_slice()),
+        "Set mutations must apply"
+    );
+    assert_eq!(
+        headers.get("x-add").map(http::HeaderValue::as_bytes),
+        Some(b"added".as_slice()),
+        "Add mutations must apply"
+    );
+    assert!(
+        headers.get("x-bad").is_none(),
+        "Add mutations with invalid values must be dropped"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Sub-Filter Context
+// ---------------------------------------------------------------------------
+
+#[test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "resource identity assertions are intentionally explicit"
+)]
+fn sub_filter_context_inherits_parent_runtime_resources() {
+    use std::{collections::HashMap, sync::Arc, time::Duration};
+
+    use praxis_core::{
+        health::HealthRegistry,
+        id::IdGenerator,
+        kv::KvStoreRegistry,
+        subrequest::{SubRequestClient, SubRequestConnector},
+        time::FixedTimeSource,
+    };
+
+    let registry = crate::FilterRegistry::with_builtins();
+    let pipeline = crate::FilterPipeline::build(&mut [], &registry).unwrap();
+    let request = crate::Request {
+        headers: HeaderMap::new(),
+        method: http::Method::POST,
+        uri: http::Uri::from_static("/v1/responses"),
+    };
+    let health_registry: HealthRegistry = Arc::new(HashMap::new());
+    let id_generator = IdGenerator::with_seed(42);
+    let kv_stores = KvStoreRegistry::new();
+    let client = SubRequestClient::new(SubRequestConnector::new(1, None));
+    let time_source = FixedTimeSource::new(Duration::from_secs(123));
+
+    let ctx = super::context::build_sub_filter_context(
+        &pipeline,
+        &request,
+        super::context::SubrequestRuntimeResources {
+            client_addr: Some(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)),
+            downstream_tls: true,
+            health_registry: Some(&health_registry),
+            id_generator: &id_generator,
+            kv_stores: Some(&kv_stores),
+            peer_identity: None,
+            request_start: std::time::Instant::now(),
+            subrequest_client: Some(&client),
+            time_source: &time_source,
+        },
+    );
+
+    assert!(std::ptr::eq(ctx.health_registry.unwrap(), &health_registry));
+    assert!(std::ptr::eq(ctx.id_generator, &id_generator));
+    assert!(std::ptr::eq(ctx.kv_stores.unwrap(), &kv_stores));
+    assert!(std::ptr::eq(ctx.subrequest_client.unwrap(), &client));
+    assert_eq!(
+        ctx.client_addr,
+        Some(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST))
+    );
+    assert!(ctx.downstream_tls);
+    assert_eq!(ctx.time_source.now(), Duration::from_secs(123));
+}
+
+// ---------------------------------------------------------------------------
+// Peer Construction
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn build_peer_applies_tls_with_explicit_sni() {
+    let tls: praxis_tls::ClusterTls = serde_yaml::from_str("sni: backend.example\nverify: true").unwrap();
+    let cached = praxis_tls::CachedClusterTls::try_from_config(&tls).unwrap();
+    let upstream = praxis_core::connectivity::Upstream {
+        address: std::sync::Arc::from("127.0.0.1:9443"),
+        connection: std::sync::Arc::new(praxis_core::connectivity::ConnectionOptions::default()),
+        tls: Some(cached),
+        authority: None,
+    };
+
+    let peer = super::transport::build_peer(&upstream).await.unwrap();
+    assert_eq!(peer.sni, "backend.example", "the configured SNI must be applied");
+}
+
+#[tokio::test]
+async fn build_peer_derives_sni_from_hostname_address() {
+    let tls: praxis_tls::ClusterTls = serde_yaml::from_str("verify: false").unwrap();
+    let cached = praxis_tls::CachedClusterTls::try_from_config(&tls).unwrap();
+    let upstream = praxis_core::connectivity::Upstream {
+        address: std::sync::Arc::from("localhost:9443"),
+        connection: std::sync::Arc::new(praxis_core::connectivity::ConnectionOptions::default()),
+        tls: Some(cached),
+        authority: None,
+    };
+
+    let peer = super::transport::build_peer(&upstream).await.unwrap();
+    assert_eq!(peer.sni, "localhost", "the SNI must derive from the address hostname");
+}

--- a/crates/filter/src/filtered_subrequest/tests.rs
+++ b/crates/filter/src/filtered_subrequest/tests.rs
@@ -90,6 +90,16 @@ fn classify_invalid_request_falls_through_to_io() {
     assert_eq!(kind, super::TransportFailure::Io);
 }
 
+#[test]
+fn classify_circuit_open_returns_503() {
+    let error = praxis_core::subrequest::SubRequestError::CircuitOpen {
+        peer: "backend".to_owned(),
+    };
+    let (status, kind) = super::transport::classify_transport_failure(&error);
+    assert_eq!(status, 503, "CircuitOpen should return 503");
+    assert_eq!(kind, super::TransportFailure::CircuitOpen);
+}
+
 // ---------------------------------------------------------------------------
 // strip_reserved_headers
 // ---------------------------------------------------------------------------

--- a/crates/filter/src/filtered_subrequest/transport.rs
+++ b/crates/filter/src/filtered_subrequest/transport.rs
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Praxis Contributors
+
+//! Transport peer construction and failure classification.
+
+use pingora_core::upstreams::peer::HttpPeer;
+use praxis_core::subrequest::SubRequestError;
+
+use super::TransportFailure;
+use crate::StreamTerminationCause;
+
+/// Convert a Praxis [`Upstream`] to a Pingora [`HttpPeer`].
+///
+/// Applies TLS settings (CA, client cert, verify toggle) and
+/// connection options (timeouts) from the upstream config. Derives
+/// SNI from the address hostname when not explicitly configured.
+///
+/// [`Upstream`]: praxis_core::connectivity::Upstream
+pub(super) async fn build_peer(
+    upstream: &praxis_core::connectivity::Upstream,
+) -> Result<HttpPeer, praxis_core::connectivity::peer::AddressResolutionError> {
+    use praxis_core::connectivity::peer as peer_utils;
+
+    let addr: &str = &upstream.address;
+    let socket_addr = peer_utils::resolve_address(addr).await?;
+    let tls_enabled = upstream.tls.is_some();
+    let sni = upstream
+        .tls
+        .as_ref()
+        .and_then(|t| t.sni().map(str::to_owned))
+        .unwrap_or_else(|| {
+            if tls_enabled {
+                peer_utils::derive_sni(addr)
+            } else {
+                String::new()
+            }
+        });
+
+    let mut peer = HttpPeer::new(socket_addr, tls_enabled, sni);
+    peer_utils::apply_connection_options(&mut peer, &upstream.connection);
+
+    if let Some(tls) = &upstream.tls {
+        peer_utils::apply_cached_tls(&mut peer, tls, addr);
+    }
+
+    Ok(peer)
+}
+
+/// Convert transport failures into a gateway status and error classification.
+pub(super) fn classify_transport_failure(error: &SubRequestError) -> (u16, TransportFailure) {
+    match error {
+        SubRequestError::AdmissionTimeout { .. } => (503, TransportFailure::AdmissionTimeout),
+        SubRequestError::CircuitOpen { .. } => (503, TransportFailure::CircuitOpen),
+        SubRequestError::Connect(_) => (502, TransportFailure::Connect),
+        SubRequestError::DeadlineExceeded => (504, TransportFailure::DeadlineExceeded),
+        SubRequestError::ResponseTooLarge { .. } => (502, TransportFailure::ResponseTooLarge),
+        _ => (502, TransportFailure::Io),
+    }
+}
+
+/// Convert transition-level transport metadata into completion-hook metadata.
+pub(super) fn stream_termination_cause(kind: TransportFailure) -> StreamTerminationCause {
+    match kind {
+        TransportFailure::AdmissionTimeout => StreamTerminationCause::AdmissionTimeout,
+        TransportFailure::CircuitOpen => StreamTerminationCause::CircuitOpen,
+        TransportFailure::Connect => StreamTerminationCause::Connect,
+        TransportFailure::Io => StreamTerminationCause::Io,
+        TransportFailure::DeadlineExceeded => StreamTerminationCause::DeadlineExceeded,
+        TransportFailure::ResponseTooLarge => StreamTerminationCause::ResponseTooLarge,
+    }
+}
+
+/// Map transport detail to the provider-neutral completion classification.
+pub(super) fn termination_cause(error: &SubRequestError) -> StreamTerminationCause {
+    match error {
+        SubRequestError::AdmissionTimeout { .. } => StreamTerminationCause::AdmissionTimeout,
+        SubRequestError::CircuitOpen { .. } => StreamTerminationCause::CircuitOpen,
+        SubRequestError::Connect(_) => StreamTerminationCause::Connect,
+        SubRequestError::DeadlineExceeded => StreamTerminationCause::DeadlineExceeded,
+        SubRequestError::StreamIdleTimeout { .. } => StreamTerminationCause::IdleTimeout,
+        SubRequestError::ResponseTooLarge { .. } => StreamTerminationCause::ResponseTooLarge,
+        _ => StreamTerminationCause::Io,
+    }
+}

--- a/crates/filter/src/lib.rs
+++ b/crates/filter/src/lib.rs
@@ -51,6 +51,7 @@ mod error_response;
 mod extensions;
 mod factory;
 mod filter;
+mod filtered_subrequest;
 pub(crate) mod load_balancing;
 mod metrics;
 pub(crate) mod path_match;


### PR DESCRIPTION
### What does this PR do?

Extracts the filter + transport sub-request lifecycle out of the `iterative_request_router` (IRR) into a caller-agnostic `FilteredSubrequestExecutor` under `filter/src/filtered_subrequest/` (`mod`, `context`, `streaming`, `sanitize`, `transport`, `continuation`, plus tests), leaving the IRR as a thin adapter that maps the executor's continuation types onto its own step/transition vocabulary. It is strictly behavior-preserving: no config surface changes, the IRR stays the only consumer, the lifecycle unit tests move to the new module boundary, and a bridge test pins the `TransportFailure -> config::TransportErrorKind` mapping so transport-error transition routing stays covered after the type split. `TerminalResponse` handling is intentionally left as-is and deferred to a focused follow-up.

### Which issue(s) does this relate to?

Fixes #1073 (part of epic #1072).

### Checklist

- [x] Signed off all commits (`git commit -s`)
- [x] Tests added or updated
- [x] Documentation updated (if applicable) — n/a: pure internal refactor, no public API, config, or doc surface change
- [ ] `make lint && make test && make test-integration` passes locally — `make lint` and `make test` (unit) pass; `make test-integration` has 3 failures (`tcp_edge_cases::tcp_connect_filter_error_drops_connection`, `tcp_edge_cases::tcp_connect_filter_rejection_drops_connection`, `tls::hot_reload_serves_rotated_certificate`) that reproduce identically on a clean `upstream/main` checkout and are unrelated to this change (this PR touches only HTTP filter code)

### Does this introduce a breaking change?

No. Pure internal refactor: no changes to configuration, public API, or runtime behavior.
