### PR TITLE
feat(admin): GET /api/stats operational snapshot (#125)

### DIFF
--- a/crates/core/src/health.rs
+++ b/crates/core/src/health.rs
@@ -348,6 +348,19 @@ impl ClusterHealthEntry {
         (healthy, total)
     }
 
+    /// Per-endpoint address and health snapshot for admin APIs.
+    ///
+    /// Returns one row per configured address, sorted by address string.
+    pub fn endpoint_statuses(&self) -> Vec<(Arc<str>, bool)> {
+        let mut rows: Vec<_> = self
+            .index
+            .iter()
+            .filter_map(|(addr, &idx)| self.endpoints.get(idx).map(|ep| (Arc::clone(addr), ep.is_healthy())))
+            .collect();
+        rows.sort_by(|a, b| a.0.cmp(&b.0));
+        rows
+    }
+
     /// Passive healthy threshold, if configured.
     pub fn passive_healthy_threshold(&self) -> Option<u32> {
         self.passive_healthy_threshold

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -46,6 +46,7 @@ praxis-tls = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml = { workspace = true }
 tokio = { workspace = true, features = ["sync", "time"] }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
@@ -53,7 +54,6 @@ tracing = { workspace = true }
 [dev-dependencies]
 rcgen = { workspace = true }
 serde_json = { workspace = true }
-serde_yaml = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 tracing-subscriber = { workspace = true }

--- a/crates/protocol/src/http/pingora/health/cluster_meta.rs
+++ b/crates/protocol/src/http/pingora/health/cluster_meta.rs
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Praxis Contributors
+
+//! Cluster endpoint metadata for admin stats snapshots.
+
+use std::{collections::HashMap, sync::Arc};
+
+use arc_swap::ArcSwap;
+use praxis_core::config::{ChainRef, Cluster, Config, FilterEntry};
+use serde::Serialize;
+
+// -----------------------------------------------------------------------------
+// Constants
+// -----------------------------------------------------------------------------
+
+/// Filter types whose config may declare inline `clusters:` lists.
+const CLUSTER_BEARING_FILTERS: &[&str] = &["load_balancer", "tcp_load_balancer"];
+
+/// Filter type that nests entries under `steps[].filters`.
+const STEP_BEARING_FILTER: &str = "iterative_request_router";
+
+// -----------------------------------------------------------------------------
+// ClusterMeta
+// -----------------------------------------------------------------------------
+
+/// Upstream endpoint addresses for one cluster (from resolved config).
+#[derive(Clone, Debug, Serialize)]
+pub struct ClusterMeta {
+    /// Cluster name.
+    pub name: String,
+    /// Upstream socket addresses (`host:port`).
+    pub endpoints: Vec<String>,
+}
+
+/// Hot-swappable cluster metadata for `/api/stats`.
+pub type ClusterMetaStore = Arc<ArcSwap<HashMap<String, ClusterMeta>>>;
+
+// -----------------------------------------------------------------------------
+// Metadata extraction
+// -----------------------------------------------------------------------------
+
+/// Build cluster metadata from configuration.
+pub fn cluster_meta_from_config(config: &Config) -> HashMap<String, ClusterMeta> {
+    let mut meta: HashMap<String, ClusterMeta> = config
+        .clusters
+        .iter()
+        .map(|cluster| (cluster.name.to_string(), cluster_meta_from_cluster(cluster)))
+        .collect();
+
+    for chain in &config.filter_chains {
+        for entry in &chain.filters {
+            collect_clusters_from_entry(entry, &mut meta);
+        }
+    }
+
+    meta
+}
+
+/// Build metadata for one configured cluster.
+fn cluster_meta_from_cluster(cluster: &Cluster) -> ClusterMeta {
+    ClusterMeta {
+        name: cluster.name.to_string(),
+        endpoints: cluster.endpoints.iter().map(|ep| ep.address().to_owned()).collect(),
+    }
+}
+
+/// Merge inline and nested load-balancer clusters into `meta`.
+fn collect_clusters_from_entry(entry: &FilterEntry, meta: &mut HashMap<String, ClusterMeta>) {
+    if CLUSTER_BEARING_FILTERS.contains(&entry.filter_type.as_str())
+        && let Some(clusters) = inline_clusters_from_entry(entry)
+    {
+        for cluster in clusters {
+            meta.entry(cluster.name.to_string())
+                .or_insert_with(|| cluster_meta_from_cluster(&cluster));
+        }
+    }
+
+    for branch in entry.branch_chains.as_deref().unwrap_or_default() {
+        for chain_ref in &branch.chains {
+            if let ChainRef::Inline { filters, .. } = chain_ref {
+                for nested in filters {
+                    collect_clusters_from_entry(nested, meta);
+                }
+            }
+        }
+    }
+
+    if entry.filter_type == STEP_BEARING_FILTER {
+        for nested in step_filters_from_entry(entry) {
+            collect_clusters_from_entry(&nested, meta);
+        }
+    }
+}
+
+/// Deserialize inline `clusters:` from a load-balancer filter entry.
+fn inline_clusters_from_entry(entry: &FilterEntry) -> Option<Vec<Cluster>> {
+    let serde_yaml::Value::Mapping(mapping) = &entry.config else {
+        return None;
+    };
+    let clusters_value = mapping.get("clusters")?;
+    serde_yaml::from_value(clusters_value.clone()).ok()
+}
+
+/// Deserialize nested filters from an `iterative_request_router` entry.
+fn step_filters_from_entry(entry: &FilterEntry) -> Vec<FilterEntry> {
+    let serde_yaml::Value::Mapping(mapping) = &entry.config else {
+        return Vec::new();
+    };
+    let Some(serde_yaml::Value::Sequence(steps)) = mapping.get("steps") else {
+        return Vec::new();
+    };
+    let mut filters = Vec::new();
+    for step in steps {
+        let serde_yaml::Value::Mapping(step_map) = step else {
+            continue;
+        };
+        let Some(step_filters) = step_map.get("filters") else {
+            continue;
+        };
+        if let Ok(parsed) = serde_yaml::from_value::<Vec<FilterEntry>>(step_filters.clone()) {
+            filters.extend(parsed);
+        }
+    }
+    filters
+}
+
+/// Wrap a metadata map in an [`ArcSwap`] store.
+pub fn new_cluster_meta_store(meta: HashMap<String, ClusterMeta>) -> ClusterMetaStore {
+    Arc::new(ArcSwap::from_pointee(meta))
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "tests")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cluster_meta_from_config_maps_endpoints() {
+        let config = Config::from_yaml(
+            r#"
+insecure_options:
+  allow_private_endpoints: true
+listeners:
+  - name: web
+    address: "127.0.0.1:8080"
+    filter_chains: [main]
+clusters:
+  - name: backend
+    endpoints:
+      - address: "127.0.0.1:9000"
+      - address: "127.0.0.1:9001"
+filter_chains:
+  - name: main
+    filters: [{ filter: static_response, status: 200 }]
+"#,
+        )
+        .expect("config should parse");
+        let meta = cluster_meta_from_config(&config);
+        let backend = meta.get("backend").expect("backend cluster");
+        assert_eq!(
+            backend.endpoints,
+            vec!["127.0.0.1:9000".to_owned(), "127.0.0.1:9001".to_owned()],
+            "endpoint addresses should match config"
+        );
+    }
+
+    #[test]
+    fn cluster_meta_from_config_includes_inline_load_balancer_clusters() {
+        let config = Config::from_yaml(
+            r#"
+insecure_options:
+  allow_private_endpoints: true
+listeners:
+  - name: web
+    address: "127.0.0.1:8080"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: load_balancer
+        clusters:
+          - name: inline-backend
+            endpoints:
+              - address: "127.0.0.1:9100"
+"#,
+        )
+        .expect("config should parse");
+        let meta = cluster_meta_from_config(&config);
+        let backend = meta.get("inline-backend").expect("inline cluster");
+        assert_eq!(
+            backend.endpoints,
+            vec!["127.0.0.1:9100".to_owned()],
+            "inline load_balancer cluster should appear in stats metadata"
+        );
+    }
+}

--- a/crates/protocol/src/http/pingora/health/mod.rs
+++ b/crates/protocol/src/http/pingora/health/mod.rs
@@ -3,6 +3,8 @@
 
 //! Health check infrastructure: admin endpoints, probes, and background runner.
 
+/// Cluster endpoint metadata for `/api/stats`. Kept ungated for reload.
+pub mod cluster_meta;
 /// Listener metadata for `GET /api/pipelines`. Kept ungated: the reload
 /// path maintains this store even when the admin API is not compiled in.
 pub mod listener_meta;
@@ -18,7 +20,10 @@ pub mod runner;
 /// Admin HTTP service (`/ready`, `/healthy`, `/metrics`, `/api/*`).
 #[cfg(feature = "admin-api")]
 mod service;
+#[cfg(feature = "admin-api")]
+mod stats_admin;
 
+pub use cluster_meta::{ClusterMeta, ClusterMetaStore, cluster_meta_from_config, new_cluster_meta_store};
 pub use listener_meta::{ListenerMeta, ListenerMetaStore, listener_meta_from_config, new_listener_meta_store};
 #[cfg(feature = "admin-api")]
 pub(in crate::http::pingora) use service::escape_json_string;
@@ -28,3 +33,5 @@ pub use service::{
     add_admin_endpoints_to_pingora_server, add_admin_endpoints_to_pingora_server_with_recorder,
     add_health_endpoint_to_pingora_server, install_prometheus_admin_recorder,
 };
+#[cfg(feature = "admin-api")]
+pub use stats_admin::{ProcessVersionInfo, StatsAdminState};

--- a/crates/protocol/src/http/pingora/health/service.rs
+++ b/crates/protocol/src/http/pingora/health/service.rs
@@ -20,7 +20,7 @@ use praxis_core::{health::HealthRegistry, kv::KvStoreRegistry};
 use tokio::time::Duration;
 use tracing::{error, info};
 
-use super::{listener_meta::ListenerMetaStore, log_level_admin, pipelines_admin};
+use super::{listener_meta::ListenerMetaStore, log_level_admin, pipelines_admin, stats_admin};
 use crate::http::pingora::{json::json_response, kv::dispatch_kv_request, metrics};
 
 /// Recorder upkeep runs independently of Prometheus scrape traffic.
@@ -156,6 +156,9 @@ pub struct PingoraAdminService {
     /// Optional runtime log-level state for `/api/log-level`.
     log_level: Option<Arc<praxis_core::logging::LogLevelState>>,
 
+    /// Optional `/api/stats` snapshot state.
+    stats: Option<stats_admin::StatsAdminState>,
+
     /// When `true`, include per-cluster detail in `/ready` responses.
     verbose: bool,
 }
@@ -165,11 +168,13 @@ impl PingoraAdminService {
     ///
     /// `kv_registry` enables `/api/kv/*` endpoints when `Some`.
     /// `pipelines` enables `GET /api/pipelines` when `Some`.
+    #[expect(clippy::too_many_arguments, reason = "admin service optional endpoint wiring")]
     pub fn new(
         health_registry: Option<HealthRegistry>,
         kv_registry: Option<KvStoreRegistry>,
         pipelines: Option<(Arc<crate::ListenerPipelines>, ListenerMetaStore)>,
         log_level: Option<Arc<praxis_core::logging::LogLevelState>>,
+        stats: Option<stats_admin::StatsAdminState>,
         verbose: bool,
     ) -> Self {
         Self {
@@ -177,6 +182,7 @@ impl PingoraAdminService {
             kv_registry,
             pipelines: pipelines.map(|(pipelines, meta)| pipelines_admin::PipelinesAdminState { pipelines, meta }),
             log_level,
+            stats,
             verbose,
         }
     }
@@ -187,6 +193,7 @@ impl PingoraAdminService {
     }
 
     /// Dispatch `/api/*` admin routes when configured.
+    #[expect(clippy::too_many_lines, reason = "admin route table")]
     async fn dispatch_admin_api(
         &self,
         http_session: &mut ServerSession,
@@ -211,6 +218,20 @@ impl PingoraAdminService {
         if path == "/api/log-level" {
             return Some(match &self.log_level {
                 Some(state) => log_level_admin::log_level_response(state, http_session, method, query).await,
+                None => json_response(404, br#"{"error":"not found"}"#),
+            });
+        }
+
+        if path == "/api/stats" {
+            return Some(match &self.stats {
+                Some(state) => {
+                    let registry = stats_admin::resolve_health_registry(
+                        self.health_registry.as_ref(),
+                        self.pipelines.as_ref(),
+                        &state.listener_meta,
+                    );
+                    stats_admin::stats_response(registry.as_ref(), state, method)
+                },
                 None => json_response(404, br#"{"error":"not found"}"#),
             });
         }
@@ -280,6 +301,9 @@ pub struct AdminEndpointOptions {
 
     /// Runtime log-level state for `/api/log-level`.
     pub log_level: Option<Arc<praxis_core::logging::LogLevelState>>,
+
+    /// Runtime stats snapshot state for `/api/stats`.
+    pub stats: Option<stats_admin::StatsAdminState>,
 
     /// When `true`, include per-cluster detail in `/ready`.
     pub verbose: bool,
@@ -404,11 +428,12 @@ pub fn add_admin_endpoints_to_pingora_server_with_recorder(
         options.kv_registry,
         options.pipelines,
         options.log_level,
+        options.stats,
         verbose,
     );
     let mut service = Service::new("admin".to_owned(), admin);
     service.add_tcp(admin_addr);
-    info!(address = %admin_addr, verbose, "admin endpoints enabled (health + metrics + kv + pipelines + log-level)");
+    info!(address = %admin_addr, verbose, "admin endpoints enabled (health + metrics + kv + pipelines + log-level + stats)");
     server.add_service(service);
 }
 

--- a/crates/protocol/src/http/pingora/health/stats_admin.rs
+++ b/crates/protocol/src/http/pingora/health/stats_admin.rs
@@ -1,0 +1,431 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Praxis Contributors
+
+//! `GET /api/stats` admin handler (#125 Phase 1).
+
+use std::{collections::BTreeMap, sync::Arc, time::Instant};
+
+use http::Response;
+use praxis_core::{config::ProtocolKind, health::HealthRegistry};
+use serde::Serialize;
+
+use super::{
+    cluster_meta::{ClusterMeta, ClusterMetaStore},
+    listener_meta::{ListenerMeta, ListenerMetaStore},
+    pipelines_admin,
+};
+use crate::http::pingora::{json::json_response, metrics};
+
+// -----------------------------------------------------------------------------
+// State
+// -----------------------------------------------------------------------------
+
+/// Build-time and runtime metadata for `/api/stats`.
+#[derive(Clone, Debug, Serialize)]
+pub struct ProcessVersionInfo {
+    /// Cargo package semver (e.g. `0.5.4`).
+    pub semver: String,
+    /// Human-readable identity: `{semver}` or `{semver} ({git_sha})` when a
+    /// build-time git SHA is available. Derived from [`Self::semver`] and
+    /// [`Self::git_sha`]; matches `praxis --version` on clean release builds.
+    pub display: String,
+    /// Short git SHA when available at build time (never includes a dirty flag).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub git_sha: Option<String>,
+}
+
+/// Handles for `/api/stats` snapshot assembly.
+pub struct StatsAdminState {
+    /// Process start instant for uptime calculation.
+    pub started_at: Instant,
+    /// Version identity from the server binary.
+    pub version: ProcessVersionInfo,
+    /// Hot-swappable listener metadata.
+    pub listener_meta: ListenerMetaStore,
+    /// Hot-swappable cluster endpoint metadata.
+    pub cluster_meta: ClusterMetaStore,
+}
+
+// -----------------------------------------------------------------------------
+// Response DTOs
+// -----------------------------------------------------------------------------
+
+/// Top-level `GET /api/stats` body.
+#[derive(Debug, Serialize)]
+struct StatsResponse {
+    /// Seconds since process start.
+    uptime_secs: u64,
+    /// Build/runtime version identity.
+    version: ProcessVersionInfo,
+    /// Documented schema gaps (not placeholder zeros).
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    gaps: BTreeMap<&'static str, &'static str>,
+    /// Per-listener operational counters.
+    listeners: Vec<ListenerStatsView>,
+    /// Per-cluster operational snapshots.
+    clusters: Vec<ClusterStatsView>,
+}
+
+/// Per-listener operational counters.
+#[derive(Debug, Serialize)]
+struct ListenerStatsView {
+    /// Listener name.
+    name: String,
+    /// Protocol kind (`http` / `tcp`).
+    protocol: ProtocolKind,
+    /// Whether listener TLS is configured.
+    tls: bool,
+    /// Active HTTP requests or open TCP sessions for this listener.
+    active_connections: u64,
+}
+
+/// Per-cluster operational snapshot.
+#[derive(Debug, Serialize)]
+struct ClusterStatsView {
+    /// Cluster name.
+    name: String,
+    /// Healthy upstream endpoints at snapshot time.
+    healthy_endpoints: u64,
+    /// Total configured upstream endpoints.
+    total_endpoints: u64,
+    /// Sum of `praxis_upstream_requests_total` for this cluster.
+    upstream_requests_total: u64,
+    /// Sum of `praxis_upstream_connect_failures_total` for this cluster.
+    upstream_connect_failures_total: u64,
+    /// Per-endpoint health rows.
+    endpoints: Vec<EndpointStatsView>,
+}
+
+/// Per-endpoint health row.
+#[derive(Debug, Serialize)]
+struct EndpointStatsView {
+    /// Upstream socket (`host:port`).
+    address: String,
+    /// Active health-check state at snapshot time.
+    healthy: bool,
+}
+
+// -----------------------------------------------------------------------------
+// Dispatch
+// -----------------------------------------------------------------------------
+
+/// Prefer the health registry pinned by live pipelines for **current** listeners
+/// (post-reload) over the startup snapshot held on the admin service.
+pub(super) fn resolve_health_registry(
+    admin_registry: Option<&HealthRegistry>,
+    pipelines: Option<&pipelines_admin::PipelinesAdminState>,
+    listener_meta: &ListenerMetaStore,
+) -> Option<HealthRegistry> {
+    let Some(state) = pipelines else {
+        return admin_registry.cloned();
+    };
+    let meta = listener_meta.load();
+    let current_listeners: std::collections::HashSet<String> = meta.keys().cloned().collect();
+    for name in state.pipelines.listener_names() {
+        if !current_listeners.contains(name) {
+            continue;
+        }
+        let Some(slot) = state.pipelines.get(name) else {
+            continue;
+        };
+        if let Some(registry) = slot.load().health_registry() {
+            return Some(Arc::clone(registry));
+        }
+    }
+    // No live pipeline exposes a registry (e.g. health checks removed on reload).
+    // Do not fall back to the startup admin snapshot — it would report stale probe state.
+    None
+}
+
+/// Handle `GET`/`HEAD` `/api/stats`.
+pub(super) fn stats_response(
+    health_registry: Option<&HealthRegistry>,
+    state: &StatsAdminState,
+    method: &str,
+) -> Response<Vec<u8>> {
+    if method != "GET" && method != "HEAD" {
+        return method_not_allowed();
+    }
+
+    let body = match build_stats_response(health_registry, state) {
+        Ok(body) => body,
+        Err(error) => {
+            tracing::error!(%error, "stats admin serialization failed");
+            return json_response(500, br#"{"error":"serialization failed"}"#);
+        },
+    };
+
+    let resp = json_response(200, &body);
+    if method == "HEAD" { as_head_response(resp) } else { resp }
+}
+
+/// Assemble the JSON body for `GET /api/stats`.
+fn build_stats_response(
+    health_registry: Option<&HealthRegistry>,
+    state: &StatsAdminState,
+) -> Result<Vec<u8>, serde_json::Error> {
+    let prom = metrics::render_prometheus().unwrap_or_default();
+    let snapshot = metrics::collect_stats_metrics(&prom);
+    let listener_meta = state.listener_meta.load();
+    let cluster_meta = state.cluster_meta.load();
+
+    let gaps = stats_gaps(&snapshot);
+
+    let mut listeners: Vec<ListenerStatsView> = listener_meta
+        .values()
+        .map(|meta| listener_stats_view(meta, &snapshot))
+        .collect();
+    listeners.sort_by(|a, b| a.name.cmp(&b.name));
+
+    let mut clusters: Vec<ClusterStatsView> = cluster_meta
+        .values()
+        .map(|meta| cluster_stats_view(meta, health_registry, &snapshot))
+        .collect();
+    clusters.sort_by(|a, b| a.name.cmp(&b.name));
+
+    serde_json::to_vec(&StatsResponse {
+        uptime_secs: state.started_at.elapsed().as_secs(),
+        version: state.version.clone(),
+        gaps,
+        listeners,
+        clusters,
+    })
+}
+
+/// Document known Phase 1 schema limitations.
+fn stats_gaps(snapshot: &metrics::StatsMetricsSnapshot) -> BTreeMap<&'static str, &'static str> {
+    let mut gaps = BTreeMap::from([(
+        "per_listener_http_requests",
+        "praxis_http_requests_total has no listener label",
+    )]);
+    if snapshot.http_active_by_listener.is_empty() && snapshot.http_active_aggregate.is_some() {
+        gaps.insert(
+            "per_listener_http_active",
+            "listener label disabled on metrics.labels; per-listener active_connections may read 0",
+        );
+    }
+    if snapshot.tcp_active_by_listener.is_empty() && snapshot.tcp_active_aggregate.is_some() {
+        gaps.insert(
+            "per_listener_tcp_active",
+            "listener label disabled on metrics.labels; per-listener TCP active_connections may read 0",
+        );
+    }
+    if snapshot.upstream_requests_by_cluster.is_empty() && snapshot.upstream_requests_aggregate.is_some() {
+        gaps.insert(
+            "per_cluster_upstream_requests",
+            "cluster label disabled on metrics.labels; per-cluster upstream_requests_total may read 0",
+        );
+    }
+    if snapshot.connect_failures_by_cluster.is_empty() && snapshot.connect_failures_aggregate.is_some() {
+        gaps.insert(
+            "per_cluster_upstream_connect_failures",
+            "cluster label disabled on metrics.labels; per-cluster upstream_connect_failures_total may read 0",
+        );
+    }
+    gaps
+}
+
+/// Build one listener row from metadata and metric snapshot.
+fn listener_stats_view(meta: &ListenerMeta, snapshot: &metrics::StatsMetricsSnapshot) -> ListenerStatsView {
+    let active_connections = match meta.protocol {
+        ProtocolKind::Http => snapshot.http_active_by_listener.get(&meta.name).copied().unwrap_or(0),
+        ProtocolKind::Tcp => snapshot.tcp_active_by_listener.get(&meta.name).copied().unwrap_or(0),
+    };
+
+    ListenerStatsView {
+        name: meta.name.clone(),
+        protocol: meta.protocol,
+        tls: meta.tls,
+        active_connections,
+    }
+}
+
+/// Build one cluster row from metadata, health registry, and metric snapshot.
+fn cluster_stats_view(
+    meta: &ClusterMeta,
+    health_registry: Option<&HealthRegistry>,
+    snapshot: &metrics::StatsMetricsSnapshot,
+) -> ClusterStatsView {
+    let endpoints = endpoint_rows(meta, health_registry);
+    let healthy_endpoints = u64::try_from(endpoints.iter().filter(|ep| ep.healthy).count()).unwrap_or(0);
+    let total_endpoints = u64::try_from(endpoints.len()).unwrap_or(0);
+
+    ClusterStatsView {
+        name: meta.name.clone(),
+        healthy_endpoints,
+        total_endpoints,
+        upstream_requests_total: snapshot
+            .upstream_requests_by_cluster
+            .get(&meta.name)
+            .copied()
+            .unwrap_or(0),
+        upstream_connect_failures_total: snapshot
+            .connect_failures_by_cluster
+            .get(&meta.name)
+            .copied()
+            .unwrap_or(0),
+        endpoints,
+    }
+}
+
+/// Build endpoint health rows for one cluster.
+#[expect(clippy::too_many_lines, reason = "registry vs config-only branches")]
+fn endpoint_rows(meta: &ClusterMeta, health_registry: Option<&HealthRegistry>) -> Vec<EndpointStatsView> {
+    let Some(registry) = health_registry else {
+        return meta
+            .endpoints
+            .iter()
+            .map(|address| EndpointStatsView {
+                address: address.clone(),
+                healthy: true,
+            })
+            .collect();
+    };
+
+    let Some(state) = registry.get(meta.name.as_str()) else {
+        return meta
+            .endpoints
+            .iter()
+            .map(|address| EndpointStatsView {
+                address: address.clone(),
+                healthy: true,
+            })
+            .collect();
+    };
+
+    let live: std::collections::HashMap<_, _> = state
+        .endpoint_statuses()
+        .into_iter()
+        .map(|(addr, healthy)| (addr.to_string(), healthy))
+        .collect();
+
+    let mut rows: Vec<_> = meta
+        .endpoints
+        .iter()
+        .map(|address| EndpointStatsView {
+            address: address.clone(),
+            healthy: live.get(address).copied().unwrap_or(true),
+        })
+        .collect();
+    rows.sort_by(|a, b| a.address.cmp(&b.address));
+    rows
+}
+
+/// Strip the body for HEAD. [`json_response`] sets `Content-Length` from the GET
+/// body; remove it after clearing the body so framing follows the empty vec
+/// (RFC 9110 §8.6 — do not send a misleading `Content-Length: 0`).
+fn as_head_response(mut resp: Response<Vec<u8>>) -> Response<Vec<u8>> {
+    *resp.body_mut() = Vec::new();
+    resp.headers_mut().remove(http::header::CONTENT_LENGTH);
+    resp
+}
+
+/// 405 with `Allow: GET, HEAD` per RFC 9110 Section 15.5.6.
+#[expect(clippy::expect_used, reason = "valid static response")]
+fn method_not_allowed() -> Response<Vec<u8>> {
+    let body = br#"{"error":"method not allowed"}"#;
+    Response::builder()
+        .status(405)
+        .header("Content-Type", "application/json")
+        .header("Content-Length", body.len())
+        .header("Allow", "GET, HEAD")
+        .body(body.to_vec())
+        .expect("valid 405 response")
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, clippy::indexing_slicing, reason = "tests")]
+mod tests {
+    use praxis_core::health::{ClusterHealthEntry, EndpointHealth};
+
+    use super::*;
+    use crate::http::pingora::health::{
+        cluster_meta::{cluster_meta_from_config, new_cluster_meta_store},
+        listener_meta::{listener_meta_from_config, new_listener_meta_store},
+    };
+
+    fn sample_state() -> StatsAdminState {
+        let config = praxis_core::config::Config::from_yaml(
+            r#"
+insecure_options:
+  allow_private_endpoints: true
+listeners:
+  - name: web
+    address: "127.0.0.1:8080"
+    filter_chains: [main]
+clusters:
+  - name: backend
+    endpoints:
+      - address: "127.0.0.1:9000"
+filter_chains:
+  - name: main
+    filters: [{ filter: static_response, status: 200 }]
+"#,
+        )
+        .expect("config should parse");
+        StatsAdminState {
+            started_at: Instant::now(),
+            version: ProcessVersionInfo {
+                semver: "0.0.0".to_owned(),
+                display: "0.0.0".to_owned(),
+                git_sha: None,
+            },
+            listener_meta: new_listener_meta_store(listener_meta_from_config(&config)),
+            cluster_meta: new_cluster_meta_store(cluster_meta_from_config(&config)),
+        }
+    }
+
+    #[test]
+    fn stats_get_returns_version_and_gaps() {
+        let state = sample_state();
+        let resp = stats_response(None, &state, "GET");
+        assert_eq!(resp.status().as_u16(), 200, "GET /api/stats should succeed");
+        let json: serde_json::Value = serde_json::from_slice(resp.body()).expect("valid JSON");
+        assert_eq!(json["version"]["semver"], "0.0.0", "semver should be present");
+        assert!(
+            json["gaps"]["per_listener_http_requests"].is_string(),
+            "per-listener HTTP request gap should be documented: {json}"
+        );
+        assert_eq!(json["listeners"][0]["name"], "web", "listener row expected");
+        assert_eq!(json["clusters"][0]["name"], "backend", "cluster row expected");
+    }
+
+    #[test]
+    fn stats_head_returns_empty_body() {
+        let state = sample_state();
+        let resp = stats_response(None, &state, "HEAD");
+        assert_eq!(resp.status().as_u16(), 200, "HEAD should succeed");
+        assert!(resp.body().is_empty(), "HEAD must not include a body");
+        assert_eq!(
+            resp.headers().get("Content-Length"),
+            None,
+            "HEAD should not send Content-Length after body is cleared"
+        );
+    }
+
+    #[test]
+    fn endpoint_rows_use_health_registry_when_present() {
+        let meta = ClusterMeta {
+            name: "backend".to_owned(),
+            endpoints: vec!["10.0.0.1:80".to_owned(), "10.0.0.2:80".to_owned()],
+        };
+        let entry = ClusterHealthEntry::new(
+            vec![EndpointHealth::new(), EndpointHealth::new()],
+            vec![Arc::from("10.0.0.1:80"), Arc::from("10.0.0.2:80")],
+            None,
+            None,
+        );
+        if let Some(ep) = entry.endpoints().get(1) {
+            ep.mark_unhealthy();
+        }
+        let registry: HealthRegistry = Arc::new([(Arc::from("backend"), Arc::new(entry))].into_iter().collect());
+
+        let rows = endpoint_rows(&meta, Some(&registry));
+        assert_eq!(rows.len(), 2, "two endpoint rows expected");
+        let down = rows
+            .iter()
+            .find(|r| r.address == "10.0.0.2:80")
+            .expect("second endpoint");
+        assert!(!down.healthy, "unhealthy endpoint should be false");
+    }
+}

--- a/crates/protocol/src/http/pingora/metrics.rs
+++ b/crates/protocol/src/http/pingora/metrics.rs
@@ -31,8 +31,11 @@ const HTTP_RESPONSE_BODY_BYTES: &str = "praxis_http_response_body_bytes";
 /// Each active request holds an RAII guard for its lifetime, so the
 /// decrement runs on every terminal path, including client aborts and
 /// reset HTTP/2 streams. TCP connections are tracked separately by
-/// `praxis_tcp_active_connections`.
+/// [`TCP_ACTIVE_CONNECTIONS`].
 const HTTP_ACTIVE_REQUESTS: &str = "praxis_http_active_requests";
+
+/// Gauge for open TCP sessions per listener.
+const TCP_ACTIVE_CONNECTIONS: &str = "praxis_tcp_active_connections";
 
 /// Counter for connections rejected by overload protection.
 const OVERLOAD_REJECTS_TOTAL: &str = "praxis_overload_rejects_total";
@@ -214,6 +217,149 @@ pub fn render_prometheus() -> Option<String> {
 /// Returns `true` if the Prometheus recorder has been installed.
 pub(crate) fn is_recorder_installed() -> bool {
     PROMETHEUS_HANDLE.get().is_some()
+}
+
+// -----------------------------------------------------------------------------
+// Stats snapshot (`GET /api/stats`)
+// -----------------------------------------------------------------------------
+
+/// Parsed operational counters for [`collect_stats_metrics`].
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct StatsMetricsSnapshot {
+    /// In-flight HTTP requests per listener (`praxis_http_active_requests`).
+    pub http_active_by_listener: std::collections::HashMap<String, u64>,
+    /// Aggregate in-flight HTTP requests when the listener label is disabled.
+    pub http_active_aggregate: Option<u64>,
+    /// Open TCP sessions per listener (`praxis_tcp_active_connections`).
+    pub tcp_active_by_listener: std::collections::HashMap<String, u64>,
+    /// Aggregate open TCP sessions when the listener label is disabled.
+    pub tcp_active_aggregate: Option<u64>,
+    /// Upstream requests grouped by cluster (`praxis_upstream_requests_total`).
+    pub upstream_requests_by_cluster: std::collections::HashMap<String, u64>,
+    /// Aggregate upstream requests when the cluster label is disabled.
+    pub upstream_requests_aggregate: Option<u64>,
+    /// Upstream connect failures grouped by cluster.
+    pub connect_failures_by_cluster: std::collections::HashMap<String, u64>,
+    /// Aggregate upstream connect failures when the cluster label is disabled.
+    pub connect_failures_aggregate: Option<u64>,
+}
+
+/// Extract operational counters needed by `/api/stats` from Prometheus text.
+#[expect(clippy::too_many_lines, reason = "metric name dispatch table")]
+pub fn collect_stats_metrics(prometheus_text: &str) -> StatsMetricsSnapshot {
+    let mut snapshot = StatsMetricsSnapshot::default();
+    for line in prometheus_text.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let Some((name, labels, value)) = parse_prometheus_sample(line) else {
+            continue;
+        };
+        match name {
+            HTTP_ACTIVE_REQUESTS => {
+                if let Some(listener) = labels.get("listener") {
+                    snapshot.http_active_by_listener.insert(listener.clone(), value);
+                } else {
+                    snapshot.http_active_aggregate = Some(value);
+                }
+            },
+            TCP_ACTIVE_CONNECTIONS => {
+                if let Some(listener) = labels.get("listener") {
+                    snapshot.tcp_active_by_listener.insert(listener.clone(), value);
+                } else {
+                    snapshot.tcp_active_aggregate = Some(value);
+                }
+            },
+            UPSTREAM_REQUESTS_TOTAL => {
+                if let Some(cluster) = labels.get("cluster") {
+                    *snapshot
+                        .upstream_requests_by_cluster
+                        .entry(cluster.clone())
+                        .or_insert(0) += value;
+                } else {
+                    snapshot.upstream_requests_aggregate =
+                        Some(snapshot.upstream_requests_aggregate.unwrap_or(0) + value);
+                }
+            },
+            UPSTREAM_CONNECT_FAILURES_TOTAL => {
+                if let Some(cluster) = labels.get("cluster") {
+                    *snapshot.connect_failures_by_cluster.entry(cluster.clone()).or_insert(0) += value;
+                } else {
+                    snapshot.connect_failures_aggregate =
+                        Some(snapshot.connect_failures_aggregate.unwrap_or(0) + value);
+                }
+            },
+            _ => {},
+        }
+    }
+    snapshot
+}
+
+/// Parsed Prometheus sample: metric name, label map, and integer value.
+type PrometheusSample<'a> = (&'a str, std::collections::HashMap<String, String>, u64);
+
+/// Parse one Prometheus text sample line into metric name, labels, and value.
+fn parse_prometheus_sample(line: &str) -> Option<PrometheusSample<'_>> {
+    let (name_and_labels, value_str) = line.rsplit_once(' ')?;
+    #[expect(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "Prometheus counter/gauge values are non-negative integers"
+    )]
+    let value = {
+        let parsed = value_str.parse::<f64>().ok()?;
+        parsed.round() as u64
+    };
+    let (name, labels) = if let Some((name, label_blob)) = name_and_labels.split_once('{') {
+        let label_blob = label_blob.strip_suffix('}')?;
+        (name, parse_prometheus_labels(label_blob))
+    } else {
+        (name_and_labels, std::collections::HashMap::new())
+    };
+    Some((name, labels, value))
+}
+
+/// Parse `{key="value",...}` label sets from Prometheus text exposition.
+///
+/// Splits on commas only outside double-quoted values so embedded commas in
+/// label values parse correctly.
+fn parse_prometheus_labels(input: &str) -> std::collections::HashMap<String, String> {
+    let mut labels = std::collections::HashMap::new();
+    let mut rest = input.trim();
+    while !rest.is_empty() {
+        let (pair, tail) = split_prometheus_label_pair(rest);
+        if let Some((key, value)) = parse_prometheus_label_pair(pair) {
+            labels.insert(key, value);
+        }
+        rest = tail;
+    }
+    labels
+}
+
+/// Split one `key="value"` pair from the head of a label-set fragment.
+fn split_prometheus_label_pair(input: &str) -> (&str, &str) {
+    let bytes = input.as_bytes();
+    let mut in_quotes = false;
+    for (index, byte) in bytes.iter().enumerate() {
+        match *byte {
+            b'"' => in_quotes = !in_quotes,
+            b',' if !in_quotes => {
+                let head = input.get(..index).unwrap_or(input);
+                let tail = input.get(index + 1..).unwrap_or("").trim_start();
+                return (head, tail);
+            },
+            _ => {},
+        }
+    }
+    (input, "")
+}
+
+/// Parse one `key="value"` pair from a Prometheus label set fragment.
+fn parse_prometheus_label_pair(pair: &str) -> Option<(String, String)> {
+    let (key, value) = pair.split_once('=')?;
+    let value = value.strip_prefix('"')?.strip_suffix('"')?;
+    Some((key.to_owned(), value.to_owned()))
 }
 
 // -----------------------------------------------------------------------------
@@ -993,6 +1139,64 @@ mod tests {
         assert!(
             body.contains("praxis_upstream_healthy_endpoints{cluster=\"kept-cluster\"} 1"),
             "kept cluster should retain its value:\n{body}"
+        );
+    }
+
+    #[test]
+    fn collect_stats_metrics_sums_cluster_counters() {
+        let text = r#"
+praxis_http_active_requests{listener="web"} 2
+praxis_tcp_active_connections{listener="tcp-in"} 1
+praxis_upstream_requests_total{cluster="backend",endpoint="127.0.0.1:1",status_class="2xx"} 3
+praxis_upstream_requests_total{cluster="backend",endpoint="127.0.0.1:2",status_class="5xx"} 1
+praxis_upstream_connect_failures_total{cluster="backend"} 2
+"#;
+        let snap = collect_stats_metrics(text);
+        assert_eq!(
+            snap.http_active_by_listener.get("web"),
+            Some(&2),
+            "HTTP active per listener should parse"
+        );
+        assert_eq!(
+            snap.tcp_active_by_listener.get("tcp-in"),
+            Some(&1),
+            "TCP active per listener should parse"
+        );
+        assert_eq!(
+            snap.upstream_requests_by_cluster.get("backend"),
+            Some(&4),
+            "upstream requests should sum by cluster"
+        );
+        assert_eq!(
+            snap.connect_failures_by_cluster.get("backend"),
+            Some(&2),
+            "connect failures should parse by cluster"
+        );
+    }
+
+    #[test]
+    fn parse_prometheus_labels_handles_commas_inside_quoted_values() {
+        let labels = parse_prometheus_labels(r#"tag="a,b",listener="web""#);
+        assert_eq!(labels.get("tag"), Some(&"a,b".to_owned()), "comma inside quotes");
+        assert_eq!(labels.get("listener"), Some(&"web".to_owned()), "second label");
+    }
+
+    #[test]
+    fn collect_stats_metrics_parses_unlabeled_upstream_counters() {
+        let text = r#"
+praxis_upstream_requests_total{status_class="2xx"} 5
+praxis_upstream_connect_failures_total 2
+"#;
+        let snap = collect_stats_metrics(text);
+        assert_eq!(
+            snap.upstream_requests_aggregate,
+            Some(5),
+            "unlabeled upstream requests should aggregate"
+        );
+        assert_eq!(
+            snap.connect_failures_aggregate,
+            Some(2),
+            "unlabeled connect failures should aggregate"
         );
     }
 

--- a/crates/server/build.rs
+++ b/crates/server/build.rs
@@ -204,7 +204,13 @@ fn emit_version_env() {
     println!("cargo:rerun-if-changed={}", git_dir.join("index").display());
 
     let pkg_version = std::env::var("CARGO_PKG_VERSION").unwrap_or_default();
-    let version = match git_version_suffix() {
+    println!("cargo:rustc-env=PRAXIS_VERSION_SEMVER={pkg_version}");
+    let git_suffix = git_version_suffix();
+    if let Some(suffix) = &git_suffix {
+        let sha = suffix.strip_suffix("-dirty").unwrap_or(suffix.as_str());
+        println!("cargo:rustc-env=PRAXIS_GIT_SHA={sha}");
+    }
+    let version = match git_suffix {
         Some(suffix) => format!("{pkg_version} ({suffix})"),
         None => pkg_version,
     };

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -34,6 +34,8 @@ pub(crate) mod reload;
 pub(crate) mod reload_diagnostics;
 mod server;
 pub(crate) mod startup_checks;
+#[cfg(feature = "admin-api")]
+mod version;
 #[cfg(feature = "config-reload")]
 pub(crate) mod watcher;
 pub use pipelines::{build_subrequest_client, resolve_pipelines};
@@ -42,6 +44,8 @@ pub use praxis_core::{
     logging::{TracingGuard, init_tracing},
 };
 pub use server::{check_root_privilege, fatal, resolve_config_path, run_server, run_server_with_registry};
+#[cfg(feature = "admin-api")]
+pub use version::process_version_info;
 
 // -----------------------------------------------------------------------------
 // External Filter Discovery

--- a/crates/server/src/reload.rs
+++ b/crates/server/src/reload.rs
@@ -54,6 +54,7 @@ pub(crate) fn reload_pipelines(
     registry: &FilterRegistry,
     live: &ListenerPipelines,
     listener_meta: &praxis_protocol::http::pingora::health::ListenerMetaStore,
+    cluster_meta: &praxis_protocol::http::pingora::health::ClusterMetaStore,
     health_shutdown: &Arc<Mutex<CancellationToken>>,
     kv_stores: &praxis_core::kv::KvStoreRegistry,
     session_stores: &Arc<praxis_filter::SessionStoreRegistry>,
@@ -148,6 +149,9 @@ pub(crate) fn reload_pipelines(
 
     listener_meta.store(Arc::new(
         praxis_protocol::http::pingora::health::listener_meta_from_config(new_config),
+    ));
+    cluster_meta.store(Arc::new(
+        praxis_protocol::http::pingora::health::cluster_meta_from_config(new_config),
     ));
 
     respawn_health_checks(old_config, new_config, &health_registry, health_shutdown);
@@ -348,7 +352,7 @@ mod tests {
 
     #[test]
     fn valid_reload_swaps_pipeline() {
-        let (live, old_config, registry, shutdown, meta) = setup_live_pipelines();
+        let (live, old_config, registry, shutdown, meta, cluster_meta) = setup_live_pipelines();
         let old_ptr = Arc::as_ptr(&live.get("web").unwrap().load());
         assert_eq!(
             meta.load().get("web").unwrap().address,
@@ -376,6 +380,7 @@ filter_chains:
             &registry,
             &live,
             &meta,
+            &cluster_meta,
             &shutdown,
             &empty_kv_stores(),
             &empty_session_stores(),
@@ -409,7 +414,7 @@ filter_chains:
 
     #[test]
     fn invalid_filter_returns_err_old_pipeline_untouched() {
-        let (live, old_config, registry, shutdown, meta) = setup_live_pipelines();
+        let (live, old_config, registry, shutdown, meta, cluster_meta) = setup_live_pipelines();
         let old_ptr = Arc::as_ptr(&live.get("web").unwrap().load());
 
         let bad_config = Config::from_yaml(
@@ -432,6 +437,7 @@ filter_chains:
             &registry,
             &live,
             &meta,
+            &cluster_meta,
             &shutdown,
             &empty_kv_stores(),
             &empty_session_stores(),
@@ -446,7 +452,7 @@ filter_chains:
 
     #[test]
     fn old_cancellation_token_cancelled_on_success() {
-        let (live, old_config, registry, shutdown, meta) = setup_live_pipelines();
+        let (live, old_config, registry, shutdown, meta, cluster_meta) = setup_live_pipelines();
         let old_token = shutdown.lock().unwrap().clone();
 
         let new_config = valid_config();
@@ -456,6 +462,7 @@ filter_chains:
             &registry,
             &live,
             &meta,
+            &cluster_meta,
             &shutdown,
             &empty_kv_stores(),
             &empty_session_stores(),
@@ -472,7 +479,7 @@ filter_chains:
 
     #[test]
     fn new_cancellation_token_created_on_success() {
-        let (live, old_config, registry, shutdown, meta) = setup_live_pipelines();
+        let (live, old_config, registry, shutdown, meta, cluster_meta) = setup_live_pipelines();
         let old_token = shutdown.lock().unwrap().clone();
 
         let new_config = valid_config();
@@ -482,6 +489,7 @@ filter_chains:
             &registry,
             &live,
             &meta,
+            &cluster_meta,
             &shutdown,
             &empty_kv_stores(),
             &empty_session_stores(),
@@ -500,7 +508,7 @@ filter_chains:
 
     #[test]
     fn health_checks_not_cancelled_on_failure() {
-        let (live, old_config, registry, shutdown, meta) = setup_live_pipelines();
+        let (live, old_config, registry, shutdown, meta, cluster_meta) = setup_live_pipelines();
         let old_token = shutdown.lock().unwrap().clone();
 
         let bad_config = Config::from_yaml(
@@ -523,6 +531,7 @@ filter_chains:
             &registry,
             &live,
             &meta,
+            &cluster_meta,
             &shutdown,
             &empty_kv_stores(),
             &empty_session_stores(),
@@ -537,7 +546,7 @@ filter_chains:
 
     #[test]
     fn new_listener_in_config_is_skipped() {
-        let (live, old_config, registry, shutdown, meta) = setup_live_pipelines();
+        let (live, old_config, registry, shutdown, meta, cluster_meta) = setup_live_pipelines();
 
         let new_config = Config::from_yaml(
             r#"
@@ -563,6 +572,7 @@ filter_chains:
             &registry,
             &live,
             &meta,
+            &cluster_meta,
             &shutdown,
             &empty_kv_stores(),
             &empty_session_stores(),
@@ -1183,6 +1193,9 @@ filter_chains:
         let meta = praxis_protocol::http::pingora::health::new_listener_meta_store(
             praxis_protocol::http::pingora::health::listener_meta_from_config(&config),
         );
+        let cluster_meta = praxis_protocol::http::pingora::health::new_cluster_meta_store(
+            praxis_protocol::http::pingora::health::cluster_meta_from_config(&config),
+        );
 
         old_health.get("backend").unwrap().endpoints()[1].mark_unhealthy();
 
@@ -1192,6 +1205,7 @@ filter_chains:
             &registry,
             &live,
             &meta,
+            &cluster_meta,
             &shutdown,
             &empty_kv_stores(),
             &empty_session_stores(),
@@ -1271,6 +1285,9 @@ filter_chains:
         let meta = praxis_protocol::http::pingora::health::new_listener_meta_store(
             praxis_protocol::http::pingora::health::listener_meta_from_config(&two),
         );
+        let cluster_meta = praxis_protocol::http::pingora::health::new_cluster_meta_store(
+            praxis_protocol::http::pingora::health::cluster_meta_from_config(&two),
+        );
 
         // First reload (new=one, old=two) removes the 'legacy' listener;
         // its pipeline stays pinned to the now probe-less first-generation
@@ -1281,6 +1298,7 @@ filter_chains:
             &registry,
             &live,
             &meta,
+            &cluster_meta,
             &shutdown,
             &empty_kv_stores(),
             &empty_session_stores(),
@@ -1301,6 +1319,7 @@ filter_chains:
             &registry,
             &live,
             &meta,
+            &cluster_meta,
             &shutdown,
             &empty_kv_stores(),
             &empty_session_stores(),
@@ -1334,6 +1353,9 @@ filter_chains:
         let meta = praxis_protocol::http::pingora::health::new_listener_meta_store(
             praxis_protocol::http::pingora::health::listener_meta_from_config(&config),
         );
+        let cluster_meta = praxis_protocol::http::pingora::health::new_cluster_meta_store(
+            praxis_protocol::http::pingora::health::cluster_meta_from_config(&config),
+        );
 
         old_health.get("backend").unwrap().endpoints()[1].mark_unhealthy();
 
@@ -1348,6 +1370,7 @@ filter_chains:
             &registry,
             &live,
             &meta,
+            &cluster_meta,
             &shutdown,
             &empty_kv_stores(),
             &empty_session_stores(),
@@ -1392,6 +1415,7 @@ filter_chains:
         FilterRegistry,
         Arc<Mutex<CancellationToken>>,
         praxis_protocol::http::pingora::health::ListenerMetaStore,
+        praxis_protocol::http::pingora::health::ClusterMetaStore,
     ) {
         let config = valid_config();
         let registry = FilterRegistry::with_builtins();
@@ -1409,7 +1433,10 @@ filter_chains:
         let meta = praxis_protocol::http::pingora::health::new_listener_meta_store(
             praxis_protocol::http::pingora::health::listener_meta_from_config(&config),
         );
-        (pipelines, config, registry, shutdown, meta)
+        let cluster_meta = praxis_protocol::http::pingora::health::new_cluster_meta_store(
+            praxis_protocol::http::pingora::health::cluster_meta_from_config(&config),
+        );
+        (pipelines, config, registry, shutdown, meta, cluster_meta)
     }
 
     /// Empty KV store registry for tests without KV stores.

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -118,7 +118,10 @@ pub fn run_server_with_registry(
 ) -> ! {
     run_startup_security_checks(&config);
 
-    // Install before pipelines and health checks emit startup metrics. The same
+    #[cfg(feature = "admin-api")]
+    let stats_started_at = std::time::Instant::now();
+
+    // Install before pipelines and health checks emit startup metrics.
     // handle is later shared by `/metrics` and the managed upkeep service.
     // Label selection is installed first and never changed: a gauge guard
     // acquired before a change and released after it would increment one
@@ -139,7 +142,14 @@ pub fn run_server_with_registry(
     let mut server = PingoraServerRuntime::new(&config);
     let _cert_shutdowns = register_protocols(&mut server, &config, &state.pipelines);
     #[cfg(feature = "admin-api")]
-    register_admin_endpoints(&mut server, &config, health_registry, &state, prometheus_recorder);
+    register_admin_endpoints(
+        &mut server,
+        &config,
+        health_registry,
+        &state,
+        prometheus_recorder,
+        stats_started_at,
+    );
 
     #[cfg(feature = "config-reload")]
     let _watcher = spawn_watcher(config_path, config, registry, state);
@@ -167,6 +177,8 @@ struct ServerState {
     pipelines: Arc<ListenerPipelines>,
     /// Hot-swappable listener metadata for admin `/api/pipelines`.
     listener_meta: praxis_protocol::http::pingora::health::ListenerMetaStore,
+    /// Hot-swappable cluster metadata for admin `/api/stats`.
+    cluster_meta: praxis_protocol::http::pingora::health::ClusterMetaStore,
     /// KV store registry.
     kv_stores: praxis_core::kv::KvStoreRegistry,
     /// Session store registry, preserved across reloads.
@@ -180,6 +192,10 @@ struct ServerState {
 }
 
 /// Build filter pipelines, health checks, and registries.
+#[expect(
+    clippy::too_many_lines,
+    reason = "pipeline resolution, health spawn, and state assembly"
+)]
 fn build_server_state(
     config: &Config,
     registry: &FilterRegistry,
@@ -206,6 +222,9 @@ fn build_server_state(
     let listener_meta = praxis_protocol::http::pingora::health::new_listener_meta_store(
         praxis_protocol::http::pingora::health::listener_meta_from_config(config),
     );
+    let cluster_meta = praxis_protocol::http::pingora::health::new_cluster_meta_store(
+        praxis_protocol::http::pingora::health::cluster_meta_from_config(config),
+    );
 
     let health_shutdown = Arc::new(Mutex::new(CancellationToken::new()));
     spawn_health_check_tasks(config, Arc::clone(health_registry), &health_shutdown);
@@ -217,6 +236,7 @@ fn build_server_state(
     ServerState {
         pipelines: Arc::new(pipelines),
         listener_meta,
+        cluster_meta,
         kv_stores,
         session_stores,
         subrequest_client,
@@ -279,6 +299,7 @@ fn spawn_watcher(
         initial_config: config,
         kv_stores: state.kv_stores,
         listener_meta: state.listener_meta,
+        cluster_meta: state.cluster_meta,
         session_stores: state.session_stores,
         pipelines: state.pipelines,
         referenced_files,
@@ -296,12 +317,17 @@ fn spawn_watcher(
 
 /// Register admin/health endpoints with the Pingora server.
 #[cfg(feature = "admin-api")]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "admin wiring needs registry, meta stores, and metrics"
+)]
 fn register_admin_endpoints(
     server: &mut PingoraServerRuntime,
     config: &Config,
     health_registry: HealthRegistry,
     state: &ServerState,
     prometheus_recorder: Option<praxis_protocol::http::pingora::health::PrometheusAdminRecorder>,
+    stats_started_at: std::time::Instant,
 ) {
     if let (Some(admin_addr), Some(prometheus_recorder)) = (&config.admin.address, prometheus_recorder) {
         let options = praxis_protocol::http::pingora::health::AdminEndpointOptions {
@@ -309,6 +335,12 @@ fn register_admin_endpoints(
             kv_registry: Some(state.kv_stores.clone()),
             pipelines: Some((Arc::clone(&state.pipelines), Arc::clone(&state.listener_meta))),
             log_level: state.log_level.clone(),
+            stats: Some(praxis_protocol::http::pingora::health::StatsAdminState {
+                started_at: stats_started_at,
+                version: crate::version::process_version_info(),
+                listener_meta: Arc::clone(&state.listener_meta),
+                cluster_meta: Arc::clone(&state.cluster_meta),
+            }),
             verbose: config.admin.verbose,
         };
         praxis_protocol::http::pingora::health::add_admin_endpoints_to_pingora_server_with_recorder(

--- a/crates/server/src/version.rs
+++ b/crates/server/src/version.rs
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Praxis Contributors
+
+//! Build-time version metadata for admin `/api/stats`.
+
+use praxis_protocol::http::pingora::health::ProcessVersionInfo;
+
+/// Version identity embedded at build time (`server/build.rs`).
+#[must_use]
+pub fn process_version_info() -> ProcessVersionInfo {
+    let semver = env!("PRAXIS_VERSION_SEMVER").to_owned();
+    let git_sha = option_env!("PRAXIS_GIT_SHA").map(str::to_owned);
+    let display = match &git_sha {
+        Some(sha) => format!("{semver} ({sha})"),
+        None => semver.clone(),
+    };
+    ProcessVersionInfo {
+        semver,
+        display,
+        git_sha,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn process_version_info_has_semver_and_display() {
+        let info = process_version_info();
+        assert!(!info.semver.is_empty(), "semver should be set at build time");
+        assert!(!info.display.is_empty(), "display should be set at build time");
+        assert!(
+            info.display.starts_with(&info.semver),
+            "display should include semver prefix: {}",
+            info.display
+        );
+    }
+}

--- a/crates/server/src/watcher.rs
+++ b/crates/server/src/watcher.rs
@@ -88,6 +88,9 @@ pub(crate) struct WatcherParams {
     /// Listener metadata for admin `/api/pipelines`, swapped on reload.
     pub(crate) listener_meta: praxis_protocol::http::pingora::health::ListenerMetaStore,
 
+    /// Cluster metadata for admin `/api/stats`, swapped on reload.
+    pub(crate) cluster_meta: praxis_protocol::http::pingora::health::ClusterMetaStore,
+
     /// Filter registry for building new pipelines.
     pub(crate) registry: Arc<FilterRegistry>,
 
@@ -202,6 +205,7 @@ async fn run_event_loop(rx: &mut mpsc::Receiver<()>, params: WatcherParams) {
         &params.registry,
         &params.pipelines,
         &params.listener_meta,
+        &params.cluster_meta,
         &params.health_shutdown,
         &params.kv_stores,
         &params.session_stores,
@@ -249,6 +253,7 @@ async fn run_event_loop(rx: &mut mpsc::Receiver<()>, params: WatcherParams) {
             &params.registry,
             &params.pipelines,
             &params.listener_meta,
+            &params.cluster_meta,
             &params.health_shutdown,
             &params.kv_stores,
             &params.session_stores,
@@ -301,6 +306,7 @@ fn handle_reload(
     registry: &FilterRegistry,
     pipelines: &ListenerPipelines,
     listener_meta: &praxis_protocol::http::pingora::health::ListenerMetaStore,
+    cluster_meta: &praxis_protocol::http::pingora::health::ClusterMetaStore,
     health_shutdown: &Arc<Mutex<CancellationToken>>,
     kv_stores: &praxis_core::kv::KvStoreRegistry,
     session_stores: &Arc<praxis_filter::SessionStoreRegistry>,
@@ -354,6 +360,7 @@ fn handle_reload(
         registry,
         pipelines,
         listener_meta,
+        cluster_meta,
         health_shutdown,
         kv_stores,
         session_stores,
@@ -932,6 +939,9 @@ mod tests {
         let listener_meta = praxis_protocol::http::pingora::health::new_listener_meta_store(
             praxis_protocol::http::pingora::health::listener_meta_from_config(&config),
         );
+        let cluster_meta = praxis_protocol::http::pingora::health::new_cluster_meta_store(
+            praxis_protocol::http::pingora::health::cluster_meta_from_config(&config),
+        );
 
         let original_hash = composite_hash(VALID_YAML, &[]);
         let mut hash = original_hash;
@@ -946,6 +956,7 @@ mod tests {
             &registry,
             &pipelines,
             &listener_meta,
+            &cluster_meta,
             &health_shutdown,
             &kv_stores,
             &session_stores,
@@ -970,6 +981,7 @@ mod tests {
             &registry,
             &pipelines,
             &listener_meta,
+            &cluster_meta,
             &health_shutdown,
             &kv_stores,
             &session_stores,
@@ -1016,6 +1028,9 @@ mod tests {
             referenced_files: Vec::new(),
             listener_meta: praxis_protocol::http::pingora::health::new_listener_meta_store(
                 praxis_protocol::http::pingora::health::listener_meta_from_config(&config),
+            ),
+            cluster_meta: praxis_protocol::http::pingora::health::new_cluster_meta_store(
+                praxis_protocol::http::pingora::health::cluster_meta_from_config(&config),
             ),
             registry,
             shutdown: shutdown.clone(),
@@ -1069,6 +1084,9 @@ mod tests {
             pipelines: Arc::clone(&pipelines),
             listener_meta: praxis_protocol::http::pingora::health::new_listener_meta_store(
                 praxis_protocol::http::pingora::health::listener_meta_from_config(&config),
+            ),
+            cluster_meta: praxis_protocol::http::pingora::health::new_cluster_meta_store(
+                praxis_protocol::http::pingora::health::cluster_meta_from_config(&config),
             ),
             registry: Arc::clone(&registry),
             shutdown: shutdown.clone(),
@@ -1130,6 +1148,9 @@ mod tests {
             pipelines: Arc::clone(&pipelines),
             listener_meta: praxis_protocol::http::pingora::health::new_listener_meta_store(
                 praxis_protocol::http::pingora::health::listener_meta_from_config(&config),
+            ),
+            cluster_meta: praxis_protocol::http::pingora::health::new_cluster_meta_store(
+                praxis_protocol::http::pingora::health::cluster_meta_from_config(&config),
             ),
             registry: Arc::clone(&registry),
             shutdown: shutdown.clone(),
@@ -1222,6 +1243,9 @@ mod tests {
             listener_meta: praxis_protocol::http::pingora::health::new_listener_meta_store(
                 praxis_protocol::http::pingora::health::listener_meta_from_config(&config),
             ),
+            cluster_meta: praxis_protocol::http::pingora::health::new_cluster_meta_store(
+                praxis_protocol::http::pingora::health::cluster_meta_from_config(&config),
+            ),
             registry,
             shutdown: shutdown.clone(),
             subrequest_client: praxis_core::subrequest::SubRequestClient::new(
@@ -1294,6 +1318,9 @@ mod tests {
             pipelines: Arc::clone(&pipelines),
             listener_meta: praxis_protocol::http::pingora::health::new_listener_meta_store(
                 praxis_protocol::http::pingora::health::listener_meta_from_config(&config),
+            ),
+            cluster_meta: praxis_protocol::http::pingora::health::new_cluster_meta_store(
+                praxis_protocol::http::pingora::health::cluster_meta_from_config(&config),
             ),
             registry: Arc::clone(&registry),
             shutdown: shutdown.clone(),
@@ -1370,6 +1397,9 @@ mod tests {
             listener_meta: praxis_protocol::http::pingora::health::new_listener_meta_store(
                 praxis_protocol::http::pingora::health::listener_meta_from_config(&config),
             ),
+            cluster_meta: praxis_protocol::http::pingora::health::new_cluster_meta_store(
+                praxis_protocol::http::pingora::health::cluster_meta_from_config(&config),
+            ),
             registry: Arc::clone(&registry),
             shutdown: shutdown.clone(),
             subrequest_client: praxis_core::subrequest::SubRequestClient::new(
@@ -1443,6 +1473,9 @@ mod tests {
             pipelines: Arc::clone(&pipelines),
             listener_meta: praxis_protocol::http::pingora::health::new_listener_meta_store(
                 praxis_protocol::http::pingora::health::listener_meta_from_config(&config),
+            ),
+            cluster_meta: praxis_protocol::http::pingora::health::new_cluster_meta_store(
+                praxis_protocol::http::pingora::health::cluster_meta_from_config(&config),
             ),
             registry: Arc::clone(&registry),
             shutdown: shutdown.clone(),
@@ -1612,6 +1645,9 @@ mod tests {
             referenced_files: Vec::new(),
             listener_meta: praxis_protocol::http::pingora::health::new_listener_meta_store(
                 praxis_protocol::http::pingora::health::listener_meta_from_config(&config),
+            ),
+            cluster_meta: praxis_protocol::http::pingora::health::new_cluster_meta_store(
+                praxis_protocol::http::pingora::health::cluster_meta_from_config(&config),
             ),
             registry: Arc::clone(&registry),
             shutdown: shutdown.clone(),

--- a/tests/integration/tests/suite/main.rs
+++ b/tests/integration/tests/suite/main.rs
@@ -81,6 +81,7 @@ mod route_templates;
 mod routing;
 mod security;
 mod sni_router;
+mod stats_admin;
 mod stream_buffer_adapter;
 mod streaming_terminal_response;
 mod tcp_access_log;

--- a/tests/integration/tests/suite/stats_admin.rs
+++ b/tests/integration/tests/suite/stats_admin.rs
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Praxis Contributors
+
+//! Integration tests for `GET /api/stats` (#125 Phase 1).
+
+use praxis_core::config::Config;
+use praxis_test_utils::{free_port, http_get, start_backend, start_full_proxy, wait_for_tcp};
+use serde_json::Value;
+
+fn stats_config_yaml(proxy_port: u16, admin_port: u16, backend_port: u16) -> String {
+    format!(
+        r#"
+insecure_options:
+  allow_private_endpoints: true
+
+admin:
+  address: "127.0.0.1:{admin_port}"
+
+listeners:
+  - name: web
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains: [main]
+
+clusters:
+  - name: backend
+    endpoints:
+      - address: "127.0.0.1:{backend_port}"
+
+filter_chains:
+  - name: main
+    filters:
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: backend
+      - filter: load_balancer
+        clusters:
+          - name: backend
+            endpoints:
+              - address: "127.0.0.1:{backend_port}"
+"#,
+    )
+}
+
+fn get_stats_json(admin_addr: &str) -> (u16, Value) {
+    let (status, body) = http_get(admin_addr, "/api/stats", None);
+    let json: Value = serde_json::from_str(&body)
+        .unwrap_or_else(|_| panic!("admin /api/stats should return JSON, got status={status} body={body}"));
+    (status, json)
+}
+
+#[test]
+fn stats_json_shape_after_live_traffic() {
+    let backend_port = start_backend("stats-api");
+    let proxy_port = free_port();
+    let admin_port = free_port();
+    let yaml = stats_config_yaml(proxy_port, admin_port, backend_port);
+    let config = Config::from_yaml(&yaml).expect("config should parse");
+    let _proxy = start_full_proxy(&config);
+    let admin_addr = format!("127.0.0.1:{admin_port}");
+    let proxy_addr = format!("127.0.0.1:{proxy_port}");
+    wait_for_tcp(&admin_addr);
+
+    let (status, _) = http_get(&proxy_addr, "/hello", None);
+    assert_eq!(status, 200, "proxy request should succeed before stats read");
+
+    let (status, json) = get_stats_json(&admin_addr);
+    assert_eq!(status, 200, "GET /api/stats should succeed: {json}");
+
+    assert!(json["uptime_secs"].as_u64().is_some(), "uptime_secs required: {json}");
+    assert!(json["version"]["semver"].is_string(), "version.semver required: {json}");
+    assert!(
+        json["version"]["display"].is_string(),
+        "version.display required: {json}"
+    );
+
+    let listeners = json["listeners"].as_array().expect("listeners array");
+    let web = listeners.iter().find(|l| l["name"] == "web").expect("web listener");
+    assert_eq!(web["protocol"], "http", "web protocol: {json}");
+    assert!(
+        json["gaps"]["per_listener_http_requests"].is_string(),
+        "per-listener HTTP request gap documented: {json}"
+    );
+
+    let clusters = json["clusters"].as_array().expect("clusters array");
+    let backend = clusters
+        .iter()
+        .find(|c| c["name"] == "backend")
+        .expect("backend cluster");
+    assert_eq!(backend["total_endpoints"], 1, "endpoint count: {json}");
+    assert_eq!(
+        backend["healthy_endpoints"], 1,
+        "healthy count without health_check: {json}"
+    );
+    assert!(
+        backend["upstream_requests_total"].as_u64().unwrap_or(0) >= 1,
+        "upstream request counter should reflect live traffic: {json}"
+    );
+    let endpoints = backend["endpoints"].as_array().expect("endpoints array");
+    assert_eq!(
+        endpoints[0]["address"],
+        format!("127.0.0.1:{backend_port}"),
+        "endpoint address: {json}"
+    );
+    assert_eq!(
+        endpoints[0]["healthy"], true,
+        "endpoint healthy without health_check: {json}"
+    );
+}

--- a/tests/utils/src/proxy.rs
+++ b/tests/utils/src/proxy.rs
@@ -334,6 +334,9 @@ fn build_full_server_with_registry(config: &Config, registry: &FilterRegistry) -
     let listener_meta = praxis_protocol::http::pingora::health::new_listener_meta_store(
         praxis_protocol::http::pingora::health::listener_meta_from_config(config),
     );
+    let cluster_meta = praxis_protocol::http::pingora::health::new_cluster_meta_store(
+        praxis_protocol::http::pingora::health::cluster_meta_from_config(config),
+    );
 
     let mut runtime = praxis_core::PingoraServerRuntime::new(config);
 
@@ -356,8 +359,14 @@ fn build_full_server_with_registry(config: &Config, registry: &FilterRegistry) -
             praxis_protocol::http::pingora::health::AdminEndpointOptions {
                 health_registry: Some(Arc::clone(&health_registry)),
                 kv_registry: Some(kv_stores),
-                pipelines: Some((Arc::clone(&pipelines), listener_meta)),
+                pipelines: Some((Arc::clone(&pipelines), Arc::clone(&listener_meta))),
                 log_level: None,
+                stats: Some(praxis_protocol::http::pingora::health::StatsAdminState {
+                    started_at: std::time::Instant::now(),
+                    version: praxis::process_version_info(),
+                    listener_meta,
+                    cluster_meta,
+                }),
                 verbose: config.admin.verbose,
             },
         );


### PR DESCRIPTION
## Summary
- Adds `GET /api/stats` returning uptime, version identity, per-listener active connections, and per-cluster upstream counters plus endpoint health snapshot.
- Hot-reload updates listener/cluster metadata; endpoint health follows live pipeline registries.
- Documents known gaps (per-listener HTTP request totals) in the JSON `gaps` object.

Closes #125

## Test plan
- [x] `cargo check -p praxis-proxy-protocol --features admin-api`
- [ ] `make fmt && make lint`
- [ ] `cargo test -p praxis-tests-integration stats_json_shape`