### PR TITLE
fix(pipeline): drive security checks from registry SecurityClass

### DIFF
--- a/crates/filter/src/pipeline/body.rs
+++ b/crates/filter/src/pipeline/body.rs
@@ -420,6 +420,7 @@ mod tests {
 
         let branch_filter = PipelineFilter {
             filter_id: 100,
+            is_security: false,
             branches: vec![],
             conditions: vec![],
             failure_mode: FailureMode::default(),
@@ -436,6 +437,7 @@ mod tests {
         };
         let parent = PipelineFilter {
             filter_id: 0,
+            is_security: false,
             branches: vec![branch],
             conditions: vec![],
             failure_mode: FailureMode::default(),
@@ -500,6 +502,7 @@ mod tests {
         };
         let parent = PipelineFilter {
             filter_id: 0,
+            is_security: false,
             branches: vec![branch],
             conditions: vec![],
             failure_mode: FailureMode::default(),
@@ -534,6 +537,7 @@ mod tests {
         };
         let parent = PipelineFilter {
             filter_id: 0,
+            is_security: false,
             branches: vec![branch],
             conditions: vec![],
             failure_mode: FailureMode::default(),

--- a/crates/filter/src/pipeline/build.rs
+++ b/crates/filter/src/pipeline/build.rs
@@ -61,6 +61,7 @@ impl FilterPipeline {
                 mem::take(&mut entry.response_conditions),
             );
             pf.failure_mode = entry.failure_mode;
+            pf.is_security = registry.is_security_filter(&entry.filter_type);
             pf.name = entry.name.as_ref().map(|n| Arc::from(n.as_str()));
             filters.push(pf);
         }

--- a/crates/filter/src/pipeline/build_branch.rs
+++ b/crates/filter/src/pipeline/build_branch.rs
@@ -171,6 +171,7 @@ fn build_filters(
             mem::take(&mut entry.response_conditions),
         );
         pf.failure_mode = entry.failure_mode;
+        pf.is_security = registry.is_security_filter(&entry.filter_type);
         pf.name = entry.name.as_ref().map(|n| Arc::from(n.as_str()));
         branch_configs.push(entry.branch_chains.take());
         filters.push(pf);

--- a/crates/filter/src/pipeline/checks.rs
+++ b/crates/filter/src/pipeline/checks.rs
@@ -26,22 +26,6 @@ use crate::{any_filter::AnyFilter, body::BodyAccess};
 // Constants
 // -----------------------------------------------------------------------------
 
-/// Filters classified as security-critical (bypass risk when conditional).
-const SECURITY_FILTERS: &[&str] = &[
-    #[cfg(feature = "basic-auth-filter")]
-    "basic_auth",
-    "cors",
-    "credential_injection",
-    "csrf",
-    "forwarded_headers",
-    "guardrails",
-    "ip_acl",
-    "peer_identity_trust",
-    #[cfg(feature = "policy-engine")]
-    "policy",
-    "rate_limit",
-];
-
 /// Filters that rewrite the request path.
 const REWRITE_FILTERS: &[&str] = &["path_rewrite", "url_rewrite"];
 
@@ -120,7 +104,7 @@ pub(super) fn check_unconditional_static_response(
 /// Security filters with request conditions (bypass risk).
 pub(super) fn check_conditional_security(names: &[&str], filters: &[PipelineFilter], errors: &mut Vec<String>) {
     for (i, (name, pf)) in names.iter().zip(filters).enumerate() {
-        if SECURITY_FILTERS.contains(name) && !pf.conditions.is_empty() {
+        if pf.is_security && !pf.conditions.is_empty() {
             errors.push(format!(
                 "security filter '{name}' at position {i} has \
                  request conditions; it will be bypassed for \
@@ -140,7 +124,7 @@ pub(super) fn check_open_security_filters(
     errors: &mut Vec<String>,
 ) {
     for (i, (name, pf)) in names.iter().zip(filters).enumerate() {
-        if SECURITY_FILTERS.contains(name) && pf.failure_mode == FailureMode::Open {
+        if pf.is_security && pf.failure_mode == FailureMode::Open {
             let msg = format!(
                 "security filter '{name}' at position {i} has \
                  failure_mode: open; runtime errors will bypass \
@@ -360,8 +344,8 @@ pub(super) fn check_skip_to_bypasses_security(filters: &[PipelineFilter], errors
                 .skip(i + 1)
                 .take(target.saturating_sub(i + 1))
             {
-                let name = skipped.filter.name();
-                if SECURITY_FILTERS.contains(&name) {
+                if skipped.is_security {
+                    let name = skipped.filter.name();
                     errors.push(format!(
                         "branch '{branch}' on filter at position {i} \
                          uses SkipTo rejoin that bypasses security \
@@ -406,8 +390,8 @@ pub(super) fn check_terminal_rejoin_bypasses_security(filters: &[PipelineFilter]
             continue;
         }
         for (later_idx, later) in filters.iter().enumerate().skip(i + 1) {
-            let name = later.filter.name();
-            if SECURITY_FILTERS.contains(&name) {
+            if later.is_security {
+                let name = later.filter.name();
                 errors.push(format!(
                     "filter at position {i} has a Terminal branch that forwards upstream (a \
                      cluster is selected in the sub-chain or earlier in the pipeline), \
@@ -570,20 +554,6 @@ mod tests {
         branch::ResolvedBranch,
         test_filters::{lb_filter, noop_filter_with_conditions, selector_filter},
     };
-
-    #[test]
-    fn security_filter_list_matches_registry_metadata() {
-        let registry = crate::FilterRegistry::with_builtins();
-        let mut expected = registry.security_filters();
-        let mut actual = SECURITY_FILTERS.to_vec();
-        expected.sort_unstable();
-        actual.sort_unstable();
-
-        assert_eq!(
-            actual, expected,
-            "pipeline checks and registry security metadata diverged"
-        );
-    }
 
     #[test]
     fn invalid_condition_header_name_rejected_at_build() {
@@ -842,7 +812,7 @@ mod tests {
     #[test]
     fn conditional_security_filter_errors() {
         let names = vec!["ip_acl"];
-        let filters = vec![make_pf(vec![make_condition()])];
+        let filters = vec![make_security_pf(vec![make_condition()])];
         let mut errors = Vec::new();
         check_conditional_security(&names, &filters, &mut errors);
         assert_eq!(errors.len(), 1, "should produce exactly one error");
@@ -856,7 +826,7 @@ mod tests {
     #[test]
     fn unconditional_security_filter_no_error() {
         let names = vec!["ip_acl"];
-        let filters = vec![make_pf(vec![])];
+        let filters = vec![make_security_pf(vec![])];
         let mut errors = Vec::new();
         check_conditional_security(&names, &filters, &mut errors);
         assert!(errors.is_empty(), "unconditional security filter should not error");
@@ -865,7 +835,7 @@ mod tests {
     #[test]
     fn open_security_filter_errors() {
         let names = vec!["ip_acl"];
-        let mut pf = make_pf(vec![]);
+        let mut pf = make_security_pf(vec![]);
         pf.failure_mode = FailureMode::Open;
         let filters = vec![pf];
         let mut errors = Vec::new();
@@ -881,7 +851,7 @@ mod tests {
     #[test]
     fn open_security_filter_allowed_demotes_to_warning() {
         let names = vec!["ip_acl"];
-        let mut pf = make_pf(vec![]);
+        let mut pf = make_security_pf(vec![]);
         pf.failure_mode = FailureMode::Open;
         let filters = vec![pf];
         let mut errors = Vec::new();
@@ -892,7 +862,7 @@ mod tests {
     #[test]
     fn closed_security_filter_no_error() {
         let names = vec!["ip_acl"];
-        let filters = vec![make_pf(vec![])];
+        let filters = vec![make_security_pf(vec![])];
         let mut errors = Vec::new();
         check_open_security_filters(&names, &filters, false, &mut errors);
         assert!(errors.is_empty(), "closed security filter should not error");
@@ -901,7 +871,7 @@ mod tests {
     #[test]
     fn open_forwarded_headers_filter_errors() {
         let names = vec!["forwarded_headers"];
-        let mut pf = make_pf(vec![]);
+        let mut pf = make_security_pf(vec![]);
         pf.failure_mode = FailureMode::Open;
         let filters = vec![pf];
         let mut errors = Vec::new();
@@ -917,7 +887,7 @@ mod tests {
     #[test]
     fn open_forwarded_headers_allowed_demotes_to_warning() {
         let names = vec!["forwarded_headers"];
-        let mut pf = make_pf(vec![]);
+        let mut pf = make_security_pf(vec![]);
         pf.failure_mode = FailureMode::Open;
         let filters = vec![pf];
         let mut errors = Vec::new();
@@ -937,6 +907,51 @@ mod tests {
         let mut errors = Vec::new();
         check_open_security_filters(&names, &filters, false, &mut errors);
         assert!(errors.is_empty(), "open non-security filter should not error");
+    }
+
+    #[test]
+    fn open_filter_named_like_builtin_without_class_no_error() {
+        // Classification is the registry SecurityClass stamp, not the type name.
+        let names = vec!["ip_acl"];
+        let mut pf = named_noop_filter("ip_acl", vec![]);
+        pf.failure_mode = FailureMode::Open;
+        let filters = vec![pf];
+        let mut errors = Vec::new();
+        check_open_security_filters(&names, &filters, false, &mut errors);
+        assert!(
+            errors.is_empty(),
+            "a filter named like a builtin security filter is not checked without is_security"
+        );
+    }
+
+    #[test]
+    fn open_custom_security_filter_errors() {
+        let names = vec!["my_auth"];
+        let mut pf = security_noop_filter("my_auth", vec![]);
+        pf.failure_mode = FailureMode::Open;
+        let filters = vec![pf];
+        let mut errors = Vec::new();
+        check_open_security_filters(&names, &filters, false, &mut errors);
+        assert_eq!(errors.len(), 1, "custom Security-class filters must be checked");
+        assert!(
+            errors[0].contains("my_auth") && errors[0].contains("failure_mode: open"),
+            "error should name the custom security filter: {}",
+            errors[0]
+        );
+    }
+
+    #[test]
+    fn conditional_custom_security_filter_errors() {
+        let names = vec!["my_auth"];
+        let filters = vec![security_noop_filter("my_auth", vec![make_condition()])];
+        let mut errors = Vec::new();
+        check_conditional_security(&names, &filters, &mut errors);
+        assert_eq!(errors.len(), 1, "custom Security-class filters must be checked");
+        assert!(
+            errors[0].contains("my_auth"),
+            "error should name the custom security filter: {}",
+            errors[0]
+        );
     }
 
     #[test]
@@ -1388,7 +1403,7 @@ mod tests {
     fn skip_to_bypassing_security_filter_errors() {
         let mut f0 = named_noop_filter("headers", vec![]);
         f0.branches = vec![make_skip_branch("skip", 2)];
-        let f1 = named_noop_filter("ip_acl", vec![]);
+        let f1 = security_noop_filter("ip_acl", vec![]);
         let f2 = named_noop_filter("load_balancer", vec![]);
         let filters = vec![f0, f1, f2];
         let mut errors = Vec::new();
@@ -1405,8 +1420,8 @@ mod tests {
     fn skip_to_bypassing_multiple_security_filters_reports_each() {
         let mut f0 = named_noop_filter("headers", vec![]);
         f0.branches = vec![make_skip_branch("big_skip", 3)];
-        let f1 = named_noop_filter("ip_acl", vec![]);
-        let f2 = named_noop_filter("cors", vec![]);
+        let f1 = security_noop_filter("ip_acl", vec![]);
+        let f2 = security_noop_filter("cors", vec![]);
         let f3 = named_noop_filter("load_balancer", vec![]);
         let filters = vec![f0, f1, f2, f3];
         let mut errors = Vec::new();
@@ -1430,11 +1445,28 @@ mod tests {
     }
 
     #[test]
+    fn skip_to_bypassing_custom_security_filter_errors() {
+        let mut f0 = named_noop_filter("headers", vec![]);
+        f0.branches = vec![make_skip_branch("skip", 2)];
+        let f1 = security_noop_filter("my_auth", vec![]);
+        let f2 = named_noop_filter("load_balancer", vec![]);
+        let filters = vec![f0, f1, f2];
+        let mut errors = Vec::new();
+        check_skip_to_bypasses_security(&filters, &mut errors);
+        assert_eq!(errors.len(), 1, "SkipTo over a custom Security filter must error");
+        assert!(
+            errors[0].contains("my_auth"),
+            "error should name the custom security filter: {}",
+            errors[0]
+        );
+    }
+
+    #[test]
     fn skip_to_landing_on_security_filter_no_error() {
         let mut f0 = named_noop_filter("headers", vec![]);
         f0.branches = vec![make_skip_branch("skip", 2)];
         let f1 = named_noop_filter("request_id", vec![]);
-        let f2 = named_noop_filter("ip_acl", vec![]);
+        let f2 = security_noop_filter("ip_acl", vec![]);
         let filters = vec![f0, f1, f2];
         let mut errors = Vec::new();
         check_skip_to_bypasses_security(&filters, &mut errors);
@@ -1448,7 +1480,7 @@ mod tests {
     fn no_branches_no_skip_to_error() {
         let filters = vec![
             named_noop_filter("headers", vec![]),
-            named_noop_filter("ip_acl", vec![]),
+            security_noop_filter("ip_acl", vec![]),
         ];
         let mut errors = Vec::new();
         check_skip_to_bypasses_security(&filters, &mut errors);
@@ -1565,6 +1597,20 @@ mod tests {
     /// Build a [`PipelineFilter`] with the given conditions.
     fn make_pf(conditions: Vec<Condition>) -> PipelineFilter {
         named_noop_filter("noop", conditions)
+    }
+
+    /// Build a security-class [`PipelineFilter`] with the given conditions.
+    fn make_security_pf(conditions: Vec<Condition>) -> PipelineFilter {
+        let mut pf = make_pf(conditions);
+        pf.is_security = true;
+        pf
+    }
+
+    /// Build a security-class noop named `name`.
+    fn security_noop_filter(name: &'static str, conditions: Vec<Condition>) -> PipelineFilter {
+        let mut pf = named_noop_filter(name, conditions);
+        pf.is_security = true;
+        pf
     }
 
     fn named_noop_filter(name: &'static str, conditions: Vec<Condition>) -> PipelineFilter {
@@ -1687,7 +1733,7 @@ mod tests {
     fn terminal_routing_branch_before_security_filter_errors() {
         let mut host = named_noop_filter("classifier", vec![]);
         host.branches = vec![make_terminal_branch("route", vec![cluster_selecting_filter()])];
-        let ip_acl = named_noop_filter("ip_acl", vec![]);
+        let ip_acl = security_noop_filter("ip_acl", vec![]);
         let filters = vec![host, ip_acl];
         let mut errors = Vec::new();
         check_terminal_rejoin_bypasses_security(&filters, &mut errors);
@@ -1710,7 +1756,7 @@ mod tests {
             "br",
             vec![named_noop_filter("request_id", vec![])],
         )];
-        let ip_acl = named_noop_filter("ip_acl", vec![]);
+        let ip_acl = security_noop_filter("ip_acl", vec![]);
         let filters = vec![host, ip_acl];
         let mut errors = Vec::new();
         check_terminal_rejoin_bypasses_security(&filters, &mut errors);
@@ -1732,7 +1778,7 @@ mod tests {
             "br",
             vec![named_noop_filter("request_id", vec![])],
         )];
-        let ip_acl = named_noop_filter("ip_acl", vec![]);
+        let ip_acl = security_noop_filter("ip_acl", vec![]);
         let filters = vec![selector, host, ip_acl];
         let mut errors = Vec::new();
         check_terminal_rejoin_bypasses_security(&filters, &mut errors);
@@ -1764,7 +1810,7 @@ mod tests {
         }];
         let mut terminal_host = named_noop_filter("headers", vec![]);
         terminal_host.branches = vec![make_terminal_branch("stop", vec![])];
-        let ip_acl = named_noop_filter("ip_acl", vec![]);
+        let ip_acl = security_noop_filter("ip_acl", vec![]);
         let filters = vec![selector_host, terminal_host, ip_acl];
         let mut errors = Vec::new();
         check_terminal_rejoin_bypasses_security(&filters, &mut errors);
@@ -1782,7 +1828,7 @@ mod tests {
 
     #[test]
     fn terminal_routing_branch_after_security_filter_no_error() {
-        let ip_acl = named_noop_filter("ip_acl", vec![]);
+        let ip_acl = security_noop_filter("ip_acl", vec![]);
         let mut host = named_noop_filter("classifier", vec![]);
         host.branches = vec![make_terminal_branch("route", vec![cluster_selecting_filter()])];
         // ip_acl runs before the routing branch, so it is not bypassed.
@@ -1792,6 +1838,26 @@ mod tests {
         assert!(
             errors.is_empty(),
             "security filter before the branch is not bypassed: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn terminal_routing_branch_before_custom_security_filter_errors() {
+        let mut host = named_noop_filter("classifier", vec![]);
+        host.branches = vec![make_terminal_branch("route", vec![cluster_selecting_filter()])];
+        let my_auth = security_noop_filter("my_auth", vec![]);
+        let filters = vec![host, my_auth];
+        let mut errors = Vec::new();
+        check_terminal_rejoin_bypasses_security(&filters, &mut errors);
+        assert_eq!(
+            errors.len(),
+            1,
+            "a terminal routing branch before a custom Security filter must be flagged"
+        );
+        assert!(
+            errors[0].contains("my_auth") && errors[0].contains("bypassing"),
+            "error should name the bypassed custom security filter: {}",
+            errors[0]
         );
     }
 }

--- a/crates/filter/src/pipeline/evaluate.rs
+++ b/crates/filter/src/pipeline/evaluate.rs
@@ -665,6 +665,7 @@ mod tests {
         let inner_branch = make_branch("inner", None, RejoinTarget::Terminal, None, vec![]);
         let outer_filter = PipelineFilter {
             filter_id: 100,
+            is_security: false,
             branches: vec![inner_branch],
             conditions: vec![],
             failure_mode: FailureMode::default(),
@@ -794,6 +795,7 @@ mod tests {
         let branch_pf_id = NEXT_TEST_ID.fetch_add(1, Ordering::SeqCst);
         let branch_pf = PipelineFilter {
             filter_id: branch_pf_id,
+            is_security: false,
             branches: vec![],
             conditions: vec![],
             failure_mode: FailureMode::default(),
@@ -829,6 +831,7 @@ mod tests {
         let branch_id = NEXT_TEST_ID.fetch_add(1, Ordering::SeqCst);
         let branch_pf = PipelineFilter {
             filter_id: branch_id,
+            is_security: false,
             branches: vec![],
             conditions: vec![],
             failure_mode: FailureMode::default(),
@@ -948,6 +951,7 @@ mod tests {
         let inner_branch = make_branch("inner_skip", None, RejoinTarget::SkipTo(42), None, vec![]);
         let outer_filter = PipelineFilter {
             filter_id: NEXT_TEST_ID.fetch_add(1, Ordering::SeqCst),
+            is_security: false,
             branches: vec![inner_branch],
             conditions: vec![],
             failure_mode: FailureMode::default(),
@@ -1058,6 +1062,7 @@ mod tests {
     fn counting_pf(counter: Arc<AtomicUsize>) -> PipelineFilter {
         PipelineFilter {
             filter_id: NEXT_TEST_ID.fetch_add(1, Ordering::SeqCst),
+            is_security: false,
             branches: vec![],
             conditions: vec![],
             failure_mode: FailureMode::default(),
@@ -1071,6 +1076,7 @@ mod tests {
     fn reject_pf(status: u16) -> PipelineFilter {
         PipelineFilter {
             filter_id: NEXT_TEST_ID.fetch_add(1, Ordering::SeqCst),
+            is_security: false,
             branches: vec![],
             conditions: vec![],
             failure_mode: FailureMode::default(),
@@ -1084,6 +1090,7 @@ mod tests {
     fn error_pf(failure_mode: FailureMode) -> PipelineFilter {
         PipelineFilter {
             filter_id: NEXT_TEST_ID.fetch_add(1, Ordering::SeqCst),
+            is_security: false,
             branches: vec![],
             conditions: vec![],
             failure_mode,
@@ -1097,6 +1104,7 @@ mod tests {
     fn stateful_pf(id: u64, log: &ObsLog) -> PipelineFilter {
         PipelineFilter {
             filter_id: NEXT_TEST_ID.fetch_add(1, Ordering::SeqCst),
+            is_security: false,
             branches: vec![],
             conditions: vec![],
             failure_mode: FailureMode::default(),
@@ -1145,6 +1153,7 @@ mod tests {
 
         let streaming_pf = PipelineFilter {
             filter_id: 99,
+            is_security: false,
             branches: vec![],
             conditions: vec![],
             failure_mode: FailureMode::default(),

--- a/crates/filter/src/pipeline/filter.rs
+++ b/crates/filter/src/pipeline/filter.rs
@@ -63,6 +63,15 @@ pub(crate) struct PipelineFilter {
     /// [`HttpFilterContext::filter_state`]: crate::HttpFilterContext::filter_state
     pub(crate) filter_id: usize,
 
+    /// Whether this filter type is [`SecurityClass::Security`].
+    ///
+    /// Stamped at pipeline build from the registry after `create`
+    /// succeeds. Config-time checks (fail-open, conditions, `SkipTo`,
+    /// `Terminal` rejoin) use this bit instead of a hardcoded name list.
+    ///
+    /// [`SecurityClass::Security`]: crate::SecurityClass::Security
+    pub(crate) is_security: bool,
+
     /// Response-phase conditions.
     pub(crate) response_conditions: Vec<ResponseCondition>,
 }
@@ -93,6 +102,7 @@ impl PipelineFilter {
             failure_mode: FailureMode::default(),
             filter,
             filter_id,
+            is_security: false,
             response_conditions,
         }
     }

--- a/crates/filter/src/pipeline/test_filters.rs
+++ b/crates/filter/src/pipeline/test_filters.rs
@@ -52,6 +52,7 @@ pub(in crate::pipeline) fn noop_filter_with_conditions(
 fn capability_filter(filter: CapabilityFilter) -> PipelineFilter {
     PipelineFilter {
         filter_id: 0,
+        is_security: false,
         branches: vec![],
         conditions: vec![],
         failure_mode: FailureMode::default(),
@@ -94,6 +95,7 @@ impl HttpFilter for CapabilityFilter {
 pub(in crate::pipeline) fn streaming_capable_filter() -> PipelineFilter {
     PipelineFilter {
         filter_id: 0,
+        is_security: false,
         branches: vec![],
         conditions: vec![],
         failure_mode: FailureMode::default(),

--- a/crates/filter/src/pipeline/tests.rs
+++ b/crates/filter/src/pipeline/tests.rs
@@ -3,15 +3,18 @@
 
 //! Tests for pipeline construction, body capabilities, execution, and ordering warnings.
 
-use std::sync::{
-    Arc,
-    atomic::{AtomicBool, AtomicUsize, Ordering},
+use std::{
+    collections::HashMap,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    },
 };
 
 use ::http::{HeaderMap, Method, StatusCode};
 use async_trait::async_trait;
 use bytes::Bytes;
-use praxis_core::config::{FailureMode, SkipPipelineChecks};
+use praxis_core::config::{BranchChainConfig, ChainRef, FailureMode, SkipPipelineChecks};
 
 use super::{
     FilterPipeline,
@@ -20,7 +23,8 @@ use super::{
     filter::PipelineFilter,
 };
 use crate::{
-    FilterAction, FilterEntry, FilterError, FilterRegistry, StreamingResponseBody, StreamingTerminalResponse,
+    FilterAction, FilterEntry, FilterError, FilterFactory, FilterRegistry, SecurityClass, StreamingResponseBody,
+    StreamingTerminalResponse,
     any_filter::AnyFilter,
     body::{BodyAccess, BodyCapabilities, BodyMode},
     filter::HttpFilter,
@@ -1238,6 +1242,130 @@ fn allow_open_forwarded_headers_with_insecure_flag() {
             .iter()
             .any(|e| e.contains("failure_mode: open") && e.contains("forwarded_headers")),
         "insecure flag should demote open forwarded_headers error to warning: {errors:?}"
+    );
+}
+
+#[test]
+fn build_stamps_is_security_from_registry_class() {
+    let mut registry = FilterRegistry::with_builtins();
+    register_named_filter(&mut registry, "my_auth", SecurityClass::Security);
+    register_named_filter(&mut registry, "my_logger", SecurityClass::Standard);
+    let mut entries = vec![
+        named_noop_entry("my_auth", FailureMode::default()),
+        named_noop_entry("my_logger", FailureMode::default()),
+    ];
+    let pipeline = FilterPipeline::build(&mut entries, &registry).unwrap();
+    assert!(
+        pipeline.filters[0].is_security,
+        "Security-class registration must stamp is_security at build"
+    );
+    assert!(
+        !pipeline.filters[1].is_security,
+        "Standard-class registration must not stamp is_security"
+    );
+}
+
+#[test]
+fn build_with_chains_stamps_is_security_on_branch_filter() {
+    let mut registry = FilterRegistry::with_builtins();
+    register_named_filter(&mut registry, "my_auth", SecurityClass::Security);
+    let mut entries = vec![FilterEntry {
+        branch_chains: Some(vec![BranchChainConfig {
+            chains: vec![ChainRef::Inline {
+                name: "auth_chain".to_owned(),
+                filters: vec![named_noop_entry("my_auth", FailureMode::default())],
+            }],
+            max_iterations: None,
+            name: "auth_branch".to_owned(),
+            on_result: None,
+            rejoin: "next".to_owned(),
+        }]),
+        ..named_noop_entry("request_id", FailureMode::default())
+    }];
+    let chains: HashMap<&str, &[FilterEntry]> = HashMap::new();
+    let pipeline = FilterPipeline::build_with_chains(&mut entries, &registry, &chains).unwrap();
+    assert_eq!(
+        pipeline.filters.len(),
+        1,
+        "top-level host should be the only parent filter"
+    );
+    assert!(
+        !pipeline.filters[0].is_security,
+        "host request_id is Standard and must not be stamped Security"
+    );
+    assert_eq!(pipeline.filters[0].branches.len(), 1, "host should carry one branch");
+    assert_eq!(
+        pipeline.filters[0].branches[0].filters.len(),
+        1,
+        "branch sub-chain should contain the custom Security filter"
+    );
+    assert!(
+        pipeline.filters[0].branches[0].filters[0].is_security,
+        "Security-class filter inside a branch must be stamped by build_with_chains"
+    );
+}
+
+#[test]
+fn errors_open_custom_security_filter() {
+    let mut registry = FilterRegistry::with_builtins();
+    register_named_filter(&mut registry, "my_auth", SecurityClass::Security);
+    let mut entries = vec![named_noop_entry("my_auth", FailureMode::Open)];
+    let pipeline = FilterPipeline::build(&mut entries, &registry).unwrap();
+    let errors = pipeline.ordering_errors(&entries, false, &SkipPipelineChecks::default());
+    assert!(
+        errors
+            .iter()
+            .any(|e| e.contains("failure_mode: open") && e.contains("my_auth")),
+        "custom Security-class filter with failure_mode: open must error: {errors:?}"
+    );
+}
+
+#[test]
+fn allow_open_custom_security_filter_with_insecure_flag() {
+    let mut registry = FilterRegistry::with_builtins();
+    register_named_filter(&mut registry, "my_auth", SecurityClass::Security);
+    let mut entries = vec![named_noop_entry("my_auth", FailureMode::Open)];
+    let pipeline = FilterPipeline::build(&mut entries, &registry).unwrap();
+    let errors = pipeline.ordering_errors(&entries, true, &SkipPipelineChecks::default());
+    assert!(
+        !errors.iter().any(|e| e.contains("failure_mode: open")),
+        "insecure flag should demote open custom security filter error to warning: {errors:?}"
+    );
+}
+
+#[test]
+fn no_error_open_custom_standard_filter() {
+    let mut registry = FilterRegistry::with_builtins();
+    register_named_filter(&mut registry, "my_logger", SecurityClass::Standard);
+    let mut entries = vec![named_noop_entry("my_logger", FailureMode::Open)];
+    let pipeline = FilterPipeline::build(&mut entries, &registry).unwrap();
+    let errors = pipeline.ordering_errors(&entries, false, &SkipPipelineChecks::default());
+    assert!(
+        !errors.iter().any(|e| e.contains("failure_mode: open")),
+        "Standard-class custom filter with failure_mode: open must not error: {errors:?}"
+    );
+}
+
+#[test]
+fn errors_conditional_custom_security_filter() {
+    let mut registry = FilterRegistry::with_builtins();
+    register_named_filter(&mut registry, "my_auth", SecurityClass::Security);
+    let mut entries = vec![FilterEntry {
+        branch_chains: None,
+        conditions: vec![when_path("/api")],
+        filter_type: "my_auth".into(),
+        config: serde_yaml::Value::Null,
+        name: None,
+        response_conditions: vec![],
+        failure_mode: FailureMode::default(),
+    }];
+    let pipeline = FilterPipeline::build(&mut entries, &registry).unwrap();
+    let errors = pipeline.ordering_errors(&entries, false, &SkipPipelineChecks::default());
+    assert!(
+        errors
+            .iter()
+            .any(|e| e.contains("security filter") && e.contains("my_auth")),
+        "custom Security-class filter with request conditions must error: {errors:?}"
     );
 }
 
@@ -2862,6 +2990,20 @@ impl HttpFilter for PassthroughFilter {
     }
 }
 
+/// Noop whose [`HttpFilter::name`] matches the registered type name.
+struct NamedNoopFilter(&'static str);
+
+#[async_trait]
+impl HttpFilter for NamedNoopFilter {
+    fn name(&self) -> &'static str {
+        self.0
+    }
+
+    async fn on_request(&self, _ctx: &mut crate::HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
+        Ok(FilterAction::Continue)
+    }
+}
+
 /// A filter that immediately rejects all requests.
 struct RejectFilter;
 
@@ -3505,7 +3647,7 @@ impl HttpFilter for GatedRecordingBodyFilter {
 
 /// Build a single `when: headers: {header: value}` request condition.
 fn gate_condition(header: &str, value: &str) -> Vec<praxis_core::config::Condition> {
-    let mut headers = std::collections::HashMap::new();
+    let mut headers = HashMap::new();
     headers.insert(header.to_owned(), value.to_owned());
     vec![praxis_core::config::Condition::When(
         praxis_core::config::ConditionMatch {
@@ -3795,6 +3937,27 @@ fn when_path(prefix: &str) -> praxis_core::config::Condition {
         methods: None,
         headers: None,
     })
+}
+
+/// Register a noop HTTP filter whose type name is `name`.
+fn register_named_filter(registry: &mut FilterRegistry, name: &'static str, class: SecurityClass) {
+    let factory = FilterFactory::Http(Arc::new(move |_| Ok(Box::new(NamedNoopFilter(name)))));
+    registry
+        .register_with_class(name, factory, class)
+        .expect("test filter name must not collide with builtins");
+}
+
+/// Build a [`FilterEntry`] for a config-less custom filter.
+fn named_noop_entry(filter_type: &str, failure_mode: FailureMode) -> FilterEntry {
+    FilterEntry {
+        branch_chains: None,
+        conditions: vec![],
+        filter_type: filter_type.into(),
+        config: serde_yaml::Value::Null,
+        name: None,
+        response_conditions: vec![],
+        failure_mode,
+    }
 }
 
 /// Build an `Unless` condition that matches on a path prefix.

--- a/docs/developing/getting-started.md
+++ b/docs/developing/getting-started.md
@@ -99,7 +99,7 @@ insecure_options:
 
 | Flag | Effect |
 | ------ | -------- |
-| `allow_open_security_filters` | Allow security-critical filters (`ip_acl`, `forwarded_headers`) to use `failure_mode: open`. Without this flag, open security filters are rejected because a runtime error would bypass security enforcement. With this flag enabled, the error is demoted to a warning. |
+| `allow_open_security_filters` | Allow filters registered as `SecurityClass::Security` (built-in examples: `ip_acl`, `forwarded_headers`; also custom filters registered as Security) to use `failure_mode: open`. Without this flag, open security filters are rejected because a runtime error would bypass security enforcement. With this flag enabled, the error is demoted to a warning. |
 | `allow_private_endpoints` | Allow cluster endpoints to resolve to loopback, link-local, or cloud metadata addresses. Blocked by default as SSRF protection for upstream targets. |
 | `allow_private_health_checks` | Allow health check endpoints that resolve to loopback (`127.0.0.0/8`), link-local (`169.254.0.0/16`), or cloud metadata addresses. Blocked by default as SSRF protection. |
 | `allow_private_upstreams` | Allow upstream connections that resolve to private or reserved IP addresses at runtime. Without this flag, DNS-resolved upstream addresses in RFC 1918, loopback, link-local, CGNAT, and IPv6 unique-local ranges are rejected to prevent DNS rebinding and SSRF attacks. |

--- a/docs/filters/README.md
+++ b/docs/filters/README.md
@@ -512,10 +512,12 @@ A filter can have both `conditions` (request phase) and
 
 ### Security Filter Restrictions
 
-Security-critical filters (`ip_acl`, `forwarded_headers`)
-reject `failure_mode: open` by default. Open failure mode
-on these filters means runtime errors would bypass security
-enforcement. To override this check, set
+Filters registered as `SecurityClass::Security` (built-in
+examples: `ip_acl`, `forwarded_headers`; also custom
+filters registered as Security) reject `failure_mode: open`
+by default. Open failure mode on these filters means
+runtime errors would bypass security enforcement. To
+override this check, set
 `insecure_options.allow_open_security_filters: true`, which
 demotes the error to a warning.
 


### PR DESCRIPTION
## Summary

- Pipeline security checks (fail-open, request conditions, SkipTo,
  Terminal rejoin) now follow registry `SecurityClass` instead of the
  hardcoded `SECURITY_FILTERS` name list.
- `PipelineFilter` carries `is_security`, stamped after
  `registry.create()` on both the flat build path and the branch-chain
  build path.
- `SECURITY_FILTERS` and `security_filter_list_matches_registry_metadata`
  are removed. Custom filters registered with
  `register_with_class(..., SecurityClass::Security)` get the same
  config-time checks as builtins (`ip_acl`, `forwarded_headers`, …).
- Operator docs describe any Security-class filter, not only named
  builtins.

This closes the gap where out-of-tree Security filters (for example
`ai_guardrails` after a praxis-ai follow-up) could set
`failure_mode: open` or conditions and bypass enforcement at config
time.

## Tested
- [x] `cargo test -p praxis-proxy-filter --lib pipeline::` (343 passed)
- [x] `cargo test -p praxis-proxy-filter --lib registry::` (14 passed)
- [x] `cargo clippy -p praxis-proxy-filter --lib --tests -- -D warnings`
- [x] `praxis-proxy --validate` with `ip_acl`:
  - closed / omitted `failure_mode`: OK
  - `failure_mode: open`: rejected (`security filter 'ip_acl' ...
    failure_mode: open`)
  - `open` + `allow_open_security_filters: true`: OK
- [x] `credential_inject` (AI filter already registered as
  `SecurityClass::Security`, never on `SECURITY_FILTERS`):
  - praxis-ai on crates.io `praxis-filter` 0.5.4 + `failure_mode: open`:
    `--validate` succeeds
  - same YAML against this branch: closed OK; `open` rejected
    (`security filter 'credential_inject' ... failure_mode: open`);
    `open` + `allow_open_security_filters: true` OK

## Context

 Design discussion:
[orgs/praxis-proxy/discussions/1044](https://github.com/orgs/praxis-proxy/discussions/1044).

## Part of:
https://github.com/praxis-proxy/ai/issues/753

## Fix:
#1069
