### PR TITLE
feat(filter): outbound chain binding with authority-bound deferred credentials

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3177,6 +3177,7 @@ dependencies = [
 name = "praxis-proxy"
 version = "0.5.4"
 dependencies = [
+ "async-trait",
  "cargo_metadata",
  "clap",
  "nix",

--- a/crates/core/src/config/mod.rs
+++ b/crates/core/src/config/mod.rs
@@ -59,7 +59,11 @@ pub use runtime::{DEFAULT_SUBREQUEST_POOL_SIZE, RuntimeConfig};
 #[cfg(feature = "otel")]
 pub(crate) use telemetry::OTLP_PROTOCOL_ENV_VAR;
 pub use telemetry::TelemetryConfig;
-pub use validate::{MAX_BRANCH_DEPTH, MAX_ITERATIONS_CEILING, TERMINAL_FILTERS, is_ssrf_sensitive};
+pub use validate::{
+    MAX_BRANCH_DEPTH, MAX_ITERATIONS_CEILING, TERMINAL_FILTERS, count_build_branches, is_ssrf_sensitive,
+    validate_chain_entries_branch_chains, validate_chain_entries_cardinality, validate_chain_entries_conditions,
+    validate_chain_entries_inline_clusters,
+};
 
 // -----------------------------------------------------------------------------
 // Config

--- a/crates/core/src/config/validate/branch_chain.rs
+++ b/crates/core/src/config/validate/branch_chain.rs
@@ -73,6 +73,112 @@ pub(crate) fn validate_branch_chains(chains: &[FilterChainConfig]) -> Result<(),
     Ok(())
 }
 
+/// Validate branch-chain constraints for a single chain's filter entries.
+///
+/// This is the entry-level slice of the whole-config `validate_branch_chains`
+/// pass: it enforces filter-name uniqueness, the per-filter branch cap, the
+/// re-entrant [`MAX_ITERATIONS_CEILING`], the inline nesting [`MAX_BRANCH_DEPTH`],
+/// the total-branch ceiling (`MAX_TOTAL_BRANCHES`), and chain-reference
+/// resolution over one list of [`FilterEntry`]. It exists so outbound chains
+/// bound at pipeline-build time — which never appear in `Config::filter_chains`
+/// — are held to the same branch-chain limits (notably the `max_iterations`
+/// ceiling that bounds re-entrant request loops) as top-level chains instead of
+/// bypassing them.
+///
+/// `known_chains` names the top-level filter chains a [`ChainRef::Named`] branch
+/// reference may resolve against; a bound chain with no reachable named chains
+/// passes an empty set.
+///
+/// `prior_branch_count` is the number of branch definitions already counted
+/// toward the total-branch ceiling elsewhere in the same build — the branches
+/// present configuration-wide and in any previously bound inline outbound chains.
+/// The ceiling bounds config complexity across the whole build, not each chain in
+/// isolation, so this chain's own branch count is added to `prior_branch_count`
+/// and the cumulative total is checked. The cumulative total is returned so a
+/// caller can thread it into the next bound chain's check; seed the first call
+/// with [`count_build_branches`] over the listener entries and every named chain
+/// so branches already present anywhere in the configuration are counted.
+///
+/// # Errors
+///
+/// Returns [`ProxyError::Config`] if a filter or branch name duplicates, a
+/// re-entrant branch exceeds `max_iterations`, inline nesting exceeds
+/// [`MAX_BRANCH_DEPTH`], a chain reference is malformed or dangling, or the
+/// cumulative branch total exceeds the maximum (`MAX_TOTAL_BRANCHES`).
+pub fn validate_chain_entries_branch_chains(
+    chain_name: &str,
+    entries: &[FilterEntry],
+    known_chains: &HashSet<&str>,
+    prior_branch_count: usize,
+) -> Result<usize, ProxyError> {
+    validate_filter_names_unique(entries, chain_name)?;
+    let initial_count = known_chains.len();
+    let mut all_names: HashSet<String> = known_chains.iter().map(|s| (*s).to_owned()).collect();
+    collect_branch_names(entries, &mut all_names, known_chains, 0)?;
+
+    let branch_count = all_names.len() - initial_count;
+    let total = prior_branch_count + branch_count;
+    if total > MAX_TOTAL_BRANCHES {
+        return Err(ProxyError::Config(format!(
+            "total branch count ({total}) exceeds maximum ({MAX_TOTAL_BRANCHES})"
+        )));
+    }
+
+    Ok(total)
+}
+
+/// Count the branch definitions across a whole pipeline build: the listener's
+/// own `entries` plus every named chain in `chains`, deduplicated by name
+/// exactly as the whole-config `validate_branch_chains` pass counts them.
+///
+/// `validate_branch_chains` enforces the total-branch ceiling only over
+/// `Config::filter_chains`; outbound chains bound at pipeline-build time never
+/// appear there. Seeding a build's shared branch budget with this
+/// configuration-wide count — rather than the listener's entries alone — makes
+/// the ceiling span the whole configuration: a named outbound chain the listener
+/// never references still counts toward the budget that later-bound *inline*
+/// chains accumulate on top of, so the config-wide pool and the inline pool
+/// cannot each sit under the ceiling while exceeding it together. In production
+/// the listener `entries` are a concatenation of chains already in `chains`, so
+/// counting both merely deduplicates; a caller that passes entries not present in
+/// `chains` (a direct build) still has those branches counted.
+///
+/// Named refs resolve to chains counted here, so they are ignored inside branch
+/// chains; `known_chains` seeds the name set so a branch or inline name colliding
+/// with a chain name is not double counted. This is a pure counter: unlike the
+/// validating pass it emits no config-typo warnings and enforces no limits, so
+/// seeding a build's budget does not re-warn about entries the whole-config pass
+/// already validated.
+pub fn count_build_branches(entries: &[FilterEntry], chains: &[&[FilterEntry]], known_chains: &HashSet<&str>) -> usize {
+    let initial_count = known_chains.len();
+    let mut all_names: HashSet<String> = known_chains.iter().map(|s| (*s).to_owned()).collect();
+    count_branch_names(entries, &mut all_names);
+    for &chain in chains {
+        count_branch_names(chain, &mut all_names);
+    }
+    all_names.len().saturating_sub(initial_count)
+}
+
+/// Recursively insert branch and inline-chain names into `all_names`, ignoring
+/// named references. The pure counting counterpart to [`collect_branch_names`],
+/// with no validation, typo warnings, or limit checks.
+fn count_branch_names(entries: &[FilterEntry], all_names: &mut HashSet<String>) {
+    for entry in entries {
+        let Some(branches) = &entry.branch_chains else {
+            continue;
+        };
+        for branch in branches {
+            all_names.insert(branch.name.clone());
+            for chain_ref in &branch.chains {
+                if let ChainRef::Inline { name, filters } = chain_ref {
+                    all_names.insert(name.clone());
+                    count_branch_names(filters, all_names);
+                }
+            }
+        }
+    }
+}
+
 /// Validate that filter names within a chain are unique.
 fn validate_filter_names_unique(filters: &[FilterEntry], chain_name: &str) -> Result<(), ProxyError> {
     let mut seen = HashSet::new();
@@ -1128,5 +1234,177 @@ filter_chains:
         status: 200
 "#;
         Config::from_yaml(yaml).unwrap();
+    }
+
+    // -------------------------------------------------------------------------
+    // Entry-level validation (validate_chain_entries_branch_chains)
+    //
+    // The whole-config pass (validate_branch_chains) is reached through
+    // Config::from_yaml above. Outbound chains bound at pipeline-build time never
+    // appear in Config::filter_chains, so they are held to the same branch limits
+    // through validate_chain_entries_branch_chains instead. These exercise that
+    // function directly.
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn chain_entries_reject_total_branch_count_over_ceiling() {
+        use std::collections::HashSet;
+
+        use crate::config::FilterEntry;
+
+        // 17 filters x 16 branches = 272 uniquely-named branches, each pointing
+        // at a known named chain so only branch names count toward the total.
+        // This exceeds MAX_TOTAL_BRANCHES; the entry-level validator must reject
+        // it exactly as the whole-config pass does, so an outbound chain cannot
+        // bypass the ceiling by never appearing in Config::filter_chains.
+        let mut yaml = String::new();
+        let mut n = 0;
+        for _ in 0..17 {
+            yaml.push_str("- filter: headers\n  branch_chains:\n");
+            for _ in 0..16 {
+                writeln!(yaml, "    - name: br_{n}\n      chains: [utility]").unwrap();
+                n += 1;
+            }
+        }
+        let entries: Vec<FilterEntry> = serde_yaml::from_str(&yaml).unwrap();
+        let known: HashSet<&str> = HashSet::from(["utility"]);
+
+        let err = super::validate_chain_entries_branch_chains("outbound", &entries, &known, 0).unwrap_err();
+        assert!(
+            err.to_string().contains("total branch count")
+                && err.to_string().contains(&super::MAX_TOTAL_BRANCHES.to_string()),
+            "an outbound chain whose branch total exceeds the ceiling must be rejected: {err}"
+        );
+    }
+
+    #[test]
+    fn chain_entries_reject_branches_over_per_filter_cap() {
+        use std::collections::HashSet;
+
+        use crate::config::FilterEntry;
+
+        // A single filter with 17 branch chains exceeds MAX_BRANCHES_PER_FILTER.
+        // Already enforced via collect_branch_names; this documents that the
+        // per-filter cardinality cap is not bypassed on the entry-level path.
+        let mut yaml = String::from("- filter: headers\n  branch_chains:\n");
+        for n in 0..17 {
+            writeln!(yaml, "    - name: br_{n}\n      chains: [utility]").unwrap();
+        }
+        let entries: Vec<FilterEntry> = serde_yaml::from_str(&yaml).unwrap();
+        let known: HashSet<&str> = HashSet::from(["utility"]);
+
+        let err = super::validate_chain_entries_branch_chains("outbound", &entries, &known, 0).unwrap_err();
+        assert!(
+            err.to_string().contains("branch chains") && err.to_string().contains("16"),
+            "a filter exceeding the per-filter branch cap must be rejected: {err}"
+        );
+    }
+
+    #[test]
+    fn chain_entries_reject_invalid_on_result_condition() {
+        use std::collections::HashSet;
+
+        use crate::config::FilterEntry;
+
+        // A branch whose on_result declares an empty filter is rejected via
+        // validate_branch. This documents that the on_result condition checks are
+        // not bypassed on the entry-level path.
+        let entries: Vec<FilterEntry> = serde_yaml::from_str(
+            "
+- filter: headers
+  branch_chains:
+    - name: br
+      on_result:
+        filter: \"\"
+        result: hit
+      chains: [utility]
+",
+        )
+        .unwrap();
+        let known: HashSet<&str> = HashSet::from(["utility"]);
+
+        let err = super::validate_chain_entries_branch_chains("outbound", &entries, &known, 0).unwrap_err();
+        assert!(
+            err.to_string().contains("on_result.filter must not be empty"),
+            "a branch with an empty on_result filter must be rejected: {err}"
+        );
+    }
+
+    #[test]
+    fn count_build_branches_counts_entries_and_named_chains_ignoring_named_refs() {
+        use std::collections::HashSet;
+
+        use crate::config::FilterEntry;
+
+        // The listener entries define two branches: one resolving against a known
+        // named chain (contributes only its branch name) and one with an inline
+        // sub-chain (contributes both the branch name and the inline name). Named
+        // refs resolve to already-counted top-level chains, so they are not counted.
+        let entries: Vec<FilterEntry> = serde_yaml::from_str(
+            "
+- filter: headers
+  branch_chains:
+    - name: br_named
+      chains: [utility]
+    - name: br_inline
+      chains:
+        - name: sub
+          filters:
+            - filter: headers
+",
+        )
+        .unwrap();
+        // A named chain that itself defines a branch: config-wide counting must
+        // count it too, on top of the listener's own branches.
+        let utility: Vec<FilterEntry> = serde_yaml::from_str(
+            "
+- filter: headers
+  branch_chains:
+    - name: u_br
+      chains: [utility]
+",
+        )
+        .unwrap();
+        let chains: [&[FilterEntry]; 1] = [utility.as_slice()];
+        let known: HashSet<&str> = HashSet::from(["utility"]);
+
+        // br_named + br_inline + sub (entries) + u_br (named chain) = 4; the chain
+        // name `utility` is not counted, and named refs are ignored.
+        assert_eq!(
+            super::count_build_branches(&entries, &chains, &known),
+            4,
+            "config-wide counting must count entries and named chains, but not named refs"
+        );
+    }
+
+    #[test]
+    fn chain_entries_branch_count_accumulates_prior_and_returns_total() {
+        use std::collections::HashSet;
+
+        use crate::config::FilterEntry;
+
+        // A chain defining 10 branches. On its own (prior 0) it passes and the
+        // cumulative total is returned. With enough prior branches from elsewhere
+        // in the same build, the same chain pushes the cumulative total past the
+        // ceiling and is rejected — proving the ceiling bounds the whole build, not
+        // each chain in isolation.
+        let mut yaml = String::from("- filter: headers\n  branch_chains:\n");
+        for n in 0..10 {
+            writeln!(yaml, "    - name: br_{n}\n      chains: [utility]").unwrap();
+        }
+        let entries: Vec<FilterEntry> = serde_yaml::from_str(&yaml).unwrap();
+        let known: HashSet<&str> = HashSet::from(["utility"]);
+
+        let total = super::validate_chain_entries_branch_chains("outbound", &entries, &known, 0).unwrap();
+        assert_eq!(total, 10, "the cumulative total must include this chain's 10 branches");
+
+        let err =
+            super::validate_chain_entries_branch_chains("outbound", &entries, &known, super::MAX_TOTAL_BRANCHES - 5)
+                .unwrap_err();
+        assert!(
+            err.to_string().contains("total branch count")
+                && err.to_string().contains(&(super::MAX_TOTAL_BRANCHES + 5).to_string()),
+            "prior branch count must accumulate into the cumulative total: {err}"
+        );
     }
 }

--- a/crates/core/src/config/validate/filter_chain.rs
+++ b/crates/core/src/config/validate/filter_chain.rs
@@ -180,6 +180,15 @@ fn empty_predicate_error(chain_name: &str, filter: &str, idx: usize, field: &str
 
 /// Filter types that must be the last filter in their chain and in
 /// the flattened listener pipeline.
+///
+/// This name list drives the config-time "terminal filter must be last"
+/// ordering check, which runs on `FilterEntry` values before any filter is
+/// instantiated and so has no trait object to query. The runtime outbound-chain
+/// rejection instead uses the `HttpFilter::produces_terminal_response`
+/// capability (filter crate). The two live at different layers and must stay in
+/// sync: any new builtin that produces a terminal response must be added here
+/// *and* override `produces_terminal_response`, or it will be enforced by only
+/// one of the two checks.
 pub const TERMINAL_FILTERS: &[&str] = &["iterative_request_router"];
 
 /// Reject terminal filters that are not last in their chain.
@@ -194,6 +203,48 @@ fn validate_terminal_filters(chains: &[FilterChainConfig]) -> Result<(), ProxyEr
                 )));
             }
         }
+    }
+    Ok(())
+}
+
+/// Reject a bound chain whose own entries exceed the per-chain filter cap.
+///
+/// A bound outbound chain never appears in `Config::filter_chains`, so the
+/// whole-config `validate_chain_cardinality` walk never sees it. This applies
+/// the same `MAX_FILTERS_PER_CHAIN` limit to a bound chain's top-level entries,
+/// so a runaway outbound chain cannot build unbounded.
+///
+/// # Errors
+///
+/// Returns [`ProxyError::Config`] if `entries` exceeds `MAX_FILTERS_PER_CHAIN`.
+pub fn validate_chain_entries_cardinality(chain_name: &str, entries: &[FilterEntry]) -> Result<(), ProxyError> {
+    if entries.len() > MAX_FILTERS_PER_CHAIN {
+        return Err(ProxyError::Config(format!(
+            "filter chain '{chain_name}' has too many filters ({}, max \
+             {MAX_FILTERS_PER_CHAIN})",
+            entries.len()
+        )));
+    }
+    Ok(())
+}
+
+/// Reject empty condition predicates on a bound chain's entries, recursing into
+/// inline branch chains and iterative-router steps.
+///
+/// A bound outbound chain never appears in `Config::filter_chains`, so the
+/// whole-config `validate_conditions` walk never sees it. This applies the same
+/// empty-`when`/`unless` rejection (see `validate_entry_conditions`) to a bound
+/// chain's entries, so an accidental match-everything predicate cannot silently
+/// disable a filter inside an outbound chain.
+///
+/// # Errors
+///
+/// Returns [`ProxyError::Config`] if any entry — including one nested in an
+/// inline branch chain or an iterative-router step — carries an empty or
+/// unmatchable condition predicate.
+pub fn validate_chain_entries_conditions(chain_name: &str, entries: &[FilterEntry]) -> Result<(), ProxyError> {
+    for entry in entries {
+        validate_entry_conditions(chain_name, entry)?;
     }
     Ok(())
 }

--- a/crates/core/src/config/validate/inline_clusters.rs
+++ b/crates/core/src/config/validate/inline_clusters.rs
@@ -35,9 +35,33 @@ pub(super) fn validate_inline_clusters(
     insecure_options: &InsecureOptions,
 ) -> Result<(), ProxyError> {
     for chain in chains {
-        for entry in &chain.filters {
-            validate_entry(&chain.name, entry, insecure_options)?;
-        }
+        validate_chain_entries_inline_clusters(&chain.name, &chain.filters, insecure_options)?;
+    }
+    Ok(())
+}
+
+/// Validate inline `clusters:` lists in a single chain's filter entries.
+///
+/// This is the entry-level slice of the whole-config `validate_inline_clusters`
+/// pass: it gates one list of [`FilterEntry`] under a given logical chain name,
+/// recursing into
+/// inline branch chains and `iterative_request_router` steps exactly as the
+/// whole-config pass does. It exists so outbound chains bound at pipeline-build
+/// time — which never appear in `Config::filter_chains` — are held to the same
+/// SSRF and insecure-TLS rules as top-level `clusters:` instead of bypassing
+/// them.
+///
+/// # Errors
+///
+/// Returns [`ProxyError::Config`] if any inline cluster is malformed, names a
+/// duplicate, or fails endpoint/TLS validation under `insecure_options`.
+pub fn validate_chain_entries_inline_clusters(
+    chain_name: &str,
+    entries: &[FilterEntry],
+    insecure_options: &InsecureOptions,
+) -> Result<(), ProxyError> {
+    for entry in entries {
+        validate_entry(chain_name, entry, insecure_options)?;
     }
     Ok(())
 }

--- a/crates/core/src/config/validate/mod.rs
+++ b/crates/core/src/config/validate/mod.rs
@@ -6,7 +6,9 @@
 use crate::errors::ProxyError;
 
 mod branch_chain;
-pub use branch_chain::{MAX_BRANCH_DEPTH, MAX_ITERATIONS_CEILING};
+pub use branch_chain::{
+    MAX_BRANCH_DEPTH, MAX_ITERATIONS_CEILING, count_build_branches, validate_chain_entries_branch_chains,
+};
 pub(in crate::config) mod cluster;
 mod filter_chain;
 mod inline_clusters;
@@ -14,7 +16,8 @@ mod listener;
 mod rules;
 
 pub use cluster::is_ssrf_sensitive;
-pub use filter_chain::TERMINAL_FILTERS;
+pub use filter_chain::{TERMINAL_FILTERS, validate_chain_entries_cardinality, validate_chain_entries_conditions};
+pub use inline_clusters::validate_chain_entries_inline_clusters;
 
 /// Maximum allowed `max_connections` value across listeners, clusters,
 /// and the global runtime setting (1 million).

--- a/crates/filter/src/binding.rs
+++ b/crates/filter/src/binding.rs
@@ -1,0 +1,1817 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 Praxis Contributors
+
+//! Outbound subrequest chain binding.
+//!
+//! A *chain-binding filter* is an application-provided HTTP filter (for
+//! example an AI callout) that owns a prebuilt outbound [`FilterPipeline`].
+//! Rather than parsing and building its outbound chain on every request, the
+//! filter binds the chain once at construction time through a
+//! [`ChainBindingContext`] and stores the resulting pipeline.
+//!
+//! The context is handed to the filter's factory by the pipeline builder. It
+//! exposes exactly one operation, [`ChainBindingContext::bind_chain`], which
+//! resolves a [`ChainRef`] into a [`FilterPipeline`]:
+//!
+//! - **Named** references resolve against the top-level `filter_chains`, so outbound chains can be shared and reused.
+//! - **Inline** references embed their filters directly.
+//!
+//! Nested filters resolve through the *active* [`FilterRegistry`], so
+//! application-registered filters are available inside outbound chains.
+//! Reference cycles and excessive nesting are rejected during construction —
+//! before the pipeline is activated — so an invalid outbound chain fails the
+//! build (and any hot reload) instead of the request.
+//!
+//! [`ChainRef`]: praxis_core::config::ChainRef
+
+use std::{
+    cell::{Cell, RefCell},
+    collections::HashMap,
+    sync::Arc,
+};
+
+use praxis_core::config::{
+    ChainRef, FilterEntry, InsecureOptions, validate_chain_entries_branch_chains, validate_chain_entries_cardinality,
+    validate_chain_entries_conditions, validate_chain_entries_inline_clusters,
+};
+
+use crate::{FilterError, filter::HttpFilter, pipeline::FilterPipeline, registry::FilterRegistry};
+
+/// Maximum nesting depth permitted when resolving outbound chain references.
+///
+/// Bounds inline-chain recursion (which carries no name for the cycle
+/// detector to catch) and caps how deep one outbound chain may pull in
+/// further outbound chains before the build is rejected.
+pub(crate) const MAX_OUTBOUND_CHAIN_DEPTH: usize = 10;
+
+/// Factory for an application filter that binds an outbound chain at
+/// construction time.
+///
+/// Registered via [`FilterRegistry::register_chain_binding`]. The factory
+/// receives the filter's configuration and a [`ChainBindingContext`] through
+/// which it resolves its configured outbound chain into a prebuilt
+/// [`FilterPipeline`]. It is an [`Arc`]'d closure so callers can capture
+/// application state (clients, credentials providers) at registration time.
+///
+/// [`FilterRegistry::register_chain_binding`]: crate::FilterRegistry::register_chain_binding
+pub type ChainBindingHttpFactory =
+    Arc<dyn Fn(&serde_yaml::Value, &ChainBindingContext<'_>) -> Result<Box<dyn HttpFilter>, FilterError> + Send + Sync>;
+
+// -----------------------------------------------------------------------------
+// ResolutionStack
+// -----------------------------------------------------------------------------
+
+/// Tracks the named chains currently being resolved so reference cycles are
+/// rejected during construction instead of recursing until a depth or
+/// instance limit trips.
+///
+/// The stack is shared across the whole pipeline build (branch resolution and
+/// outbound binding alike) via a shared reference. [`bind_chain`] takes `&self`
+/// so the public API stays ergonomic, so mutation goes through interior
+/// mutability rather than a `&mut` in any public signature.
+///
+/// [`bind_chain`]: ChainBindingContext::bind_chain
+pub(crate) struct ResolutionStack {
+    /// Names currently being resolved, innermost last.
+    active: RefCell<Vec<Box<str>>>,
+}
+
+impl ResolutionStack {
+    /// Create an empty resolution stack.
+    pub(crate) fn new() -> Self {
+        Self {
+            active: RefCell::new(Vec::new()),
+        }
+    }
+
+    /// Push `name` onto the stack, returning a guard that pops it on drop.
+    ///
+    /// Returns an error naming the cycle if `name` is already being resolved.
+    pub(crate) fn enter(&self, name: &str) -> Result<ResolutionGuard<'_>, FilterError> {
+        let mut active = self.active.borrow_mut();
+        if let Some(start) = active.iter().position(|n| n.as_ref() == name) {
+            let mut path: Vec<&str> = active.iter().skip(start).map(Box::as_ref).collect();
+            path.push(name);
+            return Err(format!("chain reference cycle detected: {}", path.join(" -> ")).into());
+        }
+        active.push(Box::from(name));
+        Ok(ResolutionGuard { stack: self })
+    }
+}
+
+/// Pops the most recently entered chain name when dropped, keeping the
+/// resolution stack balanced across early returns and panics.
+pub(crate) struct ResolutionGuard<'a> {
+    /// The stack to pop on drop.
+    stack: &'a ResolutionStack,
+}
+
+impl Drop for ResolutionGuard<'_> {
+    fn drop(&mut self) {
+        self.stack.active.borrow_mut().pop();
+    }
+}
+
+// -----------------------------------------------------------------------------
+// ChainBindingContext
+// -----------------------------------------------------------------------------
+
+/// Construction-time handle a chain-binding filter uses to resolve its
+/// configured outbound chain into a prebuilt [`FilterPipeline`].
+///
+/// The context is created by the pipeline builder and lives only for the
+/// duration of one filter's construction. It carries the active
+/// [`FilterRegistry`] (so nested filters resolve against the same registry,
+/// including application-registered filters), the top-level named-chain lookup
+/// table, the shared cycle-detection stack, and the current nesting depth.
+pub struct ChainBindingContext<'a> {
+    /// Active registry, used to instantiate nested filters.
+    registry: &'a FilterRegistry,
+
+    /// Top-level named-chain lookup table.
+    chains: &'a HashMap<&'a str, &'a [FilterEntry]>,
+
+    /// Shared cycle-detection stack.
+    stack: &'a ResolutionStack,
+
+    /// Current *outbound* nesting depth: how many outbound bindings deep this
+    /// context sits. Bounded by [`MAX_OUTBOUND_CHAIN_DEPTH`] and tracked
+    /// independently of branch nesting — a chain-binding filter reached at any
+    /// branch depth still binds at outbound depth zero.
+    outbound_depth: usize,
+
+    /// Operator's declared insecure posture, threaded so inline outbound
+    /// chains are gated by the same SSRF/TLS-verify rules as top-level chains.
+    insecure: &'a InsecureOptions,
+
+    /// Build-wide count of filter instances materialized so far, shared across
+    /// branch resolution and outbound binding alike. Binding an outbound chain
+    /// forwards this counter rather than resetting it, so a fan-out split across
+    /// binding boundaries is still bounded by one ceiling.
+    budget: &'a Cell<usize>,
+
+    /// Build-wide count of branch *definitions* seen so far, checked against the
+    /// core total-branch ceiling. Distinct from `budget` (materialized instances):
+    /// binding an *inline* outbound chain accumulates its branch definitions into
+    /// this counter rather than resetting it, so several inline bindings cannot
+    /// each stay under the ceiling while exceeding it collectively. The counter is
+    /// seeded configuration-wide — every named chain plus the listener's own
+    /// branches — so a named outbound chain the listener never references (which
+    /// still materializes when bound) is already in the baseline that inline
+    /// bindings accumulate on top of. Named outbound chains are top-level
+    /// `filter_chains` the whole-config pass already counted config-wide, so they
+    /// are validated but not re-accumulated here.
+    branch_budget: &'a Cell<usize>,
+}
+
+impl<'a> ChainBindingContext<'a> {
+    /// Create a context for resolving outbound chains at `outbound_depth`.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "bundles the build-time resources outbound binding threads through"
+    )]
+    pub(crate) fn new(
+        registry: &'a FilterRegistry,
+        chains: &'a HashMap<&'a str, &'a [FilterEntry]>,
+        stack: &'a ResolutionStack,
+        outbound_depth: usize,
+        insecure: &'a InsecureOptions,
+        budget: &'a Cell<usize>,
+        branch_budget: &'a Cell<usize>,
+    ) -> Self {
+        Self {
+            registry,
+            chains,
+            stack,
+            outbound_depth,
+            insecure,
+            budget,
+            branch_budget,
+        }
+    }
+
+    /// The active registry, used by the builder to instantiate filters.
+    pub(crate) fn registry(&self) -> &'a FilterRegistry {
+        self.registry
+    }
+
+    /// Resolve a chain reference into a prebuilt outbound [`FilterPipeline`].
+    ///
+    /// Named references resolve against the top-level `filter_chains`; inline
+    /// references embed their filters directly. Nested filters resolve through
+    /// the active registry, so application-registered filters are available.
+    /// Reference cycles and excessive nesting are rejected here, before the
+    /// pipeline is activated.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FilterError`] if the reference is unknown, forms a cycle,
+    /// exceeds the maximum nesting depth, or any nested filter fails to build.
+    pub fn bind_chain(&self, chain_ref: &ChainRef) -> Result<FilterPipeline, FilterError> {
+        if self.outbound_depth >= MAX_OUTBOUND_CHAIN_DEPTH {
+            return Err(format!("outbound chain nesting depth exceeds maximum ({MAX_OUTBOUND_CHAIN_DEPTH})").into());
+        }
+        let (name, mut entries) = self.resolve_ref(chain_ref)?;
+        // Named references participate in cycle detection; the guard pops the
+        // name when this resolution returns. Inline references carry no name to
+        // key on and are bounded by depth alone.
+        let _guard = name.map(|n| self.stack.enter(n)).transpose()?;
+        self.validate_bound_entries(name, &entries)?;
+        // The bound pipeline is independent, so filter IDs restart at zero and
+        // its branch nesting restarts at zero too — outbound binding is a fresh
+        // pipeline boundary, not a continuation of the parent's branch depth.
+        // Only the *outbound* depth advances (so runaway nested bindings are
+        // still bounded), and the materialization budget is the parent build's,
+        // forwarded so the whole build stays under one ceiling.
+        let mut next_filter_id: usize = 0;
+        let filters = crate::pipeline::build_branch::resolve_chain_filters_with_stack(
+            &mut entries,
+            self.registry,
+            self.chains,
+            0,
+            &mut next_filter_id,
+            self.insecure,
+            self.stack,
+            self.budget,
+            self.branch_budget,
+            self.outbound_depth + 1,
+        )?;
+        let pipeline = FilterPipeline::from_filters(filters);
+        Self::reject_non_http_filters(&pipeline, name)?;
+        Self::reject_terminal_filters(&pipeline, name)?;
+        // A bound outbound chain is a real pipeline, so hold it to the same
+        // structural ordering validation top-level chains face — a
+        // `load_balancer` with no cluster selector, a misplaced terminal filter,
+        // etc. would otherwise 502 at request time instead of failing the build.
+        self.enforce_bound_ordering(&pipeline, &entries, name.unwrap_or("<inline>"))?;
+        Ok(pipeline)
+    }
+
+    /// Apply the config-level gates a bound chain's entries would otherwise
+    /// bypass by never appearing in `Config::filter_chains`.
+    ///
+    /// Runs the same per-chain filter cardinality cap, empty-predicate condition
+    /// validation, inline-cluster SSRF/TLS gating, and branch-chain constraint
+    /// checks (the re-entrant `max_iterations` ceiling, nesting depth, name
+    /// uniqueness, chain-reference resolution, and the total-branch ceiling) the
+    /// whole-config validation applies to top-level chains.
+    ///
+    /// Terminal-filter rejection happens after the pipeline is built, in
+    /// [`reject_terminal_filters`], so it can scan branch sub-chains too.
+    ///
+    /// [`reject_terminal_filters`]: Self::reject_terminal_filters
+    fn validate_bound_entries(&self, name: Option<&str>, entries: &[FilterEntry]) -> Result<(), FilterError> {
+        let label = name.unwrap_or("<inline>");
+        // A bound chain never appears in `Config::filter_chains`, so the
+        // per-chain filter cap and empty-`when`/`unless` predicate validation the
+        // whole-config walk applies never reach it — enforce both here.
+        validate_chain_entries_cardinality(label, entries).map_err(|e| FilterError::from(e.to_string()))?;
+        validate_chain_entries_conditions(label, entries).map_err(|e| FilterError::from(e.to_string()))?;
+        // Inline clusters reachable only through this outbound chain never appear
+        // in `Config::filter_chains`, so gate them with the operator's declared
+        // posture — the same SSRF/insecure-TLS rules top-level clusters face.
+        validate_chain_entries_inline_clusters(label, entries, self.insecure)
+            .map_err(|e| FilterError::from(e.to_string()))?;
+        // Enforce the core branch constraints here too. `Named` branch refs
+        // resolve against the same top-level chains the runtime builder sees.
+        //
+        // The total-branch ceiling bounds branch definitions across the whole
+        // build. Only *inline* outbound chains need to accumulate into the shared
+        // budget: they never appear in `Config::filter_chains`, so the whole-config
+        // `validate_branch_chains` pass never counts them, and several inline
+        // bindings could otherwise each stay under the ceiling while exceeding it
+        // collectively. A *named* outbound chain is a top-level `filter_chain`,
+        // so that pass already counted its branches once toward the config-wide
+        // ceiling; re-counting them per binding would falsely reject the
+        // documented shared/reused named-chain pattern. Named chains are therefore
+        // validated standalone (against a zero baseline, always satisfied since the
+        // config-wide total is already <= the ceiling) without touching the budget.
+        let known_chains: std::collections::HashSet<&str> = self.chains.keys().copied().collect();
+        if name.is_none() {
+            let prior = self.branch_budget.get();
+            let total = validate_chain_entries_branch_chains(label, entries, &known_chains, prior)
+                .map_err(|e| FilterError::from(e.to_string()))?;
+            self.branch_budget.set(total);
+        } else {
+            validate_chain_entries_branch_chains(label, entries, &known_chains, 0)
+                .map_err(|e| FilterError::from(e.to_string()))?;
+        }
+        Ok(())
+    }
+
+    /// Reject a bound pipeline that holds a filter below the HTTP layer.
+    ///
+    /// A filtered sub-request runs only the HTTP request phase, so a TCP-level
+    /// filter builds without error but the executor never invokes it — the
+    /// config silently behaves unlike what the operator wrote.
+    fn reject_non_http_filters(pipeline: &FilterPipeline, name: Option<&str>) -> Result<(), FilterError> {
+        let tcp_filters = pipeline.non_http_filters();
+        if !tcp_filters.is_empty() {
+            return Err(format!(
+                "outbound chain '{}' contains TCP-level filter(s) [{}] that an HTTP filtered \
+                 sub-request cannot run",
+                name.unwrap_or("<inline>"),
+                tcp_filters.join(", ")
+            )
+            .into());
+        }
+        Ok(())
+    }
+
+    /// Reject a bound pipeline that holds a terminal filter, at any depth.
+    ///
+    /// A terminal filter short-circuits the request phase with a response and no
+    /// upstream. The filtered sub-request executor forwards to a resolved
+    /// upstream and never surfaces such a response — it drops the terminal action
+    /// and then errors that no upstream resolved — so reject terminal filters
+    /// regardless of position (unlike a top-level chain, where a terminal filter
+    /// is valid as the last entry). Scans branch sub-chains too, so one buried in
+    /// a branch is caught at build time rather than activating at runtime.
+    fn reject_terminal_filters(pipeline: &FilterPipeline, name: Option<&str>) -> Result<(), FilterError> {
+        let terminal = pipeline.terminal_filters();
+        if !terminal.is_empty() {
+            return Err(format!(
+                "outbound chain '{}' contains terminal filter(s) [{}] that an HTTP filtered \
+                 sub-request cannot run (it forwards to a resolved upstream and cannot surface a \
+                 terminal response)",
+                name.unwrap_or("<inline>"),
+                terminal.join(", ")
+            )
+            .into());
+        }
+        Ok(())
+    }
+
+    /// Resolve a [`ChainRef`] into its optional cycle-detection name and an
+    /// owned copy of its filter entries.
+    ///
+    /// Named references are looked up in the top-level `filter_chains`; inline
+    /// references carry their filters directly and have no name to key cycle
+    /// detection on.
+    fn resolve_ref<'r>(&self, chain_ref: &'r ChainRef) -> Result<(Option<&'r str>, Vec<FilterEntry>), FilterError> {
+        match chain_ref {
+            ChainRef::Named(name) => {
+                let entries = self
+                    .chains
+                    .get(name.as_str())
+                    .ok_or_else(|| FilterError::from(format!("outbound chain references unknown chain '{name}'")))?
+                    .to_vec();
+                Ok((Some(name.as_str()), entries))
+            },
+            ChainRef::Inline { filters, .. } => Ok((None, filters.clone())),
+        }
+    }
+
+    /// Apply top-level structural ordering validation to a bound pipeline.
+    ///
+    /// Honors the operator's declared skip posture the same way the server's
+    /// `validate_pipeline` does: downgrade to warnings under
+    /// `skip_pipeline_validation`, otherwise reject the build.
+    fn enforce_bound_ordering(
+        &self,
+        pipeline: &FilterPipeline,
+        entries: &[FilterEntry],
+        chain_label: &str,
+    ) -> Result<(), FilterError> {
+        let errors = pipeline.ordering_errors(
+            entries,
+            self.insecure.allow_open_security_filters,
+            &self.insecure.skip_pipeline_checks,
+        );
+        if self.insecure.skip_pipeline_validation {
+            for msg in &errors {
+                tracing::warn!(outbound_chain = chain_label, "{msg}");
+            }
+        } else if !errors.is_empty() {
+            return Err(format!(
+                "outbound chain '{chain_label}' failed pipeline validation: {}",
+                errors.join("; ")
+            )
+            .into());
+        }
+        Ok(())
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[cfg(test)]
+#[expect(clippy::allow_attributes, reason = "blanket test suppressions")]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    reason = "tests"
+)]
+mod tests {
+    use std::sync::{
+        Mutex,
+        atomic::{AtomicBool, Ordering},
+    };
+
+    use async_trait::async_trait;
+    use praxis_core::config::{BranchChainConfig, FailureMode, MAX_BRANCH_DEPTH, SkipPipelineChecks};
+
+    use super::*;
+    use crate::{FilterAction, FilterFactory, HttpFilterContext};
+
+    // -------------------------------------------------------------------------
+    // Test Utilities
+    // -------------------------------------------------------------------------
+
+    // A no-op filter standing in for an application callout.
+    struct ProbeFilter;
+
+    #[async_trait]
+    impl HttpFilter for ProbeFilter {
+        fn name(&self) -> &'static str {
+            "test_callout"
+        }
+
+        async fn on_request(&self, _ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
+            Ok(FilterAction::Continue)
+        }
+    }
+
+    // Register a chain-binding callout filter that resolves the `outbound_chain`
+    // key of its config and records the number of filters it bound into `sink`.
+    fn register_probe(registry: &mut FilterRegistry, sink: Arc<Mutex<Option<usize>>>) {
+        registry
+            .register_chain_binding(
+                "test_callout",
+                Arc::new(move |config: &serde_yaml::Value, ctx: &ChainBindingContext<'_>| {
+                    let raw = config
+                        .get("outbound_chain")
+                        .cloned()
+                        .ok_or_else(|| FilterError::from("missing outbound_chain"))?;
+                    let chain_ref: ChainRef = serde_yaml::from_value(raw)
+                        .map_err(|e| FilterError::from(format!("bad outbound_chain: {e}")))?;
+                    let pipeline = ctx.bind_chain(&chain_ref)?;
+                    *sink.lock().expect("sink lock") = Some(pipeline.len());
+                    let filter: Box<dyn HttpFilter> = Box::new(ProbeFilter);
+                    Ok(filter)
+                }),
+            )
+            .expect("register chain binding");
+    }
+
+    // Parse a `Vec<FilterEntry>` from YAML.
+    fn entries(yaml: &str) -> Vec<FilterEntry> {
+        serde_yaml::from_str(yaml).expect("parse entries")
+    }
+
+    // A minimal filter entry with no branches or config.
+    fn make_entry(filter_type: &str) -> FilterEntry {
+        FilterEntry {
+            branch_chains: None,
+            conditions: vec![],
+            config: serde_yaml::Value::Mapping(serde_yaml::Mapping::new()),
+            failure_mode: FailureMode::default(),
+            filter_type: filter_type.to_owned(),
+            name: None,
+            response_conditions: vec![],
+        }
+    }
+
+    // A one-filter chain whose branch fans out over `refs` named references to
+    // `target`. Nesting these multiplies the materialized instance count,
+    // mirroring the expansion the instance ceiling guards against.
+    fn fanout_chain(target: &str, refs: usize, branch: &str) -> Vec<FilterEntry> {
+        vec![FilterEntry {
+            branch_chains: Some(vec![BranchChainConfig {
+                chains: std::iter::repeat_with(|| ChainRef::Named(target.to_owned()))
+                    .take(refs)
+                    .collect(),
+                max_iterations: None,
+                name: branch.to_owned(),
+                on_result: None,
+                rejoin: "next".to_owned(),
+            }]),
+            ..make_entry("request_id")
+        }]
+    }
+
+    // A reference chain-binding callout that owns a prebuilt outbound pipeline.
+    //
+    // This is the pattern an application callout (for example an AI provider
+    // filter) follows: bind the outbound chain once at construction, hold it as
+    // an `Arc<FilterPipeline>`, and delegate the framework's nesting hooks so the
+    // bound pipeline participates in runtime-resource propagation, hot-reload
+    // file discovery, and insecure-option application.
+    struct OutboundCallout {
+        outbound: Arc<FilterPipeline>,
+    }
+
+    #[async_trait]
+    impl HttpFilter for OutboundCallout {
+        fn name(&self) -> &'static str {
+            "outbound_callout"
+        }
+
+        fn visit_nested_pipelines(&mut self, visitor: &mut dyn FnMut(&mut FilterPipeline)) {
+            if let Some(pipeline) = Arc::get_mut(&mut self.outbound) {
+                visitor(pipeline);
+            } else {
+                debug_assert!(false, "outbound pipeline must be uniquely owned during configuration");
+            }
+        }
+
+        fn referenced_files(&self) -> Vec<std::path::PathBuf> {
+            self.outbound.referenced_files()
+        }
+
+        fn apply_insecure_options(&self, options: &InsecureOptions) {
+            self.outbound.apply_insecure_options(options);
+        }
+
+        async fn on_request(&self, _ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
+            Ok(FilterAction::Continue)
+        }
+    }
+
+    // Register the reference callout, binding whatever `outbound_chain` resolves
+    // to into a prebuilt pipeline owned by the returned filter.
+    fn register_outbound_callout(registry: &mut FilterRegistry) {
+        registry
+            .register_chain_binding(
+                "outbound_callout",
+                Arc::new(|config: &serde_yaml::Value, ctx: &ChainBindingContext<'_>| {
+                    let raw = config
+                        .get("outbound_chain")
+                        .cloned()
+                        .ok_or_else(|| FilterError::from("missing outbound_chain"))?;
+                    let chain_ref: ChainRef = serde_yaml::from_value(raw)
+                        .map_err(|e| FilterError::from(format!("bad outbound_chain: {e}")))?;
+                    let outbound = ctx.bind_chain(&chain_ref)?;
+                    let filter: Box<dyn HttpFilter> = Box::new(OutboundCallout {
+                        outbound: Arc::new(outbound),
+                    });
+                    Ok(filter)
+                }),
+            )
+            .expect("register outbound_callout");
+    }
+
+    // A nested filter, placed inside an outbound chain, that declares a
+    // referenced document so a test can prove the bound pipeline is reachable by
+    // hot-reload file discovery.
+    struct OutboundProbeFilter;
+
+    #[async_trait]
+    impl HttpFilter for OutboundProbeFilter {
+        fn name(&self) -> &'static str {
+            "outbound_probe"
+        }
+
+        fn referenced_files(&self) -> Vec<std::path::PathBuf> {
+            vec![std::path::PathBuf::from("/etc/praxis/outbound-probe-doc.yaml")]
+        }
+
+        async fn on_request(&self, _ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
+            Ok(FilterAction::Continue)
+        }
+    }
+
+    fn register_outbound_probe(registry: &mut FilterRegistry) {
+        registry
+            .register(
+                "outbound_probe",
+                FilterFactory::Http(Arc::new(|_| Ok(Box::new(OutboundProbeFilter)))),
+            )
+            .expect("register outbound_probe");
+    }
+
+    // A custom (non-builtin) filter that declares it can return a terminal
+    // response and does so. Its name is not a hard-coded builtin terminal name,
+    // so name-based detection would miss it; capability-based detection must
+    // still reject it inside an outbound chain.
+    struct CustomTerminalFilter;
+
+    #[async_trait]
+    impl HttpFilter for CustomTerminalFilter {
+        fn name(&self) -> &'static str {
+            "custom_terminal"
+        }
+
+        fn produces_terminal_response(&self) -> bool {
+            true
+        }
+
+        async fn on_request(&self, _ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
+            Ok(FilterAction::TerminalResponse(Box::new(crate::TerminalResponse::new(
+                200,
+            ))))
+        }
+    }
+
+    fn register_custom_terminal(registry: &mut FilterRegistry) {
+        registry
+            .register(
+                "custom_terminal",
+                FilterFactory::Http(Arc::new(|_| Ok(Box::new(CustomTerminalFilter)))),
+            )
+            .expect("register custom_terminal");
+    }
+
+    // A nested filter that records whether `apply_insecure_options` reached it.
+    struct InsecureSinkFilter {
+        applied: Arc<AtomicBool>,
+    }
+
+    #[async_trait]
+    impl HttpFilter for InsecureSinkFilter {
+        fn name(&self) -> &'static str {
+            "insecure_sink"
+        }
+
+        fn apply_insecure_options(&self, _options: &InsecureOptions) {
+            self.applied.store(true, Ordering::SeqCst);
+        }
+
+        async fn on_request(&self, _ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
+            Ok(FilterAction::Continue)
+        }
+    }
+
+    fn register_insecure_sink(registry: &mut FilterRegistry, applied: Arc<AtomicBool>) {
+        registry
+            .register(
+                "insecure_sink",
+                FilterFactory::Http(Arc::new(move |_| {
+                    let filter: Box<dyn HttpFilter> = Box::new(InsecureSinkFilter {
+                        applied: Arc::clone(&applied),
+                    });
+                    Ok(filter)
+                })),
+            )
+            .expect("register insecure_sink");
+    }
+
+    #[test]
+    fn binds_inline_outbound_chain() {
+        let sink = Arc::new(Mutex::new(None));
+        let mut registry = FilterRegistry::with_builtins();
+        register_probe(&mut registry, Arc::clone(&sink));
+
+        let mut top = entries(
+            "
+- filter: test_callout
+  outbound_chain:
+    name: outbound
+    filters:
+      - filter: request_id
+      - filter: headers
+",
+        );
+        let chains = HashMap::new();
+        FilterPipeline::build_with_chains(&mut top, &registry, &chains, &InsecureOptions::default())
+            .expect("build pipeline");
+
+        assert_eq!(
+            *sink.lock().expect("sink lock"),
+            Some(2),
+            "callout should bind the 2-filter inline outbound chain"
+        );
+    }
+
+    #[test]
+    fn binds_named_outbound_chain() {
+        let sink = Arc::new(Mutex::new(None));
+        let mut registry = FilterRegistry::with_builtins();
+        register_probe(&mut registry, Arc::clone(&sink));
+
+        let outbound = entries("- filter: request_id\n- filter: headers\n- filter: compression\n");
+        let chains: HashMap<&str, &[FilterEntry]> = HashMap::from([("outbound", outbound.as_slice())]);
+        let mut top = entries("- filter: test_callout\n  outbound_chain: outbound\n");
+        FilterPipeline::build_with_chains(&mut top, &registry, &chains, &InsecureOptions::default())
+            .expect("build pipeline");
+
+        assert_eq!(
+            *sink.lock().expect("sink lock"),
+            Some(3),
+            "callout should resolve the named outbound chain against filter_chains"
+        );
+    }
+
+    #[test]
+    fn unknown_named_outbound_chain_errors() {
+        let sink = Arc::new(Mutex::new(None));
+        let mut registry = FilterRegistry::with_builtins();
+        register_probe(&mut registry, Arc::clone(&sink));
+
+        let chains = HashMap::new();
+        let mut top = entries("- filter: test_callout\n  outbound_chain: missing\n");
+        let err = FilterPipeline::build_with_chains(&mut top, &registry, &chains, &InsecureOptions::default())
+            .err()
+            .expect("build should fail");
+
+        assert!(
+            err.to_string().contains("unknown chain") && err.to_string().contains("missing"),
+            "an outbound reference to an undefined chain must fail the build: {err}"
+        );
+    }
+
+    #[test]
+    fn direct_cycle_rejected() {
+        let sink = Arc::new(Mutex::new(None));
+        let mut registry = FilterRegistry::with_builtins();
+        register_probe(&mut registry, Arc::clone(&sink));
+
+        let a = entries("- filter: test_callout\n  outbound_chain: a\n");
+        let chains: HashMap<&str, &[FilterEntry]> = HashMap::from([("a", a.as_slice())]);
+        let mut top = entries("- filter: test_callout\n  outbound_chain: a\n");
+        let err = FilterPipeline::build_with_chains(&mut top, &registry, &chains, &InsecureOptions::default())
+            .err()
+            .expect("build should fail");
+
+        assert!(
+            err.to_string().contains("cycle") && err.to_string().contains("a -> a"),
+            "a chain that binds itself must be rejected as a cycle, not a depth error: {err}"
+        );
+    }
+
+    #[test]
+    fn indirect_cycle_rejected() {
+        let sink = Arc::new(Mutex::new(None));
+        let mut registry = FilterRegistry::with_builtins();
+        register_probe(&mut registry, Arc::clone(&sink));
+
+        let a = entries("- filter: test_callout\n  outbound_chain: b\n");
+        let b = entries("- filter: test_callout\n  outbound_chain: a\n");
+        let chains: HashMap<&str, &[FilterEntry]> = HashMap::from([("a", a.as_slice()), ("b", b.as_slice())]);
+        let mut top = entries("- filter: test_callout\n  outbound_chain: a\n");
+        let err = FilterPipeline::build_with_chains(&mut top, &registry, &chains, &InsecureOptions::default())
+            .err()
+            .expect("build should fail");
+
+        assert!(
+            err.to_string().contains("cycle") && err.to_string().contains("a -> b -> a"),
+            "an a -> b -> a cycle across outbound chains must be reported as a cycle: {err}"
+        );
+    }
+
+    #[test]
+    fn excessive_nesting_rejected() {
+        let sink = Arc::new(Mutex::new(None));
+        let mut registry = FilterRegistry::with_builtins();
+        register_probe(&mut registry, Arc::clone(&sink));
+
+        // A non-cyclic line c0 -> c1 -> ... -> c10 exceeds the nesting cap;
+        // no name repeats, so cycle detection does not fire and the depth
+        // limit is what must reject the build.
+        let names: Vec<String> = (0..=MAX_OUTBOUND_CHAIN_DEPTH).map(|i| format!("c{i}")).collect();
+        let owned: Vec<Vec<FilterEntry>> = (0..=MAX_OUTBOUND_CHAIN_DEPTH)
+            .map(|i| entries(&format!("- filter: test_callout\n  outbound_chain: c{}\n", i + 1)))
+            .collect();
+        let chains: HashMap<&str, &[FilterEntry]> = names
+            .iter()
+            .zip(owned.iter())
+            .map(|(name, e)| (name.as_str(), e.as_slice()))
+            .collect();
+        let mut top = entries("- filter: test_callout\n  outbound_chain: c0\n");
+        let err = FilterPipeline::build_with_chains(&mut top, &registry, &chains, &InsecureOptions::default())
+            .err()
+            .expect("build should fail");
+
+        assert!(
+            err.to_string().contains("nesting depth"),
+            "an outbound chain nested past the maximum depth must be rejected: {err}"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Inline-cluster safety gating (issue #1074, F1)
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn inline_outbound_chain_ssrf_endpoint_rejected() {
+        // An inline cluster reachable only through an outbound chain must be
+        // gated by the same SSRF rules as a top-level `clusters:` list. With the
+        // strict default posture, an endpoint resolving to a loopback address
+        // must fail the build instead of silently bypassing the check.
+        let mut registry = FilterRegistry::with_builtins();
+        register_outbound_callout(&mut registry);
+
+        let mut top = entries(
+            "
+- filter: outbound_callout
+  outbound_chain:
+    name: outbound
+    filters:
+      - filter: load_balancer
+        clusters:
+          - name: web
+            endpoints:
+              - address: \"127.0.0.1:80\"
+",
+        );
+        let chains = HashMap::new();
+        let err = FilterPipeline::build_with_chains(&mut top, &registry, &chains, &InsecureOptions::default())
+            .err()
+            .expect("build should fail");
+
+        assert!(
+            err.to_string().contains("sensitive address"),
+            "an inline outbound-chain endpoint resolving to a sensitive address must be rejected \
+             unless insecure_options.allow_private_endpoints is set: {err}"
+        );
+    }
+
+    #[test]
+    fn inline_outbound_chain_ssrf_endpoint_allowed_with_flag() {
+        // The same chain must build when the operator opts in to private
+        // endpoints, proving the gate is threaded from the declared posture and
+        // not an unconditional rejection.
+        let mut registry = FilterRegistry::with_builtins();
+        register_outbound_callout(&mut registry);
+
+        let mut top = entries(
+            "
+- filter: outbound_callout
+  outbound_chain:
+    name: outbound
+    filters:
+      - filter: load_balancer
+        clusters:
+          - name: web
+            endpoints:
+              - address: \"127.0.0.1:80\"
+",
+        );
+        let chains = HashMap::new();
+        // Opt in to the private endpoint (the concern under test) and skip the
+        // unrelated lb-without-router ordering check so a lone load_balancer —
+        // the minimal cluster-bearing chain — does not fail for a reason other
+        // than SSRF gating.
+        let insecure = InsecureOptions {
+            allow_private_endpoints: true,
+            skip_pipeline_checks: SkipPipelineChecks {
+                lb_without_router: true,
+                ..SkipPipelineChecks::default()
+            },
+            ..InsecureOptions::default()
+        };
+        FilterPipeline::build_with_chains(&mut top, &registry, &chains, &insecure)
+            .expect("outbound chain with an opted-in private endpoint must build");
+    }
+
+    // -------------------------------------------------------------------------
+    // Materialization budget across binding boundaries (issue #1074, F2)
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn outbound_binding_does_not_reset_materialization_budget() {
+        // Each outbound chain fans out to ~59k filter instances — comfortably
+        // under the 100k ceiling on its own. Binding two of them in one build
+        // materializes ~118k total. If binding reset the budget, a config could
+        // split an unbounded fan-out across binding boundaries and evade the
+        // ceiling entirely, so the budget must be shared across the whole build.
+        let mut registry = FilterRegistry::with_builtins();
+        register_probe(&mut registry, Arc::new(Mutex::new(None)));
+
+        let leaf = vec![make_entry("request_id")];
+        let c1 = fanout_chain("leaf", 20, "b1");
+        let c2 = fanout_chain("c1", 20, "b2");
+        let c3 = fanout_chain("c2", 20, "b3");
+        let outbound = fanout_chain("c3", 7, "b_out"); // 1 + 7*8421 = 58_948 instances
+        let chains: HashMap<&str, &[FilterEntry]> = HashMap::from([
+            ("leaf", leaf.as_slice()),
+            ("c1", c1.as_slice()),
+            ("c2", c2.as_slice()),
+            ("c3", c3.as_slice()),
+            ("outbound", outbound.as_slice()),
+        ]);
+
+        let mut top = entries(
+            "
+- filter: test_callout
+  outbound_chain: outbound
+- filter: test_callout
+  outbound_chain: outbound
+",
+        );
+        let err = FilterPipeline::build_with_chains(&mut top, &registry, &chains, &InsecureOptions::default())
+            .err()
+            .expect("two ~59k outbound bindings must exceed the shared 100k budget");
+
+        assert!(
+            err.to_string().contains("filter instances"),
+            "binding an outbound chain must not reset the materialization budget: {err}"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Total-branch budget across binding boundaries (issue #1074)
+    //
+    // `MAX_TOTAL_BRANCHES` bounds config complexity across the whole build, not
+    // each chain in isolation. Bound outbound chains never appear in
+    // `Config::filter_chains`, so the whole-config `validate_branch_chains` pass
+    // never counts their branches. If each binding counted its branches from a
+    // fresh zero, several bindings could each stay under the ceiling while
+    // exceeding it collectively — and the branches already present in the
+    // listener config would go uncounted. The budget must accumulate across the
+    // whole build.
+    // -------------------------------------------------------------------------
+
+    // Build the YAML for an outbound-binding callout whose inline outbound chain
+    // defines `branches` branch chains, packed at the per-filter cap of 16, each
+    // resolving against the known named chain `utility` so only the branch name
+    // (not an inline sub-chain name) counts toward the total-branch ceiling.
+    fn outbound_callout_with_branches(branches: usize) -> String {
+        use std::fmt::Write as _;
+        let mut s = String::from("- filter: outbound_callout\n  outbound_chain:\n    name: outbound\n    filters:\n");
+        let mut emitted = 0;
+        while emitted < branches {
+            s.push_str("      - filter: request_id\n        branch_chains:\n");
+            for _ in 0..16 {
+                if emitted >= branches {
+                    break;
+                }
+                writeln!(s, "          - name: br_{emitted}\n            chains: [utility]").unwrap();
+                emitted += 1;
+            }
+        }
+        s
+    }
+
+    #[test]
+    fn outbound_bindings_share_total_branch_budget() {
+        // Two outbound bindings, each defining 144 branch chains — comfortably
+        // under the 256 ceiling on its own, but 288 together. If binding reset
+        // the branch count, a config could split an unbounded branch count across
+        // binding boundaries and evade the ceiling entirely, so the total must be
+        // shared across the whole build.
+        let mut registry = FilterRegistry::with_builtins();
+        register_outbound_callout(&mut registry);
+
+        let utility = entries("- filter: headers\n");
+        let chains: HashMap<&str, &[FilterEntry]> = HashMap::from([("utility", utility.as_slice())]);
+
+        let top_yaml = format!(
+            "{}{}",
+            outbound_callout_with_branches(144),
+            outbound_callout_with_branches(144)
+        );
+        let mut top = entries(&top_yaml);
+        let err = FilterPipeline::build_with_chains(&mut top, &registry, &chains, &InsecureOptions::default())
+            .err()
+            .expect("two 144-branch outbound bindings must exceed the shared 256-branch ceiling");
+
+        assert!(
+            err.to_string().contains("total branch count") && err.to_string().contains("256"),
+            "binding an outbound chain must not reset the total-branch budget: {err}"
+        );
+    }
+
+    #[test]
+    fn outbound_binding_branch_budget_counts_listener_branches() {
+        // The listener pipeline already defines 144 branch chains at its top
+        // level, and a single outbound binding adds 144 more. Neither exceeds the
+        // ceiling alone, but 288 together must. The bound chain's budget must be
+        // seeded with the branches already present in the listener config, not
+        // start from zero.
+        let mut registry = FilterRegistry::with_builtins();
+        register_outbound_callout(&mut registry);
+
+        let utility = entries("- filter: headers\n");
+        let chains: HashMap<&str, &[FilterEntry]> = HashMap::from([("utility", utility.as_slice())]);
+
+        // 144 branch chains at the listener top level (9 filters x 16 branches).
+        let mut listener_branches = {
+            use std::fmt::Write as _;
+            let mut s = String::new();
+            let mut emitted = 0;
+            while emitted < 144 {
+                s.push_str("- filter: request_id\n  branch_chains:\n");
+                for _ in 0..16 {
+                    if emitted >= 144 {
+                        break;
+                    }
+                    writeln!(s, "    - name: top_br_{emitted}\n      chains: [utility]").unwrap();
+                    emitted += 1;
+                }
+            }
+            s
+        };
+        // One outbound binding that adds another 144 branch chains.
+        listener_branches.push_str(&outbound_callout_with_branches(144));
+
+        let mut top = entries(&listener_branches);
+        let err = FilterPipeline::build_with_chains(&mut top, &registry, &chains, &InsecureOptions::default())
+            .err()
+            .expect("listener branches plus a bound chain's branches must exceed the shared ceiling");
+
+        assert!(
+            err.to_string().contains("total branch count") && err.to_string().contains("256"),
+            "the bound chain's branch budget must count the listener's existing branches: {err}"
+        );
+    }
+
+    // Build top-level filter entries defining `count` branch chains (packed at
+    // the 16-per-filter cap), each resolving to the known named chain `utility`
+    // so only the branch name — not an inline sub-chain name — counts toward the
+    // total-branch ceiling. `prefix` keeps branch names unique within the chain.
+    fn filters_with_branches(count: usize, prefix: &str) -> String {
+        use std::fmt::Write as _;
+        let mut s = String::new();
+        let mut emitted = 0;
+        while emitted < count {
+            s.push_str("- filter: request_id\n  branch_chains:\n");
+            for _ in 0..16 {
+                if emitted >= count {
+                    break;
+                }
+                writeln!(s, "    - name: {prefix}_{emitted}\n      chains: [utility]").unwrap();
+                emitted += 1;
+            }
+        }
+        s
+    }
+
+    #[test]
+    fn reused_named_outbound_chain_counts_branches_once() {
+        // A named outbound chain is a top-level `filter_chain`, already counted
+        // (and capped at 256) config-wide by `validate_branch_chains`. Binding it
+        // from several callouts must not re-count its branches per binding — that
+        // would falsely reject the documented shared/reused named-outbound-chain
+        // pattern for a config the whole-config pass accepts. Only inline
+        // outbound chains, which never appear in `Config::filter_chains`, escape
+        // that pass and so must accumulate into the shared budget.
+        let mut registry = FilterRegistry::with_builtins();
+        register_outbound_callout(&mut registry);
+
+        let utility = entries("- filter: headers\n");
+        // A named `outbound` chain defining 130 branch chains: under the 256
+        // ceiling on its own, but 260 if wrongly counted once per binding.
+        let outbound_yaml = filters_with_branches(130, "nb");
+        let outbound = entries(&outbound_yaml);
+        let chains: HashMap<&str, &[FilterEntry]> =
+            HashMap::from([("utility", utility.as_slice()), ("outbound", outbound.as_slice())]);
+
+        // Two callouts, each binding the SAME named chain by reference (a bare
+        // string resolves to ChainRef::Named).
+        let mut top = entries(
+            "
+- filter: outbound_callout
+  outbound_chain: outbound
+- filter: outbound_callout
+  outbound_chain: outbound
+",
+        );
+        FilterPipeline::build_with_chains(&mut top, &registry, &chains, &InsecureOptions::default())
+            .expect("a shared named outbound chain's branches must be counted once, not per binding");
+    }
+
+    #[test]
+    fn outbound_named_and_inline_branches_share_config_wide_budget() {
+        // The total-branch ceiling is configuration-wide, not per listener. A
+        // named outbound chain the listener never references still materializes
+        // when bound, and the whole-config `validate_branch_chains` pass counts it
+        // toward the ceiling. Seeding the build budget with only the listener's
+        // own branches would let a bound named chain (200) and an inline outbound
+        // chain (100) each stay under the ceiling while 300 branch definitions
+        // materialize in one build — twice the ceiling's intent. The seed must
+        // span the whole configuration so the two pools cannot be additive.
+        let mut registry = FilterRegistry::with_builtins();
+        register_outbound_callout(&mut registry);
+
+        let utility = entries("- filter: headers\n");
+        // A named chain with 200 branch chains that the listener does not list in
+        // its `filter_chains`, so a listener-scoped seed would not count it.
+        let named_yaml = filters_with_branches(200, "nb");
+        let named = entries(&named_yaml);
+        let chains: HashMap<&str, &[FilterEntry]> =
+            HashMap::from([("utility", utility.as_slice()), ("named_ob", named.as_slice())]);
+
+        // One callout binds the named 200-branch chain by reference; a second
+        // binds an inline chain of 100 branches. 300 branch definitions
+        // materialize in one build.
+        let top_yaml = format!(
+            "- filter: outbound_callout\n  outbound_chain: named_ob\n{}",
+            outbound_callout_with_branches(100)
+        );
+        let mut top = entries(&top_yaml);
+        let err = FilterPipeline::build_with_chains(&mut top, &registry, &chains, &InsecureOptions::default())
+            .err()
+            .expect("a bound named chain (200) plus an inline chain (100) must exceed the config-wide 256 ceiling");
+
+        assert!(
+            err.to_string().contains("total branch count") && err.to_string().contains("256"),
+            "the branch budget must span the whole configuration, not just the listener's own branches: {err}"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Outbound-depth vs branch-depth decoupling (issue #1074, F5)
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn outbound_binding_branch_depth_starts_fresh() {
+        // A bound outbound pipeline is an independent pipeline: its branch
+        // nesting restarts at zero rather than continuing the parent's. An
+        // outbound chain whose internal branches nest to the maximum branch
+        // depth must therefore build. If binding leaked the parent's depth into
+        // the bound pipeline (one counter conflating branch and outbound
+        // nesting), the same chain would spuriously trip the branch-depth
+        // ceiling one level early.
+        let mut registry = FilterRegistry::with_builtins();
+        register_outbound_callout(&mut registry);
+
+        // outbound(0) -> d1(1) -> ... -> d{n}(n) -> leaf(n+1); with the fix the
+        // deepest resolve lands at exactly MAX_BRANCH_DEPTH and is accepted.
+        let intermediate = MAX_BRANCH_DEPTH - 1;
+        let leaf = vec![make_entry("request_id")];
+        let owned: Vec<Vec<FilterEntry>> = (1..=intermediate)
+            .map(|i| {
+                let target = if i == intermediate {
+                    "leaf".to_owned()
+                } else {
+                    format!("d{}", i + 1)
+                };
+                fanout_chain(&target, 1, &format!("b{i}"))
+            })
+            .collect();
+        let names: Vec<String> = (1..=intermediate).map(|i| format!("d{i}")).collect();
+        let outbound = fanout_chain("d1", 1, "b0");
+
+        let mut chains: HashMap<&str, &[FilterEntry]> =
+            HashMap::from([("leaf", leaf.as_slice()), ("outbound", outbound.as_slice())]);
+        for (name, chain) in names.iter().zip(owned.iter()) {
+            chains.insert(name.as_str(), chain.as_slice());
+        }
+
+        let mut top = entries("- filter: outbound_callout\n  outbound_chain: outbound\n");
+        FilterPipeline::build_with_chains(&mut top, &registry, &chains, &InsecureOptions::default())
+            .expect("an outbound chain nested to the maximum branch depth must build");
+    }
+
+    // -------------------------------------------------------------------------
+    // Outbound-pipeline ordering validation (issue #1074, F3)
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn outbound_chain_ordering_violation_rejected() {
+        // A bound outbound chain is a real pipeline and must pass the same
+        // structural ordering validation as a top-level chain. A load_balancer
+        // with no preceding cluster selector would 502 at runtime, so it must
+        // fail the build instead of binding silently. The endpoint uses a
+        // non-sensitive TEST-NET address so the SSRF gate does not fire first
+        // and mask the ordering error under test.
+        let mut registry = FilterRegistry::with_builtins();
+        register_outbound_callout(&mut registry);
+
+        let mut top = entries(
+            "
+- filter: outbound_callout
+  outbound_chain:
+    name: outbound
+    filters:
+      - filter: load_balancer
+        clusters:
+          - name: web
+            endpoints:
+              - address: \"192.0.2.1:80\"
+",
+        );
+        let chains = HashMap::new();
+        let err = FilterPipeline::build_with_chains(&mut top, &registry, &chains, &InsecureOptions::default())
+            .err()
+            .expect("build should fail");
+
+        assert!(
+            err.to_string().contains("without a preceding router"),
+            "an outbound chain whose load_balancer has no cluster selector must fail ordering \
+             validation, not bind silently: {err}"
+        );
+    }
+
+    #[test]
+    fn outbound_chain_ordering_violation_downgraded_with_skip_flag() {
+        // The same chain must build when the operator skips that ordering check,
+        // proving the gate is threaded from the declared posture rather than an
+        // unconditional rejection.
+        let mut registry = FilterRegistry::with_builtins();
+        register_outbound_callout(&mut registry);
+
+        let mut top = entries(
+            "
+- filter: outbound_callout
+  outbound_chain:
+    name: outbound
+    filters:
+      - filter: load_balancer
+        clusters:
+          - name: web
+            endpoints:
+              - address: \"192.0.2.1:80\"
+",
+        );
+        let chains = HashMap::new();
+        let insecure = InsecureOptions {
+            skip_pipeline_checks: SkipPipelineChecks {
+                lb_without_router: true,
+                ..SkipPipelineChecks::default()
+            },
+            ..InsecureOptions::default()
+        };
+        FilterPipeline::build_with_chains(&mut top, &registry, &chains, &insecure)
+            .expect("outbound chain must build when the ordering check is skipped");
+    }
+
+    // -------------------------------------------------------------------------
+    // Review remediation: branch-chain constraint enforcement
+    //
+    // Inline outbound chains never appear in `Config::filter_chains`, so the
+    // whole-config `validate_branch_chains` pass never sees them. Their branch
+    // chains must still face the same core constraints — notably the
+    // `max_iterations <= 100` ceiling that bounds re-entrant request loops —
+    // instead of bypassing them and permitting an extremely long loop.
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn outbound_chain_branch_max_iterations_over_ceiling_rejected() {
+        let mut registry = FilterRegistry::with_builtins();
+        register_outbound_callout(&mut registry);
+
+        // A branch that re-enters more than the ceiling permits must fail the
+        // build; the runtime branch builder only requires `max_iterations` to be
+        // present for backward rejoins and never enforces the ceiling, so
+        // without a bind-time check this loop would activate unbounded.
+        let mut top = entries(
+            "
+- filter: outbound_callout
+  outbound_chain:
+    name: outbound
+    filters:
+      - filter: request_id
+        branch_chains:
+          - name: loop
+            max_iterations: 101
+            rejoin: next
+            chains:
+              - name: sub
+                filters:
+                  - filter: headers
+",
+        );
+        let chains = HashMap::new();
+        let err = FilterPipeline::build_with_chains(&mut top, &registry, &chains, &InsecureOptions::default())
+            .err()
+            .expect("build should fail");
+
+        assert!(
+            err.to_string().contains("max_iterations") && err.to_string().contains("101"),
+            "an outbound-chain branch exceeding the max_iterations ceiling must be rejected at \
+             build time, not activate an unbounded re-entrant loop: {err}"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Review remediation: protocol-level suitability of bound filters
+    //
+    // A filtered sub-request runs an HTTP pipeline. A TCP-level filter placed in
+    // an outbound chain builds without error but the HTTP executor silently
+    // skips it at runtime, so the invalid configuration activates and behaves
+    // unlike what the operator wrote. Reject it at build time.
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn outbound_chain_with_tcp_filter_rejected() {
+        let mut registry = FilterRegistry::with_builtins();
+        register_outbound_callout(&mut registry);
+
+        let mut top = entries(
+            "
+- filter: outbound_callout
+  outbound_chain:
+    name: outbound
+    filters:
+      - filter: tcp_access_log
+",
+        );
+        let chains = HashMap::new();
+        let err = FilterPipeline::build_with_chains(&mut top, &registry, &chains, &InsecureOptions::default())
+            .err()
+            .expect("build should fail");
+
+        assert!(
+            err.to_string().contains("tcp_access_log")
+                && (err.to_string().contains("TCP") || err.to_string().contains("HTTP")),
+            "a TCP-level filter in an HTTP outbound chain must be rejected at build time, not \
+             silently skipped at runtime: {err}"
+        );
+    }
+
+    #[test]
+    fn outbound_chain_with_branch_nested_tcp_filter_rejected() {
+        // The TCP-level filter is buried inside a branch sub-chain of the
+        // outbound chain, not at its top level. The runtime executor skips it
+        // just the same, so the build-time rejection must scan branch sub-chains
+        // too — not only the top-level filter list.
+        let mut registry = FilterRegistry::with_builtins();
+        register_outbound_callout(&mut registry);
+
+        let mut top = entries(
+            "
+- filter: outbound_callout
+  outbound_chain:
+    name: outbound
+    filters:
+      - filter: request_id
+        branch_chains:
+          - name: b1
+            chains:
+              - name: inner
+                filters:
+                  - filter: tcp_access_log
+",
+        );
+        let chains = HashMap::new();
+        let err = FilterPipeline::build_with_chains(&mut top, &registry, &chains, &InsecureOptions::default())
+            .err()
+            .expect("build should fail");
+
+        assert!(
+            err.to_string().contains("tcp_access_log")
+                && (err.to_string().contains("TCP") || err.to_string().contains("HTTP")),
+            "a TCP-level filter nested inside a branch of an HTTP outbound chain must be rejected at \
+             build time, not silently skipped at runtime: {err}"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Review remediation: terminal filters rejected in outbound chains
+    //
+    // A terminal filter (e.g. `iterative_request_router`) can short-circuit the
+    // request phase with a response and no upstream. The filtered sub-request
+    // executor forwards to a resolved upstream and never surfaces that response,
+    // so it drops the terminal action and then errors that no upstream resolved.
+    // Reject terminal filters at build time instead.
+    // -------------------------------------------------------------------------
+
+    #[test]
+    #[expect(clippy::too_many_lines, reason = "inline valid-IRR YAML fixture")]
+    fn outbound_chain_with_terminal_filter_rejected() {
+        let mut registry = FilterRegistry::with_builtins();
+        register_outbound_callout(&mut registry);
+
+        // A fully valid IRR (so nothing else fails the build first): one step
+        // with a router + load_balancer over a non-sensitive TEST-NET endpoint.
+        let mut top = entries(
+            "
+- filter: outbound_callout
+  outbound_chain:
+    name: outbound
+    filters:
+      - filter: iterative_request_router
+        initial_step: only
+        max_iterations: 3
+        steps:
+          - name: only
+            filters:
+              - filter: router
+                routes:
+                  - path_prefix: \"/\"
+                    cluster: svc
+              - filter: load_balancer
+                clusters:
+                  - name: svc
+                    endpoints:
+                      - \"192.0.2.1:80\"
+            on_result:
+              - default: true
+                done: true
+",
+        );
+        let chains = HashMap::new();
+        let err = FilterPipeline::build_with_chains(&mut top, &registry, &chains, &InsecureOptions::default())
+            .err()
+            .expect("build should fail");
+
+        assert!(
+            err.to_string().contains("terminal") && err.to_string().contains("iterative_request_router"),
+            "a terminal filter in an outbound chain must be rejected at build time, not activate \
+             and drop its terminal response at runtime: {err}"
+        );
+    }
+
+    #[test]
+    #[expect(clippy::too_many_lines, reason = "inline valid-IRR YAML fixture nested in a branch")]
+    fn outbound_chain_with_branch_nested_terminal_filter_rejected() {
+        // The terminal filter is buried inside a branch sub-chain of the outbound
+        // chain, not at its top level. It activates and drops its terminal
+        // response at runtime just the same, so the build-time rejection must
+        // scan branch sub-chains too — not only the top-level entry list.
+        let mut registry = FilterRegistry::with_builtins();
+        register_outbound_callout(&mut registry);
+
+        let mut top = entries(
+            "
+- filter: outbound_callout
+  outbound_chain:
+    name: outbound
+    filters:
+      - filter: request_id
+        branch_chains:
+          - name: b1
+            chains:
+              - name: inner
+                filters:
+                  - filter: iterative_request_router
+                    initial_step: only
+                    max_iterations: 3
+                    steps:
+                      - name: only
+                        filters:
+                          - filter: router
+                            routes:
+                              - path_prefix: \"/\"
+                                cluster: svc
+                          - filter: load_balancer
+                            clusters:
+                              - name: svc
+                                endpoints:
+                                  - \"192.0.2.1:80\"
+                        on_result:
+                          - default: true
+                            done: true
+",
+        );
+        let chains = HashMap::new();
+        let err = FilterPipeline::build_with_chains(&mut top, &registry, &chains, &InsecureOptions::default())
+            .err()
+            .expect("build should fail");
+
+        assert!(
+            err.to_string().contains("terminal") && err.to_string().contains("iterative_request_router"),
+            "a terminal filter nested inside a branch of an outbound chain must be rejected at build \
+             time, not activate and drop its terminal response at runtime: {err}"
+        );
+    }
+
+    #[test]
+    fn outbound_chain_with_custom_terminal_filter_rejected() {
+        // A *custom* filter — not the builtin `iterative_request_router` — that
+        // declares it produces terminal responses. Name-based detection only
+        // knows the hard-coded builtin terminal names, so it would let this
+        // through; the executor would then drop its terminal action and error
+        // that no upstream resolved. Capability-based detection must reject it at
+        // build time.
+        let mut registry = FilterRegistry::with_builtins();
+        register_outbound_callout(&mut registry);
+        register_custom_terminal(&mut registry);
+
+        let mut top = entries(
+            "
+- filter: outbound_callout
+  outbound_chain:
+    name: outbound
+    filters:
+      - filter: custom_terminal
+",
+        );
+        let chains = HashMap::new();
+        let err = FilterPipeline::build_with_chains(&mut top, &registry, &chains, &InsecureOptions::default())
+            .err()
+            .expect("build should fail");
+
+        assert!(
+            err.to_string().contains("terminal") && err.to_string().contains("custom_terminal"),
+            "a custom filter that declares it produces terminal responses must be rejected in an \
+             outbound chain, not escape because its name is not a hard-coded builtin: {err}"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Review remediation: bound chains face the top-level per-chain filter cap
+    // and empty-predicate condition validation
+    //
+    // A bound outbound chain never appears in `Config::filter_chains`, so the
+    // whole-config `validate_filter_chains` walk never sees it. Without an
+    // explicit bind-time check it would bypass the per-chain filter cardinality
+    // limit and the `when`/`unless` empty-predicate validation top-level chains
+    // face.
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn outbound_chain_over_filter_limit_rejected() {
+        let mut registry = FilterRegistry::with_builtins();
+        register_outbound_callout(&mut registry);
+
+        // 101 filters — one past the per-chain cap. A bound chain must face the
+        // same limit, or a runaway outbound chain builds unbounded.
+        let filters_yaml = "      - filter: request_id\n".repeat(101);
+        let top_yaml =
+            format!("- filter: outbound_callout\n  outbound_chain:\n    name: outbound\n    filters:\n{filters_yaml}");
+        let mut top = entries(&top_yaml);
+        let chains = HashMap::new();
+        let err = FilterPipeline::build_with_chains(&mut top, &registry, &chains, &InsecureOptions::default())
+            .err()
+            .expect("build should fail");
+
+        assert!(
+            err.to_string().contains("too many filters") && err.to_string().contains("101"),
+            "an outbound chain exceeding the per-chain filter limit must be rejected at build time, \
+             not build unbounded: {err}"
+        );
+    }
+
+    #[test]
+    fn outbound_chain_empty_condition_rejected() {
+        let mut registry = FilterRegistry::with_builtins();
+        register_outbound_callout(&mut registry);
+
+        // An empty `unless` predicate matches every request, so it silently
+        // disables the filter — almost always a config accident.
+        let mut top = entries(
+            "
+- filter: outbound_callout
+  outbound_chain:
+    name: outbound
+    filters:
+      - filter: request_id
+        conditions:
+          - unless: {}
+",
+        );
+        let chains = HashMap::new();
+        let err = FilterPipeline::build_with_chains(&mut top, &registry, &chains, &InsecureOptions::default())
+            .err()
+            .expect("build should fail");
+
+        assert!(
+            err.to_string().contains("condition 0 is empty"),
+            "an outbound chain filter with an empty condition predicate must be rejected at build \
+             time, the same as a top-level chain: {err}"
+        );
+    }
+
+    #[test]
+    fn outbound_chain_branch_nested_empty_condition_rejected() {
+        // The empty predicate is buried inside a branch sub-chain of the outbound
+        // chain, not at its top level. Condition validation must recurse into
+        // branch sub-chains too, matching the top-level walk.
+        let mut registry = FilterRegistry::with_builtins();
+        register_outbound_callout(&mut registry);
+
+        let mut top = entries(
+            "
+- filter: outbound_callout
+  outbound_chain:
+    name: outbound
+    filters:
+      - filter: request_id
+        branch_chains:
+          - name: b1
+            chains:
+              - name: inner
+                filters:
+                  - filter: headers
+                    conditions:
+                      - unless: {}
+",
+        );
+        let chains = HashMap::new();
+        let err = FilterPipeline::build_with_chains(&mut top, &registry, &chains, &InsecureOptions::default())
+            .err()
+            .expect("build should fail");
+
+        assert!(
+            err.to_string().contains("condition 0 is empty"),
+            "an empty condition predicate nested inside a branch of an outbound chain must be \
+             rejected at build time: {err}"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Reload / runtime-propagation contract (issue #1074, requirement 4)
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn outbound_chain_surfaces_referenced_files_for_reload() {
+        let mut registry = FilterRegistry::with_builtins();
+        register_outbound_callout(&mut registry);
+        register_outbound_probe(&mut registry);
+
+        let mut top = entries(
+            "
+- filter: outbound_callout
+  outbound_chain:
+    name: outbound
+    filters:
+      - filter: outbound_probe
+",
+        );
+        let chains = HashMap::new();
+        let parent = FilterPipeline::build_with_chains(&mut top, &registry, &chains, &InsecureOptions::default())
+            .expect("build pipeline");
+
+        assert!(
+            parent
+                .referenced_files()
+                .contains(&std::path::PathBuf::from("/etc/praxis/outbound-probe-doc.yaml")),
+            "the rebuilt parent must surface documents referenced inside the bound outbound chain so \
+             editing them triggers a hot reload"
+        );
+    }
+
+    #[test]
+    fn outbound_chain_surfaces_branch_nested_referenced_files_for_reload() {
+        // The file-referencing filter is buried inside a branch sub-chain of the
+        // outbound chain. Hot-reload file discovery must still surface its
+        // document, or editing a document referenced only from a branch would not
+        // trigger a reload.
+        let mut registry = FilterRegistry::with_builtins();
+        register_outbound_callout(&mut registry);
+        register_outbound_probe(&mut registry);
+
+        let mut top = entries(
+            "
+- filter: outbound_callout
+  outbound_chain:
+    name: outbound
+    filters:
+      - filter: request_id
+        branch_chains:
+          - name: b1
+            chains:
+              - name: inner
+                filters:
+                  - filter: outbound_probe
+",
+        );
+        let chains = HashMap::new();
+        let parent = FilterPipeline::build_with_chains(&mut top, &registry, &chains, &InsecureOptions::default())
+            .expect("build pipeline");
+
+        assert!(
+            parent
+                .referenced_files()
+                .contains(&std::path::PathBuf::from("/etc/praxis/outbound-probe-doc.yaml")),
+            "the rebuilt parent must surface documents referenced by filters nested inside a branch of \
+             the bound outbound chain so editing them triggers a hot reload"
+        );
+    }
+
+    #[test]
+    fn outbound_pipeline_receives_and_retains_runtime_resources() {
+        // A chain-binding filter owns its outbound pipeline; the framework reaches
+        // it only through `visit_nested_pipelines`. Bind through the public API,
+        // then drive the same propagation the parent pipeline's `set_*` methods
+        // perform, and confirm the resource reaches — and persists on — the bound
+        // pipeline.
+        let mut registry = FilterRegistry::with_builtins();
+        register_outbound_callout(&mut registry);
+
+        let stack = ResolutionStack::new();
+        let chains: HashMap<&str, &[FilterEntry]> = HashMap::new();
+        let insecure = InsecureOptions::default();
+        let (budget, branch_budget) = (Cell::new(0), Cell::new(0));
+        let ctx = ChainBindingContext::new(&registry, &chains, &stack, 0, &insecure, &budget, &branch_budget);
+        let chain_ref = ChainRef::Inline {
+            name: "outbound".to_owned(),
+            filters: entries("- filter: request_id\n- filter: headers\n"),
+        };
+        let outbound = ctx.bind_chain(&chain_ref).expect("bind outbound chain");
+        let mut callout = OutboundCallout {
+            outbound: Arc::new(outbound),
+        };
+
+        assert!(
+            !callout.outbound.records_filter_duration_metrics(),
+            "the bound pipeline starts with metrics recording disabled"
+        );
+
+        callout.visit_nested_pipelines(&mut |pipeline| pipeline.set_record_filter_duration_metrics(true));
+
+        assert!(
+            callout.outbound.records_filter_duration_metrics(),
+            "a runtime resource set on the parent must propagate into the bound outbound pipeline"
+        );
+
+        // Re-observe through a fresh visit to prove the value persisted on the
+        // bound pipeline rather than being a transient during-visit view.
+        let mut observed = false;
+        callout.visit_nested_pipelines(&mut |pipeline| observed = pipeline.records_filter_duration_metrics());
+        assert!(
+            observed,
+            "the propagated runtime resource must persist on the bound outbound pipeline"
+        );
+    }
+
+    #[test]
+    fn outbound_chain_receives_insecure_options() {
+        let applied = Arc::new(AtomicBool::new(false));
+        let mut registry = FilterRegistry::with_builtins();
+        register_outbound_callout(&mut registry);
+        register_insecure_sink(&mut registry, Arc::clone(&applied));
+
+        let mut top = entries(
+            "
+- filter: outbound_callout
+  outbound_chain:
+    name: outbound
+    filters:
+      - filter: insecure_sink
+",
+        );
+        let chains = HashMap::new();
+        let parent = FilterPipeline::build_with_chains(&mut top, &registry, &chains, &InsecureOptions::default())
+            .expect("build pipeline");
+
+        parent.apply_insecure_options(&InsecureOptions::default());
+
+        assert!(
+            applied.load(Ordering::SeqCst),
+            "insecure options applied to the parent must reach filters inside the bound outbound chain"
+        );
+    }
+
+    #[test]
+    fn outbound_chain_applies_insecure_options_to_branch_nested_filters() {
+        // The insecure-option-aware filter is buried inside a branch sub-chain of
+        // the outbound chain. Insecure options applied to the parent must still
+        // reach it, or a branch-contained filter would silently keep its secure
+        // defaults while the operator believed the override applied everywhere.
+        let applied = Arc::new(AtomicBool::new(false));
+        let mut registry = FilterRegistry::with_builtins();
+        register_outbound_callout(&mut registry);
+        register_insecure_sink(&mut registry, Arc::clone(&applied));
+
+        let mut top = entries(
+            "
+- filter: outbound_callout
+  outbound_chain:
+    name: outbound
+    filters:
+      - filter: request_id
+        branch_chains:
+          - name: b1
+            chains:
+              - name: inner
+                filters:
+                  - filter: insecure_sink
+",
+        );
+        let chains = HashMap::new();
+        let parent = FilterPipeline::build_with_chains(&mut top, &registry, &chains, &InsecureOptions::default())
+            .expect("build pipeline");
+
+        parent.apply_insecure_options(&InsecureOptions::default());
+
+        assert!(
+            applied.load(Ordering::SeqCst),
+            "insecure options applied to the parent must reach filters nested inside a branch of the \
+             bound outbound chain"
+        );
+    }
+
+    #[test]
+    #[expect(clippy::too_many_lines, reason = "two-version reload with explicit YAML fixtures")]
+    fn rebuilt_outbound_pipeline_reflects_config_change() {
+        let sink = Arc::new(Mutex::new(None));
+        let mut registry = FilterRegistry::with_builtins();
+        register_probe(&mut registry, Arc::clone(&sink));
+        let chains = HashMap::new();
+
+        // v1: a 2-filter outbound chain.
+        let mut v1 = entries(
+            "
+- filter: test_callout
+  outbound_chain:
+    name: outbound
+    filters:
+      - filter: request_id
+      - filter: headers
+",
+        );
+        FilterPipeline::build_with_chains(&mut v1, &registry, &chains, &InsecureOptions::default()).expect("build v1");
+        assert_eq!(
+            *sink.lock().expect("sink lock"),
+            Some(2),
+            "v1 binds a 2-filter outbound chain"
+        );
+
+        // v2 (a reload): a 3-filter outbound chain must re-bind from the new config.
+        let mut v2 = entries(
+            "
+- filter: test_callout
+  outbound_chain:
+    name: outbound
+    filters:
+      - filter: request_id
+      - filter: headers
+      - filter: compression
+",
+        );
+        FilterPipeline::build_with_chains(&mut v2, &registry, &chains, &InsecureOptions::default()).expect("build v2");
+        assert_eq!(
+            *sink.lock().expect("sink lock"),
+            Some(3),
+            "rebuilding after a config change must re-bind the outbound chain from the new config"
+        );
+    }
+}

--- a/crates/filter/src/builtins/http/traffic_management/iterative_request_router/mod.rs
+++ b/crates/filter/src/builtins/http/traffic_management/iterative_request_router/mod.rs
@@ -312,6 +312,14 @@ impl HttpFilter for IterativeRequestRouterFilter {
         "iterative_request_router"
     }
 
+    fn produces_terminal_response(&self) -> bool {
+        // IRR resolves a sub-request and returns its response as a terminal
+        // action, so it can never run inside a filtered sub-request's outbound
+        // chain. Declaring the capability lets bind-time validation reject it
+        // without relying on a name match.
+        true
+    }
+
     fn request_body_access(&self) -> crate::body::BodyAccess {
         crate::body::BodyAccess::ReadOnly
     }

--- a/crates/filter/src/credentials.rs
+++ b/crates/filter/src/credentials.rs
@@ -1,0 +1,634 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Praxis Contributors
+
+//! Authority-bound deferred credentials for outbound sub-requests.
+//!
+//! A chain-binding filter (for example an AI callout) frequently must attach a
+//! secret — an API key, a bearer token — to the outbound sub-request it drives.
+//! Injecting that secret into the sub-request headers before the destination is
+//! resolved would leak it to whatever authority the outbound chain happens to
+//! select, turning a routing mistake or SSRF into credential exfiltration.
+//!
+//! [`DeferredCredential`] closes that gap: the caller binds each secret to the
+//! authority (`host` or `host:port`) permitted to receive it and stages the set
+//! as [`PendingCredentials`] in the request extensions projected into the child
+//! context. The sub-request executor materializes a credential *only after* it
+//! has resolved and validated the destination, and *only* into a request bound
+//! for the matching authority. Credentials whose authority does not match the
+//! resolved destination are dropped, their secrets zeroized, and never sent.
+
+use http::{HeaderMap, HeaderName, HeaderValue};
+use zeroize::Zeroizing;
+
+use crate::FilterError;
+
+/// A canonicalized logical HTTP authority: a lowercased host and an explicit
+/// port.
+///
+/// Canonicalization makes credential matching robust to the incidental
+/// differences (host casing, an implicit port) that would otherwise let a
+/// credential silently fail to match the destination it was issued for.
+#[derive(Clone, PartialEq, Eq)]
+struct CanonicalAuthority {
+    /// Lowercased host (DNS name or IP literal, IPv6 without brackets).
+    host: Box<str>,
+    /// Explicit port.
+    port: u16,
+}
+
+/// Parse `input` into a [`CanonicalAuthority`], lowercasing the host.
+///
+/// Accepts `host:port`, bracketed IPv6 (`[::1]:443`), or — when `default_port`
+/// supplies one — a bare `host`. A bare host with no `default_port` is rejected
+/// as ambiguous: a credential must not silently bind to "some port" on a host.
+fn parse_canonical(input: &str, default_port: Option<u16>) -> Result<CanonicalAuthority, FilterError> {
+    if input.is_empty() {
+        return Err("authority must not be empty".into());
+    }
+    let (host, port) = split_host_port(input)?;
+    if host.is_empty() {
+        return Err(format!("authority '{input}' has an empty host").into());
+    }
+    let port = port.or(default_port).ok_or_else(|| -> FilterError {
+        format!("authority '{input}' must specify an explicit port ('host:port')").into()
+    })?;
+    Ok(CanonicalAuthority {
+        host: host.to_ascii_lowercase().into_boxed_str(),
+        port,
+    })
+}
+
+/// Split `input` into its host and optional explicit port.
+///
+/// Handles bracketed IPv6 (`[::1]:443`) and distinguishes an unbracketed IPv6
+/// literal — which keeps its `:` in the host and carries no separable port —
+/// from an ordinary `host:port` pair.
+fn split_host_port(input: &str) -> Result<(&str, Option<u16>), FilterError> {
+    if let Some(rest) = input.strip_prefix('[') {
+        let Some((host, after)) = rest.split_once(']') else {
+            return Err(format!("authority '{input}' has an unclosed IPv6 bracket").into());
+        };
+        match after.strip_prefix(':') {
+            Some(port_str) => Ok((host, Some(parse_port(port_str, input)?))),
+            None if after.is_empty() => Ok((host, None)),
+            None => Err(format!("authority '{input}' has trailing characters after ']'").into()),
+        }
+    } else if let Some((host, port_str)) = input.rsplit_once(':') {
+        // A host that still contains ':' is an unbracketed IPv6 literal, which
+        // carries no separable port; treat the whole input as a bare host.
+        if host.contains(':') {
+            Ok((input, None))
+        } else {
+            Ok((host, Some(parse_port(port_str, input)?)))
+        }
+    } else {
+        Ok((input, None))
+    }
+}
+
+/// Parse a `u16` port with authority context on failure.
+fn parse_port(port_str: &str, input: &str) -> Result<u16, FilterError> {
+    port_str
+        .parse::<u16>()
+        .map_err(|e| -> FilterError { format!("authority '{input}' has an invalid port '{port_str}': {e}").into() })
+}
+
+/// Validate and lowercase a bare wildcard host, rejecting any explicit port.
+///
+/// A port on a wildcard host means the caller wanted an exact authority; binding
+/// it as a "host" would produce a scope that can never match (the same silent
+/// mismatch a host-only exact authority would cause), so reject it outright.
+fn canonical_host(input: &str) -> Result<Box<str>, FilterError> {
+    if input.is_empty() {
+        return Err("host must not be empty".into());
+    }
+    let host = if let Some(rest) = input.strip_prefix('[') {
+        let Some((host, after)) = rest.split_once(']') else {
+            return Err(format!("host '{input}' has an unclosed IPv6 bracket").into());
+        };
+        if !after.is_empty() {
+            return Err(format!("host wildcard '{input}' must not include a port").into());
+        }
+        host
+    } else if input.rsplit_once(':').is_some_and(|(host, _)| !host.contains(':')) {
+        // `host:port` where the host part carries no further ':' — an explicit
+        // port. (An unbracketed IPv6 literal keeps its ':' in the host part and
+        // falls through to the bare-host branch.)
+        return Err(format!("host wildcard '{input}' must not include a port").into());
+    } else {
+        input
+    };
+    if host.is_empty() {
+        return Err(format!("host '{input}' has an empty host").into());
+    }
+    Ok(host.to_ascii_lowercase().into_boxed_str())
+}
+
+/// Classify a header a deferred credential must never inject, returning a human
+/// description of why, or `None` when the header is safe to carry a credential.
+///
+/// Credentials are injected *after* sub-request sanitization, so a routing
+/// header (`Host`) could retarget the request past authority authorization, and
+/// a message-framing (`Content-Length`) or hop-by-hop header could re-introduce
+/// a boundary the sanitizer stripped — a request-smuggling vector. A credential
+/// may only carry an end-to-end, non-routing header.
+fn forbidden_credential_header(header: &HeaderName) -> Option<&'static str> {
+    let name = header.as_str();
+    if name == http::header::HOST.as_str() {
+        Some("the routing Host header")
+    } else if name == http::header::CONTENT_LENGTH.as_str() {
+        Some("a message-framing header")
+    } else if praxis_core::reserved_headers::HOP_BY_HOP_HEADERS.contains(&name) {
+        Some("a hop-by-hop header")
+    } else {
+        None
+    }
+}
+
+/// The set of destinations a credential may be delivered to.
+enum CredentialScope {
+    /// Exactly this canonical `host:port`.
+    Authority(CanonicalAuthority),
+    /// Any port on this lowercased host. An explicitly opted-in wildcard, so a
+    /// host-only scope is a deliberate choice rather than a silent ambiguity.
+    HostWildcard {
+        /// Lowercased host matched against a destination regardless of its port.
+        host: Box<str>,
+    },
+}
+
+impl CredentialScope {
+    /// Whether a destination resolved to `resolved` is in scope.
+    fn matches(&self, resolved: &CanonicalAuthority) -> bool {
+        match self {
+            Self::Authority(authority) => *authority == *resolved,
+            Self::HostWildcard { host } => host.as_ref() == resolved.host.as_ref(),
+        }
+    }
+}
+
+/// The resolved destination of a sub-request.
+///
+/// Separates the *logical* HTTP authority — what the upstream is addressed as,
+/// and the key credentials are matched against — from the *transport* endpoint
+/// where bytes actually travel. A logical authority that omits a port inherits
+/// the transport's, so a credential bound to `host:port` still matches an
+/// upstream whose authority override is a bare host.
+pub(crate) struct ResolvedDestination<'a> {
+    /// Logical HTTP authority (`upstream.authority` override, else the transport
+    /// address). Credentials are matched against this, never the transport.
+    pub(crate) authority: &'a str,
+    /// Transport endpoint (`host:port`); supplies the default port when the
+    /// logical authority omits one.
+    pub(crate) transport: &'a str,
+}
+
+impl ResolvedDestination<'_> {
+    /// Canonicalize the logical authority, defaulting a missing port to the
+    /// transport's. Returns `None` if it does not yield a usable `host:port`.
+    fn canonicalize(&self) -> Option<CanonicalAuthority> {
+        // The transport is always a concrete `host:port`, so it supplies the
+        // default port a bare authority override omits. An unparseable transport
+        // leaves no port to fall back on, so the destination is unresolvable.
+        let transport_port = parse_canonical(self.transport, None).ok()?.port;
+        parse_canonical(self.authority, Some(transport_port)).ok()
+    }
+}
+
+/// A secret header value bound to the logical HTTP authority permitted to
+/// receive it.
+///
+/// The secret is held in [`Zeroizing`] so it is wiped from memory on drop.
+/// `DeferredCredential` deliberately implements no `Debug`/`Display` and
+/// exposes no accessor for the secret; the only way the value leaves the type
+/// is a successful, authority-matched injection during sub-request execution.
+pub struct DeferredCredential {
+    /// Destinations permitted to receive this secret.
+    scope: CredentialScope,
+    /// Header the secret is injected under.
+    header: HeaderName,
+    /// Assembled header value, zeroized on drop.
+    value: Zeroizing<String>,
+}
+
+impl DeferredCredential {
+    /// Bind `value` under `header`, deliverable only to `authority`.
+    ///
+    /// `authority` is the canonical logical HTTP authority (`host:port`) the
+    /// outbound chain must resolve before the secret is injected. A host-only
+    /// authority is rejected as ambiguous; bind to any port on a host with
+    /// [`DeferredCredential::new_host_wildcard`] instead.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FilterError`] if `authority` is not a valid `host:port`, if
+    /// `header` names a reserved `x-praxis-*` header (a credential must not
+    /// smuggle framework-trust headers past sanitization), or if `value` is not
+    /// a valid HTTP header value.
+    pub fn new(authority: &str, header: HeaderName, value: impl Into<String>) -> Result<Self, FilterError> {
+        let authority = parse_canonical(authority, None)
+            .map_err(|error| -> FilterError { format!("deferred credential {error}").into() })?;
+        Self::build(CredentialScope::Authority(authority), header, value)
+    }
+
+    /// Bind `value` under `header`, deliverable to any port on `host`.
+    ///
+    /// This is the *explicit* opt-in for a host-only scope: unlike [`new`], which
+    /// rejects a host with no port as ambiguous, `new_host_wildcard` makes
+    /// "deliver to `host` regardless of port" a deliberate, auditable choice.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FilterError`] if `host` is empty or itself carries a port
+    /// (bind an exact `host:port` with [`new`] instead), if `header` is
+    /// reserved, or if `value` is not a valid HTTP header value.
+    ///
+    /// [`new`]: DeferredCredential::new
+    pub fn new_host_wildcard(host: &str, header: HeaderName, value: impl Into<String>) -> Result<Self, FilterError> {
+        let host =
+            canonical_host(host).map_err(|error| -> FilterError { format!("deferred credential {error}").into() })?;
+        Self::build(CredentialScope::HostWildcard { host }, header, value)
+    }
+
+    /// Shared constructor tail: header-name and value validation.
+    fn build(scope: CredentialScope, header: HeaderName, value: impl Into<String>) -> Result<Self, FilterError> {
+        if praxis_core::reserved_headers::is_reserved(header.as_str()) {
+            return Err(format!("deferred credential header '{header}' is reserved for internal use").into());
+        }
+        if let Some(class) = forbidden_credential_header(&header) {
+            return Err(
+                format!("deferred credential header '{header}' is {class} and cannot carry a credential").into(),
+            );
+        }
+        let value = Zeroizing::new(value.into());
+        // Validate up front so a malformed secret fails at construction rather
+        // than silently at the injection point deep inside the executor.
+        HeaderValue::from_str(&value).map_err(|error| -> FilterError {
+            format!("deferred credential value is not a valid header value: {error}").into()
+        })?;
+        Ok(Self { scope, header, value })
+    }
+
+    /// Inject the secret into `headers` iff `resolved` is within the
+    /// credential's scope, returning whether it was injected.
+    ///
+    /// On a match the header is set, replacing any existing value so a
+    /// client-supplied credential cannot shadow the gateway-managed one. On a
+    /// mismatch nothing is written and the secret stays sealed until drop.
+    fn inject_canonical(&self, resolved: &CanonicalAuthority, headers: &mut HeaderMap) -> bool {
+        if !self.scope.matches(resolved) {
+            return false;
+        }
+        // The value was validated in `new`, so this cannot fail; degrade to a
+        // no-op rather than panic if that invariant ever regresses. Building the
+        // `HeaderValue` only on a match keeps an unzeroized copy of the secret
+        // off the heap for every destination it is *not* authorized for.
+        let Ok(value) = HeaderValue::from_str(&self.value) else {
+            return false;
+        };
+        headers.insert(self.header.clone(), value);
+        true
+    }
+}
+
+/// A set of [`DeferredCredential`]s staged for the sub-request executor to
+/// materialize after destination resolution.
+///
+/// Insert this into the [`RequestExtensions`] projected into the child context.
+/// The executor drains it at the destination-bound injection point and injects
+/// only the credentials authorized for the resolved authority.
+///
+/// [`RequestExtensions`]: crate::extensions::RequestExtensions
+#[derive(Default)]
+pub struct PendingCredentials {
+    /// Staged authority-bound credentials.
+    credentials: Vec<DeferredCredential>,
+}
+
+impl PendingCredentials {
+    /// Create an empty credential set.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Stage another authority-bound credential.
+    pub fn push(&mut self, credential: DeferredCredential) -> &mut Self {
+        self.credentials.push(credential);
+        self
+    }
+
+    /// Whether no credentials are staged.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.credentials.is_empty()
+    }
+
+    /// Inject every credential authorized for `destination` into `headers`,
+    /// returning the number injected.
+    ///
+    /// Consumes the set; credentials whose scope does not match the resolved
+    /// logical authority are dropped and their secrets zeroized without ever
+    /// being written. The destination is canonicalized once for the whole set.
+    pub(crate) fn inject_authorized(self, destination: &ResolvedDestination<'_>, headers: &mut HeaderMap) -> usize {
+        let Some(resolved) = destination.canonicalize() else {
+            return 0;
+        };
+        self.credentials
+            .iter()
+            .filter(|credential| credential.inject_canonical(&resolved, headers))
+            .count()
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[cfg(test)]
+#[expect(clippy::allow_attributes, reason = "blanket test suppressions")]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, reason = "tests")]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Test Utilities
+    // -------------------------------------------------------------------------
+
+    // Build a credential bound to `authority` injecting `Authorization: value`.
+    fn credential(authority: &str, value: &str) -> DeferredCredential {
+        DeferredCredential::new(authority, HeaderName::from_static("authorization"), value.to_owned())
+            .expect("valid credential")
+    }
+
+    // A fully-qualified resolved destination whose transport equals its logical
+    // authority (the common case where no authority override is configured).
+    fn resolved(authority: &str) -> ResolvedDestination<'_> {
+        ResolvedDestination {
+            authority,
+            transport: authority,
+        }
+    }
+
+    // Inject a single credential against a fully-qualified destination string,
+    // exercising the same canonicalize + scope-match path the executor drives
+    // through `PendingCredentials::inject_authorized`.
+    fn inject_if_authorized(cred: &DeferredCredential, authority: &str, headers: &mut HeaderMap) -> bool {
+        resolved(authority)
+            .canonicalize()
+            .is_some_and(|resolved| cred.inject_canonical(&resolved, headers))
+    }
+
+    #[test]
+    fn credential_injects_on_authority_match() {
+        let cred = credential("api.example.com:443", "Bearer sk-secret");
+        let mut headers = HeaderMap::new();
+
+        let injected = inject_if_authorized(&cred, "api.example.com:443", &mut headers);
+
+        assert!(injected, "matching authority should inject the credential");
+        assert_eq!(
+            headers.get("authorization").and_then(|v| v.to_str().ok()),
+            Some("Bearer sk-secret"),
+            "the secret header should be present for the authorized destination"
+        );
+    }
+
+    #[test]
+    fn credential_dropped_on_authority_mismatch() {
+        let cred = credential("api.example.com:443", "Bearer sk-secret");
+        let mut headers = HeaderMap::new();
+
+        let injected = inject_if_authorized(&cred, "evil.example.com:443", &mut headers);
+
+        assert!(!injected, "mismatched authority must not inject the credential");
+        assert!(
+            !headers.contains_key("authorization"),
+            "the secret must never reach an unauthorized destination"
+        );
+    }
+
+    #[test]
+    fn credential_replaces_client_supplied_value() {
+        let cred = credential("api.example.com:443", "Bearer gateway-managed");
+        let mut headers = HeaderMap::new();
+        headers.insert("authorization", HeaderValue::from_static("Bearer client-supplied"));
+
+        let injected = inject_if_authorized(&cred, "api.example.com:443", &mut headers);
+
+        assert!(injected);
+        assert_eq!(
+            headers.get_all("authorization").iter().count(),
+            1,
+            "injection must replace, not append to, a client-supplied credential"
+        );
+        assert_eq!(
+            headers.get("authorization").and_then(|v| v.to_str().ok()),
+            Some("Bearer gateway-managed"),
+        );
+    }
+
+    #[test]
+    fn pending_credentials_inject_only_authorized() {
+        let mut pending = PendingCredentials::new();
+        pending.push(credential("api.example.com:443", "Bearer for-api")).push(
+            DeferredCredential::new(
+                "other.example.com:443",
+                HeaderName::from_static("x-api-key"),
+                "for-other",
+            )
+            .unwrap(),
+        );
+        assert!(!pending.is_empty());
+
+        let mut headers = HeaderMap::new();
+        let injected = pending.inject_authorized(&resolved("api.example.com:443"), &mut headers);
+
+        assert_eq!(
+            injected, 1,
+            "only the credential bound to the resolved authority injects"
+        );
+        assert_eq!(
+            headers.get("authorization").and_then(|v| v.to_str().ok()),
+            Some("Bearer for-api"),
+        );
+        assert!(
+            !headers.contains_key("x-api-key"),
+            "a credential for a different authority must not be materialized"
+        );
+    }
+
+    #[test]
+    fn deferred_credential_rejects_host_only_authority() {
+        let err = DeferredCredential::new(
+            "api.example.com",
+            HeaderName::from_static("authorization"),
+            "Bearer sk-secret",
+        )
+        .err()
+        .expect("a host-only authority is ambiguous (which port?) and must be rejected");
+        assert!(
+            err.to_string().contains("port"),
+            "the error must explain that an explicit port is required: {err}"
+        );
+    }
+
+    #[test]
+    fn credential_authority_match_is_case_insensitive() {
+        // DNS names are case-insensitive, so a credential bound to a mixed-case
+        // authority must still match a canonicalized lowercase destination.
+        let cred = credential("API.Example.COM:443", "Bearer sk-secret");
+        let mut headers = HeaderMap::new();
+
+        let injected = inject_if_authorized(&cred, "api.example.com:443", &mut headers);
+
+        assert!(
+            injected,
+            "host comparison must be case-insensitive after canonicalization"
+        );
+    }
+
+    #[test]
+    fn credential_host_wildcard_matches_any_port() {
+        // The explicit host-only opt-in: one credential authorized for every
+        // port on its host, so a backend reachable on 443 and 8443 needs a
+        // single binding rather than one per port.
+        let cred = DeferredCredential::new_host_wildcard(
+            "api.example.com",
+            HeaderName::from_static("authorization"),
+            "Bearer sk-secret",
+        )
+        .expect("a bare host is a valid wildcard scope");
+
+        for authority in ["api.example.com:443", "api.example.com:8443"] {
+            let mut headers = HeaderMap::new();
+            assert!(
+                inject_if_authorized(&cred, authority, &mut headers),
+                "a host wildcard must match any port on its host: {authority}"
+            );
+        }
+
+        let mut headers = HeaderMap::new();
+        assert!(
+            !inject_if_authorized(&cred, "evil.example.com:443", &mut headers),
+            "a host wildcard must not match a different host"
+        );
+    }
+
+    #[test]
+    fn deferred_credential_host_wildcard_rejects_port() {
+        // A port on a wildcard host is a mistake: the caller meant an exact
+        // authority. Reject it rather than silently binding to a host that can
+        // never match (the F7 footgun in wildcard clothing).
+        let err = DeferredCredential::new_host_wildcard(
+            "api.example.com:443",
+            HeaderName::from_static("authorization"),
+            "Bearer sk-secret",
+        )
+        .err()
+        .expect("a wildcard host must not carry a port");
+        assert!(
+            err.to_string().contains("port"),
+            "the error must explain that a wildcard host must not include a port: {err}"
+        );
+    }
+
+    #[test]
+    fn credential_uses_transport_port_when_authority_omits_it() {
+        // A cluster with a bare authority override (`api.example.com`) whose
+        // transport carries the port: the logical authority inherits the
+        // transport's port, so a credential bound to `host:port` still matches.
+        let mut pending = PendingCredentials::new();
+        pending.push(credential("api.example.com:443", "Bearer sk-secret"));
+        let mut headers = HeaderMap::new();
+        let injected = pending.inject_authorized(
+            &ResolvedDestination {
+                authority: "api.example.com",
+                transport: "10.0.0.5:443",
+            },
+            &mut headers,
+        );
+        assert_eq!(
+            injected, 1,
+            "a bare logical authority must inherit the transport port to match a :443 credential"
+        );
+
+        // A transport on a different port must not satisfy a :443 credential.
+        let mut pending = PendingCredentials::new();
+        pending.push(credential("api.example.com:443", "Bearer sk-secret"));
+        let mut headers = HeaderMap::new();
+        let injected = pending.inject_authorized(
+            &ResolvedDestination {
+                authority: "api.example.com",
+                transport: "10.0.0.5:8443",
+            },
+            &mut headers,
+        );
+        assert_eq!(
+            injected, 0,
+            "the transport port (8443) must not match a credential bound to :443"
+        );
+    }
+
+    #[test]
+    fn deferred_credential_rejects_reserved_header() {
+        let err = DeferredCredential::new(
+            "api.example.com:443",
+            HeaderName::from_static("x-praxis-subrequest-depth"),
+            "value",
+        )
+        .err()
+        .expect("a reserved header must be rejected");
+        assert!(err.to_string().contains("reserved"), "{err}");
+    }
+
+    #[test]
+    fn deferred_credential_rejects_host_header() {
+        // Injection happens after sanitization, so a credential naming `Host`
+        // would overwrite the authority-pinned Host and retarget the request to
+        // an attacker-chosen destination *after* it was authorized.
+        let err = DeferredCredential::new(
+            "api.example.com:443",
+            HeaderName::from_static("host"),
+            "evil.example.com",
+        )
+        .err()
+        .expect("Host must be rejected: a credential must not retarget the request after authorization");
+        assert!(
+            err.to_string().to_ascii_lowercase().contains("host"),
+            "the error must name the Host header: {err}"
+        );
+    }
+
+    #[test]
+    fn deferred_credential_rejects_framing_and_hop_by_hop_headers() {
+        // Re-introducing a framing or connection-scoped header past sanitization
+        // could resurrect a request-smuggling boundary the sanitizer stripped.
+        for name in [
+            "content-length",
+            "transfer-encoding",
+            "connection",
+            "proxy-authorization",
+        ] {
+            let err = DeferredCredential::new("api.example.com:443", HeaderName::from_static(name), "1")
+                .err()
+                .unwrap_or_else(|| panic!("'{name}' must be rejected as a framing/hop-by-hop credential header"));
+            assert!(
+                !err.to_string().is_empty(),
+                "'{name}' rejection must carry an explanatory error"
+            );
+        }
+    }
+
+    #[test]
+    fn deferred_credential_rejects_invalid_value() {
+        let err = DeferredCredential::new(
+            "api.example.com:443",
+            HeaderName::from_static("authorization"),
+            "bad\nvalue",
+        )
+        .err()
+        .expect("a value with control characters must be rejected");
+        assert!(err.to_string().contains("valid header value"), "{err}");
+    }
+}

--- a/crates/filter/src/credentials.rs
+++ b/crates/filter/src/credentials.rs
@@ -279,12 +279,24 @@ impl DeferredCredential {
         if !self.scope.matches(resolved) {
             return false;
         }
-        // The value was validated in `new`, so this cannot fail; degrade to a
-        // no-op rather than panic if that invariant ever regresses. Building the
-        // `HeaderValue` only on a match keeps an unzeroized copy of the secret
-        // off the heap for every destination it is *not* authorized for.
-        let Ok(value) = HeaderValue::from_str(&self.value) else {
-            return false;
+        // The value was validated in `new`, so this cannot fail; narrate the
+        // broken invariant and degrade to a no-op rather than panic (or silently
+        // drop) if it ever regresses. Building the `HeaderValue` only on a match
+        // keeps an unzeroized copy of the secret off the heap for every
+        // destination it is *not* authorized for.
+        let value = match HeaderValue::from_str(&self.value) {
+            Ok(value) => value,
+            Err(error) => {
+                // `error` (http's InvalidHeaderValue) never echoes the offending
+                // bytes, and the secret value itself is deliberately not logged.
+                tracing::warn!(
+                    header = %self.header,
+                    %error,
+                    "deferred credential value failed re-validation at injection; \
+                     dropping credential without sending (a pre-validated invariant regressed)"
+                );
+                return false;
+            },
         };
         headers.insert(self.header.clone(), value);
         true
@@ -377,6 +389,37 @@ mod tests {
         resolved(authority)
             .canonicalize()
             .is_some_and(|resolved| cred.inject_canonical(&resolved, headers))
+    }
+
+    // Run `f` under a capturing tracing subscriber, returning its value paired
+    // with everything it logged at warn level or above on this thread.
+    fn capture_logs<T, F: FnOnce() -> T>(f: F) -> (T, String) {
+        use std::sync::{Arc, Mutex};
+
+        #[derive(Clone)]
+        struct Buffer(Arc<Mutex<Vec<u8>>>);
+
+        impl std::io::Write for Buffer {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                self.0.lock().expect("buffer lock").extend_from_slice(buf);
+                Ok(buf.len())
+            }
+
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let buffer = Buffer(Arc::new(Mutex::new(Vec::new())));
+        let writer = buffer.clone();
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(move || writer.clone())
+            .with_ansi(false)
+            .with_max_level(tracing::Level::WARN)
+            .finish();
+        let out = tracing::subscriber::with_default(subscriber, f);
+        let bytes = buffer.0.lock().expect("buffer lock").clone();
+        (out, String::from_utf8_lossy(&bytes).into_owned())
     }
 
     #[test]
@@ -630,5 +673,136 @@ mod tests {
         .err()
         .expect("a value with control characters must be rejected");
         assert!(err.to_string().contains("valid header value"), "{err}");
+    }
+
+    #[test]
+    fn credential_matches_bracketed_ipv6_authority() {
+        // `[::1]:443` takes the bracketed-with-port branch in `split_host_port`:
+        // the host keeps its colons, the port is parsed after `]`.
+        let cred = credential("[::1]:443", "Bearer sk-secret");
+        let mut headers = HeaderMap::new();
+
+        let injected = inject_if_authorized(&cred, "[::1]:443", &mut headers);
+
+        assert!(injected, "a bracketed IPv6 authority must match itself");
+        assert_eq!(
+            headers.get("authorization").and_then(|v| v.to_str().ok()),
+            Some("Bearer sk-secret"),
+        );
+    }
+
+    #[test]
+    fn credential_host_wildcard_matches_bracketed_ipv6_any_port() {
+        // `[::1]` is the bracketed-without-port branch: a valid wildcard host
+        // that must match the IPv6 literal on every port.
+        let cred = DeferredCredential::new_host_wildcard(
+            "[::1]",
+            HeaderName::from_static("authorization"),
+            "Bearer sk-secret",
+        )
+        .expect("a bracketed IPv6 literal is a valid wildcard host");
+
+        for authority in ["[::1]:443", "[::1]:8443"] {
+            let mut headers = HeaderMap::new();
+            assert!(
+                inject_if_authorized(&cred, authority, &mut headers),
+                "an IPv6 host wildcard must match any port on its host: {authority}"
+            );
+        }
+    }
+
+    #[test]
+    fn credential_host_wildcard_accepts_unbracketed_ipv6() {
+        // `::1` (unbracketed) keeps its colons in the host part, so `canonical_host`
+        // falls through to the bare-host branch and accepts it as a wildcard that
+        // still matches the canonicalized (bracket-stripped) destination host.
+        let cred =
+            DeferredCredential::new_host_wildcard("::1", HeaderName::from_static("authorization"), "Bearer sk-secret")
+                .expect("an unbracketed IPv6 literal is accepted as a wildcard host");
+        let mut headers = HeaderMap::new();
+
+        assert!(
+            inject_if_authorized(&cred, "[::1]:443", &mut headers),
+            "an unbracketed IPv6 wildcard must match the same literal on any port"
+        );
+    }
+
+    #[test]
+    fn deferred_credential_rejects_unbracketed_ipv6_authority() {
+        // `::1` has no separable port (its trailing `:1` is part of the literal),
+        // so an exact authority binding is ambiguous and must be rejected — the
+        // caller must bracket it (`[::1]:443`) or use a host wildcard.
+        let err = DeferredCredential::new("::1", HeaderName::from_static("authorization"), "Bearer sk-secret")
+            .err()
+            .expect("an unbracketed IPv6 literal carries no separable port and must be rejected");
+        assert!(
+            err.to_string().contains("port"),
+            "the error must explain that an explicit port is required: {err}"
+        );
+    }
+
+    #[test]
+    fn deferred_credential_rejects_bracketed_ipv6_without_port() {
+        // `[::1]` takes the bracketed-without-port branch in `split_host_port`,
+        // yielding a host with no port; an exact binding still needs an explicit
+        // port, so it must be rejected just like the unbracketed literal.
+        let err = DeferredCredential::new("[::1]", HeaderName::from_static("authorization"), "Bearer sk-secret")
+            .err()
+            .expect("a bracketed IPv6 literal without a port must be rejected");
+        assert!(
+            err.to_string().contains("port"),
+            "the error must explain that an explicit port is required: {err}"
+        );
+    }
+
+    #[test]
+    fn deferred_credential_host_wildcard_rejects_bracketed_ipv6_with_port() {
+        // A bracketed IPv6 literal carrying a port hits the bracket branch of
+        // `canonical_host`: a wildcard host must not include a port (the caller
+        // meant an exact authority), so it is rejected.
+        let err = DeferredCredential::new_host_wildcard(
+            "[::1]:443",
+            HeaderName::from_static("authorization"),
+            "Bearer sk-secret",
+        )
+        .err()
+        .expect("a bracketed IPv6 wildcard host must not carry a port");
+        assert!(
+            err.to_string().contains("port"),
+            "the error must explain that a wildcard host must not include a port: {err}"
+        );
+    }
+
+    #[test]
+    fn inject_warns_and_drops_when_prevalidated_value_regresses() {
+        // Force the "unreachable" invariant-violation branch by constructing a
+        // credential whose value bypasses `build`'s up-front validation. Injection
+        // must degrade to a no-op AND narrate the broken invariant at warn level,
+        // never silently drop — and the diagnostic must never leak the secret.
+        let cred = DeferredCredential {
+            scope: CredentialScope::Authority(parse_canonical("api.example.com:443", None).expect("valid authority")),
+            header: HeaderName::from_static("authorization"),
+            value: Zeroizing::new("SENTINELSECRET\nx".to_owned()),
+        };
+        let resolved = resolved("api.example.com:443")
+            .canonicalize()
+            .expect("resolvable destination");
+        let mut headers = HeaderMap::new();
+
+        let (injected, logs) = capture_logs(|| cred.inject_canonical(&resolved, &mut headers));
+
+        assert!(!injected, "a regressed invariant must degrade to a no-op, not inject");
+        assert!(
+            !headers.contains_key("authorization"),
+            "no header may be written on the invariant-violation fallback path"
+        );
+        assert!(
+            logs.contains("WARN"),
+            "the broken invariant must be narrated at warn level, not silently dropped: {logs:?}"
+        );
+        assert!(
+            !logs.contains("SENTINELSECRET"),
+            "the diagnostic must never leak the secret value: {logs:?}"
+        );
     }
 }

--- a/crates/filter/src/filter.rs
+++ b/crates/filter/src/filter.rs
@@ -119,6 +119,23 @@ pub trait HttpFilter: Send + Sync {
         false
     }
 
+    /// Whether this filter may return a terminal [`FilterAction`] — one that
+    /// short-circuits the request phase with a response and no upstream
+    /// (`TerminalResponse` / `StreamingTerminalResponse`).
+    ///
+    /// Pipeline validation uses this declaration to reject terminal filters from
+    /// outbound chains bound into a filtered sub-request: that executor forwards
+    /// to a resolved upstream and cannot surface such a response, so it would
+    /// drop the action and then error that no upstream resolved. Any filter that
+    /// can return a terminal action must override this, so detection is not
+    /// limited to the hard-coded builtin terminal names in [`TERMINAL_FILTERS`].
+    ///
+    /// [`FilterAction`]: crate::FilterAction
+    /// [`TERMINAL_FILTERS`]: praxis_core::config::TERMINAL_FILTERS
+    fn produces_terminal_response(&self) -> bool {
+        false
+    }
+
     /// Visit pipelines owned by this filter.
     ///
     /// Framework filters that embed nested pipelines override this hook so

--- a/crates/filter/src/filtered_subrequest/context.rs
+++ b/crates/filter/src/filtered_subrequest/context.rs
@@ -29,6 +29,9 @@ pub(super) struct SubrequestRuntimeResources<'a> {
     /// Named runtime key-value stores.
     pub(super) kv_stores: Option<&'a praxis_core::kv::KvStoreRegistry>,
 
+    /// Shared sticky-session store registry.
+    pub(super) session_stores: Option<&'a Arc<crate::SessionStoreRegistry>>,
+
     /// Verified downstream mTLS identity.
     pub(super) peer_identity: Option<&'a Arc<praxis_tls::TlsPeerIdentity>>,
 
@@ -67,7 +70,7 @@ pub(super) fn build_sub_filter_context<'a>(
         health_registry: runtime.health_registry,
         id_generator: runtime.id_generator,
         kv_stores: runtime.kv_stores,
-        session_stores: None,
+        session_stores: runtime.session_stores,
         metrics_route: None,
         peer_identity: runtime.peer_identity.cloned(),
         prior_pre_read_mutations: Vec::new(),

--- a/crates/filter/src/filtered_subrequest/mod.rs
+++ b/crates/filter/src/filtered_subrequest/mod.rs
@@ -11,11 +11,15 @@
 //! either buffered or streaming mode, and captures a
 //! [`FilteredSubrequestContinuation`] the caller drives to completion.
 //!
-//! The executor is caller-agnostic. It owns three transient extension
-//! mechanisms end-to-end — [`RetainedFilterResults`], [`PendingStreamChunks`],
-//! and [`StreamTermination`] — and never inspects caller-injected extension
-//! types. Callers that stash their own state in the request extensions recover
-//! it from [`FilteredSubrequestError::into_parts`],
+//! The executor owns three transient extension mechanisms end-to-end —
+//! [`RetainedFilterResults`], [`PendingStreamChunks`], and
+//! [`StreamTermination`] — and recognizes one framework-defined caller-staged
+//! channel, [`PendingCredentials`]: it drains that channel and materializes each
+//! authority-bound secret only after resolving the destination (see
+//! [`DeferredCredential`](crate::DeferredCredential)). It otherwise never
+//! inspects caller-injected extension types. Callers that stash their own state
+//! in the request extensions recover it from
+//! [`FilteredSubrequestError::into_parts`],
 //! [`FilteredSubrequestContinuation::into_parent_extensions`], or
 //! [`FilteredSubrequestContinuation::into_completion`], and strip it themselves.
 //!
@@ -57,7 +61,7 @@ use self::{
     context::{SubrequestRuntimeResources, build_sub_filter_context},
     sanitize::{
         apply_pre_read_header_mutations, apply_request_header_mutations, body_exceeds_limit, ensure_destination_host,
-        response_body_exceeds_limits, sanitize_subrequest_headers, sanitize_subresponse_headers,
+        response_body_exceeds_limits, sanitize_subrequest_headers, sanitize_subresponse_headers, set_authority_host,
         streaming_transport_limit, strip_reserved_headers, subresponse_from_rejection,
     },
     transport::{build_peer, classify_transport_failure, stream_termination_cause},
@@ -65,12 +69,16 @@ use self::{
 pub(crate) use self::{
     continuation::{FilteredSubrequestContinuation, SubrequestCompletion},
     sanitize::normalize_response_status,
-    streaming::FilteredStreamingBody,
+    streaming::{CalloutStreamingBody, FilteredStreamingBody},
 };
 use crate::{
     FilterAction, FilterError, FilterPipeline, StreamTermination, StreamTerminationCause, SubRequest,
-    SubRequestResponseMode, SubResponse, actions::Rejection, context::PendingStreamChunks,
-    extensions::RequestExtensions, results::RetainedFilterResults,
+    SubRequestResponseMode, SubResponse,
+    actions::Rejection,
+    context::PendingStreamChunks,
+    credentials::{PendingCredentials, ResolvedDestination},
+    extensions::RequestExtensions,
+    results::RetainedFilterResults,
 };
 
 /// Idle timeout applied to a streaming sub-request transport.
@@ -118,9 +126,14 @@ pub(crate) enum TransportFailure {
     ResponseTooLarge,
 }
 
-/// Owned downstream request attributes needed after the outer hook returns.
+/// Owned downstream request attributes carried into a filtered sub-request.
+///
+/// A chain-binding callout builds this from its request context so the nested
+/// pipeline sees the real client identity, transport security, and request
+/// clock — the inputs security and observability filters in an outbound chain
+/// depend on.
 #[derive(Clone)]
-pub(crate) struct SubrequestRuntime {
+pub struct SubrequestRuntime {
     /// Original downstream client address.
     pub(crate) client_addr: Option<std::net::IpAddr>,
     /// Whether the original downstream uses TLS.
@@ -129,6 +142,29 @@ pub(crate) struct SubrequestRuntime {
     pub(crate) peer_identity: Option<Arc<praxis_tls::TlsPeerIdentity>>,
     /// Start time of the logical client request.
     pub(crate) request_start: Instant,
+}
+
+impl SubrequestRuntime {
+    /// Capture the downstream attributes to forward into a filtered sub-request.
+    ///
+    /// `client_addr`, `downstream_tls`, and `peer_identity` come from the
+    /// originating client connection; `request_start` is the instant the logical
+    /// client request began, used for consistent duration accounting across the
+    /// sub-request.
+    #[must_use]
+    pub fn new(
+        client_addr: Option<std::net::IpAddr>,
+        downstream_tls: bool,
+        peer_identity: Option<Arc<praxis_tls::TlsPeerIdentity>>,
+        request_start: Instant,
+    ) -> Self {
+        Self {
+            client_addr,
+            downstream_tls,
+            peer_identity,
+            request_start,
+        }
+    }
 }
 
 /// A captured sub-response together with its origin classification.
@@ -225,8 +261,46 @@ pub(crate) struct FilteredSubrequestInput<'a> {
     pub(crate) extensions: RequestExtensions,
 }
 
+/// The response an outbound chain produced for a callout.
+///
+/// The outbound chain — not the calling method — decides whether the response
+/// is delivered whole or streamed, by whether a filter selects a streaming
+/// sub-request response. [`run`](FilteredSubrequestExecutor::run) surfaces that
+/// choice so the caller handles each shape explicitly, mirroring the epic's
+/// "one buffered or streaming subrequest" contract.
+pub enum CalloutResponse {
+    /// The complete response, fully filtered through the response-body phase.
+    Buffered(SubResponse),
+    /// Transition-time headers now, with the body pulled through the outbound
+    /// chain's response-body filters as it flows.
+    Streaming {
+        /// Status and headers after the response-header phase; the body field
+        /// is empty because the payload is delivered through `body`.
+        response: SubResponse,
+        /// Pull-based response body. Each [`next_chunk`] applies the outbound
+        /// chain's response-body filters and, after upstream EOF, flushes any
+        /// completion output the chain emits before yielding `None`. An
+        /// upstream failure the chain did not convert into a valid terminal
+        /// sequence surfaces as an error after buffered chunks drain.
+        ///
+        /// [`next_chunk`]: crate::StreamingResponseBody::next_chunk
+        body: Box<dyn crate::StreamingResponseBody>,
+    },
+}
+
+/// No-op retained-state accounting for callers that keep no cross-sub-request
+/// state, so the callout entry point never has to expose the
+/// [`RetainedStateAccounting`] hook.
+struct NoRetainedState;
+
+impl RetainedStateAccounting for NoRetainedState {
+    fn exceeds_limit(&self, _extensions: &RequestExtensions) -> bool {
+        false
+    }
+}
+
 /// Executes exactly one filtered sub-request and returns owned continuation state.
-pub(crate) struct FilteredSubrequestExecutor {
+pub struct FilteredSubrequestExecutor {
     /// Caller-supplied retained-state ceiling accounting.
     accounting: Box<dyn RetainedStateAccounting + Send + Sync>,
     /// Shared transport client.
@@ -266,6 +340,168 @@ impl FilteredSubrequestExecutor {
             max_response_bytes,
             max_state_bytes,
             step_timeout,
+        }
+    }
+
+    /// Build an executor for an application callout that runs a single bound
+    /// outbound chain and keeps no cross-sub-request retained state.
+    ///
+    /// This is the small constructor a chain-binding filter (for example an AI
+    /// provider callout) uses together with [`run`]. `client` is the
+    /// shared sub-request transport (available from
+    /// `HttpFilterContext::subrequest_client`); `downstream` carries the
+    /// originating client attributes; `depth` is the current sub-request nesting
+    /// depth; `max_response_bytes` caps the response (the buffered body, or the
+    /// cumulative bytes emitted by a streaming body); `step_timeout` bounds the
+    /// sub-request's own duration within the caller's deadline.
+    ///
+    /// [`run`]: Self::run
+    #[must_use]
+    pub fn for_callout(
+        client: praxis_core::subrequest::SubRequestClient,
+        downstream: SubrequestRuntime,
+        depth: u8,
+        max_response_bytes: usize,
+        step_timeout: Duration,
+    ) -> Self {
+        // A callout retains no state across sub-requests, so the response ceiling
+        // doubles as the stream-chunk emission ceiling.
+        Self::new(
+            Box::new(NoRetainedState),
+            client,
+            depth,
+            downstream,
+            max_response_bytes,
+            max_response_bytes,
+            step_timeout,
+        )
+    }
+
+    /// Run `request` through `pipeline` as a filtered sub-request and return the
+    /// response the outbound chain produced — buffered or streaming.
+    ///
+    /// This is the deliberately small entry point for application callout
+    /// filters that bound an outbound chain via
+    /// [`ChainBindingContext::bind_chain`]. It runs the request, request-body,
+    /// response, and (for buffered responses) response-body phases; enforces the
+    /// resolved destination authority, DNS/SSRF, TLS/SNI, Host, deadline, and
+    /// transport limits; and materializes any staged [`PendingCredentials`] only
+    /// after the destination is resolved. `extensions` is the caller-staged
+    /// projection moved into the isolated child context.
+    ///
+    /// The outbound chain decides the response shape: a filter that selects a
+    /// streaming sub-request response yields [`CalloutResponse::Streaming`] with
+    /// the transition-time headers and a pull-based body that keeps applying the
+    /// chain's response-body filters as chunks flow; otherwise the fully
+    /// filtered response is returned as [`CalloutResponse::Buffered`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FilterError`] if a filter phase errors or the deadline is
+    /// exceeded before the response transition. For a streaming response, errors
+    /// that occur while pulling the body surface from
+    /// [`StreamingResponseBody::next_chunk`](crate::StreamingResponseBody::next_chunk)
+    /// instead.
+    ///
+    /// # Examples
+    ///
+    /// A callout drives its prebuilt outbound chain to a response. In production
+    /// the pipeline comes from [`ChainBindingContext::bind_chain`] at
+    /// construction and the shared client from the filter's
+    /// [`HttpFilterContext`]; here both are built directly so the example runs,
+    /// and a `static_response` filter answers locally so no upstream is needed.
+    ///
+    /// ```
+    /// use std::{
+    ///     sync::Arc,
+    ///     time::{Duration, Instant},
+    /// };
+    ///
+    /// use praxis_core::subrequest::{SubRequestClient, SubRequestConnector};
+    /// use praxis_filter::{
+    ///     CalloutResponse, FilterEntry, FilterPipeline, FilterRegistry, FilteredSubrequestExecutor,
+    ///     RequestExtensions, SubRequest, SubrequestRuntime,
+    /// };
+    ///
+    /// let rt = tokio::runtime::Builder::new_current_thread()
+    ///     .enable_all()
+    ///     .build()
+    ///     .unwrap();
+    /// rt.block_on(async {
+    ///     // The outbound chain a callout binds once at construction.
+    ///     let registry = FilterRegistry::with_builtins();
+    ///     let mut chain: Vec<FilterEntry> = serde_yaml::from_str(
+    ///         "- filter: static_response\n  status: 200\n  body: hello from the outbound chain\n",
+    ///     )
+    ///     .unwrap();
+    ///     let outbound = Arc::new(FilterPipeline::build(&mut chain, &registry).unwrap());
+    ///
+    ///     // At request time the callout builds an executor from the shared client
+    ///     // and the downstream attributes it reads off its `HttpFilterContext`.
+    ///     let client = SubRequestClient::new(SubRequestConnector::new(1, None));
+    ///     let downstream = SubrequestRuntime::new(None, false, None, Instant::now());
+    ///     let executor = FilteredSubrequestExecutor::for_callout(
+    ///         client,
+    ///         downstream,
+    ///         0,                      // sub-request nesting depth
+    ///         1 << 20,                // 1 MiB response ceiling
+    ///         Duration::from_secs(5), // per-sub-request step timeout
+    ///     );
+    ///
+    ///     let request = SubRequest {
+    ///         method: http::Method::GET,
+    ///         uri: http::Uri::from_static("/"),
+    ///         headers: http::HeaderMap::new(),
+    ///         body: bytes::Bytes::new(),
+    ///     };
+    ///     let deadline = Instant::now() + Duration::from_secs(5);
+    ///     let response = match executor
+    ///         .run(&outbound, &request, RequestExtensions::default(), deadline)
+    ///         .await
+    ///         .expect("the outbound chain produces a response")
+    ///     {
+    ///         CalloutResponse::Buffered(response) => response,
+    ///         CalloutResponse::Streaming { .. } => unreachable!("static_response is buffered"),
+    ///     };
+    ///
+    ///     assert_eq!(response.status, 200);
+    ///     assert_eq!(&response.body[..], b"hello from the outbound chain");
+    /// });
+    /// ```
+    ///
+    /// [`ChainBindingContext::bind_chain`]: crate::ChainBindingContext::bind_chain
+    /// [`HttpFilterContext`]: crate::HttpFilterContext
+    #[expect(clippy::large_futures, reason = "delegates to the full step future")]
+    #[expect(
+        clippy::large_stack_frames,
+        reason = "delegates to execute, which reconstructs a full filter context"
+    )]
+    pub async fn run(
+        &self,
+        pipeline: &Arc<FilterPipeline>,
+        request: &SubRequest,
+        extensions: RequestExtensions,
+        deadline: Instant,
+    ) -> Result<CalloutResponse, FilterError> {
+        let input = FilteredSubrequestInput {
+            pipeline,
+            request,
+            label: "callout",
+            iteration: 0,
+            deadline,
+            extensions,
+        };
+        let OpenedSubrequest { continuation, kind } =
+            self.execute(input).await.map_err(|error| error.into_parts().0)?;
+        match kind {
+            OpenedResponse::Complete(outcome) => Ok(CalloutResponse::Buffered(outcome.response)),
+            OpenedResponse::Streaming { body, outcome } => Ok(CalloutResponse::Streaming {
+                response: outcome.response,
+                body: Box::new(CalloutStreamingBody::new(
+                    FilteredStreamingBody::new(body, continuation),
+                    self.max_response_bytes,
+                )),
+            }),
         }
     }
 
@@ -320,6 +556,7 @@ impl FilteredSubrequestExecutor {
             health_registry: pipeline.health_registry(),
             id_generator: pipeline.id_generator(),
             kv_stores: pipeline.kv_stores(),
+            session_stores: pipeline.session_stores(),
             peer_identity: self.downstream.peer_identity.as_ref(),
             request_start: self.downstream.request_start,
             subrequest_client: Some(&self.client),
@@ -336,7 +573,7 @@ impl FilteredSubrequestExecutor {
         let in_transport = Arc::new(AtomicBool::new(false));
         let in_transport_inner = Arc::clone(&in_transport);
 
-        let step_span = tracing::info_span!("iterative_subrequest", step = label, iteration = iteration);
+        let step_span = tracing::info_span!("filtered_subrequest", step = label, iteration = iteration);
 
         let timed: Result<Result<RawResponse, FilterError>, tokio::time::error::Elapsed> =
             tokio::time::timeout(step_budget, async {
@@ -393,11 +630,62 @@ impl FilteredSubrequestExecutor {
             let upstream = filter_ctx.upstream.as_ref().ok_or_else(|| -> FilterError {
                 format!("filtered_subrequest: step '{label}' did not resolve an upstream").into()
             })?;
+            let destination_authority = Arc::clone(&upstream.address);
+            // The credential-matching key and upstream Host are the *logical*
+            // authority the operator configured for this upstream (`authority`
+            // override), not the transport endpoint bytes travel to. Derived
+            // from trusted config, never the client-influenced Host header.
+            let authority_override: Option<Arc<str>> = upstream
+                .authority
+                .as_ref()
+                .and_then(|value| value.to_str().ok())
+                .map(Arc::from);
+            // Fall back to the transport only when no override is set.
+            let logical_authority: Arc<str> = authority_override
+                .clone()
+                .unwrap_or_else(|| Arc::clone(&destination_authority));
             in_transport_inner.store(true, Ordering::Release);
             let peer = build_peer(upstream, pipeline.allow_private_upstreams()).await;
             apply_request_header_mutations(&mut sub_headers, &filter_ctx);
-            ensure_destination_host(&mut sub_headers, &upstream.address)?;
+            // Mirror the normal proxy path (`apply_authority_override`): a
+            // configured authority override becomes the upstream Host,
+            // replacing any prior step's or caller's Host. Without an override,
+            // default the Host to the transport endpoint only when absent.
+            match authority_override.as_deref() {
+                Some(authority) => set_authority_host(&mut sub_headers, authority)?,
+                None => ensure_destination_host(&mut sub_headers, &destination_authority)?,
+            }
             sanitize_subrequest_headers(&mut sub_headers);
+            // Destination-bound credential injection: only now that the upstream
+            // authority is resolved do we materialize staged secrets, and only
+            // into a request bound for the authority each credential was issued
+            // for. Injecting after sanitization keeps the credential header from
+            // being stripped as hop-by-hop/framing.
+            if let Some(pending) = filter_ctx.extensions.remove::<PendingCredentials>() {
+                let destination = ResolvedDestination {
+                    authority: &logical_authority,
+                    transport: &destination_authority,
+                };
+                let injected = pending.inject_authorized(&destination, &mut sub_headers);
+                if injected > 0 {
+                    // A credential was authorized against `logical_authority`, so
+                    // the upstream must see exactly that authority as its Host. Pin
+                    // it here — replacing any step- or caller-set Host the
+                    // no-override path preserved — so a secret can never be
+                    // delivered under a divergent Host to a shared-vhost endpoint.
+                    // (With an override the Host already equals `logical_authority`;
+                    // this keeps that true.) A staged credential that matched
+                    // nothing injects no secret, so it must not retarget the Host —
+                    // doing so would silently change virtual-host routing.
+                    set_authority_host(&mut sub_headers, &logical_authority)?;
+                    tracing::debug!(
+                        authority = %logical_authority,
+                        transport = %destination_authority,
+                        injected,
+                        "materialized destination-bound credentials"
+                    );
+                }
+            }
             let request = SubRequest {
                 method: current_request.method.clone(),
                 uri: filter_ctx.rewritten_path.as_ref().map_or_else(
@@ -481,7 +769,7 @@ impl FilteredSubrequestExecutor {
                         },
                         Err(error) => {
                             let (status, kind) = classify_transport_failure(&error);
-                            warn!(step = label, %error, status, "IRR streaming transport failure");
+                            warn!(step = label, %error, status, "filtered sub-request streaming transport failure");
                             let response = SubResponse { status, headers: HeaderMap::new(), body: Bytes::new() };
                             response_header.status = http::StatusCode::from_u16(status)
                                 .map_err(|source| -> FilterError { source.into() })?;
@@ -522,7 +810,7 @@ impl FilteredSubrequestExecutor {
                             Ok(response) => (response, ResponseOrigin::Upstream, None),
                             Err(error) => {
                                 let (status, kind) = classify_transport_failure(&error);
-                                warn!(step = label, %error, status, "IRR buffered transport failure");
+                                warn!(step = label, %error, status, "filtered sub-request buffered transport failure");
                                 (
                                     SubResponse { status, headers: HeaderMap::new(), body: Bytes::new() },
                                     ResponseOrigin::Transport,
@@ -531,7 +819,7 @@ impl FilteredSubrequestExecutor {
                             },
                         },
                         Err(error) => {
-                            warn!(step = label, %error, status = 502_u16, "IRR buffered transport failure");
+                            warn!(step = label, %error, status = 502_u16, "filtered sub-request buffered transport failure");
                             (
                                 SubResponse { status: 502, headers: HeaderMap::new(), body: Bytes::new() },
                                 ResponseOrigin::Transport,

--- a/crates/filter/src/filtered_subrequest/sanitize.rs
+++ b/crates/filter/src/filtered_subrequest/sanitize.rs
@@ -123,6 +123,18 @@ pub(super) fn ensure_destination_host(headers: &mut HeaderMap, address: &str) ->
     Ok(())
 }
 
+/// Force the upstream `Host` to the configured logical authority, replacing any
+/// inbound value. Mirrors the normal proxy path's `apply_authority_override`:
+/// when an operator configures `authority` on the upstream, that is the Host the
+/// upstream must see — regardless of what a prior step or the caller supplied.
+pub(super) fn set_authority_host(headers: &mut HeaderMap, authority: &str) -> Result<(), FilterError> {
+    let value = http::HeaderValue::from_str(authority).map_err(|error| -> FilterError {
+        format!("filtered_subrequest: invalid upstream authority Host: {error}").into()
+    })?;
+    headers.insert(http::header::HOST, value);
+    Ok(())
+}
+
 /// Remove connection-scoped and proxy-internal response metadata.
 pub(super) fn sanitize_subresponse_headers(headers: &mut HeaderMap) {
     strip_hop_by_hop_headers(headers, RESPONSE_HOP_BY_HOP);

--- a/crates/filter/src/filtered_subrequest/streaming.rs
+++ b/crates/filter/src/filtered_subrequest/streaming.rs
@@ -349,8 +349,34 @@ impl CalloutStreamingBody {
         }
     }
 
-    /// Account one outgoing chunk against the response byte ceiling.
+    /// Account one outgoing chunk against the response byte ceiling, ending the
+    /// stream if it does not fit.
+    ///
+    /// A breach is *terminal*. The rejected chunk is never emitted, so
+    /// `emitted_bytes` does not advance; without marking the stream finished a
+    /// caller that polled again would resume around the hole and keep delivering
+    /// later chunks against the stale count, handing the consumer a body with a
+    /// gap in it instead of an error-terminated stream. Marking it finished and
+    /// dropping queued chunks makes the next poll report end-of-stream, matching
+    /// the `deferred_error` arm of [`next_chunk`](CalloutStreamingBody::next_chunk).
+    ///
+    /// The inner body is deliberately left in place: tearing it down here would
+    /// have to drop the upstream synchronously, whereas a subsequent
+    /// [`cancel`](CalloutStreamingBody::cancel) or
+    /// [`suppress`](CalloutStreamingBody::suppress) can still cancel it
+    /// asynchronously and recover the parent extensions.
     fn checked(&mut self, chunk: Bytes) -> Result<Option<Bytes>, FilterError> {
+        let outcome = self.account(chunk);
+        if outcome.is_err() {
+            self.finished = true;
+            self.pending.clear();
+        }
+        outcome
+    }
+
+    /// Add `chunk` to the emitted-byte total, rejecting a counter overflow or a
+    /// breach of the response ceiling.
+    fn account(&mut self, chunk: Bytes) -> Result<Option<Bytes>, FilterError> {
         let total = self
             .emitted_bytes
             .checked_add(chunk.len())

--- a/crates/filter/src/filtered_subrequest/streaming.rs
+++ b/crates/filter/src/filtered_subrequest/streaming.rs
@@ -114,7 +114,7 @@ impl FilteredStreamingBody {
             cluster_retry_state_released: false,
             endpoint_reselector: None,
             pinned_endpoint_address: None,
-            session_stores: None,
+            session_stores: cont.pipeline.session_stores(),
             structured_metadata: std::mem::take(&mut cont.structured_metadata),
             subrequest_client: cont.pipeline.subrequest_client(),
             subrequest_response_mode: crate::context::SubRequestResponseMode::Streaming,
@@ -300,5 +300,152 @@ impl StreamingResponseBody for FilteredStreamingBody {
 
     fn swap_extensions(&mut self, extensions: &mut RequestExtensions) {
         self.exchange_extensions(extensions);
+    }
+}
+
+/// Single-round streaming body handed back to an application callout.
+///
+/// Wraps [`FilteredStreamingBody`] and closes the two gaps a bare wrapper would
+/// leave for a caller that only pulls [`next_chunk`](StreamingResponseBody::next_chunk):
+///
+/// - At upstream EOF the inner body withholds its completion output (a terminal SSE event, a closing bracket) in favor
+///   of `into_finished_parts`. This adapter drains and emits it before yielding the terminal `None`, so the chain's
+///   last bytes are not silently dropped.
+/// - An upstream termination the chain did not convert into a valid terminal sequence is surfaced as an error after
+///   already-emitted chunks drain, rather than passing off a truncated stream as a clean end.
+///
+/// It also enforces the callout's response byte ceiling across emitted chunks.
+/// This is the single-step analog of the iterative request router's
+/// `IrrStreamingSession`; it has no transitions because a callout runs exactly
+/// one bound chain.
+pub(crate) struct CalloutStreamingBody {
+    /// Active upstream-backed body; `None` once completion has been drained.
+    inner: Option<FilteredStreamingBody>,
+    /// Completion chunks queued ahead of the terminal `None`.
+    pending: VecDeque<Bytes>,
+    /// Extensions recovered after `inner` is consumed, for `swap_extensions`.
+    held_extensions: Option<RequestExtensions>,
+    /// Error surfaced after `pending` drains (unhandled termination).
+    deferred_error: Option<FilterError>,
+    /// Cumulative emitted bytes, checked against `max_response_bytes`.
+    emitted_bytes: usize,
+    /// Response byte ceiling for the logical stream.
+    max_response_bytes: usize,
+    /// Whether the terminal `None` has been reached.
+    finished: bool,
+}
+
+impl CalloutStreamingBody {
+    /// Wrap an opened streaming body with completion flushing and a byte ceiling.
+    pub(crate) fn new(inner: FilteredStreamingBody, max_response_bytes: usize) -> Self {
+        Self {
+            inner: Some(inner),
+            pending: VecDeque::new(),
+            held_extensions: None,
+            deferred_error: None,
+            emitted_bytes: 0,
+            max_response_bytes,
+            finished: false,
+        }
+    }
+
+    /// Account one outgoing chunk against the response byte ceiling.
+    fn checked(&mut self, chunk: Bytes) -> Result<Option<Bytes>, FilterError> {
+        let total = self
+            .emitted_bytes
+            .checked_add(chunk.len())
+            .ok_or_else(|| -> FilterError { "filtered_subrequest: stream byte count overflow".into() })?;
+        if total > self.max_response_bytes {
+            return Err("filtered_subrequest: streaming response exceeds configured body limit"
+                .to_owned()
+                .into());
+        }
+        self.emitted_bytes = total;
+        Ok(Some(chunk))
+    }
+
+    /// Consume the inner body at EOF, queueing completion output or recording an
+    /// unhandled termination to surface after buffered chunks drain.
+    fn drain_completion(&mut self) -> Result<(), FilterError> {
+        let (continuation, completion_output) = self
+            .inner
+            .take()
+            .ok_or_else(|| -> FilterError { "filtered_subrequest: streaming body already consumed".into() })?
+            .into_finished_parts();
+        let completion = continuation.into_completion();
+        self.held_extensions = Some(completion.extensions);
+        if let Some(termination) = completion.termination.as_ref().filter(|t| !t.is_handled()) {
+            let cause = termination.cause();
+            self.deferred_error =
+                Some(format!("filtered_subrequest: unhandled upstream stream termination: {cause:?}").into());
+            return Ok(());
+        }
+        self.pending.extend(completion.pending_chunks);
+        self.pending.extend(completion_output.filter(|bytes| !bytes.is_empty()));
+        self.finished = true;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl StreamingResponseBody for CalloutStreamingBody {
+    async fn next_chunk(&mut self) -> Result<Option<Bytes>, FilterError> {
+        loop {
+            if let Some(chunk) = self.pending.pop_front() {
+                return self.checked(chunk);
+            }
+            if let Some(error) = self.deferred_error.take() {
+                self.finished = true;
+                self.inner = None;
+                return Err(error);
+            }
+            if self.finished {
+                return Ok(None);
+            }
+            let inner = self
+                .inner
+                .as_mut()
+                .ok_or_else(|| -> FilterError { "filtered_subrequest: streaming body has no active source".into() })?;
+            match inner.next_chunk().await? {
+                Some(chunk) => return self.checked(chunk),
+                None => self.drain_completion()?,
+            }
+        }
+    }
+
+    async fn suppress(&mut self) -> Result<(), FilterError> {
+        self.pending.clear();
+        self.deferred_error = None;
+        // Recover the parent extensions before propagating any completion error:
+        // the completion lifecycle writes them back into the continuation even
+        // when a body filter rejects, so `held_extensions` must be populated on
+        // every path out (matching `cancel` and `drain_completion`).
+        let outcome = if let Some(mut inner) = self.inner.take() {
+            let result = inner.suppress().await;
+            self.held_extensions = Some(inner.into_continuation().into_parent_extensions());
+            result
+        } else {
+            Ok(())
+        };
+        self.finished = true;
+        outcome
+    }
+
+    async fn cancel(&mut self) {
+        self.pending.clear();
+        self.deferred_error = None;
+        if let Some(mut inner) = self.inner.take() {
+            inner.cancel().await;
+            self.held_extensions = Some(inner.into_continuation().into_parent_extensions());
+        }
+        self.finished = true;
+    }
+
+    fn swap_extensions(&mut self, extensions: &mut RequestExtensions) {
+        if let Some(inner) = self.inner.as_mut() {
+            inner.swap_extensions(extensions);
+        } else if let Some(held) = self.held_extensions.as_mut() {
+            std::mem::swap(held, extensions);
+        }
     }
 }

--- a/crates/filter/src/filtered_subrequest/tests.rs
+++ b/crates/filter/src/filtered_subrequest/tests.rs
@@ -1389,6 +1389,81 @@ async fn run_streaming_enforces_response_byte_ceiling() {
 
 #[tokio::test]
 #[expect(clippy::large_futures, reason = "drives the full executor future in a test")]
+async fn run_streaming_ceiling_breach_ends_the_stream() {
+    use std::{
+        sync::Arc,
+        time::{Duration, Instant},
+    };
+
+    // A 20-byte upstream body (hex chunk length 14), behind a chain whose
+    // completion hook emits a 14-byte terminal event at EOF.
+    let (addr, backend) = spawn_raw_backend(
+        "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n14\r\nAAAAAAAAAAAAAAAAAAAA\r\n0\r\n\r\n",
+    )
+    .await;
+    let registry = callout_registry();
+    let mut entries: Vec<crate::FilterEntry> =
+        serde_yaml::from_str(&routed_chain_yaml(addr, "- filter: test_terminal_event\n")).unwrap();
+    let pipeline = Arc::new(crate::FilterPipeline::build(&mut entries, &registry).unwrap());
+
+    // 20 bytes of body cannot fit under a 15-byte ceiling however the upstream
+    // frames it, so some chunk must be rejected. A rejected chunk is never
+    // emitted and so never advances `emitted_bytes` — leaving room for the
+    // 14-byte completion event to pass the check afterwards. A stream that kept
+    // running would therefore resume around the hole and hand the caller a body
+    // with a gap in it instead of an error-terminated one.
+    let executor = streaming_executor(15);
+    let request = crate::SubRequest {
+        method: http::Method::GET,
+        uri: http::Uri::from_static("/"),
+        headers: HeaderMap::new(),
+        body: bytes::Bytes::new(),
+    };
+    let deadline = Instant::now() + Duration::from_secs(5);
+
+    let mut body = match executor
+        .run(&pipeline, &request, crate::RequestExtensions::default(), deadline)
+        .await
+        .expect("streaming callout should open")
+    {
+        crate::CalloutResponse::Streaming { body, .. } => body,
+        crate::CalloutResponse::Buffered(_) => panic!("the chain selected streaming mode"),
+    };
+
+    // Pull until the ceiling rejects a chunk, whatever framing the upstream used.
+    let mut breach = None;
+    for _ in 0_u8..32 {
+        match body.next_chunk().await {
+            Ok(Some(_)) => {},
+            Ok(None) => break,
+            Err(error) => {
+                breach = Some(error);
+                break;
+            },
+        }
+    }
+    let breach = breach.expect("20 bytes of body must breach a 15-byte ceiling");
+    assert!(
+        breach.to_string().contains("exceeds configured body limit"),
+        "the breach must be the body-limit error: {breach}"
+    );
+
+    let resumed = body.next_chunk().await;
+    backend.abort();
+
+    let observed = match &resumed {
+        Ok(Some(chunk)) => format!("resumed with {} more bytes", chunk.len()),
+        Ok(None) => "end of stream".to_owned(),
+        Err(error) => format!("error: {error}"),
+    };
+    assert!(
+        matches!(resumed, Ok(None)),
+        "a ceiling breach must end the stream; polling again must not resume it, got {observed}"
+    );
+}
+
+#[tokio::test]
+#[expect(clippy::large_futures, reason = "drives the full executor future in a test")]
 async fn run_streaming_surfaces_unhandled_upstream_termination() {
     use std::{
         sync::Arc,

--- a/crates/filter/src/filtered_subrequest/tests.rs
+++ b/crates/filter/src/filtered_subrequest/tests.rs
@@ -429,6 +429,7 @@ fn sub_filter_context_inherits_parent_runtime_resources() {
             health_registry: Some(&health_registry),
             id_generator: &id_generator,
             kv_stores: Some(&kv_stores),
+            session_stores: None,
             peer_identity: None,
             request_start: std::time::Instant::now(),
             subrequest_client: Some(&client),
@@ -507,4 +508,1117 @@ async fn build_peer_rejects_hostname_resolving_to_private_address() {
     super::transport::build_peer(&upstream, true)
         .await
         .expect("allow_private_upstreams must permit the same upstream");
+}
+
+// ---------------------------------------------------------------------------
+// Public callout entry point (run)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[expect(clippy::large_futures, reason = "drives the full executor future in a test")]
+async fn run_returns_buffered_for_locally_produced_response() {
+    use std::{
+        sync::Arc,
+        time::{Duration, Instant},
+    };
+
+    use praxis_core::subrequest::{SubRequestClient, SubRequestConnector};
+
+    // A bound outbound chain that terminates locally with a fixed response, so
+    // the executor never has to contact a real upstream.
+    let registry = crate::FilterRegistry::with_builtins();
+    let mut entries: Vec<crate::FilterEntry> = serde_yaml::from_str(
+        "
+- filter: static_response
+  status: 200
+  body: hello from outbound
+",
+    )
+    .unwrap();
+    let pipeline = Arc::new(crate::FilterPipeline::build(&mut entries, &registry).unwrap());
+
+    // Construct the executor through the deliberately small public surface an
+    // application callout uses.
+    let client = SubRequestClient::new(SubRequestConnector::new(1, None));
+    let downstream = crate::SubrequestRuntime::new(None, false, None, Instant::now());
+    let executor = crate::FilteredSubrequestExecutor::for_callout(
+        client,
+        downstream,
+        0,         // depth
+        1_048_576, // 1 MiB per-response ceiling
+        Duration::from_secs(5),
+    );
+
+    let request = crate::SubRequest {
+        method: http::Method::GET,
+        uri: http::Uri::from_static("/"),
+        headers: HeaderMap::new(),
+        body: bytes::Bytes::new(),
+    };
+    let deadline = Instant::now() + Duration::from_secs(5);
+
+    let response = match executor
+        .run(&pipeline, &request, crate::RequestExtensions::default(), deadline)
+        .await
+        .expect("run should return the locally-produced response")
+    {
+        crate::CalloutResponse::Buffered(response) => response,
+        crate::CalloutResponse::Streaming { .. } => {
+            panic!("a locally-produced static response must be buffered, not streaming")
+        },
+    };
+
+    assert_eq!(
+        response.status, 200,
+        "the outbound chain's static status must be returned"
+    );
+    assert_eq!(
+        response.body,
+        bytes::Bytes::from_static(b"hello from outbound"),
+        "the outbound chain's static body must be returned buffered"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test Utilities: session-store propagation recorder
+// ---------------------------------------------------------------------------
+
+// Records whether the sub-request filter context carried the session-store
+// registry at the moment each hook ran, so propagation of the parent pipeline's
+// session stores into the executor's sub-request context can be asserted
+// end-to-end.
+struct SessionStoreRecorderFilter {
+    saw_on_request: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    saw_on_response_body: std::sync::Arc<std::sync::atomic::AtomicBool>,
+}
+
+#[async_trait::async_trait]
+impl crate::HttpFilter for SessionStoreRecorderFilter {
+    fn name(&self) -> &'static str {
+        "test_session_store_recorder"
+    }
+
+    async fn on_request(
+        &self,
+        ctx: &mut crate::HttpFilterContext<'_>,
+    ) -> Result<crate::FilterAction, crate::FilterError> {
+        self.saw_on_request
+            .store(ctx.session_stores.is_some(), std::sync::atomic::Ordering::SeqCst);
+        Ok(crate::FilterAction::Continue)
+    }
+
+    fn response_body_access(&self) -> crate::BodyAccess {
+        crate::BodyAccess::ReadWrite
+    }
+
+    fn on_response_body(
+        &self,
+        ctx: &mut crate::HttpFilterContext<'_>,
+        _body: &mut Option<bytes::Bytes>,
+        _end_of_stream: bool,
+    ) -> Result<crate::FilterAction, crate::FilterError> {
+        self.saw_on_response_body
+            .store(ctx.session_stores.is_some(), std::sync::atomic::Ordering::SeqCst);
+        Ok(crate::FilterAction::Continue)
+    }
+}
+
+// Register `test_session_store_recorder` over the builtins, wired to the given
+// observation flags.
+fn recorder_registry(
+    saw_on_request: &std::sync::Arc<std::sync::atomic::AtomicBool>,
+    saw_on_response_body: &std::sync::Arc<std::sync::atomic::AtomicBool>,
+) -> crate::FilterRegistry {
+    let saw_on_request = std::sync::Arc::clone(saw_on_request);
+    let saw_on_response_body = std::sync::Arc::clone(saw_on_response_body);
+    let mut registry = crate::FilterRegistry::with_builtins();
+    registry
+        .register(
+            "test_session_store_recorder",
+            crate::FilterFactory::Http(std::sync::Arc::new(move |_| {
+                Ok(Box::new(SessionStoreRecorderFilter {
+                    saw_on_request: std::sync::Arc::clone(&saw_on_request),
+                    saw_on_response_body: std::sync::Arc::clone(&saw_on_response_body),
+                }))
+            })),
+        )
+        .unwrap();
+    registry
+}
+
+#[tokio::test]
+#[expect(clippy::large_futures, reason = "drives the full executor future in a test")]
+async fn buffered_subrequest_context_inherits_parent_session_stores() {
+    use std::{
+        sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+        },
+        time::{Duration, Instant},
+    };
+
+    use praxis_core::subrequest::{SubRequestClient, SubRequestConnector};
+
+    let saw_on_request = Arc::new(AtomicBool::new(false));
+    let saw_on_response_body = Arc::new(AtomicBool::new(false));
+    let registry = recorder_registry(&saw_on_request, &saw_on_response_body);
+
+    // The recorder observes the context, then a static response terminates the
+    // chain locally so the executor never contacts an upstream.
+    let mut entries: Vec<crate::FilterEntry> = serde_yaml::from_str(
+        "
+- filter: test_session_store_recorder
+- filter: static_response
+  status: 200
+  body: hello from outbound
+",
+    )
+    .unwrap();
+    let mut pipeline = crate::FilterPipeline::build(&mut entries, &registry).unwrap();
+    pipeline.set_session_stores(Arc::new(crate::SessionStoreRegistry::new()));
+    let pipeline = Arc::new(pipeline);
+
+    let client = SubRequestClient::new(SubRequestConnector::new(1, None));
+    let downstream = crate::SubrequestRuntime::new(None, false, None, Instant::now());
+    let executor =
+        crate::FilteredSubrequestExecutor::for_callout(client, downstream, 0, 1_048_576, Duration::from_secs(5));
+
+    let request = crate::SubRequest {
+        method: http::Method::GET,
+        uri: http::Uri::from_static("/"),
+        headers: HeaderMap::new(),
+        body: bytes::Bytes::new(),
+    };
+    let deadline = Instant::now() + Duration::from_secs(5);
+
+    executor
+        .run(&pipeline, &request, crate::RequestExtensions::default(), deadline)
+        .await
+        .expect("run should return the locally-produced response");
+
+    assert!(
+        saw_on_request.load(Ordering::SeqCst),
+        "a filter in a bound outbound chain must see the parent pipeline's session stores"
+    );
+}
+
+#[tokio::test]
+#[expect(clippy::large_futures, reason = "drives the full executor future in a test")]
+async fn subrequest_binds_credentials_to_logical_authority_not_transport() {
+    use std::{
+        sync::{Arc, Mutex},
+        time::{Duration, Instant},
+    };
+
+    use praxis_core::subrequest::{SubRequestClient, SubRequestConnector};
+
+    let captured = Arc::new(Mutex::new(Vec::new()));
+    let (addr, backend) =
+        spawn_capturing_backend("HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok", Arc::clone(&captured)).await;
+
+    // The upstream's logical authority (`api.internal`) differs from its
+    // transport endpoint (`127.0.0.1:<port>`). A credential bound to the logical
+    // authority must be delivered; one bound to the transport host must not.
+    let chain = format!(
+        "
+- filter: router
+  routes:
+    - path_prefix: \"/\"
+      cluster: backend
+- filter: load_balancer
+  clusters:
+    - name: backend
+      endpoints:
+        - \"{addr}\"
+      http:
+        authority: api.internal
+"
+    );
+    let registry = crate::FilterRegistry::with_builtins();
+    let mut entries: Vec<crate::FilterEntry> = serde_yaml::from_str(&chain).unwrap();
+    let pipeline = Arc::new(crate::FilterPipeline::build(&mut entries, &registry).unwrap());
+
+    let mut pending = crate::PendingCredentials::new();
+    pending.push(
+        crate::DeferredCredential::new_host_wildcard(
+            "api.internal",
+            http::HeaderName::from_static("x-cred-logical"),
+            "logical-secret",
+        )
+        .unwrap(),
+    );
+    pending.push(
+        crate::DeferredCredential::new_host_wildcard(
+            "127.0.0.1",
+            http::HeaderName::from_static("x-cred-transport"),
+            "transport-secret",
+        )
+        .unwrap(),
+    );
+    let mut extensions = crate::RequestExtensions::default();
+    extensions.insert(pending);
+
+    let client = SubRequestClient::new(SubRequestConnector::new(1, None));
+    let downstream = crate::SubrequestRuntime::new(None, false, None, Instant::now());
+    let executor =
+        crate::FilteredSubrequestExecutor::for_callout(client, downstream, 0, 1_048_576, Duration::from_secs(5));
+
+    let request = crate::SubRequest {
+        method: http::Method::GET,
+        uri: http::Uri::from_static("/"),
+        headers: HeaderMap::new(),
+        body: bytes::Bytes::new(),
+    };
+    let deadline = Instant::now() + Duration::from_secs(5);
+
+    executor
+        .run(&pipeline, &request, extensions, deadline)
+        .await
+        .expect("buffered callout should return a response");
+    backend.abort();
+
+    let received = String::from_utf8(captured.lock().unwrap().clone())
+        .unwrap()
+        .to_ascii_lowercase();
+    assert!(
+        received.contains("x-cred-logical"),
+        "a credential bound to the logical authority must be injected: {received:?}"
+    );
+    assert!(
+        !received.contains("x-cred-transport"),
+        "a credential bound to the transport host must NOT be injected: {received:?}"
+    );
+}
+
+#[tokio::test]
+#[expect(clippy::large_futures, reason = "drives the full executor future in a test")]
+async fn subrequest_sends_logical_authority_as_host_not_transport() {
+    use std::{
+        sync::{Arc, Mutex},
+        time::{Duration, Instant},
+    };
+
+    use praxis_core::subrequest::{SubRequestClient, SubRequestConnector};
+
+    let captured = Arc::new(Mutex::new(Vec::new()));
+    let (addr, backend) =
+        spawn_capturing_backend("HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok", Arc::clone(&captured)).await;
+
+    // The cluster overrides the logical authority (`api.internal`); its transport
+    // endpoint is `127.0.0.1:<port>`. Mirroring the normal proxy path's authority
+    // override, the upstream must receive the logical authority as its Host — not
+    // the transport address, and not a stale inbound Host.
+    let chain = format!(
+        "
+- filter: router
+  routes:
+    - path_prefix: \"/\"
+      cluster: backend
+- filter: load_balancer
+  clusters:
+    - name: backend
+      endpoints:
+        - \"{addr}\"
+      http:
+        authority: api.internal
+"
+    );
+    let registry = crate::FilterRegistry::with_builtins();
+    let mut entries: Vec<crate::FilterEntry> = serde_yaml::from_str(&chain).unwrap();
+    let pipeline = Arc::new(crate::FilterPipeline::build(&mut entries, &registry).unwrap());
+
+    let client = SubRequestClient::new(SubRequestConnector::new(1, None));
+    let downstream = crate::SubrequestRuntime::new(None, false, None, Instant::now());
+    let executor =
+        crate::FilteredSubrequestExecutor::for_callout(client, downstream, 0, 1_048_576, Duration::from_secs(5));
+
+    // A stale inbound Host must not survive an authority override.
+    let mut headers = HeaderMap::new();
+    headers.insert(http::header::HOST, http::HeaderValue::from_static("stale.example.com"));
+    let request = crate::SubRequest {
+        method: http::Method::GET,
+        uri: http::Uri::from_static("/"),
+        headers,
+        body: bytes::Bytes::new(),
+    };
+    let deadline = Instant::now() + Duration::from_secs(5);
+
+    executor
+        .run(&pipeline, &request, crate::RequestExtensions::default(), deadline)
+        .await
+        .expect("buffered callout should return a response");
+    backend.abort();
+
+    let received = String::from_utf8(captured.lock().unwrap().clone())
+        .unwrap()
+        .to_ascii_lowercase();
+    assert!(
+        received.contains("host: api.internal"),
+        "the upstream must receive the logical authority override as its Host: {received:?}"
+    );
+    assert!(
+        !received.contains(&addr.to_string()),
+        "the transport address must not leak into the upstream Host: {received:?}"
+    );
+    assert!(
+        !received.contains("stale.example.com"),
+        "a stale inbound Host must be replaced by the authority override: {received:?}"
+    );
+}
+
+#[tokio::test]
+#[expect(clippy::large_futures, reason = "drives the full executor future in a test")]
+async fn subrequest_credential_injection_pins_host_to_credential_authority() {
+    use std::{
+        sync::{Arc, Mutex},
+        time::{Duration, Instant},
+    };
+
+    use praxis_core::subrequest::{SubRequestClient, SubRequestConnector};
+
+    let captured = Arc::new(Mutex::new(Vec::new()));
+    let (addr, backend) =
+        spawn_capturing_backend("HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok", Arc::clone(&captured)).await;
+
+    // No authority override: the credential is authorized against the transport
+    // endpoint. A stale inbound Host must NOT survive to the upstream, or a
+    // shared-vhost endpoint could route the injected secret to a different vhost
+    // than the one the credential was authorized for.
+    let chain = format!(
+        "
+- filter: router
+  routes:
+    - path_prefix: \"/\"
+      cluster: backend
+- filter: load_balancer
+  clusters:
+    - name: backend
+      endpoints:
+        - \"{addr}\"
+"
+    );
+    let registry = crate::FilterRegistry::with_builtins();
+    let mut entries: Vec<crate::FilterEntry> = serde_yaml::from_str(&chain).unwrap();
+    let pipeline = Arc::new(crate::FilterPipeline::build(&mut entries, &registry).unwrap());
+
+    let transport_host = addr.ip().to_string();
+    let mut pending = crate::PendingCredentials::new();
+    pending.push(
+        crate::DeferredCredential::new_host_wildcard(
+            &transport_host,
+            http::HeaderName::from_static("x-cred-transport"),
+            "transport-secret",
+        )
+        .unwrap(),
+    );
+    let mut extensions = crate::RequestExtensions::default();
+    extensions.insert(pending);
+
+    let client = SubRequestClient::new(SubRequestConnector::new(1, None));
+    let downstream = crate::SubrequestRuntime::new(None, false, None, Instant::now());
+    let executor =
+        crate::FilteredSubrequestExecutor::for_callout(client, downstream, 0, 1_048_576, Duration::from_secs(5));
+
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        http::header::HOST,
+        http::HeaderValue::from_static("shared-vhost.example"),
+    );
+    let request = crate::SubRequest {
+        method: http::Method::GET,
+        uri: http::Uri::from_static("/"),
+        headers,
+        body: bytes::Bytes::new(),
+    };
+    let deadline = Instant::now() + Duration::from_secs(5);
+
+    executor
+        .run(&pipeline, &request, extensions, deadline)
+        .await
+        .expect("buffered callout should return a response");
+    backend.abort();
+
+    let received = String::from_utf8(captured.lock().unwrap().clone())
+        .unwrap()
+        .to_ascii_lowercase();
+    assert!(
+        received.contains("x-cred-transport"),
+        "a credential bound to the transport authority must be injected: {received:?}"
+    );
+    assert!(
+        received.contains(&format!("host: {addr}")),
+        "when a credential is injected the Host must equal the credential's authority (the transport): {received:?}"
+    );
+    assert!(
+        !received.contains("shared-vhost.example"),
+        "a stale inbound Host must not carry the injected secret to a divergent vhost: {received:?}"
+    );
+}
+
+#[tokio::test]
+#[expect(clippy::large_futures, reason = "drives the full executor future in a test")]
+async fn subrequest_unmatched_staged_credential_preserves_custom_host() {
+    use std::{
+        sync::{Arc, Mutex},
+        time::{Duration, Instant},
+    };
+
+    use praxis_core::subrequest::{SubRequestClient, SubRequestConnector};
+
+    let captured = Arc::new(Mutex::new(Vec::new()));
+    let (addr, backend) =
+        spawn_capturing_backend("HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok", Arc::clone(&captured)).await;
+
+    // No authority override: the logical authority equals the transport endpoint.
+    // A credential is staged, but bound to a *different* authority that never
+    // matches this destination, so nothing is injected. A caller-set Host that
+    // selects a virtual host must survive untouched — pinning the Host to the
+    // transport only when a secret is actually delivered, never for a staged
+    // credential that matched nothing.
+    let chain = format!(
+        "
+- filter: router
+  routes:
+    - path_prefix: \"/\"
+      cluster: backend
+- filter: load_balancer
+  clusters:
+    - name: backend
+      endpoints:
+        - \"{addr}\"
+"
+    );
+    let registry = crate::FilterRegistry::with_builtins();
+    let mut entries: Vec<crate::FilterEntry> = serde_yaml::from_str(&chain).unwrap();
+    let pipeline = Arc::new(crate::FilterPipeline::build(&mut entries, &registry).unwrap());
+
+    let mut pending = crate::PendingCredentials::new();
+    pending.push(
+        crate::DeferredCredential::new_host_wildcard(
+            "other.example",
+            http::HeaderName::from_static("x-cred-other"),
+            "other-secret",
+        )
+        .unwrap(),
+    );
+    let mut extensions = crate::RequestExtensions::default();
+    extensions.insert(pending);
+
+    let client = SubRequestClient::new(SubRequestConnector::new(1, None));
+    let downstream = crate::SubrequestRuntime::new(None, false, None, Instant::now());
+    let executor =
+        crate::FilteredSubrequestExecutor::for_callout(client, downstream, 0, 1_048_576, Duration::from_secs(5));
+
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        http::header::HOST,
+        http::HeaderValue::from_static("custom-vhost.example"),
+    );
+    let request = crate::SubRequest {
+        method: http::Method::GET,
+        uri: http::Uri::from_static("/"),
+        headers,
+        body: bytes::Bytes::new(),
+    };
+    let deadline = Instant::now() + Duration::from_secs(5);
+
+    executor
+        .run(&pipeline, &request, extensions, deadline)
+        .await
+        .expect("buffered callout should return a response");
+    backend.abort();
+
+    let received = String::from_utf8(captured.lock().unwrap().clone())
+        .unwrap()
+        .to_ascii_lowercase();
+    assert!(
+        !received.contains("x-cred-other"),
+        "a credential bound to a non-matching authority must not be injected: {received:?}"
+    );
+    assert!(
+        received.contains("host: custom-vhost.example"),
+        "an unmatched staged credential must not retarget a caller-set Host: {received:?}"
+    );
+    assert!(
+        !received.contains(&format!("host: {addr}")),
+        "the transport endpoint must not overwrite the Host when no credential is injected: {received:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test Utilities: streaming callout harness
+// ---------------------------------------------------------------------------
+
+// A filter that selects a streaming sub-request response, so the executor
+// dispatches the outbound chain in streaming mode.
+struct StreamingSelectorFilter;
+
+#[async_trait::async_trait]
+impl crate::HttpFilter for StreamingSelectorFilter {
+    fn name(&self) -> &'static str {
+        "test_streaming_selector"
+    }
+
+    fn may_select_streaming_subrequest_response(&self) -> bool {
+        true
+    }
+
+    async fn on_request(
+        &self,
+        ctx: &mut crate::HttpFilterContext<'_>,
+    ) -> Result<crate::FilterAction, crate::FilterError> {
+        ctx.set_subrequest_response_mode(crate::SubRequestResponseMode::Streaming);
+        Ok(crate::FilterAction::Continue)
+    }
+}
+
+// A response-body filter that emits a terminal marker at end-of-stream, the way
+// an SSE aggregator closes a stream. This output is produced only by the
+// completion lifecycle, so it proves the streaming body flushes completion
+// output rather than dropping it at upstream EOF.
+struct TerminalEventFilter;
+
+#[async_trait::async_trait]
+impl crate::HttpFilter for TerminalEventFilter {
+    fn name(&self) -> &'static str {
+        "test_terminal_event"
+    }
+
+    async fn on_request(
+        &self,
+        _ctx: &mut crate::HttpFilterContext<'_>,
+    ) -> Result<crate::FilterAction, crate::FilterError> {
+        Ok(crate::FilterAction::Continue)
+    }
+
+    fn response_body_access(&self) -> crate::BodyAccess {
+        crate::BodyAccess::ReadWrite
+    }
+
+    fn on_response_body(
+        &self,
+        _ctx: &mut crate::HttpFilterContext<'_>,
+        body: &mut Option<bytes::Bytes>,
+        end_of_stream: bool,
+    ) -> Result<crate::FilterAction, crate::FilterError> {
+        if end_of_stream && body.is_none() {
+            *body = Some(bytes::Bytes::from_static(b"data: [DONE]\n\n"));
+        }
+        Ok(crate::FilterAction::Continue)
+    }
+}
+
+// A response-body filter that rejects at end-of-stream, so the streaming body's
+// completion lifecycle (run by both EOF draining and `suppress`) fails. Models a
+// guardrail that blocks the final aggregated frame.
+struct RejectOnCompletionFilter;
+
+#[async_trait::async_trait]
+impl crate::HttpFilter for RejectOnCompletionFilter {
+    fn name(&self) -> &'static str {
+        "test_reject_on_completion"
+    }
+
+    async fn on_request(
+        &self,
+        _ctx: &mut crate::HttpFilterContext<'_>,
+    ) -> Result<crate::FilterAction, crate::FilterError> {
+        Ok(crate::FilterAction::Continue)
+    }
+
+    fn response_body_access(&self) -> crate::BodyAccess {
+        crate::BodyAccess::ReadWrite
+    }
+
+    fn on_response_body(
+        &self,
+        _ctx: &mut crate::HttpFilterContext<'_>,
+        _body: &mut Option<bytes::Bytes>,
+        end_of_stream: bool,
+    ) -> Result<crate::FilterAction, crate::FilterError> {
+        if end_of_stream {
+            return Ok(crate::FilterAction::Reject(crate::Rejection::status(503)));
+        }
+        Ok(crate::FilterAction::Continue)
+    }
+}
+
+// A caller-injected extension type, used to prove the parent's extensions survive
+// the streaming body's inner->held transition even when completion fails.
+#[derive(Debug, PartialEq, Eq)]
+struct CalloutParentMarker(&'static str);
+
+// Build a registry with the builtins plus the streaming callout test filters.
+fn callout_registry() -> crate::FilterRegistry {
+    let mut registry = crate::FilterRegistry::with_builtins();
+    registry
+        .register(
+            "test_streaming_selector",
+            crate::FilterFactory::Http(std::sync::Arc::new(|_| Ok(Box::new(StreamingSelectorFilter)))),
+        )
+        .unwrap();
+    registry
+        .register(
+            "test_terminal_event",
+            crate::FilterFactory::Http(std::sync::Arc::new(|_| Ok(Box::new(TerminalEventFilter)))),
+        )
+        .unwrap();
+    registry
+        .register(
+            "test_reject_on_completion",
+            crate::FilterFactory::Http(std::sync::Arc::new(|_| Ok(Box::new(RejectOnCompletionFilter)))),
+        )
+        .unwrap();
+    registry
+}
+
+// Spawn a raw TCP backend that replies with a fixed response for each accept.
+async fn spawn_raw_backend(response: &'static str) -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
+    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let handle = tokio::spawn(async move {
+        loop {
+            let Ok((mut socket, _)) = listener.accept().await else {
+                return;
+            };
+            let mut buf = vec![0_u8; 8192];
+            let _bytes_read = socket.read(&mut buf).await;
+            socket.write_all(response.as_bytes()).await.unwrap();
+            socket.flush().await.unwrap();
+        }
+    });
+    (addr, handle)
+}
+
+// Spawn a raw TCP backend that captures the first request it receives into
+// `captured`, then replies with a fixed response for each accept.
+async fn spawn_capturing_backend(
+    response: &'static str,
+    captured: std::sync::Arc<std::sync::Mutex<Vec<u8>>>,
+) -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
+    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let handle = tokio::spawn(async move {
+        loop {
+            let Ok((mut socket, _)) = listener.accept().await else {
+                return;
+            };
+            let mut buf = vec![0_u8; 8192];
+            let bytes_read = socket.read(&mut buf).await.unwrap_or(0);
+            {
+                let mut slot = captured.lock().unwrap();
+                if slot.is_empty()
+                    && let Some(request) = buf.get(..bytes_read)
+                {
+                    slot.extend_from_slice(request);
+                }
+            }
+            socket.write_all(response.as_bytes()).await.unwrap();
+            socket.flush().await.unwrap();
+        }
+    });
+    (addr, handle)
+}
+
+// Route the outbound chain to a real backend address.
+fn routed_chain_yaml(addr: std::net::SocketAddr, extra: &str) -> String {
+    format!(
+        "
+- filter: test_streaming_selector
+- filter: router
+  routes:
+    - path_prefix: \"/\"
+      cluster: backend
+- filter: load_balancer
+  clusters:
+    - name: backend
+      endpoints:
+        - \"{addr}\"
+{extra}"
+    )
+}
+
+// Build a streaming callout executor over a fresh client.
+fn streaming_executor(max_response_bytes: usize) -> crate::FilteredSubrequestExecutor {
+    use std::time::{Duration, Instant};
+
+    use praxis_core::subrequest::{SubRequestClient, SubRequestConnector};
+
+    let client = SubRequestClient::new(SubRequestConnector::new(4, None));
+    let downstream = crate::SubrequestRuntime::new(None, false, None, Instant::now());
+    crate::FilteredSubrequestExecutor::for_callout(client, downstream, 0, max_response_bytes, Duration::from_secs(5))
+}
+
+// Drain a streaming body to completion, returning the concatenated payload.
+async fn drain(body: &mut Box<dyn crate::StreamingResponseBody>) -> Result<Vec<u8>, crate::FilterError> {
+    let mut out = Vec::new();
+    while let Some(chunk) = body.next_chunk().await? {
+        out.extend_from_slice(&chunk);
+    }
+    Ok(out)
+}
+
+#[tokio::test]
+#[expect(clippy::large_futures, reason = "drives the full executor future in a test")]
+async fn run_streaming_flushes_completion_output_after_upstream_eof() {
+    use std::{
+        sync::Arc,
+        time::{Duration, Instant},
+    };
+
+    let (addr, backend) =
+        spawn_raw_backend("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n").await;
+    let registry = callout_registry();
+    let mut entries: Vec<crate::FilterEntry> =
+        serde_yaml::from_str(&routed_chain_yaml(addr, "- filter: test_terminal_event\n")).unwrap();
+    let pipeline = Arc::new(crate::FilterPipeline::build(&mut entries, &registry).unwrap());
+
+    let executor = streaming_executor(1_048_576);
+    let request = crate::SubRequest {
+        method: http::Method::GET,
+        uri: http::Uri::from_static("/"),
+        headers: HeaderMap::new(),
+        body: bytes::Bytes::new(),
+    };
+    let deadline = Instant::now() + Duration::from_secs(5);
+
+    let mut body = match executor
+        .run(&pipeline, &request, crate::RequestExtensions::default(), deadline)
+        .await
+        .expect("streaming callout should open")
+    {
+        crate::CalloutResponse::Streaming { response, body } => {
+            assert_eq!(response.status, 200, "the transition-time status must be surfaced");
+            body
+        },
+        crate::CalloutResponse::Buffered(_) => panic!("the chain selected streaming mode"),
+    };
+
+    let payload = drain(&mut body).await.expect("streaming body should drain cleanly");
+    backend.abort();
+
+    assert_eq!(
+        payload, b"hellodata: [DONE]\n\n",
+        "the streaming body must yield the upstream chunk AND the completion output"
+    );
+}
+
+#[tokio::test]
+#[expect(clippy::large_futures, reason = "drives the full executor future in a test")]
+async fn run_streaming_yields_upstream_chunks_for_clean_eof() {
+    use std::{
+        sync::Arc,
+        time::{Duration, Instant},
+    };
+
+    let (addr, backend) =
+        spawn_raw_backend("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n").await;
+    let registry = callout_registry();
+    let mut entries: Vec<crate::FilterEntry> = serde_yaml::from_str(&routed_chain_yaml(addr, "")).unwrap();
+    let pipeline = Arc::new(crate::FilterPipeline::build(&mut entries, &registry).unwrap());
+
+    let executor = streaming_executor(1_048_576);
+    let request = crate::SubRequest {
+        method: http::Method::GET,
+        uri: http::Uri::from_static("/"),
+        headers: HeaderMap::new(),
+        body: bytes::Bytes::new(),
+    };
+    let deadline = Instant::now() + Duration::from_secs(5);
+
+    let mut body = match executor
+        .run(&pipeline, &request, crate::RequestExtensions::default(), deadline)
+        .await
+        .expect("streaming callout should open")
+    {
+        crate::CalloutResponse::Streaming { body, .. } => body,
+        crate::CalloutResponse::Buffered(_) => panic!("the chain selected streaming mode"),
+    };
+
+    let payload = drain(&mut body).await.expect("streaming body should drain cleanly");
+    backend.abort();
+
+    assert_eq!(payload, b"hello", "the upstream chunk must be delivered on a clean EOF");
+}
+
+#[tokio::test]
+#[expect(clippy::large_futures, reason = "drives the full executor future in a test")]
+async fn run_streaming_enforces_response_byte_ceiling() {
+    use std::{
+        sync::Arc,
+        time::{Duration, Instant},
+    };
+
+    let (addr, backend) =
+        spawn_raw_backend("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n").await;
+    let registry = callout_registry();
+    let mut entries: Vec<crate::FilterEntry> = serde_yaml::from_str(&routed_chain_yaml(addr, "")).unwrap();
+    let pipeline = Arc::new(crate::FilterPipeline::build(&mut entries, &registry).unwrap());
+
+    // A ceiling below the upstream chunk size forces the body to reject it.
+    let executor = streaming_executor(3);
+    let request = crate::SubRequest {
+        method: http::Method::GET,
+        uri: http::Uri::from_static("/"),
+        headers: HeaderMap::new(),
+        body: bytes::Bytes::new(),
+    };
+    let deadline = Instant::now() + Duration::from_secs(5);
+
+    let mut body = match executor
+        .run(&pipeline, &request, crate::RequestExtensions::default(), deadline)
+        .await
+        .expect("streaming callout should open")
+    {
+        crate::CalloutResponse::Streaming { body, .. } => body,
+        crate::CalloutResponse::Buffered(_) => panic!("the chain selected streaming mode"),
+    };
+
+    let result = drain(&mut body).await;
+    backend.abort();
+
+    assert!(
+        result.is_err_and(|error| error.to_string().contains("exceeds configured body limit")),
+        "a chunk beyond the response ceiling must surface as an error"
+    );
+}
+
+#[tokio::test]
+#[expect(clippy::large_futures, reason = "drives the full executor future in a test")]
+async fn run_streaming_surfaces_unhandled_upstream_termination() {
+    use std::{
+        sync::Arc,
+        time::{Duration, Instant},
+    };
+
+    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+    // Chunked framing that promises a large chunk, then closes mid-payload.
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let backend = tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        let mut buf = vec![0_u8; 8192];
+        let _bytes_read = socket.read(&mut buf).await;
+        socket
+            .write_all(b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\nff\r\npartial")
+            .await
+            .unwrap();
+        socket.flush().await.unwrap();
+        drop(socket);
+    });
+    let registry = callout_registry();
+    let mut entries: Vec<crate::FilterEntry> = serde_yaml::from_str(&routed_chain_yaml(addr, "")).unwrap();
+    let pipeline = Arc::new(crate::FilterPipeline::build(&mut entries, &registry).unwrap());
+
+    let executor = streaming_executor(1_048_576);
+    let request = crate::SubRequest {
+        method: http::Method::GET,
+        uri: http::Uri::from_static("/"),
+        headers: HeaderMap::new(),
+        body: bytes::Bytes::new(),
+    };
+    let deadline = Instant::now() + Duration::from_secs(5);
+
+    let mut body = match executor
+        .run(&pipeline, &request, crate::RequestExtensions::default(), deadline)
+        .await
+        .expect("streaming callout should open")
+    {
+        crate::CalloutResponse::Streaming { body, .. } => body,
+        crate::CalloutResponse::Buffered(_) => panic!("the chain selected streaming mode"),
+    };
+
+    let mut errored = false;
+    loop {
+        match body.next_chunk().await {
+            Ok(Some(_)) => {},
+            Ok(None) => break,
+            Err(_) => {
+                errored = true;
+                break;
+            },
+        }
+    }
+    backend.abort();
+
+    assert!(
+        errored,
+        "an unhandled mid-stream upstream failure must surface as an error, not a clean end"
+    );
+}
+
+#[tokio::test]
+#[expect(clippy::large_futures, reason = "drives the full executor future in a test")]
+async fn run_streaming_cancel_discards_upstream() {
+    use std::{
+        sync::Arc,
+        time::{Duration, Instant},
+    };
+
+    let (addr, backend) =
+        spawn_raw_backend("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n").await;
+    let registry = callout_registry();
+    let mut entries: Vec<crate::FilterEntry> = serde_yaml::from_str(&routed_chain_yaml(addr, "")).unwrap();
+    let pipeline = Arc::new(crate::FilterPipeline::build(&mut entries, &registry).unwrap());
+
+    let executor = streaming_executor(1_048_576);
+    let request = crate::SubRequest {
+        method: http::Method::GET,
+        uri: http::Uri::from_static("/"),
+        headers: HeaderMap::new(),
+        body: bytes::Bytes::new(),
+    };
+    let deadline = Instant::now() + Duration::from_secs(5);
+
+    let mut body = match executor
+        .run(&pipeline, &request, crate::RequestExtensions::default(), deadline)
+        .await
+        .expect("streaming callout should open")
+    {
+        crate::CalloutResponse::Streaming { body, .. } => body,
+        crate::CalloutResponse::Buffered(_) => panic!("the chain selected streaming mode"),
+    };
+
+    body.cancel().await;
+    backend.abort();
+
+    assert!(
+        body.next_chunk().await.unwrap().is_none(),
+        "a cancelled streaming body must yield no further chunks"
+    );
+}
+
+#[tokio::test]
+#[expect(clippy::large_futures, reason = "drives the full executor future in a test")]
+async fn run_streaming_suppress_error_preserves_parent_extensions() {
+    use std::{
+        sync::Arc,
+        time::{Duration, Instant},
+    };
+
+    let (addr, backend) =
+        spawn_raw_backend("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n").await;
+    let registry = callout_registry();
+    // The completion filter rejects at end-of-stream, so `suppress` (which runs
+    // the completion lifecycle) fails.
+    let mut entries: Vec<crate::FilterEntry> =
+        serde_yaml::from_str(&routed_chain_yaml(addr, "- filter: test_reject_on_completion")).unwrap();
+    let pipeline = Arc::new(crate::FilterPipeline::build(&mut entries, &registry).unwrap());
+
+    let executor = streaming_executor(1_048_576);
+    let request = crate::SubRequest {
+        method: http::Method::GET,
+        uri: http::Uri::from_static("/"),
+        headers: HeaderMap::new(),
+        body: bytes::Bytes::new(),
+    };
+    let mut extensions = crate::RequestExtensions::default();
+    extensions.insert(CalloutParentMarker("preserved"));
+    let deadline = Instant::now() + Duration::from_secs(5);
+
+    let mut body = match executor
+        .run(&pipeline, &request, extensions, deadline)
+        .await
+        .expect("streaming callout should open")
+    {
+        crate::CalloutResponse::Streaming { body, .. } => body,
+        crate::CalloutResponse::Buffered(_) => panic!("the chain selected streaming mode"),
+    };
+
+    // Suppressing the body runs the completion lifecycle, which the guardrail
+    // rejects, so `suppress` surfaces an error.
+    let suppressed = body.suppress().await;
+    assert!(
+        suppressed.is_err(),
+        "a completion-phase rejection must surface from suppress: {suppressed:?}"
+    );
+
+    // Despite the error, the caller-injected extension must survive the body's
+    // inner->held transition so the parent request context can recover it.
+    let mut parent = crate::RequestExtensions::default();
+    body.swap_extensions(&mut parent);
+    backend.abort();
+
+    assert_eq!(
+        parent.get::<CalloutParentMarker>(),
+        Some(&CalloutParentMarker("preserved")),
+        "the parent extension must survive a suppress completion error"
+    );
+    assert!(
+        body.next_chunk().await.unwrap().is_none(),
+        "a suppressed body must terminate cleanly, not surface a spurious source error"
+    );
+}
+
+#[tokio::test]
+#[expect(clippy::large_futures, reason = "drives the full executor future in a test")]
+async fn streaming_response_body_context_inherits_parent_session_stores() {
+    use std::{
+        sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+        },
+        time::{Duration, Instant},
+    };
+
+    let (addr, backend) =
+        spawn_raw_backend("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n").await;
+
+    let saw_on_request = Arc::new(AtomicBool::new(false));
+    let saw_on_response_body = Arc::new(AtomicBool::new(false));
+
+    // The streaming harness needs the streaming selector plus the recorder.
+    let mut registry = callout_registry();
+    {
+        let saw_on_request = Arc::clone(&saw_on_request);
+        let saw_on_response_body = Arc::clone(&saw_on_response_body);
+        registry
+            .register(
+                "test_session_store_recorder",
+                crate::FilterFactory::Http(Arc::new(move |_| {
+                    Ok(Box::new(SessionStoreRecorderFilter {
+                        saw_on_request: Arc::clone(&saw_on_request),
+                        saw_on_response_body: Arc::clone(&saw_on_response_body),
+                    }))
+                })),
+            )
+            .unwrap();
+    }
+
+    let mut entries: Vec<crate::FilterEntry> =
+        serde_yaml::from_str(&routed_chain_yaml(addr, "- filter: test_session_store_recorder\n")).unwrap();
+    let mut pipeline = crate::FilterPipeline::build(&mut entries, &registry).unwrap();
+    pipeline.set_session_stores(Arc::new(crate::SessionStoreRegistry::new()));
+    let pipeline = Arc::new(pipeline);
+
+    let executor = streaming_executor(1_048_576);
+    let request = crate::SubRequest {
+        method: http::Method::GET,
+        uri: http::Uri::from_static("/"),
+        headers: HeaderMap::new(),
+        body: bytes::Bytes::new(),
+    };
+    let deadline = Instant::now() + Duration::from_secs(5);
+
+    let mut body = match executor
+        .run(&pipeline, &request, crate::RequestExtensions::default(), deadline)
+        .await
+        .expect("streaming callout should open")
+    {
+        crate::CalloutResponse::Streaming { body, .. } => body,
+        crate::CalloutResponse::Buffered(_) => panic!("the chain selected streaming mode"),
+    };
+
+    drain(&mut body).await.expect("streaming body should drain cleanly");
+    backend.abort();
+
+    assert!(
+        saw_on_response_body.load(Ordering::SeqCst),
+        "a response-body filter in a streaming outbound chain must see the parent pipeline's session stores"
+    );
 }

--- a/crates/filter/src/lib.rs
+++ b/crates/filter/src/lib.rs
@@ -43,10 +43,12 @@
 
 mod actions;
 mod any_filter;
+mod binding;
 pub mod body;
 pub mod builtins;
 mod condition;
 mod context;
+mod credentials;
 mod error_response;
 mod extensions;
 mod factory;
@@ -63,6 +65,7 @@ mod tcp_filter;
 
 pub use actions::{FilterAction, Rejection, StreamingResponseBody, StreamingTerminalResponse, TerminalResponse};
 pub use any_filter::AnyFilter;
+pub use binding::{ChainBindingContext, ChainBindingHttpFactory};
 pub use body::{BodyAccess, BodyBuffer, BodyBufferOverflow, BodyCapabilities, BodyMode};
 #[cfg(feature = "basic-auth-filter")]
 pub use builtins::BasicAuthFilter;
@@ -81,6 +84,7 @@ pub use context::{
     HttpFilterContext, PendingHeaderResult, Request, Response, StreamTermination, StreamTerminationCause,
     SubRequestResponseMode, TrustedHeaderMutation,
 };
+pub use credentials::{DeferredCredential, PendingCredentials};
 pub use error_response::{
     ErrorResponseContext, ErrorResponseFormatter, ErrorResponseFormatterHandle, FormattedErrorResponse,
 };
@@ -90,6 +94,7 @@ pub use factory::{
     tcp_builtin,
 };
 pub use filter::{Filter, FilterContext, FilterError, HttpFilter};
+pub use filtered_subrequest::{CalloutResponse, FilteredSubrequestExecutor, SubrequestRuntime};
 pub use pipeline::{
     FilterPipeline, PipelineExtension,
     introspection::{BodyAccessInfo, BranchConditionInfo, BranchIntrospection, FilterIntrospection},

--- a/crates/filter/src/pipeline/build.rs
+++ b/crates/filter/src/pipeline/build.rs
@@ -17,7 +17,7 @@
 use std::{collections::HashMap, mem, sync::Arc};
 
 use praxis_core::{
-    config::{FilterEntry, SkipPipelineChecks},
+    config::{FilterEntry, InsecureOptions, SkipPipelineChecks},
     id::IdGenerator,
     time::SystemTimeSource,
 };
@@ -80,6 +80,12 @@ impl FilterPipeline {
     /// configurations. The actual filters for this pipeline come
     /// from `entries`.
     ///
+    /// `insecure_options` is the operator's declared security posture. It is
+    /// threaded into outbound chain binding so that inline clusters reachable
+    /// only through a chain-binding filter's outbound chain are gated by the
+    /// same SSRF and insecure-TLS rules as top-level `clusters:`, instead of
+    /// silently bypassing them.
+    ///
     /// # Errors
     ///
     /// Returns [`FilterError`] if any filter fails to instantiate
@@ -90,13 +96,14 @@ impl FilterPipeline {
         entries: &mut [FilterEntry],
         registry: &FilterRegistry,
         chains: &HashMap<&str, &[FilterEntry]>,
+        insecure_options: &InsecureOptions,
     ) -> Result<Self, FilterError> {
-        let filters = super::build_branch::resolve_chain_filters(entries, registry, chains, 0)?;
+        let filters = super::build_branch::resolve_chain_filters(entries, registry, chains, 0, insecure_options)?;
         Ok(Self::from_filters(filters))
     }
 
     /// Create a pipeline from an already-resolved filter list.
-    fn from_filters(filters: Vec<PipelineFilter>) -> Self {
+    pub(crate) fn from_filters(filters: Vec<PipelineFilter>) -> Self {
         let body_capabilities = compute_body_capabilities(&filters);
         let compression = extract_compression_config(&filters);
         let may_select_streaming_subrequest_response = filters_may_select_streaming_subrequest_response(&filters);

--- a/crates/filter/src/pipeline/build_branch.rs
+++ b/crates/filter/src/pipeline/build_branch.rs
@@ -33,13 +33,15 @@
 //! [`build`]: super::build
 //! [`pipeline_filter_type_names`]: BuildContext::pipeline_filter_type_names
 
-use std::{collections::HashMap, mem, sync::Arc};
+use std::{cell::Cell, collections::HashMap, mem, sync::Arc};
 
-use praxis_core::config::{BranchChainConfig, BranchCondition, ChainRef, FilterEntry, MAX_BRANCH_DEPTH};
+use praxis_core::config::{
+    BranchChainConfig, BranchCondition, ChainRef, FilterEntry, InsecureOptions, MAX_BRANCH_DEPTH, count_build_branches,
+};
 use tracing::debug;
 
-/// Hard ceiling on the total number of filter instances a single pipeline
-/// may materialize during branch resolution.
+/// Hard ceiling on the total number of filter instances one build may
+/// materialize across branch resolution and outbound binding combined.
 ///
 /// Branch chains expand named references recursively, so the instance count
 /// is the *product* of per-branch reference counts across the nesting depth,
@@ -47,15 +49,21 @@ use tracing::debug;
 /// validator bounds branch and filter counts individually, but neither bounds
 /// that product: a small config (e.g. 8 named references per branch, 10 levels
 /// deep) expands to ~10^9 filter instances, exhausting memory at startup or on
-/// hot reload. Counting materialized instances against this ceiling fails such
-/// a config fast instead.
+/// hot reload. Outbound binding recurses through the same expansion, so the
+/// budget is shared across the whole build — not reset per bound pipeline —
+/// and counting materialized instances against this ceiling fails such a
+/// config fast instead.
 const MAX_PIPELINE_FILTER_INSTANCES: usize = 100_000;
 
 use super::{
     branch::{RejoinTarget, ResolvedBranch, ResolvedBranchCondition},
     filter::PipelineFilter,
 };
-use crate::{FilterError, registry::FilterRegistry};
+use crate::{
+    FilterError,
+    binding::{ChainBindingContext, ResolutionStack},
+    registry::FilterRegistry,
+};
 
 // -----------------------------------------------------------------------------
 // BuildContext
@@ -80,6 +88,32 @@ struct BuildContext<'a> {
 
     /// Filter registry for instantiating filters.
     registry: &'a FilterRegistry,
+
+    /// Operator's declared insecure posture, threaded so outbound chains bound
+    /// from inside a branch are gated by the same rules as top-level chains.
+    insecure: &'a InsecureOptions,
+
+    /// Shared cycle-detection stack, threaded through nested resolution so a
+    /// chain reference that re-enters an in-progress chain is rejected.
+    stack: &'a ResolutionStack,
+
+    /// Build-wide count of materialized filter instances, checked against
+    /// [`MAX_PIPELINE_FILTER_INSTANCES`]. Shared across branch resolution and
+    /// outbound binding so the ceiling bounds the whole build, not each pipeline.
+    budget: &'a Cell<usize>,
+
+    /// Build-wide count of branch *definitions* seen so far, checked against the
+    /// core total-branch ceiling. Distinct from `budget` (materialized instances):
+    /// this counts config-text branch definitions and is shared across the listener
+    /// pipeline and every bound outbound chain so bindings cannot each reset it and
+    /// evade the ceiling collectively.
+    branch_budget: &'a Cell<usize>,
+
+    /// Outbound nesting depth of the pipeline being resolved, forwarded into
+    /// each [`ChainBindingContext`] so a chain-binding filter reached through
+    /// branch resolution binds at the correct outbound depth rather than
+    /// inheriting the branch depth.
+    outbound_depth: usize,
 }
 
 // -----------------------------------------------------------------------------
@@ -98,29 +132,79 @@ pub(super) fn resolve_chain_filters(
     registry: &FilterRegistry,
     chains: &HashMap<&str, &[FilterEntry]>,
     depth: usize,
+    insecure: &InsecureOptions,
 ) -> Result<Vec<PipelineFilter>, FilterError> {
     let mut next_filter_id: usize = 0;
-    resolve_chain_filters_with_counter(entries, registry, chains, depth, &mut next_filter_id)
+    let stack = ResolutionStack::new();
+    let budget = Cell::new(0);
+    // Seed the shared branch budget with the configuration-wide branch count —
+    // this pipeline's own entries plus every named chain — so bound outbound
+    // chains are counted on top of the whole configuration rather than each
+    // starting from zero. A named outbound chain the listener never references
+    // still materializes when bound and is already counted config-wide by
+    // `validate_branch_chains`, so seeding config-wide (not listener-scoped)
+    // keeps the named pool and the later-accumulated inline pool from each
+    // sitting under the ceiling while exceeding it together. `Named` refs resolve
+    // to chains counted here, so they are not counted again when bound.
+    let known: std::collections::HashSet<&str> = chains.keys().copied().collect();
+    let chain_slices: Vec<&[FilterEntry]> = chains.values().copied().collect();
+    let branch_budget = Cell::new(count_build_branches(entries, &chain_slices, &known));
+    resolve_chain_filters_with_stack(
+        entries,
+        registry,
+        chains,
+        depth,
+        &mut next_filter_id,
+        insecure,
+        &stack,
+        &budget,
+        &branch_budget,
+        0,
+    )
 }
 
-/// Inner implementation that threads a shared counter for unique filter IDs.
-fn resolve_chain_filters_with_counter(
+/// Inner implementation that threads a shared filter-ID counter and a shared
+/// cycle-detection stack through all recursive resolution.
+///
+/// The stack lets outbound-chain binding (via [`ChainBindingContext`]) and
+/// branch resolution share one view of the chains currently being expanded, so
+/// a cycle is rejected regardless of which path re-enters an in-progress chain.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "threads shared filter-ID and cycle-detection state through recursive resolution"
+)]
+pub(crate) fn resolve_chain_filters_with_stack(
     entries: &mut [FilterEntry],
     registry: &FilterRegistry,
     chains: &HashMap<&str, &[FilterEntry]>,
     depth: usize,
     next_filter_id: &mut usize,
+    insecure: &InsecureOptions,
+    stack: &ResolutionStack,
+    budget: &Cell<usize>,
+    branch_budget: &Cell<usize>,
+    outbound_depth: usize,
 ) -> Result<Vec<PipelineFilter>, FilterError> {
     if depth > MAX_BRANCH_DEPTH {
         return Err(format!("branch nesting depth exceeds maximum ({MAX_BRANCH_DEPTH})").into());
     }
-    let (mut filters, branch_configs) = build_filters(entries, registry, next_filter_id)?;
+    // Branch depth and outbound depth are tracked independently: `depth` bounds
+    // branch nesting within this pipeline, while `outbound_depth` bounds how many
+    // outbound bindings deep we are. The binding context carries only the latter.
+    let binding_ctx =
+        ChainBindingContext::new(registry, chains, stack, outbound_depth, insecure, budget, branch_budget);
+    let (mut filters, branch_configs) = build_filters(entries, next_filter_id, &binding_ctx, budget)?;
     let pipeline_filter_type_names: Vec<&str> = filters.iter().map(|pf| pf.filter.name()).collect();
     let mut bctx = BuildContext {
         chains,
         next_filter_id,
         pipeline_filter_type_names,
         registry,
+        insecure,
+        stack,
+        budget,
+        branch_budget,
+        outbound_depth,
     };
     let name_index = build_name_index(&filters);
     attach_branches(&mut filters, branch_configs, &mut bctx, &name_index, depth)?;
@@ -141,13 +225,16 @@ type BranchConfigs = Vec<Option<Vec<BranchChainConfig>>>;
 #[expect(clippy::too_many_lines, reason = "per-entry filter construction is linear")]
 fn build_filters(
     entries: &mut [FilterEntry],
-    registry: &FilterRegistry,
     next_filter_id: &mut usize,
+    binding_ctx: &ChainBindingContext<'_>,
+    budget: &Cell<usize>,
 ) -> Result<(Vec<PipelineFilter>, BranchConfigs), FilterError> {
     let mut filters = Vec::with_capacity(entries.len());
     let mut branch_configs: BranchConfigs = Vec::with_capacity(entries.len());
     for entry in entries.iter_mut() {
-        let filter = registry.create(&entry.filter_type, &entry.config)?;
+        let filter = binding_ctx
+            .registry()
+            .create_with_binding(&entry.filter_type, &entry.config, binding_ctx)?;
         let has_conditions = !entry.conditions.is_empty() || !entry.response_conditions.is_empty();
         debug!(
             filter = filter.name(),
@@ -156,11 +243,15 @@ fn build_filters(
         );
         let filter_id = *next_filter_id;
         *next_filter_id += 1;
-        if *next_filter_id > MAX_PIPELINE_FILTER_INSTANCES {
+        // Count against the build-wide budget so a fan-out that spans branch
+        // resolution and outbound binding cannot evade the ceiling by resetting
+        // a per-pipeline counter at each binding boundary.
+        budget.set(budget.get() + 1);
+        if budget.get() > MAX_PIPELINE_FILTER_INSTANCES {
             return Err(format!(
-                "branch resolution exceeded {MAX_PIPELINE_FILTER_INSTANCES} filter instances; \
-                 a branch chain likely fans out over named references (reduce references per branch \
-                 or nesting depth)"
+                "pipeline build exceeded {MAX_PIPELINE_FILTER_INSTANCES} filter instances; \
+                 a branch or outbound chain likely fans out over named references (reduce \
+                 references per branch or nesting depth)"
             )
             .into());
         }
@@ -171,7 +262,7 @@ fn build_filters(
             mem::take(&mut entry.response_conditions),
         );
         pf.failure_mode = entry.failure_mode;
-        pf.is_security = registry.is_security_filter(&entry.filter_type);
+        pf.is_security = binding_ctx.registry().is_security_filter(&entry.filter_type);
         pf.name = entry.name.as_ref().map(|n| Arc::from(n.as_str()));
         branch_configs.push(entry.branch_chains.take());
         filters.push(pf);
@@ -323,20 +414,32 @@ fn resolve_chain_refs(
 ) -> Result<Vec<PipelineFilter>, FilterError> {
     let mut filters = Vec::new();
     for chain_ref in refs {
-        let mut entries = match chain_ref {
-            ChainRef::Named(name) => bctx
-                .chains
-                .get(name.as_str())
-                .ok_or_else(|| FilterError::from(format!("branch references unknown chain '{name}'")))?
-                .to_vec(),
-            ChainRef::Inline { filters: f, .. } => f.clone(),
+        let (name, mut entries) = match chain_ref {
+            ChainRef::Named(name) => {
+                let entries = bctx
+                    .chains
+                    .get(name.as_str())
+                    .ok_or_else(|| FilterError::from(format!("branch references unknown chain '{name}'")))?
+                    .to_vec();
+                (Some(name.as_str()), entries)
+            },
+            ChainRef::Inline { filters: f, .. } => (None, f.clone()),
         };
-        filters.append(&mut resolve_chain_filters_with_counter(
+        // Track named-chain expansion on the shared stack so a chain that
+        // re-enters itself (directly or through outbound binding) is rejected
+        // with a cycle error rather than hitting the depth/instance backstops.
+        let _guard = name.map(|n| bctx.stack.enter(n)).transpose()?;
+        filters.append(&mut resolve_chain_filters_with_stack(
             &mut entries,
             bctx.registry,
             bctx.chains,
             depth,
             bctx.next_filter_id,
+            bctx.insecure,
+            bctx.stack,
+            bctx.budget,
+            bctx.branch_budget,
+            bctx.outbound_depth,
         )?);
     }
     Ok(filters)
@@ -423,7 +526,13 @@ mod tests {
             make_entry("request_id", Some("first")),
             make_entry("request_id", Some("second")),
         ];
-        let (filters, _) = build_filters(&mut entries, &registry, &mut 0).unwrap();
+        let chains: HashMap<&str, &[FilterEntry]> = HashMap::new();
+        let stack = ResolutionStack::new();
+        let insecure = InsecureOptions::default();
+        let budget = Cell::new(0);
+        let branch_budget = Cell::new(0);
+        let ctx = ChainBindingContext::new(&registry, &chains, &stack, 0, &insecure, &budget, &branch_budget);
+        let (filters, _) = build_filters(&mut entries, &mut 0, &ctx, &budget).unwrap();
         let index = build_name_index(&filters);
         assert_eq!(index.get("first"), Some(&vec![0]), "first filter at index 0");
         assert_eq!(index.get("second"), Some(&vec![1]), "second filter at index 1");
@@ -433,7 +542,13 @@ mod tests {
     fn build_name_index_unnamed_skipped() {
         let registry = FilterRegistry::with_builtins();
         let mut entries = vec![make_entry("request_id", None), make_entry("request_id", Some("named"))];
-        let (filters, _) = build_filters(&mut entries, &registry, &mut 0).unwrap();
+        let chains: HashMap<&str, &[FilterEntry]> = HashMap::new();
+        let stack = ResolutionStack::new();
+        let insecure = InsecureOptions::default();
+        let budget = Cell::new(0);
+        let branch_budget = Cell::new(0);
+        let ctx = ChainBindingContext::new(&registry, &chains, &stack, 0, &insecure, &budget, &branch_budget);
+        let (filters, _) = build_filters(&mut entries, &mut 0, &ctx, &budget).unwrap();
         let index = build_name_index(&filters);
         assert_eq!(index.len(), 1, "only named filters should appear");
         assert_eq!(index.get("named"), Some(&vec![1]), "named filter at index 1");
@@ -458,7 +573,7 @@ mod tests {
 ";
         let mut entries: Vec<FilterEntry> = serde_yaml::from_str(yaml).unwrap();
         let chains = HashMap::new();
-        let err = resolve_chain_filters(&mut entries, &registry, &chains, 0).unwrap_err();
+        let err = resolve_chain_filters(&mut entries, &registry, &chains, 0, &InsecureOptions::default()).unwrap_err();
         assert!(
             err.to_string().contains("ambiguous") && err.to_string().contains("shared"),
             "a rejoin targeting a duplicated name must fail the build: {err}"
@@ -476,7 +591,7 @@ mod tests {
 ";
         let mut entries: Vec<FilterEntry> = serde_yaml::from_str(yaml).unwrap();
         let chains = HashMap::new();
-        let filters = resolve_chain_filters(&mut entries, &registry, &chains, 0).unwrap();
+        let filters = resolve_chain_filters(&mut entries, &registry, &chains, 0, &InsecureOptions::default()).unwrap();
         assert_eq!(
             filters.len(),
             2,
@@ -491,7 +606,13 @@ mod tests {
             make_entry("request_id", Some("shared")),
             make_entry("request_id", Some("shared")),
         ];
-        let (filters, _) = build_filters(&mut entries, &registry, &mut 0).unwrap();
+        let chains: HashMap<&str, &[FilterEntry]> = HashMap::new();
+        let stack = ResolutionStack::new();
+        let insecure = InsecureOptions::default();
+        let budget = Cell::new(0);
+        let branch_budget = Cell::new(0);
+        let ctx = ChainBindingContext::new(&registry, &chains, &stack, 0, &insecure, &budget, &branch_budget);
+        let (filters, _) = build_filters(&mut entries, &mut 0, &ctx, &budget).unwrap();
         let index = build_name_index(&filters);
         assert_eq!(
             index.get("shared"),
@@ -625,7 +746,7 @@ mod tests {
         ]);
         // ~20^4 = 160k instances, over the 100k ceiling.
         let mut top = fanout_chain("c3", 20, "b0");
-        let err = resolve_chain_filters(&mut top, &registry, &chains, 0).unwrap_err();
+        let err = resolve_chain_filters(&mut top, &registry, &chains, 0, &InsecureOptions::default()).unwrap_err();
         assert!(
             err.to_string().contains("filter instances"),
             "an unbounded named-reference fan-out must fail the build: {err}"
@@ -647,7 +768,7 @@ mod tests {
             }]),
             ..make_entry("request_id", None)
         }];
-        let filters = resolve_chain_filters(&mut entries, &registry, &chains, 0).unwrap();
+        let filters = resolve_chain_filters(&mut entries, &registry, &chains, 0, &InsecureOptions::default()).unwrap();
         assert_eq!(filters.len(), 1, "should have 1 main filter");
         assert_eq!(filters[0].branches.len(), 1, "should have 1 branch");
         assert_eq!(filters[0].branches[0].filters.len(), 1, "branch should have 1 filter");
@@ -678,7 +799,7 @@ mod tests {
             }]),
             ..make_entry("request_id", None)
         }];
-        let filters = resolve_chain_filters(&mut entries, &registry, &chains, 0).unwrap();
+        let filters = resolve_chain_filters(&mut entries, &registry, &chains, 0, &InsecureOptions::default()).unwrap();
         assert_eq!(
             filters[0].branches[0].filters.len(),
             1,
@@ -706,7 +827,7 @@ mod tests {
             },
             make_entry("request_id", Some("target")),
         ];
-        let filters = resolve_chain_filters(&mut entries, &registry, &chains, 0).unwrap();
+        let filters = resolve_chain_filters(&mut entries, &registry, &chains, 0, &InsecureOptions::default()).unwrap();
         assert!(
             matches!(filters[0].branches[0].rejoin, RejoinTarget::SkipTo(1)),
             "rejoin should be SkipTo(1)"
@@ -718,11 +839,20 @@ mod tests {
         let registry = FilterRegistry::with_builtins();
         let chains: HashMap<&str, &[FilterEntry]> = HashMap::new();
         let mut next_id: usize = 0;
+        let stack = ResolutionStack::new();
+        let insecure = InsecureOptions::default();
+        let budget = Cell::new(0);
+        let branch_budget = Cell::new(0);
         let mut bctx = BuildContext {
             chains: &chains,
             next_filter_id: &mut next_id,
             pipeline_filter_type_names: vec![],
             registry: &registry,
+            insecure: &insecure,
+            stack: &stack,
+            budget: &budget,
+            branch_budget: &branch_budget,
+            outbound_depth: 0,
         };
         let refs = vec![ChainRef::Named("nonexistent".to_owned())];
         let err = resolve_chain_refs(&refs, &mut bctx, 0).unwrap_err();
@@ -737,7 +867,14 @@ mod tests {
         let registry = FilterRegistry::with_builtins();
         let chains: HashMap<&str, &[FilterEntry]> = HashMap::new();
         let mut entries = vec![make_entry("request_id", None)];
-        let err = resolve_chain_filters(&mut entries, &registry, &chains, MAX_BRANCH_DEPTH + 1).unwrap_err();
+        let err = resolve_chain_filters(
+            &mut entries,
+            &registry,
+            &chains,
+            MAX_BRANCH_DEPTH + 1,
+            &InsecureOptions::default(),
+        )
+        .unwrap_err();
         assert!(
             err.to_string().contains("nesting depth"),
             "should report depth exceeded: {err}"
@@ -765,7 +902,7 @@ mod tests {
             }]),
             ..make_entry("request_id", None)
         }];
-        let filters = resolve_chain_filters(&mut entries, &registry, &chains, 0).unwrap();
+        let filters = resolve_chain_filters(&mut entries, &registry, &chains, 0, &InsecureOptions::default()).unwrap();
         let branch = &filters[0].branches[0];
         assert!(branch.condition.is_some(), "branch should have a condition");
         let cond = branch.condition.as_ref().unwrap();
@@ -796,7 +933,7 @@ mod tests {
             },
             make_entry("request_id", None),
         ];
-        let err = resolve_chain_filters(&mut entries, &registry, &chains, 0).unwrap_err();
+        let err = resolve_chain_filters(&mut entries, &registry, &chains, 0, &InsecureOptions::default()).unwrap_err();
         assert!(
             err.to_string().contains("max_iterations"),
             "backward rejoin without max_iterations should be rejected: {err}"
@@ -823,7 +960,7 @@ mod tests {
             },
             make_entry("request_id", None),
         ];
-        let filters = resolve_chain_filters(&mut entries, &registry, &chains, 0).unwrap();
+        let filters = resolve_chain_filters(&mut entries, &registry, &chains, 0, &InsecureOptions::default()).unwrap();
         assert!(
             matches!(filters[0].branches[0].rejoin, RejoinTarget::ReEnter(0)),
             "backward rejoin with max_iterations should be accepted"
@@ -880,7 +1017,7 @@ mod tests {
             }]),
             ..make_entry("request_id", None)
         }];
-        let err = resolve_chain_filters(&mut entries, &registry, &chains, 0).unwrap_err();
+        let err = resolve_chain_filters(&mut entries, &registry, &chains, 0, &InsecureOptions::default()).unwrap_err();
         assert!(
             err.to_string()
                 .contains("must name the filter the branch is attached to"),
@@ -910,7 +1047,7 @@ mod tests {
             },
             make_entry("request_id", None),
         ];
-        let filters = resolve_chain_filters(&mut entries, &registry, &chains, 0).unwrap();
+        let filters = resolve_chain_filters(&mut entries, &registry, &chains, 0, &InsecureOptions::default()).unwrap();
         let ids = collect_ids(&filters);
         let unique: std::collections::HashSet<usize> = ids.iter().copied().collect();
         assert_eq!(
@@ -947,7 +1084,7 @@ mod tests {
             }]),
             ..make_entry("request_id", None)
         }];
-        let filters = resolve_chain_filters(&mut entries, &registry, &chains, 0).unwrap();
+        let filters = resolve_chain_filters(&mut entries, &registry, &chains, 0, &InsecureOptions::default()).unwrap();
         let ids = collect_ids(&filters);
         let unique: std::collections::HashSet<usize> = ids.iter().copied().collect();
         assert_eq!(ids.len(), 3, "should have top-level + branch + nested branch filters");
@@ -985,7 +1122,7 @@ mod tests {
                 ..make_entry("request_id", None)
             },
         ];
-        let filters = resolve_chain_filters(&mut entries, &registry, &chains, 0).unwrap();
+        let filters = resolve_chain_filters(&mut entries, &registry, &chains, 0, &InsecureOptions::default()).unwrap();
         let ids = collect_ids(&filters);
         let unique: std::collections::HashSet<usize> = ids.iter().copied().collect();
         assert_eq!(ids.len(), 4, "2 top-level + 2 branch filters");
@@ -1015,7 +1152,7 @@ mod tests {
             },
             make_entry("request_id", None),
         ];
-        let filters = resolve_chain_filters(&mut entries, &registry, &chains, 0).unwrap();
+        let filters = resolve_chain_filters(&mut entries, &registry, &chains, 0, &InsecureOptions::default()).unwrap();
         let ids = collect_ids(&filters);
         let unique: std::collections::HashSet<usize> = ids.iter().copied().collect();
         assert_eq!(ids.len(), 5, "3 top-level + 2 branch filters");

--- a/crates/filter/src/pipeline/checks.rs
+++ b/crates/filter/src/pipeline/checks.rs
@@ -116,7 +116,11 @@ pub(super) fn check_conditional_security(names: &[&str], filters: &[PipelineFilt
 
 /// Security filters with `failure_mode: open` (bypass risk on error).
 ///
-/// When `allow` is `true`, the error is demoted to a warning.
+/// When `allow` is `true`, the error is demoted to a warning. Walks branch
+/// sub-chains recursively, so a security filter buried inside a branch is held
+/// to the same guardrail as a top-level one rather than silently escaping it —
+/// matching [`check_skip_to_bypasses_security`] and
+/// [`check_terminal_rejoin_bypasses_security`].
 pub(super) fn check_open_security_filters(
     names: &[&str],
     filters: &[PipelineFilter],
@@ -124,21 +128,49 @@ pub(super) fn check_open_security_filters(
     errors: &mut Vec<String>,
 ) {
     for (i, (name, pf)) in names.iter().zip(filters).enumerate() {
-        if pf.is_security && pf.failure_mode == FailureMode::Open {
-            let msg = format!(
-                "security filter '{name}' at position {i} has \
-                 failure_mode: open; runtime errors will bypass \
-                 security enforcement"
-            );
-            if allow {
-                warn!(
-                    filter = %name,
-                    "{msg}; allowed by insecure_options.allow_open_security_filters"
-                );
-            } else {
-                errors.push(msg);
-            }
+        report_open_security_filter(name, pf, &format!("position {i}"), allow, errors);
+        for branch in &pf.branches {
+            check_open_security_in_branch(&branch.filters, &branch.name, allow, errors);
         }
+    }
+}
+
+/// Apply the `failure_mode: open` guardrail to every filter inside one branch
+/// sub-chain, recursing through nested branches.
+fn check_open_security_in_branch(filters: &[PipelineFilter], branch_name: &str, allow: bool, errors: &mut Vec<String>) {
+    let location = format!("branch '{branch_name}'");
+    for pf in filters {
+        report_open_security_filter(pf.filter.name(), pf, &location, allow, errors);
+        for branch in &pf.branches {
+            check_open_security_in_branch(&branch.filters, &branch.name, allow, errors);
+        }
+    }
+}
+
+/// Emit the `failure_mode: open` diagnostic for one filter: an error, or a
+/// warning when `allow` demotes it via `insecure_options`.
+fn report_open_security_filter(
+    name: &str,
+    filter: &PipelineFilter,
+    location: &str,
+    allow: bool,
+    errors: &mut Vec<String>,
+) {
+    if !filter.is_security || filter.failure_mode != FailureMode::Open {
+        return;
+    }
+    let msg = format!(
+        "security filter '{name}' at {location} has \
+         failure_mode: open; runtime errors will bypass \
+         security enforcement"
+    );
+    if allow {
+        warn!(
+            filter = %name,
+            "{msg}; allowed by insecure_options.allow_open_security_filters"
+        );
+    } else {
+        errors.push(msg);
     }
 }
 
@@ -907,6 +939,68 @@ mod tests {
         let mut errors = Vec::new();
         check_open_security_filters(&names, &filters, false, &mut errors);
         assert!(errors.is_empty(), "open non-security filter should not error");
+    }
+
+    #[test]
+    fn open_security_filter_nested_in_branch_errors() {
+        // A security filter with failure_mode: open buried inside a branch
+        // sub-chain must be held to the same guardrail as a top-level one; branch
+        // nesting must not silently defeat the check.
+        let names = vec!["headers"];
+        let mut nested = security_noop_filter("ip_acl", vec![]);
+        nested.failure_mode = FailureMode::Open;
+        let filters = vec![host_with_branch(vec![nested])];
+        let mut errors = Vec::new();
+        check_open_security_filters(&names, &filters, false, &mut errors);
+        assert_eq!(
+            errors.len(),
+            1,
+            "branch-nested open security filter should error: {errors:?}"
+        );
+        assert!(
+            errors[0].contains("failure_mode: open") && errors[0].contains("ip_acl"),
+            "error should mention ip_acl with failure_mode: open: {}",
+            errors[0]
+        );
+    }
+
+    #[test]
+    fn open_security_filter_nested_in_branch_allowed_demotes_to_warning() {
+        // The insecure_options opt-out must apply to branch-nested security
+        // filters exactly as it does at the top level.
+        let names = vec!["headers"];
+        let mut nested = security_noop_filter("ip_acl", vec![]);
+        nested.failure_mode = FailureMode::Open;
+        let filters = vec![host_with_branch(vec![nested])];
+        let mut errors = Vec::new();
+        check_open_security_filters(&names, &filters, true, &mut errors);
+        assert!(
+            errors.is_empty(),
+            "allow flag should demote branch-nested open security filter to warning: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn open_security_filter_nested_two_levels_deep_errors() {
+        // The recursion must reach a security filter buried inside a branch of a
+        // branch, not just a first-level branch.
+        let names = vec!["headers"];
+        let mut deep = security_noop_filter("ip_acl", vec![]);
+        deep.failure_mode = FailureMode::Open;
+        let inner_host = host_with_branch(vec![deep]);
+        let filters = vec![host_with_branch(vec![inner_host])];
+        let mut errors = Vec::new();
+        check_open_security_filters(&names, &filters, false, &mut errors);
+        assert_eq!(
+            errors.len(),
+            1,
+            "open security filter two branch levels deep should error: {errors:?}"
+        );
+        assert!(
+            errors[0].contains("failure_mode: open") && errors[0].contains("ip_acl"),
+            "error should mention ip_acl with failure_mode: open: {}",
+            errors[0]
+        );
     }
 
     #[test]

--- a/crates/filter/src/pipeline/mod.rs
+++ b/crates/filter/src/pipeline/mod.rs
@@ -33,7 +33,7 @@
 pub(crate) mod body;
 pub(crate) mod branch;
 mod build;
-mod build_branch;
+pub(crate) mod build_branch;
 mod checks;
 mod clusters;
 pub(crate) mod evaluate;
@@ -306,6 +306,58 @@ impl FilterPipeline {
             .collect()
     }
 
+    /// Names of filters in this pipeline that operate below the HTTP layer.
+    ///
+    /// Unlike [`filters_unsupported_by`], which honors a listener's protocol
+    /// stack (an HTTP listener legitimately runs TCP-level filters at the
+    /// connection layer), this reports filters that a *filtered sub-request*
+    /// cannot run: that executor drives only the HTTP request phase, so any
+    /// filter whose protocol level is not [`ProtocolKind::Http`] is never
+    /// invoked. Binding one into an outbound chain is a silent runtime no-op;
+    /// this surfaces it at build time.
+    ///
+    /// [`filters_unsupported_by`]: Self::filters_unsupported_by
+    /// [`ProtocolKind::Http`]: praxis_core::config::ProtocolKind::Http
+    pub fn non_http_filters(&self) -> Vec<&'static str> {
+        let mut names = Vec::new();
+        for_each_pipeline_filter(&self.filters, &mut |pf| {
+            if pf.filter.protocol_level() != praxis_core::config::ProtocolKind::Http {
+                names.push(pf.filter.name());
+            }
+        });
+        names
+    }
+
+    /// Names of terminal filters in this pipeline, recursively including those
+    /// nested inside branch sub-chains.
+    ///
+    /// A terminal filter short-circuits the request phase with a response and no
+    /// upstream. The HTTP filtered sub-request executor forwards to a resolved
+    /// upstream and cannot surface such a response, so a terminal filter bound
+    /// into an outbound chain — at the top level or buried in a branch — must be
+    /// rejected at build time rather than silently activate and drop its response
+    /// at runtime.
+    ///
+    /// Detection is capability-based
+    /// ([`HttpFilter::produces_terminal_response`]), not a match against the
+    /// hard-coded builtin names in [`TERMINAL_FILTERS`], so a custom filter that
+    /// can return a terminal action is caught even though its name is unknown to
+    /// the builtin list.
+    ///
+    /// [`HttpFilter::produces_terminal_response`]: crate::HttpFilter::produces_terminal_response
+    /// [`TERMINAL_FILTERS`]: praxis_core::config::TERMINAL_FILTERS
+    pub fn terminal_filters(&self) -> Vec<&'static str> {
+        let mut names = Vec::new();
+        for_each_pipeline_filter(&self.filters, &mut |pf| {
+            if let crate::any_filter::AnyFilter::Http(filter) = &pf.filter
+                && filter.produces_terminal_response()
+            {
+                names.push(filter.name());
+            }
+        });
+        names
+    }
+
     /// Whether any filter of `type_name` has request conditions matching
     /// `request` (an unconditional entry always matches).
     ///
@@ -386,6 +438,7 @@ impl FilterPipeline {
 
     /// Set the shared [`crate::SessionStoreRegistry`] for this pipeline.
     pub fn set_session_stores(&mut self, stores: Arc<crate::SessionStoreRegistry>) {
+        self.visit_nested_pipelines(&mut |pipeline| pipeline.set_session_stores(Arc::clone(&stores)));
         self.session_stores = Some(stores);
     }
 
@@ -449,20 +502,16 @@ impl FilterPipeline {
     /// Without this, a filter that loads an external document never picks up edits
     /// to it, because the reload gate only ever sees the main config's bytes.
     ///
-    /// Mirrors [`Self::apply_insecure_options`], including its limitation: only
-    /// top-level filters are walked, not filters nested inside branch chains. A
-    /// document referenced solely from a branch is therefore not observed. That is
-    /// the same blind spot the insecure-options walk already has, and widening both
-    /// belongs in one change rather than half of one here.
+    /// Walks branch sub-chains recursively, so a document referenced solely from
+    /// a filter inside a branch is observed too.
     pub fn referenced_files(&self) -> Vec<std::path::PathBuf> {
-        self.filters
-            .iter()
-            .filter_map(|pf| match &pf.filter {
-                crate::any_filter::AnyFilter::Http(f) => Some(f.referenced_files()),
-                crate::any_filter::AnyFilter::Tcp(_) => None,
-            })
-            .flatten()
-            .collect()
+        let mut files = Vec::new();
+        for_each_pipeline_filter(&self.filters, &mut |pf| {
+            if let crate::any_filter::AnyFilter::Http(f) = &pf.filter {
+                files.extend(f.referenced_files());
+            }
+        });
+        files
     }
 
     /// Whether upstream hostnames are allowed to resolve to private or
@@ -486,26 +535,57 @@ impl FilterPipeline {
 
     /// Apply [`InsecureOptions`] to all filters in the pipeline.
     ///
-    /// Delegates to each filter's [`apply_insecure_options`] method.
-    /// Filters that support insecure overrides (e.g. CSRF log-only
-    /// mode) handle the relevant flags; others ignore the call.
+    /// Delegates to each filter's [`apply_insecure_options`] method, recursing
+    /// into branch sub-chains so a filter buried in a branch honors the override
+    /// too. Filters that support insecure overrides (e.g. CSRF log-only mode)
+    /// handle the relevant flags; others ignore the call.
     ///
     /// [`apply_insecure_options`]: crate::HttpFilter::apply_insecure_options
     /// [`InsecureOptions`]: praxis_core::config::InsecureOptions
     pub fn apply_insecure_options(&self, options: &InsecureOptions) {
-        for pf in &self.filters {
+        for_each_pipeline_filter(&self.filters, &mut |pf| {
             if let crate::any_filter::AnyFilter::Http(f) = &pf.filter {
                 f.apply_insecure_options(options);
             }
-        }
+        });
     }
 
-    /// Apply a mutation to every pipeline directly embedded by a filter.
+    /// Apply a mutation to every pipeline directly embedded by a filter,
+    /// including filters nested inside branch sub-chains.
     fn visit_nested_pipelines(&mut self, visitor: &mut dyn FnMut(&mut FilterPipeline)) {
-        for pf in &mut self.filters {
-            if let crate::any_filter::AnyFilter::Http(filter) = &mut pf.filter {
-                filter.visit_nested_pipelines(visitor);
-            }
+        visit_branch_nested_pipelines(&mut self.filters, visitor);
+    }
+}
+
+/// Visit every filter in `filters` and, recursively, every filter nested inside
+/// their branch sub-chains.
+///
+/// The shared read-only walk behind the pipeline-wide scans (non-HTTP filter
+/// detection, terminal-filter detection, referenced-file discovery, insecure
+/// option application) so a filter buried in a branch is treated exactly like a
+/// top-level one rather than silently skipped.
+fn for_each_pipeline_filter(filters: &[PipelineFilter], visit: &mut dyn FnMut(&PipelineFilter)) {
+    for pf in filters {
+        visit(pf);
+        for branch in &pf.branches {
+            for_each_pipeline_filter(&branch.filters, visit);
+        }
+    }
+}
+
+/// Invoke each filter's [`visit_nested_pipelines`], descending recursively into
+/// branch sub-chains so pipelines embedded by branch-contained filters (for
+/// example an outbound chain bound by a callout placed inside a branch) receive
+/// the same mutation as top-level ones.
+///
+/// [`visit_nested_pipelines`]: crate::HttpFilter::visit_nested_pipelines
+fn visit_branch_nested_pipelines(filters: &mut [PipelineFilter], visitor: &mut dyn FnMut(&mut FilterPipeline)) {
+    for pf in filters {
+        if let crate::any_filter::AnyFilter::Http(filter) = &mut pf.filter {
+            filter.visit_nested_pipelines(visitor);
+        }
+        for branch in &mut pf.branches {
+            visit_branch_nested_pipelines(&mut branch.filters, visitor);
         }
     }
 }

--- a/crates/filter/src/pipeline/tests.rs
+++ b/crates/filter/src/pipeline/tests.rs
@@ -1283,7 +1283,13 @@ fn build_with_chains_stamps_is_security_on_branch_filter() {
         ..named_noop_entry("request_id", FailureMode::default())
     }];
     let chains: HashMap<&str, &[FilterEntry]> = HashMap::new();
-    let pipeline = FilterPipeline::build_with_chains(&mut entries, &registry, &chains).unwrap();
+    let pipeline = FilterPipeline::build_with_chains(
+        &mut entries,
+        &registry,
+        &chains,
+        &praxis_core::config::InsecureOptions::default(),
+    )
+    .unwrap();
     assert_eq!(
         pipeline.filters.len(),
         1,
@@ -4845,4 +4851,139 @@ mod filter_duration_metrics_tests {
         pipeline.set_time_source(source);
         let _time_source = pipeline.time_source();
     }
+}
+
+// -----------------------------------------------------------------------------
+// Runtime Resource Propagation
+// -----------------------------------------------------------------------------
+
+// A filter that owns a nested pipeline and exposes it through
+// `visit_nested_pipelines`, so recursion of runtime-resource setters can be
+// observed without depending on the outbound-callout filter.
+struct NestedPipelineFilter {
+    nested: FilterPipeline,
+}
+
+#[async_trait]
+impl HttpFilter for NestedPipelineFilter {
+    fn name(&self) -> &'static str {
+        "nested_pipeline_filter"
+    }
+
+    async fn on_request(&self, _ctx: &mut crate::HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
+        Ok(FilterAction::Continue)
+    }
+
+    fn visit_nested_pipelines(&mut self, visitor: &mut dyn FnMut(&mut FilterPipeline)) {
+        visitor(&mut self.nested);
+    }
+}
+
+#[test]
+fn set_session_stores_propagates_into_nested_pipelines() {
+    let parent_filter = NestedPipelineFilter {
+        nested: make_pipeline(vec![]),
+    };
+    let mut parent = make_pipeline(vec![Box::new(parent_filter)]);
+
+    parent.set_session_stores(Arc::new(crate::SessionStoreRegistry::new()));
+
+    let mut nested_has_stores = false;
+    parent.visit_nested_pipelines(&mut |pipeline| {
+        nested_has_stores = pipeline.session_stores().is_some();
+    });
+    assert!(
+        nested_has_stores,
+        "set_session_stores must reach nested outbound pipelines like set_kv_stores does"
+    );
+}
+
+// A terminal-filter stand-in that declares the terminal-response capability yet
+// no body access. It models a terminal filter the branch body-access check would
+// NOT reject (unlike the real IRR, which always declares body access), so
+// terminal detection must recurse into branch sub-chains on its own to catch it.
+struct TerminalDouble;
+
+#[async_trait]
+impl HttpFilter for TerminalDouble {
+    fn name(&self) -> &'static str {
+        "iterative_request_router"
+    }
+
+    fn produces_terminal_response(&self) -> bool {
+        true
+    }
+
+    async fn on_request(&self, _ctx: &mut crate::HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
+        Ok(FilterAction::Continue)
+    }
+}
+
+#[test]
+fn terminal_filters_detects_filter_nested_in_branch() {
+    // A terminal filter buried inside a branch sub-chain must be reported. The
+    // top-level-only scan would miss it, letting it activate and drop its
+    // terminal response at runtime inside an outbound chain.
+    let mut parent = make_pipeline(vec![Box::new(CountingFilter {
+        counter: Arc::new(AtomicUsize::new(0)),
+    })]);
+    parent.filters[0].branches = vec![ResolvedBranch {
+        condition: None,
+        filters: vec![PipelineFilter::new(
+            10,
+            AnyFilter::Http(Box::new(TerminalDouble)),
+            vec![],
+            vec![],
+        )],
+        max_iterations: None,
+        name: Arc::from("br"),
+        rejoin: RejoinTarget::Next,
+    }];
+
+    assert!(
+        parent.terminal_filters().contains(&"iterative_request_router"),
+        "terminal_filters must find a terminal filter nested inside a branch sub-chain"
+    );
+}
+
+#[test]
+fn set_session_stores_propagates_into_branch_nested_pipelines() {
+    // A nested-pipeline filter placed INSIDE a branch sub-chain, not at the top
+    // level. Runtime-resource setters route through `visit_nested_pipelines`,
+    // which must descend into branch sub-chains so a branch-contained callout's
+    // bound outbound pipeline receives resources too — not just top-level ones.
+    let branch_filter = NestedPipelineFilter {
+        nested: make_pipeline(vec![]),
+    };
+    let mut parent = make_pipeline(vec![Box::new(CountingFilter {
+        counter: Arc::new(AtomicUsize::new(0)),
+    })]);
+    parent.filters[0].branches = vec![ResolvedBranch {
+        condition: None,
+        filters: vec![PipelineFilter::new(
+            10,
+            AnyFilter::Http(Box::new(branch_filter)),
+            vec![],
+            vec![],
+        )],
+        max_iterations: None,
+        name: Arc::from("br"),
+        rejoin: RejoinTarget::Next,
+    }];
+
+    parent.set_session_stores(Arc::new(crate::SessionStoreRegistry::new()));
+
+    // Observe the branch-nested embedded pipeline directly — reach into the
+    // branch filter and query its own nested pipeline — so the assertion does
+    // not depend on the very traversal under test.
+    let mut nested_has_stores = false;
+    if let AnyFilter::Http(filter) = &mut parent.filters[0].branches[0].filters[0].filter {
+        filter.visit_nested_pipelines(&mut |pipeline| {
+            nested_has_stores = pipeline.session_stores().is_some();
+        });
+    }
+    assert!(
+        nested_has_stores,
+        "set_session_stores must reach pipelines embedded by filters inside branch sub-chains"
+    );
 }

--- a/crates/filter/src/registry.rs
+++ b/crates/filter/src/registry.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 
 use crate::{
     any_filter::AnyFilter,
+    binding::{ChainBindingContext, ChainBindingHttpFactory},
     factory::{FilterFactory, HttpFilterFactoryFn, TcpFilterFactoryFn, http_builtin, tcp_builtin},
     filter::FilterError,
 };
@@ -57,6 +58,10 @@ enum RegisteredFilterFactory {
 
     /// A built-in HTTP factory that resolves nested filters.
     HttpWithRegistry(RegistryHttpFilterFactory),
+
+    /// An application HTTP factory that binds an outbound subrequest chain at
+    /// construction time via a [`ChainBindingContext`].
+    ChainBinding(ChainBindingHttpFactory),
 }
 
 /// Factory for a built-in HTTP filter that resolves nested filters
@@ -65,11 +70,38 @@ type RegistryHttpFilterFactory =
     fn(&serde_yaml::Value, &FilterRegistry) -> Result<Box<dyn crate::filter::HttpFilter>, FilterError>;
 
 impl RegisteredFilterFactory {
-    /// Instantiate the registered filter.
+    /// Instantiate the registered filter without an outbound-chain binding
+    /// context.
+    ///
+    /// A [`ChainBinding`](Self::ChainBinding) factory cannot resolve its
+    /// outbound chain without a [`ChainBindingContext`], so this path rejects
+    /// it and directs callers to [`FilterPipeline::build_with_chains`], which
+    /// supplies one.
+    ///
+    /// [`FilterPipeline::build_with_chains`]: crate::FilterPipeline::build_with_chains
     fn create(&self, config: &serde_yaml::Value, registry: &FilterRegistry) -> Result<AnyFilter, FilterError> {
         match self {
             Self::Standard(factory) => factory.create(config),
             Self::HttpWithRegistry(factory) => Ok(AnyFilter::Http(factory(config, registry)?)),
+            Self::ChainBinding(_) => Err(FilterError::from(
+                "this filter binds an outbound subrequest chain and must be built via \
+                 FilterPipeline::build_with_chains",
+            )),
+        }
+    }
+
+    /// Instantiate the registered filter, supplying an outbound-chain binding
+    /// context to [`ChainBinding`](Self::ChainBinding) factories.
+    fn create_with_binding(
+        &self,
+        config: &serde_yaml::Value,
+        registry: &FilterRegistry,
+        ctx: &ChainBindingContext<'_>,
+    ) -> Result<AnyFilter, FilterError> {
+        match self {
+            Self::Standard(factory) => factory.create(config),
+            Self::HttpWithRegistry(factory) => Ok(AnyFilter::Http(factory(config, registry)?)),
+            Self::ChainBinding(factory) => Ok(AnyFilter::Http(factory(config, ctx)?)),
         }
     }
 }
@@ -164,6 +196,134 @@ impl FilterRegistry {
         Ok(())
     }
 
+    /// Registers an application HTTP filter that binds an outbound subrequest
+    /// chain at construction time, with [`SecurityClass::Standard`].
+    ///
+    /// The factory receives a [`ChainBindingContext`] and resolves its
+    /// configured outbound chain into a prebuilt [`FilterPipeline`]. This is
+    /// the mechanism application callout filters (e.g. Praxis AI) use to bind
+    /// reusable outbound chains against the active registry.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FilterError`] if the name is already registered.
+    ///
+    /// # Examples
+    ///
+    /// Register an application callout that binds its `outbound_chain` once at
+    /// construction. Building — or hot-reloading — a pipeline that names the
+    /// callout resolves and prebuilds the outbound chain against the active
+    /// registry, so a missing filter, a reference cycle, or excessive nesting
+    /// fails the build instead of a request:
+    ///
+    /// ```
+    /// use std::{collections::HashMap, sync::Arc};
+    ///
+    /// use async_trait::async_trait;
+    /// use praxis_core::config::{ChainRef, FilterEntry, InsecureOptions};
+    /// use praxis_filter::{
+    ///     ChainBindingContext, FilterAction, FilterError, FilterPipeline, FilterRegistry, HttpFilter,
+    ///     HttpFilterContext,
+    /// };
+    ///
+    /// // The application filter owns the prebuilt outbound pipeline.
+    /// struct AiCallout {
+    ///     outbound: Arc<FilterPipeline>,
+    /// }
+    ///
+    /// #[async_trait]
+    /// impl HttpFilter for AiCallout {
+    ///     fn name(&self) -> &'static str {
+    ///         "ai_callout"
+    ///     }
+    ///
+    ///     // Delegate the framework's nesting hooks so the bound pipeline joins
+    ///     // runtime-resource propagation, hot-reload file discovery, and
+    ///     // insecure-option application.
+    ///     fn visit_nested_pipelines(&mut self, visitor: &mut dyn FnMut(&mut FilterPipeline)) {
+    ///         if let Some(pipeline) = Arc::get_mut(&mut self.outbound) {
+    ///             visitor(pipeline);
+    ///         }
+    ///     }
+    ///     fn referenced_files(&self) -> Vec<std::path::PathBuf> {
+    ///         self.outbound.referenced_files()
+    ///     }
+    ///     fn apply_insecure_options(&self, options: &InsecureOptions) {
+    ///         self.outbound.apply_insecure_options(options);
+    ///     }
+    ///
+    ///     async fn on_request(
+    ///         &self,
+    ///         _ctx: &mut HttpFilterContext<'_>,
+    ///     ) -> Result<FilterAction, FilterError> {
+    ///         Ok(FilterAction::Continue)
+    ///     }
+    /// }
+    ///
+    /// let mut registry = FilterRegistry::with_builtins();
+    /// registry
+    ///     .register_chain_binding(
+    ///         "ai_callout",
+    ///         Arc::new(|config: &serde_yaml::Value, ctx: &ChainBindingContext<'_>| {
+    ///             let raw = config
+    ///                 .get("outbound_chain")
+    ///                 .cloned()
+    ///                 .ok_or_else(|| FilterError::from("ai_callout: missing outbound_chain"))?;
+    ///             let chain_ref: ChainRef = serde_yaml::from_value(raw)
+    ///                 .map_err(|e| FilterError::from(format!("ai_callout: bad outbound_chain: {e}")))?;
+    ///             // Resolve + prebuild the outbound chain against the active registry.
+    ///             let outbound = ctx.bind_chain(&chain_ref)?;
+    ///             let filter: Box<dyn HttpFilter> = Box::new(AiCallout {
+    ///                 outbound: Arc::new(outbound),
+    ///             });
+    ///             Ok(filter)
+    ///         }),
+    ///     )
+    ///     .unwrap();
+    ///
+    /// // Building a pipeline that uses the callout binds its outbound chain now,
+    /// // before any request is served; a hot reload rebuilds it the same way.
+    /// let mut top: Vec<FilterEntry> = serde_yaml::from_str(
+    ///     "- filter: ai_callout\n  outbound_chain:\n    name: outbound\n    filters:\n      - filter: request_id\n",
+    /// )
+    /// .unwrap();
+    /// let chains: HashMap<&str, &[FilterEntry]> = HashMap::new();
+    /// FilterPipeline::build_with_chains(&mut top, &registry, &chains, &InsecureOptions::default())
+    ///     .expect("the outbound chain is validated and bound at build time");
+    /// ```
+    ///
+    /// [`ChainBindingContext`]: crate::ChainBindingContext
+    /// [`FilterPipeline`]: crate::FilterPipeline
+    pub fn register_chain_binding(&mut self, name: &str, factory: ChainBindingHttpFactory) -> Result<(), FilterError> {
+        self.register_chain_binding_with_class(name, factory, SecurityClass::Standard)
+    }
+
+    /// Registers a chain-binding filter with an explicit [`SecurityClass`].
+    ///
+    /// See [`register_chain_binding`](Self::register_chain_binding).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FilterError`] if the name is already registered.
+    pub fn register_chain_binding_with_class(
+        &mut self,
+        name: &str,
+        factory: ChainBindingHttpFactory,
+        security_class: SecurityClass,
+    ) -> Result<(), FilterError> {
+        if self.filters.contains_key(name) {
+            return Err(format!("duplicate filter name: '{name}'").into());
+        }
+        self.filters.insert(
+            name.to_owned(),
+            FilterRegistration {
+                factory: RegisteredFilterFactory::ChainBinding(factory),
+                security_class,
+            },
+        );
+        Ok(())
+    }
+
     /// Instantiates a filter by type name and config.
     ///
     /// ```
@@ -192,6 +352,29 @@ impl FilterRegistry {
             .get(name)
             .ok_or_else(|| -> FilterError { format!("unknown filter type: '{name}'").into() })?;
         registration.factory.create(config, self)
+    }
+
+    /// Instantiates a filter, supplying a [`ChainBindingContext`] so
+    /// chain-binding filters can bind their outbound chains.
+    ///
+    /// Used by the branch-aware pipeline builder. Non-binding filters ignore
+    /// the context and behave exactly as under [`create`](Self::create).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FilterError`] if the filter type is unknown or instantiation
+    /// fails.
+    pub(crate) fn create_with_binding(
+        &self,
+        name: &str,
+        config: &serde_yaml::Value,
+        ctx: &ChainBindingContext<'_>,
+    ) -> Result<AnyFilter, FilterError> {
+        let registration = self
+            .filters
+            .get(name)
+            .ok_or_else(|| -> FilterError { format!("unknown filter type: '{name}'").into() })?;
+        registration.factory.create_with_binding(config, self, ctx)
     }
 
     /// Returns the names of all registered filter types.

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -40,6 +40,7 @@ tikv-jemallocator = { workspace = true }
 cargo_metadata = { workspace = true }
 
 [dev-dependencies]
+async-trait = { workspace = true }
 tempfile = { workspace = true }
 tracing-subscriber = { workspace = true }
 

--- a/crates/server/src/pipelines.rs
+++ b/crates/server/src/pipelines.rs
@@ -117,7 +117,8 @@ pub fn resolve_pipelines(
 
         validate_terminal_position(&entries, &listener.name)?;
 
-        let mut pipeline = FilterPipeline::build_with_chains(&mut entries, registry, &chains)?;
+        let mut pipeline =
+            FilterPipeline::build_with_chains(&mut entries, registry, &chains, &config.insecure_options)?;
         configure_pipeline(
             &mut pipeline,
             config,

--- a/crates/server/src/reload.rs
+++ b/crates/server/src/reload.rs
@@ -413,6 +413,185 @@ filter_chains:
     }
 
     #[test]
+    fn reload_rebinds_outbound_chain_and_reinjects_runtime_resources() {
+        use async_trait::async_trait;
+        use praxis_core::config::ChainRef;
+        use praxis_filter::{
+            ChainBindingContext, FilterAction, FilterError, FilterPipeline, HttpFilter, HttpFilterContext,
+        };
+
+        // Per-configuration snapshot of what the framework injected into the
+        // bound outbound pipeline: whether the KV registry landed, and the
+        // identity (pointer) of the session-store registry that reached it.
+        type Injection = (bool, Option<usize>);
+
+        // A reference chain-binding callout: it binds an outbound chain once and
+        // owns the resulting pipeline, delegating `visit_nested_pipelines` so the
+        // bound pipeline participates in runtime-resource propagation. After each
+        // visit it records what the nested pipeline now holds, so a test can prove
+        // the *server's* configure/reload path reaches the outbound chain.
+        struct ObservingCallout {
+            outbound: Arc<FilterPipeline>,
+            injections: Arc<Mutex<Vec<Injection>>>,
+        }
+
+        #[async_trait]
+        impl HttpFilter for ObservingCallout {
+            fn name(&self) -> &'static str {
+                "observing_callout"
+            }
+
+            fn visit_nested_pipelines(&mut self, visitor: &mut dyn FnMut(&mut FilterPipeline)) {
+                if let Some(pipeline) = Arc::get_mut(&mut self.outbound) {
+                    visitor(pipeline);
+                    let snapshot = (
+                        pipeline.kv_stores().is_some(),
+                        pipeline.session_stores().map(|stores| Arc::as_ptr(stores).addr()),
+                    );
+                    self.injections.lock().unwrap().push(snapshot);
+                }
+            }
+
+            async fn on_request(&self, _ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
+                Ok(FilterAction::Continue)
+            }
+        }
+
+        let injections: Arc<Mutex<Vec<Injection>>> = Arc::new(Mutex::new(Vec::new()));
+        let mut registry = FilterRegistry::with_builtins();
+        let factory_injections = Arc::clone(&injections);
+        registry
+            .register_chain_binding(
+                "observing_callout",
+                Arc::new(move |config: &serde_yaml::Value, ctx: &ChainBindingContext<'_>| {
+                    let raw = config
+                        .get("outbound_chain")
+                        .cloned()
+                        .ok_or_else(|| FilterError::from("missing outbound_chain"))?;
+                    let chain_ref: ChainRef = serde_yaml::from_value(raw)
+                        .map_err(|e| FilterError::from(format!("bad outbound_chain: {e}")))?;
+                    let outbound = ctx.bind_chain(&chain_ref)?;
+                    let filter: Box<dyn HttpFilter> = Box::new(ObservingCallout {
+                        outbound: Arc::new(outbound),
+                        injections: Arc::clone(&factory_injections),
+                    });
+                    Ok(filter)
+                }),
+            )
+            .expect("register observing_callout");
+
+        let session_stores = empty_session_stores();
+        let expected_session_ptr = Arc::as_ptr(&session_stores).addr();
+        let kv_stores = empty_kv_stores();
+        let health_registry: HealthRegistry = Arc::new(HashMap::new());
+        let subrequest_client = empty_subrequest_client();
+
+        // v1: a one-filter outbound chain behind the chain-binding callout.
+        let old_config = Config::from_yaml(
+            r#"
+listeners:
+  - name: web
+    address: "127.0.0.1:8080"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: observing_callout
+        outbound_chain:
+          name: outbound
+          filters:
+            - filter: request_id
+"#,
+        )
+        .unwrap();
+
+        let live = resolve_pipelines(
+            &old_config,
+            &registry,
+            &health_registry,
+            &kv_stores,
+            &session_stores,
+            &subrequest_client,
+        )
+        .unwrap();
+
+        // The initial build must already have driven the KV and session
+        // registries into the bound outbound pipeline.
+        let after_build = injections.lock().unwrap().clone();
+        let build_count = after_build.len();
+        assert!(
+            after_build
+                .iter()
+                .any(|(kv, session)| *kv && *session == Some(expected_session_ptr)),
+            "resolve_pipelines must inject KV and session stores into the bound outbound pipeline"
+        );
+
+        let old_ptr = Arc::as_ptr(&live.get("web").unwrap().load());
+
+        // v2 (a reload): the outbound chain gains a second filter, forcing a
+        // genuine re-bind of a freshly constructed outbound pipeline.
+        let new_config = Config::from_yaml(
+            r#"
+listeners:
+  - name: web
+    address: "127.0.0.1:8080"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: observing_callout
+        outbound_chain:
+          name: outbound
+          filters:
+            - filter: request_id
+            - filter: headers
+"#,
+        )
+        .unwrap();
+
+        let shutdown = Arc::new(Mutex::new(CancellationToken::new()));
+        let meta = praxis_protocol::http::pingora::health::new_listener_meta_store(
+            praxis_protocol::http::pingora::health::listener_meta_from_config(&old_config),
+        );
+        let cluster_meta = praxis_protocol::http::pingora::health::new_cluster_meta_store(
+            praxis_protocol::http::pingora::health::cluster_meta_from_config(&old_config),
+        );
+
+        reload_pipelines(
+            &new_config,
+            &old_config,
+            &registry,
+            &live,
+            &meta,
+            &cluster_meta,
+            &shutdown,
+            &kv_stores,
+            &session_stores,
+            &subrequest_client,
+            None,
+        )
+        .unwrap();
+
+        // The ArcSwap swap installed a rebuilt pipeline...
+        let new_ptr = Arc::as_ptr(&live.get("web").unwrap().load());
+        assert_ne!(old_ptr, new_ptr, "reload must swap in a rebuilt pipeline");
+
+        // ...and the reload's configure pass re-injected KV and session stores
+        // into the newly bound outbound pipeline, not just the top-level one.
+        let after_reload = injections.lock().unwrap().clone();
+        assert!(
+            after_reload.len() > build_count,
+            "reload must re-run configuration over the rebuilt outbound pipeline"
+        );
+        assert!(
+            after_reload[build_count..]
+                .iter()
+                .any(|(kv, session)| *kv && *session == Some(expected_session_ptr)),
+            "reload must re-inject KV and session stores into the rebuilt bound outbound pipeline"
+        );
+    }
+
+    #[test]
     fn invalid_filter_returns_err_old_pipeline_untouched() {
         let (live, old_config, registry, shutdown, meta, cluster_meta) = setup_live_pipelines();
         let old_ptr = Arc::as_ptr(&live.get("web").unwrap().load());

--- a/tests/schema/tests/suite/examples/branching/reentrance.rs
+++ b/tests/schema/tests/suite/examples/branching/reentrance.rs
@@ -68,7 +68,8 @@ filter_chains:
             entries.extend_from_slice(filters);
         }
     }
-    let result = praxis_filter::FilterPipeline::build_with_chains(&mut entries, &registry, &chains);
+    let result =
+        praxis_filter::FilterPipeline::build_with_chains(&mut entries, &registry, &chains, &config.insecure_options);
     assert!(result.is_err(), "backward rejoin without max_iterations should fail");
     let err = result.err().unwrap();
     assert!(
@@ -380,7 +381,8 @@ filter_chains:
             entries.extend_from_slice(filters);
         }
     }
-    let result = praxis_filter::FilterPipeline::build_with_chains(&mut entries, &registry, &chains);
+    let result =
+        praxis_filter::FilterPipeline::build_with_chains(&mut entries, &registry, &chains, &config.insecure_options);
     assert!(
         result.is_err(),
         "self-referencing rejoin without max_iterations should fail"

--- a/tests/schema/tests/suite/examples/observability/access_log_fields.rs
+++ b/tests/schema/tests/suite/examples/observability/access_log_fields.rs
@@ -41,5 +41,11 @@ fn access_log_fields_example_builds_pipeline() {
             .unwrap_or_else(|| panic!("unknown chain {chain_name}"));
         entries.extend_from_slice(filters);
     }
-    FilterPipeline::build_with_chains(&mut entries, &registry, &chains).expect("pipeline should build");
+    FilterPipeline::build_with_chains(
+        &mut entries,
+        &registry,
+        &chains,
+        &praxis_core::config::InsecureOptions::default(),
+    )
+    .expect("pipeline should build");
 }

--- a/tests/utils/src/proxy.rs
+++ b/tests/utils/src/proxy.rs
@@ -104,7 +104,8 @@ fn resolve_listener_pipeline(config: &Config, listener: &Listener, registry: &Fi
         entries.extend_from_slice(filters);
     }
 
-    let mut pipeline = FilterPipeline::build_with_chains(&mut entries, registry, &chains).unwrap();
+    let mut pipeline =
+        FilterPipeline::build_with_chains(&mut entries, registry, &chains, &config.insecure_options).unwrap();
     pipeline
         .apply_body_limits(
             config.body_limits.max_request_bytes,


### PR DESCRIPTION
### What does this PR do?

Implements issue #1074: lets a filter bind a nested "outbound" filter chain (named or inline) that runs against the resolved upstream, exposing a small public `FilteredSubrequestExecutor::run()` API that returns either a buffered or a streaming response. Bound chains are held to the same validation top-level chains face — filter-count cap, empty-predicate rejection, inline-cluster SSRF/insecure-TLS gating, branch-chain constraints (max-iterations ceiling, nesting depth, per-filter and configuration-wide total-branch caps), and rejection of terminal/TCP filters — all of which they would otherwise bypass by never appearing in `Config::filter_chains`, with every scan traversing branch sub-chains. Credentials are staged during request processing and materialized only into a request bound for the canonical logical authority they were issued for, after header sanitization, and only when actually injected, so a secret cannot reach a shared-vhost endpoint under a different `Host`. Bound outbound chains participate fully in the config-reload contract, being rebuilt and re-injected with runtime resources (KV stores, session stores, subrequest client) including into nested and branch-embedded pipelines. No IRR or AI-client migration is included.

### Which issue(s) does this relate to?

Fixes #1074

### Checklist

- [x] Signed off all commits (`git commit -s`)
- [x] Tests added or updated
- [x] Documentation updated (if applicable)
- [x] `make lint && make test && make test-integration` passes locally

### Does this introduce a breaking change?

No.
