### PR TITLE
feat: catalog generation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -226,11 +226,26 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set up Rust
+        uses: praxis-proxy/conventions/.github/actions/setup-rust@dc77dbd3a55ce96e8e31a3c8d36cea4952617dd3 # v0.1.0
+
+      - name: Generate and validate Core catalog artifact
+        env:
+          PRAXIS_SOURCE_REVISION: ${{ github.sha }}
+        run: |
+          cargo xtask generate-config-catalog
+          cargo xtask lint-config-catalog
+          cargo test -p praxis-proxy-config-catalog --all-features
+
       - name: Create draft pre-release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ github.ref_name }}
-        run: gh release create "$TAG" --generate-notes --prerelease --draft
+        run: |
+          VERSION="${TAG#v}"
+          ARTIFACT="praxis-core-config-catalog-${VERSION}.json"
+          cp docs/catalog/config-catalog.json "$ARTIFACT"
+          gh release create "$TAG" --generate-notes --prerelease --draft "$ARTIFACT"
 
   # ----------------------------------------------------------------------------
   # Phase 2 (release published): publish the crates to crates.io for real

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,6 +28,50 @@ env:
   V: ${{ inputs.debug && '1' || '' }}
 
 jobs:
+  # The catalog is a data-only public contract and must remain consumable by
+  # browser/WASM configuration tools.
+  config-catalog-wasm:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up Rust
+        uses: praxis-proxy/conventions/.github/actions/setup-rust@dc77dbd3a55ce96e8e31a3c8d36cea4952617dd3 # v0.1.0
+      - name: Install WASM target
+        run: rustup target add wasm32-unknown-unknown
+      - name: Check catalog for WASM
+        run: cargo check -p praxis-proxy-config-catalog --target wasm32-unknown-unknown
+
+  config-catalog-profiles:
+    name: catalog profile (${{ matrix.feature || 'default' }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - feature: ''
+          - feature: basic-auth-filter
+          - feature: policy-engine
+          - feature: otel
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up Rust
+        uses: praxis-proxy/conventions/.github/actions/setup-rust@dc77dbd3a55ce96e8e31a3c8d36cea4952617dd3 # v0.1.0
+      - name: Check registry/catalog parity
+        run: >-
+          cargo test -p xtask
+          ${{ matrix.feature != '' && format('--features {0}', matrix.feature) || '' }}
+          config_catalog
+
   # ----------------------------------------------------------------------------
   # Lint (fmt + clippy)
   # ----------------------------------------------------------------------------

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,8 @@ docs/**/
 !docs/filters/tcp/
 !docs/filters/tcp/*/
 !docs/operating/
+!docs/catalog/
+!docs/catalog/config-catalog.json
 !docs/proposals/
 
 # Praxis config files

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3195,6 +3195,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "praxis-proxy-config-catalog"
+version = "0.5.4"
+dependencies = [
+ "semver",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "praxis-proxy-core"
 version = "0.5.4"
 dependencies = [
@@ -5726,7 +5735,9 @@ dependencies = [
  "nix",
  "plotters",
  "praxis-proxy",
+ "praxis-proxy-config-catalog",
  "praxis-proxy-core",
+ "praxis-proxy-filter",
  "quote",
  "serde_json",
  "syn 3.0.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
 
     # Praxis Proxy Framework
     "crates/core",
+    "crates/config-catalog",
     "crates/filter",
     "crates/protocol",
     "crates/tls",
@@ -81,6 +82,7 @@ proptest = "1.11.0"
 quote = "1.0.47"
 praxis = { path = "crates/server", package = "praxis-proxy" }
 praxis-core = { version = "0.5.4", path = "crates/core", package = "praxis-proxy-core" }
+praxis-config-catalog = { version = "0.5.4", path = "crates/config-catalog", package = "praxis-proxy-config-catalog" }
 praxis-filter = { version = "0.5.4", path = "crates/filter", package = "praxis-proxy-filter" }
 praxis-protocol = { version = "0.5.4", path = "crates/protocol", package = "praxis-proxy-protocol" }
 praxis-tls = { version = "0.5.4", path = "crates/tls", package = "praxis-proxy-tls" }
@@ -89,6 +91,7 @@ secrecy = { version = "0.10.3", features = ["serde"] }
 serde = { version = "1.0.229", features = ["derive", "rc"] }
 smallvec = "1.16.0"
 serde_json = "1.0.151"
+semver = "1.0.27"
 sha2 = "0.11.0"
 subtle = "2.6.1"
 rcgen = "0.14.10"

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ LINT_EXTRA_CMDS := typos taplo shellcheck actionlint
 	check-prereqs-extra \
 	check-prereqs-nightly \
 	check-prereqs-nightly-toolchain \
-	setup-hooks \
+	setup-hooks generate-config-catalog lint-config-catalog \
 	help
 
 # Uses --version rather than command -v so we catch broken installs.
@@ -322,6 +322,7 @@ lint:
 	cargo xtask lint-example-tests
 	cargo xtask sync-example-readme
 	cargo xtask lint-filter-docs
+	cargo xtask lint-config-catalog
 
 lint-extra: check-prereqs-extra
 	typos
@@ -331,6 +332,12 @@ lint-extra: check-prereqs-extra
 
 generate-filter-docs:
 	cargo xtask generate-filter-docs
+
+generate-config-catalog:
+	cargo xtask generate-config-catalog
+
+lint-config-catalog:
+	cargo xtask lint-config-catalog
 
 mutants:
 	cargo mutants --workspace
@@ -348,7 +355,7 @@ audit:
 	cargo audit
 	cargo deny check
 
-PUBLISH_CRATES := praxis-proxy-tls praxis-proxy-core \
+PUBLISH_CRATES := praxis-proxy-config-catalog praxis-proxy-tls praxis-proxy-core \
 	praxis-proxy-filter praxis-proxy-protocol praxis-proxy
 
 publish-dry-run:
@@ -441,6 +448,8 @@ help:
 	@echo "  lint                 clippy (default + optional features) + rustfmt check + filter docs"
 	@echo "  lint-extra           typos + taplo + shellcheck + actionlint"
 	@echo "  generate-filter-docs generate per-filter docs under docs/filters/"
+	@echo "  generate-config-catalog generate the machine-readable configuration catalog"
+	@echo "  lint-config-catalog verify the machine-readable configuration catalog"
 	@echo "  fmt                  format with nightly rustfmt"
 	@echo "  audit                cargo audit + cargo deny"
 	@echo "  semver               cargo semver-checks"

--- a/crates/config-catalog/Cargo.toml
+++ b/crates/config-catalog/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "praxis-proxy-config-catalog"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "WASM-safe serialized configuration catalog types for Praxis"
+
+[features]
+default = []
+generator = []
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+semver = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/config-catalog/src/lib.rs
+++ b/crates/config-catalog/src/lib.rs
@@ -1,0 +1,1380 @@
+//! Stable, runtime-independent types used to describe Praxis configuration.
+//!
+//! This crate deliberately contains no proxy, filesystem, YAML, or async
+//! dependencies so it can be consumed by browser/WASM configuration tools.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::{Deserialize, Serialize};
+
+/// Current wire format version.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct CatalogFormatVersion {
+    /// Incompatible changes increment the major version.
+    pub major: u16,
+    /// Additive changes increment the minor version.
+    pub minor: u16,
+}
+
+/// Component producing a catalog fragment.
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "snake_case")]
+#[expect(
+    missing_docs,
+    reason = "serialized enum variants are defined by the catalog wire contract"
+)]
+pub enum ProducerComponent {
+    Core,
+    Ai,
+    Extension,
+}
+
+/// Producer provenance.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct ProducerInfo {
+    /// Logical producer kind.
+    pub component: ProducerComponent,
+    /// Package name.
+    pub package: String,
+    /// Package version.
+    pub version: String,
+    /// Optional source revision.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_revision: Option<String>,
+}
+
+/// Compatibility requirements for a fragment.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct CatalogCompatibility {
+    /// Required catalog format major version.
+    pub requires_format_major: u16,
+    /// Optional compatible Core package requirement.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requires_core: Option<VersionRequirement>,
+}
+
+/// Features available when a fragment was generated.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct FeatureProfile {
+    /// Features enabled for this artifact.
+    #[serde(default)]
+    pub available: BTreeSet<String>,
+    /// Features enabled by default.
+    #[serde(default)]
+    pub default_enabled: BTreeSet<String>,
+}
+
+/// Stable schema identifier.
+#[derive(Clone, Debug, Default, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(transparent)]
+pub struct SchemaId(pub String);
+
+impl From<String> for SchemaId {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl From<&str> for SchemaId {
+    fn from(value: &str) -> Self {
+        Self(value.to_owned())
+    }
+}
+
+impl std::fmt::Display for SchemaId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// A semver requirement for the Core package.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(transparent)]
+pub struct VersionRequirement(pub String);
+
+impl From<String> for VersionRequirement {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl From<&str> for VersionRequirement {
+    fn from(value: &str) -> Self {
+        Self(value.to_owned())
+    }
+}
+
+/// A complete producer-owned catalog fragment.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct CatalogFragment {
+    /// Wire format version.
+    pub format_version: CatalogFormatVersion,
+    /// Producer provenance.
+    pub producer: ProducerInfo,
+    /// Compatibility requirements.
+    pub compatibility: CatalogCompatibility,
+    /// Feature profile used to generate this fragment.
+    pub feature_profile: FeatureProfile,
+    /// Named reusable schemas.
+    #[serde(default)]
+    pub schemas: BTreeMap<SchemaId, ConfigSchema>,
+    /// Root configuration descriptors.
+    #[serde(default)]
+    pub roots: Vec<RootConfigDescriptor>,
+    /// Filter descriptors.
+    #[serde(default)]
+    pub filters: Vec<FilterDescriptor>,
+    /// Non-fatal generation diagnostics.
+    #[serde(default)]
+    pub diagnostics: Vec<CatalogDiagnostic>,
+}
+
+/// A validated composition of one Core fragment and extension fragments.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct MergedCatalog {
+    /// Combined catalog data.
+    pub fragment: CatalogFragment,
+    /// Producer identities included in the composition.
+    pub producers: Vec<ProducerInfo>,
+}
+
+/// Named configuration schema.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ConfigSchema {
+    /// Stable identifier.
+    pub id: SchemaId,
+    /// Human-readable title.
+    pub title: String,
+    /// Documentation.
+    #[serde(default)]
+    pub description: String,
+    /// Schema node.
+    pub node: SchemaNode,
+    /// Whether this schema is intentionally shared across producer fragments.
+    ///
+    /// Identical definitions may be coalesced during merge only when both
+    /// producers explicitly opt in. Provenance is still retained on the
+    /// resulting schema.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub shared: bool,
+    /// Producer provenance, populated for merged catalogs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub producer: Option<ProducerInfo>,
+}
+
+/// Omit a false wire flag while retaining serde's default for old fragments.
+#[expect(
+    clippy::trivially_copy_pass_by_ref,
+    reason = "serde skip_serializing_if requires a reference predicate"
+)]
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
+/// Schema node for a configuration value.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SchemaNode {
+    /// Node shape.
+    pub kind: SchemaKind,
+    /// Optional title.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    /// Documentation.
+    #[serde(default)]
+    pub description: String,
+    /// Literal default value.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default: Option<serde_json::Value>,
+    /// Example values.
+    #[serde(default)]
+    pub examples: Vec<serde_json::Value>,
+    /// Portable constraints.
+    #[serde(default)]
+    pub rules: Vec<PortableRule>,
+    /// Whether the value contains credentials or other secrets.
+    #[serde(default)]
+    pub sensitive: bool,
+}
+
+impl SchemaNode {
+    /// Construct a schema node with empty optional metadata.
+    #[must_use]
+    pub fn simple(kind: SchemaKind) -> Self {
+        Self {
+            kind,
+            title: None,
+            description: String::new(),
+            default: None,
+            examples: Vec::new(),
+            rules: Vec::new(),
+            sensitive: false,
+        }
+    }
+
+    /// Construct an array schema node.
+    #[must_use]
+    pub fn array(items: SchemaNode) -> Self {
+        Self::simple(SchemaKind::Array {
+            items: Box::new(items),
+            min_items: None,
+            max_items: None,
+        })
+    }
+
+    /// Construct a map schema node.
+    #[must_use]
+    pub fn map(values: SchemaNode) -> Self {
+        Self::simple(SchemaKind::Map {
+            values: Box::new(values),
+        })
+    }
+
+    /// Construct an object schema node.
+    #[must_use]
+    pub fn object(fields: Vec<ObjectField>) -> Self {
+        Self::simple(SchemaKind::Object {
+            fields,
+            additional_properties: false,
+        })
+    }
+
+    /// Construct an enum of string values.
+    #[must_use]
+    pub fn enum_strings(values: Vec<String>) -> Self {
+        Self::simple(SchemaKind::Enum {
+            values: values.into_iter().map(serde_json::Value::String).collect(),
+        })
+    }
+
+    /// Construct a literal schema node.
+    #[must_use]
+    pub fn literal(value: serde_json::Value) -> Self {
+        Self::simple(SchemaKind::Literal { value })
+    }
+
+    /// Construct a one-of schema node.
+    #[must_use]
+    pub fn one_of(variants: Vec<SchemaNode>) -> Self {
+        Self::one_of_with_discriminator(variants, None)
+    }
+
+    /// Construct a tagged union schema with an optional discriminator field.
+    #[must_use]
+    pub fn one_of_with_discriminator(variants: Vec<SchemaNode>, discriminator: Option<String>) -> Self {
+        Self::simple(SchemaKind::OneOf {
+            variants,
+            discriminator,
+        })
+    }
+
+    /// Construct a reference schema node.
+    #[must_use]
+    pub fn reference(schema_id: String) -> Self {
+        Self::simple(SchemaKind::Reference {
+            schema_id: SchemaId(schema_id),
+        })
+    }
+}
+
+/// Serializable configuration shape.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+#[expect(
+    missing_docs,
+    reason = "serialized schema variants are defined by the catalog wire contract"
+)]
+pub enum SchemaKind {
+    /// Unresolved source types are retained only for diagnostics and always
+    /// rejected by validation; generators must never emit this variant.
+    Any,
+    Boolean,
+    Integer,
+    Number,
+    String,
+    Null,
+    Literal {
+        value: serde_json::Value,
+    },
+    Enum {
+        values: Vec<serde_json::Value>,
+    },
+    Object {
+        fields: Vec<ObjectField>,
+        additional_properties: bool,
+    },
+    Array {
+        items: Box<SchemaNode>,
+        min_items: Option<usize>,
+        max_items: Option<usize>,
+    },
+    Map {
+        values: Box<SchemaNode>,
+    },
+    OneOf {
+        variants: Vec<SchemaNode>,
+        discriminator: Option<String>,
+    },
+    Reference {
+        schema_id: SchemaId,
+    },
+}
+
+/// Field in an object schema.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[expect(missing_docs, reason = "serialized fields are defined by the catalog wire contract")]
+pub struct ObjectField {
+    pub serialized_name: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub aliases: Vec<String>,
+    pub schema: SchemaNode,
+    pub required: bool,
+    #[serde(default)]
+    pub flattened: bool,
+}
+
+/// A filter's configuration descriptor.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[expect(missing_docs, reason = "serialized fields are defined by the catalog wire contract")]
+pub struct FilterDescriptor {
+    pub name: String,
+    pub protocol: Protocol,
+    pub category: String,
+    #[serde(default)]
+    pub description: String,
+    pub config_schema: SchemaId,
+    #[serde(default)]
+    pub required_features: BTreeSet<String>,
+    pub capabilities: FilterCapabilities,
+    #[serde(default)]
+    pub examples: Vec<ConfigExample>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<SourceLocation>,
+    /// Producer provenance retained when fragments are merged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub producer: Option<ProducerInfo>,
+}
+
+/// Runtime phase capabilities of a filter.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[expect(missing_docs, reason = "serialized fields are defined by the catalog wire contract")]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "phase capability flags are an independent wire contract"
+)]
+pub struct FilterCapabilities {
+    #[serde(default)]
+    pub security_class: SecurityClass,
+    #[serde(default)]
+    pub request_headers: bool,
+    #[serde(default)]
+    pub request_body: bool,
+    #[serde(default)]
+    pub response_headers: bool,
+    #[serde(default)]
+    pub response_body: bool,
+    #[serde(default)]
+    pub terminal: bool,
+}
+
+/// Example YAML configuration.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[expect(missing_docs, reason = "serialized fields are defined by the catalog wire contract")]
+pub struct ConfigExample {
+    pub yaml: String,
+}
+
+/// Source location relative to the producer repository.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[expect(missing_docs, reason = "serialized fields are defined by the catalog wire contract")]
+pub struct SourceLocation {
+    pub path: String,
+    pub line: Option<u32>,
+}
+
+/// Root configuration descriptor.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[expect(missing_docs, reason = "serialized fields are defined by the catalog wire contract")]
+pub struct RootConfigDescriptor {
+    pub name: String,
+    pub schema: SchemaId,
+}
+
+/// A portable validation rule.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[expect(missing_docs, reason = "serialized fields are defined by the catalog wire contract")]
+pub struct PortableRule {
+    pub code: String,
+    pub target: String,
+    pub kind: RuleKind,
+    #[serde(default)]
+    pub parameters: BTreeMap<String, serde_json::Value>,
+    pub message: String,
+}
+
+/// A generator diagnostic.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[expect(missing_docs, reason = "serialized fields are defined by the catalog wire contract")]
+pub struct CatalogDiagnostic {
+    pub severity: DiagnosticSeverity,
+    pub code: String,
+    pub target: String,
+    pub message: String,
+}
+
+/// Protocol implemented by a filter.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "snake_case")]
+#[expect(missing_docs, reason = "variants are defined by the catalog wire contract")]
+pub enum Protocol {
+    Http,
+    Tcp,
+}
+
+/// Security classification for a filter.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "snake_case")]
+#[expect(missing_docs, reason = "variants are defined by the catalog wire contract")]
+pub enum SecurityClass {
+    #[default]
+    Standard,
+    Security,
+}
+
+/// Severity of a generation diagnostic.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "snake_case")]
+#[expect(missing_docs, reason = "variants are defined by the catalog wire contract")]
+pub enum DiagnosticSeverity {
+    Info,
+    Warning,
+    Error,
+}
+
+/// Portable validation rule kinds supported by format version 1.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "snake_case")]
+#[expect(missing_docs, reason = "variants are defined by the catalog wire contract")]
+pub enum RuleKind {
+    NumericBounds,
+    LengthBounds,
+    Pattern,
+    NonEmpty,
+    MutualExclusion,
+    AtLeastOne,
+    UniqueItems,
+    ReferenceToNamedObject,
+}
+
+impl CatalogFragment {
+    /// Validate the complete fragment contract.
+    ///
+    /// # Errors
+    ///
+    /// Returns a structured error when any semantic identity, compatibility
+    /// requirement, or schema reference violates the wire contract.
+    pub fn validate(&self) -> Result<(), ValidationError> {
+        if self.format_version.major != self.compatibility.requires_format_major {
+            return Err(ValidationError::Compatibility {
+                expected: self.format_version.major,
+                found: self.compatibility.requires_format_major,
+            });
+        }
+        self.validate_descriptors()?;
+        if !self
+            .feature_profile
+            .default_enabled
+            .is_subset(&self.feature_profile.available)
+        {
+            return Err(ValidationError::UnknownFeature {
+                filter: "feature_profile.default_enabled".to_owned(),
+            });
+        }
+        if let Some(filter) = self
+            .filters
+            .iter()
+            .find(|filter| !filter.required_features.is_subset(&self.feature_profile.available))
+        {
+            return Err(ValidationError::UnknownFeature {
+                filter: filter.name.clone(),
+            });
+        }
+        self.validate_schema_ids()?;
+        self.validate_schema_nodes()?;
+        Ok(())
+    }
+
+    /// Validate descriptor identity and references.
+    fn validate_descriptors(&self) -> Result<(), ValidationError> {
+        let mut names = BTreeSet::new();
+        let mut sources = BTreeSet::new();
+        for filter in &self.filters {
+            if !names.insert(&filter.name) {
+                return Err(ValidationError::DuplicateFilter(filter.name.clone()));
+            }
+            if let Some(source) = &filter.source
+                && !sources.insert((&filter.name, &source.path, source.line))
+            {
+                return Err(ValidationError::DuplicateSource(source.path.clone()));
+            }
+            if !self.schemas.contains_key(&filter.config_schema) {
+                return Err(ValidationError::DanglingSchema {
+                    target: filter.config_schema.clone(),
+                });
+            }
+        }
+        let mut roots = BTreeSet::new();
+        for root in &self.roots {
+            if !roots.insert(&root.name) {
+                return Err(ValidationError::Duplicate {
+                    kind: "root",
+                    name: root.name.clone(),
+                });
+            }
+            if !self.schemas.contains_key(&root.schema) {
+                return Err(ValidationError::DanglingSchema {
+                    target: root.schema.clone(),
+                });
+            }
+        }
+        Ok(())
+    }
+
+    /// Validate map keys against embedded schema IDs.
+    fn validate_schema_ids(&self) -> Result<(), ValidationError> {
+        for (id, schema) in &self.schemas {
+            if id != &schema.id {
+                return Err(ValidationError::SchemaIdMismatch {
+                    key: id.clone(),
+                    embedded: schema.id.clone(),
+                });
+            }
+        }
+        Ok(())
+    }
+
+    /// Validate every schema node recursively.
+    fn validate_schema_nodes(&self) -> Result<(), ValidationError> {
+        for (id, schema) in &self.schemas {
+            validate_node(&schema.node, &self.schemas).map_err(|error| ValidationError::Schema {
+                id: id.clone(),
+                source: Box::new(error),
+            })?;
+        }
+        Ok(())
+    }
+}
+
+/// Structured errors returned by fragment validation.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[expect(missing_docs, reason = "variants describe stable structured generator failures")]
+pub enum ValidationError {
+    Compatibility { expected: u16, found: u16 },
+    Duplicate { kind: &'static str, name: String },
+    DanglingSchema { target: SchemaId },
+    SchemaIdMismatch { key: SchemaId, embedded: SchemaId },
+    UnresolvedAny,
+    Schema { id: SchemaId, source: Box<Self> },
+    MissingFeatures { filter: String },
+    DuplicateFilter(String),
+    DuplicateSource(String),
+    UnknownFeature { filter: String },
+}
+
+impl ValidationError {
+    /// Stable machine-readable error code.
+    #[must_use]
+    pub const fn code(&self) -> &'static str {
+        match self {
+            Self::Compatibility { .. } => "format_major_mismatch",
+            Self::Duplicate { .. } => "duplicate_identity",
+            Self::DuplicateFilter(_) => "duplicate_filter",
+            Self::DuplicateSource(_) => "duplicate_source",
+            Self::DanglingSchema { .. } => "dangling_reference",
+            Self::SchemaIdMismatch { .. } => "schema_id_mismatch",
+            Self::UnresolvedAny => "unresolved_any",
+            Self::Schema { source, .. } => source.code(),
+            Self::MissingFeatures { .. } => "missing_features",
+            Self::UnknownFeature { .. } => "unknown_feature",
+        }
+    }
+}
+
+impl std::fmt::Display for ValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Compatibility { expected, found } => {
+                write!(f, "format major {found} is incompatible with {expected}")
+            },
+            Self::Duplicate { kind, name } => write!(f, "duplicate {kind}: {name}"),
+            Self::DanglingSchema { target } => write!(f, "dangling schema: {target}"),
+            Self::SchemaIdMismatch { key, embedded } => {
+                write!(f, "schema key {key} does not match embedded id {embedded}")
+            },
+            Self::UnresolvedAny => f.write_str("unresolved `any` schema is not allowed"),
+            Self::DuplicateFilter(name) => write!(f, "duplicate filter: {name}"),
+            Self::DuplicateSource(path) => write!(f, "duplicate filter source: {path}"),
+            Self::MissingFeatures { filter } | Self::UnknownFeature { filter } => {
+                write!(f, "filter {filter} requires unavailable features")
+            },
+            Self::Schema { id, source } => write!(f, "{id}: {source}"),
+        }
+    }
+}
+
+/// Validate a schema node and every nested reference.
+fn validate_node(node: &SchemaNode, schemas: &BTreeMap<SchemaId, ConfigSchema>) -> Result<(), ValidationError> {
+    match &node.kind {
+        SchemaKind::Any => Err(ValidationError::UnresolvedAny),
+        SchemaKind::Reference { schema_id } if !schemas.contains_key(schema_id) => {
+            Err(ValidationError::DanglingSchema {
+                target: schema_id.clone(),
+            })
+        },
+        SchemaKind::Object { fields, .. } => fields
+            .iter()
+            .try_for_each(|field| validate_node(&field.schema, schemas)),
+        SchemaKind::Array { items, .. } => validate_node(items, schemas),
+        SchemaKind::Map { values } => validate_node(values, schemas),
+        SchemaKind::OneOf { variants, .. } => variants.iter().try_for_each(|variant| validate_node(variant, schemas)),
+        SchemaKind::Boolean
+        | SchemaKind::Integer
+        | SchemaKind::Number
+        | SchemaKind::String
+        | SchemaKind::Null
+        | SchemaKind::Literal { .. }
+        | SchemaKind::Enum { .. }
+        | SchemaKind::Reference { .. } => Ok(()),
+    }
+}
+
+/// Host-side catalog generation helpers.
+///
+/// The serialized model above is intentionally usable in WASM. This module is
+/// enabled only by the `generator` feature and is the single policy seam for
+/// validating and rendering producer fragments. Consumers provide discovery
+/// data and descriptors; they do not implement their own finalization rules.
+pub mod generator {
+    use std::collections::BTreeSet;
+
+    use super::{CatalogFragment, ConfigSchema, MergedCatalog};
+
+    /// Errors produced while finalizing a catalog fragment.
+    #[cfg(feature = "generator")]
+    #[derive(Debug)]
+    pub enum GenerationError {
+        /// The fragment violates the catalog contract.
+        Invalid(crate::ValidationError),
+        /// JSON serialization failed.
+        Serialization(serde_json::Error),
+    }
+
+    #[cfg(feature = "generator")]
+    impl std::fmt::Display for GenerationError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Invalid(error) => error.fmt(f),
+                Self::Serialization(error) => write!(f, "catalog serialization failed: {error}"),
+            }
+        }
+    }
+
+    #[cfg(feature = "generator")]
+    impl std::error::Error for GenerationError {}
+
+    /// Validate and render a producer fragment deterministically.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if validation fails or JSON serialization fails.
+    #[cfg(feature = "generator")]
+    pub fn render(mut fragment: CatalogFragment) -> Result<Vec<u8>, GenerationError> {
+        let producer = fragment.producer.clone();
+        for schema in fragment.schemas.values_mut() {
+            schema.producer.get_or_insert_with(|| producer.clone());
+        }
+        for filter in &mut fragment.filters {
+            filter.producer.get_or_insert_with(|| producer.clone());
+        }
+        fragment.filters.sort_by(|left, right| {
+            (&left.protocol, &left.category, &left.name).cmp(&(&right.protocol, &right.category, &right.name))
+        });
+        fragment.validate().map_err(GenerationError::Invalid)?;
+        let mut bytes = serde_json::to_vec_pretty(&fragment).map_err(GenerationError::Serialization)?;
+        bytes.push(b'\n');
+        Ok(bytes)
+    }
+
+    /// Validate a fragment without rendering it.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the fragment violates the catalog contract.
+    #[cfg(feature = "generator")]
+    pub fn validate(fragment: &CatalogFragment) -> Result<(), GenerationError> {
+        fragment.validate().map_err(GenerationError::Invalid)
+    }
+
+    /// Merge a Core fragment with one or more extension fragments.
+    ///
+    /// The operation is pure: inputs are validated, semantic collections are
+    /// combined, and the returned fragment is rendered with the same policy as
+    /// a single producer. Extension provenance remains on each descriptor's
+    /// source path; duplicate names or schema IDs are rejected closed.
+    ///
+    /// # Errors
+    ///
+    /// Returns a structured error when an input is invalid or identities and
+    /// compatibility requirements collide.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "merge keeps the producer identity transaction explicit"
+    )]
+    pub fn merge(core: CatalogFragment, extensions: Vec<CatalogFragment>) -> Result<MergedCatalog, MergeError> {
+        core.validate().map_err(MergeError::InvalidCore)?;
+        if core.producer.component != crate::ProducerComponent::Core {
+            return Err(MergeError::ProducerKind("core fragment required first".to_owned()));
+        }
+        let mut producers = vec![core.producer.clone()];
+        let mut merged = core;
+        let core_producer = merged.producer.clone();
+        for filter in &mut merged.filters {
+            filter.producer.get_or_insert_with(|| core_producer.clone());
+        }
+        for schema in merged.schemas.values_mut() {
+            schema.producer.get_or_insert_with(|| core_producer.clone());
+        }
+        let mut identities = BTreeSet::new();
+        identities.insert((merged.producer.package.clone(), merged.producer.source_revision.clone()));
+        for extension in extensions {
+            let identity = (
+                extension.producer.package.clone(),
+                extension.producer.source_revision.clone(),
+            );
+            if !identities.insert(identity) {
+                return Err(MergeError::DuplicateProducer);
+            }
+            producers.push(extension.producer.clone());
+            merge_extension(&mut merged, extension)?;
+        }
+        merged.validate().map_err(MergeError::Merged)?;
+        merged.filters.sort_by(|left, right| {
+            (&left.protocol, &left.category, &left.name).cmp(&(&right.protocol, &right.category, &right.name))
+        });
+        Ok(MergedCatalog {
+            fragment: merged,
+            producers,
+        })
+    }
+
+    /// Validate extension compatibility and append its owned data.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "merge invariants are kept together at the pure merge seam"
+    )]
+    fn merge_extension(merged: &mut CatalogFragment, mut extension: CatalogFragment) -> Result<(), MergeError> {
+        if extension.format_version.major != merged.format_version.major {
+            return Err(MergeError::FormatMajor {
+                expected: merged.format_version.major,
+                found: extension.format_version.major,
+            });
+        }
+        if !extension.roots.is_empty() {
+            return Err(MergeError::ExtensionRoots);
+        }
+        extension.validate().map_err(MergeError::InvalidExtension)?;
+        if extension.producer.component == crate::ProducerComponent::Core {
+            return Err(MergeError::ProducerKind(
+                "only one Core fragment may be merged".to_owned(),
+            ));
+        }
+        if let Some(requirement) = extension.compatibility.requires_core.as_ref()
+            && !version_satisfies(&merged.producer.version, &requirement.0)?
+        {
+            return Err(MergeError::CoreRequirement(requirement.0.clone()));
+        }
+        for filter in &extension.filters {
+            if !filter.required_features.is_subset(&extension.feature_profile.available) {
+                return Err(MergeError::MissingFeatures);
+            }
+        }
+        for filter in &mut extension.filters {
+            filter.producer = Some(extension.producer.clone());
+        }
+        for (id, schema) in extension.schemas {
+            let owned_schema = ConfigSchema {
+                producer: Some(extension.producer.clone()),
+                ..schema
+            };
+            if let Some(existing) = merged.schemas.get(&id) {
+                if !(existing.shared && owned_schema.shared && schemas_equal_ignoring_producer(existing, &owned_schema))
+                {
+                    return Err(MergeError::DuplicateSchema(id));
+                }
+                continue;
+            }
+            merged.schemas.insert(id, owned_schema);
+        }
+        merged.filters.extend(extension.filters);
+        merged.diagnostics.extend(extension.diagnostics);
+        merged
+            .feature_profile
+            .available
+            .extend(extension.feature_profile.available);
+        merged
+            .feature_profile
+            .default_enabled
+            .extend(extension.feature_profile.default_enabled);
+        Ok(())
+    }
+
+    /// Compare schema definitions while excluding merge-populated provenance.
+    fn schemas_equal_ignoring_producer(left: &ConfigSchema, right: &ConfigSchema) -> bool {
+        let mut left = left.clone();
+        let mut right = right.clone();
+        left.producer = None;
+        right.producer = None;
+        serde_json::to_value(left).ok() == serde_json::to_value(right).ok()
+    }
+
+    /// Check the supported major-version requirement syntax.
+    fn version_satisfies(version: &str, requirement: &str) -> Result<bool, MergeError> {
+        let version =
+            semver::Version::parse(version).map_err(|_error| MergeError::MalformedVersion(version.to_owned()))?;
+        let requirement = semver::VersionReq::parse(requirement)
+            .map_err(|_error| MergeError::MalformedRequirement(requirement.to_owned()))?;
+        Ok(requirement.matches(&version))
+    }
+
+    /// Errors returned when combining producer fragments.
+    #[derive(Debug)]
+    #[expect(missing_docs, reason = "variants describe stable structured merge failures")]
+    pub enum MergeError {
+        /// The Core input is invalid.
+        InvalidCore(crate::ValidationError),
+        /// An extension input is invalid.
+        InvalidExtension(crate::ValidationError),
+        /// The resulting fragment is invalid.
+        Merged(crate::ValidationError),
+        /// A fragment has an incompatible wire major.
+        FormatMajor { expected: u16, found: u16 },
+        /// A producer-kind constraint was violated.
+        ProducerKind(String),
+        /// Two producers declared the same schema ID.
+        DuplicateSchema(crate::SchemaId),
+        /// The extension requires a Core version that is not present.
+        CoreRequirement(String),
+        /// The extension requires unavailable features.
+        MissingFeatures,
+        /// Two fragments declared the same producer identity.
+        DuplicateProducer,
+        /// Extensions may not contribute roots.
+        ExtensionRoots,
+        /// Core producer version was malformed.
+        MalformedVersion(String),
+        /// Extension Core requirement was malformed.
+        MalformedRequirement(String),
+    }
+
+    impl std::fmt::Display for MergeError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::InvalidCore(error) => write!(f, "invalid Core fragment: {error}"),
+                Self::InvalidExtension(error) => write!(f, "invalid extension fragment: {error}"),
+                Self::FormatMajor { expected, found } => {
+                    write!(f, "format major {found} is incompatible with {expected}")
+                },
+                Self::Merged(error) => write!(f, "invalid merged fragment: {error}"),
+                Self::ProducerKind(error) => f.write_str(error),
+                Self::DuplicateSchema(id) => write!(f, "duplicate schema: {id}"),
+                Self::CoreRequirement(requirement) => write!(f, "Core version does not satisfy {requirement}"),
+                Self::MissingFeatures => f.write_str("extension requires unavailable features"),
+                Self::DuplicateProducer => f.write_str("duplicate producer identity"),
+                Self::ExtensionRoots => f.write_str("extensions may not define roots"),
+                Self::MalformedVersion(version) => write!(f, "malformed Core version: {version}"),
+                Self::MalformedRequirement(requirement) => write!(f, "malformed Core requirement: {requirement}"),
+            }
+        }
+    }
+
+    impl MergeError {
+        /// Stable machine-readable merge error code.
+        #[must_use]
+        pub const fn code(&self) -> &'static str {
+            match self {
+                Self::InvalidCore(error) | Self::InvalidExtension(error) | Self::Merged(error) => error.code(),
+                Self::FormatMajor { .. } => "incompatible_format",
+                Self::ProducerKind(_) => "non_core_first",
+                Self::DuplicateSchema(_) => "schema_collision",
+                Self::CoreRequirement(_) => "incompatible_core_version",
+                Self::MissingFeatures => "unknown_feature",
+                Self::DuplicateProducer => "duplicate_producer",
+                Self::ExtensionRoots => "extension_roots",
+                Self::MalformedVersion(_) => "malformed_version",
+                Self::MalformedRequirement(_) => "malformed_requirement",
+            }
+        }
+    }
+
+    impl std::error::Error for MergeError {}
+
+    #[cfg(test)]
+    mod tests {
+        use std::collections::BTreeMap;
+
+        use super::*;
+        use crate::{
+            CatalogCompatibility, CatalogFormatVersion, FeatureProfile, FilterCapabilities, ProducerComponent,
+            ProducerInfo, Protocol, SchemaId, SchemaKind, SchemaNode,
+        };
+
+        fn fragment() -> CatalogFragment {
+            CatalogFragment {
+                format_version: CatalogFormatVersion { major: 1, minor: 0 },
+                producer: ProducerInfo {
+                    component: ProducerComponent::Core,
+                    package: "test".to_owned(),
+                    version: "0.0.0".to_owned(),
+                    source_revision: None,
+                },
+                compatibility: CatalogCompatibility::default(),
+                feature_profile: FeatureProfile::default(),
+                schemas: BTreeMap::default(),
+                roots: Vec::new(),
+                filters: Vec::new(),
+                diagnostics: Vec::new(),
+            }
+        }
+
+        fn owned(component: ProducerComponent, package: &str) -> CatalogFragment {
+            let mut value = fragment();
+            value.producer = ProducerInfo {
+                component,
+                package: package.to_owned(),
+                version: "1.2.3".to_owned(),
+                source_revision: Some(package.to_owned()),
+            };
+            value.compatibility.requires_format_major = 1;
+            value.feature_profile.available.insert("feature-a".to_owned());
+            value
+        }
+
+        fn with_filter(mut value: CatalogFragment, name: &str, schema: &str) -> CatalogFragment {
+            value.schemas.insert(
+                schema.into(),
+                ConfigSchema {
+                    id: schema.into(),
+                    title: name.to_owned(),
+                    description: String::new(),
+                    shared: false,
+                    node: SchemaNode::simple(SchemaKind::String),
+                    producer: None,
+                },
+            );
+            value.filters.push(crate::FilterDescriptor {
+                name: name.to_owned(),
+                protocol: Protocol::Http,
+                category: "test".to_owned(),
+                description: String::new(),
+                config_schema: schema.into(),
+                required_features: BTreeSet::new(),
+                capabilities: FilterCapabilities::default(),
+                examples: Vec::new(),
+                source: None,
+                producer: None,
+            });
+            value
+        }
+
+        #[cfg(feature = "generator")]
+        #[test]
+        fn render_rejects_dangling_schema() {
+            let mut value = fragment();
+            value.filters.push(crate::FilterDescriptor {
+                name: "z".to_owned(),
+                protocol: Protocol::Http,
+                category: "b".to_owned(),
+                description: String::new(),
+                config_schema: "missing".into(),
+                required_features: BTreeSet::default(),
+                capabilities: FilterCapabilities::default(),
+                examples: Vec::new(),
+                source: None,
+                producer: None,
+            });
+            assert!(render(value).is_err(), "dangling schemas must be rejected");
+        }
+
+        #[test]
+        #[expect(
+            clippy::expect_used,
+            clippy::min_ident_chars,
+            reason = "merge success assertions remain concise"
+        )]
+        fn merge_sorts_and_preserves_roots_and_provenance() {
+            let mut core = with_filter(owned(ProducerComponent::Core, "core"), "z", "core.z");
+            core.roots.push(crate::RootConfigDescriptor {
+                name: "Config".to_owned(),
+                schema: "core.z".into(),
+            });
+            let extension = with_filter(owned(ProducerComponent::Extension, "ext"), "a", "ext.a");
+            let merged = merge(core, vec![extension]).expect("compatible fragments merge");
+            assert_eq!(
+                merged
+                    .fragment
+                    .filters
+                    .iter()
+                    .map(|f| f.name.as_str())
+                    .collect::<Vec<_>>(),
+                ["a", "z"]
+            );
+            assert_eq!(merged.fragment.roots.len(), 1);
+            assert!(merged.fragment.filters.iter().all(|f| f.producer.is_some()));
+            assert!(merged.fragment.schemas.values().all(|s| s.producer.is_some()));
+        }
+
+        #[test]
+        #[expect(
+            clippy::expect_used,
+            clippy::indexing_slicing,
+            clippy::too_many_lines,
+            reason = "matrix test intentionally enumerates each stable merge failure code"
+        )]
+        fn merge_reports_exact_contract_errors() {
+            let core = owned(ProducerComponent::Core, "core");
+            let mut wrong_format = owned(ProducerComponent::Extension, "fmt");
+            wrong_format.format_version.major = 2;
+            assert_eq!(
+                merge(core.clone(), vec![wrong_format])
+                    .expect_err("format mismatch")
+                    .code(),
+                "incompatible_format"
+            );
+
+            let mut bad_version = owned(ProducerComponent::Extension, "version");
+            bad_version.compatibility.requires_core = Some("not semver".into());
+            assert_eq!(
+                merge(core.clone(), vec![bad_version])
+                    .expect_err("malformed requirement")
+                    .code(),
+                "malformed_requirement"
+            );
+
+            let mut bad_feature = with_filter(
+                owned(ProducerComponent::Extension, "feature"),
+                "feature",
+                "feature.schema",
+            );
+            bad_feature.filters[0].required_features.insert("missing".to_owned());
+            assert_eq!(
+                merge(core.clone(), vec![bad_feature])
+                    .expect_err("unknown feature")
+                    .code(),
+                "unknown_feature"
+            );
+
+            let mut roots = owned(ProducerComponent::Extension, "roots");
+            roots.roots.push(crate::RootConfigDescriptor {
+                name: "Root".to_owned(),
+                schema: "missing".into(),
+            });
+            assert_eq!(
+                merge(core.clone(), vec![roots]).expect_err("extension roots").code(),
+                "extension_roots"
+            );
+
+            let duplicate = owned(ProducerComponent::Extension, "core");
+            assert_eq!(
+                merge(core.clone(), vec![duplicate])
+                    .expect_err("duplicate producer")
+                    .code(),
+                "duplicate_producer"
+            );
+            let non_core = owned(ProducerComponent::Extension, "first");
+            assert_eq!(
+                merge(non_core, Vec::new()).expect_err("Core must be first").code(),
+                "non_core_first"
+            );
+        }
+
+        #[test]
+        #[expect(
+            clippy::expect_used,
+            clippy::shadow_unrelated,
+            reason = "collision assertions use exact structured error codes"
+        )]
+        fn merge_rejects_filter_and_schema_collisions() {
+            let core = with_filter(owned(ProducerComponent::Core, "core"), "same", "core.same");
+            let filter = with_filter(owned(ProducerComponent::Extension, "ext"), "same", "ext.same");
+            assert_eq!(
+                merge(core, vec![filter]).expect_err("duplicate filter").code(),
+                "duplicate_filter"
+            );
+            let core = with_filter(owned(ProducerComponent::Core, "core"), "core", "shared");
+            let extension = with_filter(owned(ProducerComponent::Extension, "ext"), "ext", "shared");
+            assert_eq!(
+                merge(core, vec![extension]).expect_err("schema collision").code(),
+                "schema_collision"
+            );
+        }
+
+        #[test]
+        #[expect(
+            clippy::expect_used,
+            reason = "shared-schema merge assertions need readable failures"
+        )]
+        fn merge_allows_identical_explicitly_shared_schema() {
+            let mut core = with_filter(owned(ProducerComponent::Core, "core"), "core", "shared");
+            let mut extension = with_filter(owned(ProducerComponent::Extension, "ext"), "ext", "shared");
+            core.schemas
+                .get_mut(&SchemaId("shared".into()))
+                .expect("shared schema")
+                .shared = true;
+            extension
+                .schemas
+                .get_mut(&SchemaId("shared".into()))
+                .expect("shared schema")
+                .shared = true;
+            extension
+                .schemas
+                .get_mut(&SchemaId("shared".into()))
+                .expect("shared schema")
+                .title = "core".into();
+            let merged = merge(core, vec![extension]).expect("shared definitions may be coalesced");
+            assert_eq!(merged.fragment.schemas.len(), 1);
+            assert_eq!(
+                merged
+                    .fragment
+                    .schemas
+                    .get(&SchemaId("shared".into()))
+                    .expect("merged shared schema")
+                    .producer
+                    .as_ref()
+                    .expect("schema provenance")
+                    .package,
+                "core"
+            );
+        }
+
+        #[test]
+        #[expect(
+            clippy::expect_used,
+            reason = "shared-schema negative assertions need readable failures"
+        )]
+        fn merge_requires_both_shared_and_identical_definitions() {
+            let mut core = with_filter(owned(ProducerComponent::Core, "core"), "core", "shared");
+            let mut extension = with_filter(owned(ProducerComponent::Extension, "ext"), "ext", "shared");
+            core.schemas
+                .get_mut(&SchemaId("shared".into()))
+                .expect("shared schema")
+                .shared = true;
+            assert_eq!(
+                merge(core.clone(), vec![extension.clone()])
+                    .expect_err("one-sided sharing")
+                    .code(),
+                "schema_collision"
+            );
+            extension
+                .schemas
+                .get_mut(&SchemaId("shared".into()))
+                .expect("shared schema")
+                .shared = true;
+            extension
+                .schemas
+                .get_mut(&SchemaId("shared".into()))
+                .expect("shared schema")
+                .title = "different".into();
+            assert_eq!(
+                merge(core, vec![extension])
+                    .expect_err("different shared definitions")
+                    .code(),
+                "schema_collision"
+            );
+        }
+
+        #[test]
+        fn fragment_allows_distinct_filters_from_one_source_file() {
+            let mut value = with_filter(owned(ProducerComponent::Core, "core"), "first", "first");
+            value.filters[0].source = Some(crate::SourceLocation {
+                path: "src/filter.rs".to_owned(),
+                line: Some(10),
+            });
+            let mut second = with_filter(value.clone(), "second", "second");
+            second.filters[1].source = Some(crate::SourceLocation {
+                path: "src/filter.rs".to_owned(),
+                line: Some(10),
+            });
+            second.validate().expect("distinct descriptors may share a source file");
+        }
+    }
+}
+
+/// Pure fragment composition APIs available to WASM consumers.
+pub mod merge {
+    pub use super::generator::{MergeError, merge};
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[expect(clippy::expect_used, reason = "default-surface smoke test needs a clear failure")]
+    fn default_surface_exposes_pure_merge() {
+        let fragment = CatalogFragment {
+            format_version: CatalogFormatVersion { major: 1, minor: 0 },
+            producer: ProducerInfo {
+                component: ProducerComponent::Core,
+                package: "core".into(),
+                version: "1.0.0".into(),
+                source_revision: None,
+            },
+            compatibility: CatalogCompatibility {
+                requires_format_major: 1,
+                requires_core: None,
+            },
+            feature_profile: FeatureProfile::default(),
+            schemas: BTreeMap::new(),
+            roots: Vec::new(),
+            filters: Vec::new(),
+            diagnostics: Vec::new(),
+        };
+        let merged = merge::merge(fragment, Vec::new()).expect("pure merge is available without generator feature");
+        assert_eq!(merged.producers.len(), 1);
+    }
+
+    #[test]
+    #[expect(
+        clippy::expect_used,
+        reason = "invalid fixture must produce a structured validation error"
+    )]
+    fn default_enabled_features_must_be_available() {
+        let fragment = CatalogFragment {
+            format_version: CatalogFormatVersion { major: 1, minor: 0 },
+            producer: ProducerInfo {
+                component: ProducerComponent::Core,
+                package: "core".into(),
+                version: "1.0.0".into(),
+                source_revision: None,
+            },
+            compatibility: CatalogCompatibility {
+                requires_format_major: 1,
+                requires_core: None,
+            },
+            feature_profile: FeatureProfile {
+                available: BTreeSet::new(),
+                default_enabled: BTreeSet::from(["missing-feature".to_owned()]),
+            },
+            schemas: BTreeMap::new(),
+            roots: Vec::new(),
+            filters: Vec::new(),
+            diagnostics: Vec::new(),
+        };
+
+        assert_eq!(
+            fragment.validate().expect_err("invalid feature profile").code(),
+            "unknown_feature"
+        );
+    }
+
+    #[test]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "round-trip fixture defines the complete wire shape"
+    )]
+    #[expect(clippy::expect_used, reason = "round-trip assertions need readable failure messages")]
+    fn fragment_round_trips_and_validates() {
+        let id = "core.filter.http.test".to_owned();
+        let mut fragment = CatalogFragment {
+            format_version: CatalogFormatVersion { major: 1, minor: 0 },
+            producer: ProducerInfo {
+                component: ProducerComponent::Core,
+                package: "core".into(),
+                version: "0.1.0".into(),
+                source_revision: None,
+            },
+            compatibility: CatalogCompatibility {
+                requires_format_major: 1,
+                requires_core: None,
+            },
+            feature_profile: FeatureProfile::default(),
+            schemas: BTreeMap::new(),
+            roots: vec![],
+            filters: vec![],
+            diagnostics: vec![],
+        };
+        fragment.schemas.insert(
+            SchemaId(id.clone()),
+            ConfigSchema {
+                id: SchemaId(id.clone()),
+                title: "Test".into(),
+                description: String::new(),
+                shared: false,
+                node: SchemaNode {
+                    kind: SchemaKind::String,
+                    title: None,
+                    description: String::new(),
+                    default: None,
+                    examples: vec![],
+                    rules: vec![],
+                    sensitive: false,
+                },
+                producer: None,
+            },
+        );
+        fragment.filters.push(FilterDescriptor {
+            name: "test".into(),
+            protocol: Protocol::Http,
+            category: "test".into(),
+            description: String::new(),
+            config_schema: SchemaId(id),
+            required_features: BTreeSet::new(),
+            capabilities: FilterCapabilities::default(),
+            examples: vec![],
+            source: None,
+            producer: None,
+        });
+        fragment.validate().expect("fixture must validate");
+        let encoded = serde_json::to_string(&fragment).expect("catalog must serialize");
+        let decoded: CatalogFragment = serde_json::from_str(&encoded).expect("catalog must deserialize");
+        assert_eq!(decoded.filters.len(), 1);
+    }
+
+    #[test]
+    #[expect(clippy::too_many_lines, reason = "negative fixture documents the fail-closed policy")]
+    fn unresolved_any_is_rejected_fail_closed() {
+        let mut fragment = CatalogFragment {
+            format_version: CatalogFormatVersion { major: 1, minor: 0 },
+            producer: ProducerInfo {
+                component: ProducerComponent::Core,
+                package: "core".into(),
+                version: "0.1.0".into(),
+                source_revision: None,
+            },
+            compatibility: CatalogCompatibility {
+                requires_format_major: 1,
+                requires_core: None,
+            },
+            feature_profile: FeatureProfile::default(),
+            schemas: BTreeMap::new(),
+            roots: Vec::new(),
+            filters: Vec::new(),
+            diagnostics: Vec::new(),
+        };
+        let id: SchemaId = "core.any".into();
+        fragment.schemas.insert(
+            id.clone(),
+            ConfigSchema {
+                id,
+                title: "Any".into(),
+                description: String::new(),
+                shared: false,
+                node: SchemaNode::simple(SchemaKind::Any),
+                producer: None,
+            },
+        );
+        assert!(
+            matches!(fragment.validate(), Err(ValidationError::Schema { source, .. }) if matches!(*source, ValidationError::UnresolvedAny)),
+            "unresolved source types must fail closed"
+        );
+    }
+}

--- a/docs/catalog/config-catalog.json
+++ b/docs/catalog/config-catalog.json
@@ -1,0 +1,10865 @@
+{
+  "format_version": {
+    "major": 1,
+    "minor": 0
+  },
+  "producer": {
+    "component": "core",
+    "package": "praxis-proxy-core",
+    "version": "0.5.4"
+  },
+  "compatibility": {
+    "requires_format_major": 1
+  },
+  "feature_profile": {
+    "available": [
+      "basic-auth-filter",
+      "default",
+      "otel",
+      "policy-engine"
+    ],
+    "default_enabled": []
+  },
+  "schemas": {
+    "core.filter.entry.config": {
+      "id": "core.filter.entry.config",
+      "title": "Filter configuration payload",
+      "description": "Discriminated filter payload; the selected filter supplies the referenced configuration schema.",
+      "node": {
+        "kind": {
+          "kind": "one_of",
+          "variants": [
+            {
+              "kind": {
+                "kind": "reference",
+                "schema_id": "core.filter.http.observability.access_log"
+              },
+              "description": "",
+              "examples": [],
+              "rules": [],
+              "sensitive": false
+            },
+            {
+              "kind": {
+                "kind": "reference",
+                "schema_id": "core.filter.http.observability.request_id"
+              },
+              "description": "",
+              "examples": [],
+              "rules": [],
+              "sensitive": false
+            },
+            {
+              "kind": {
+                "kind": "reference",
+                "schema_id": "core.filter.http.observability.trace_context"
+              },
+              "description": "",
+              "examples": [],
+              "rules": [],
+              "sensitive": false
+            },
+            {
+              "kind": {
+                "kind": "reference",
+                "schema_id": "core.filter.http.payload_processing.compression"
+              },
+              "description": "",
+              "examples": [],
+              "rules": [],
+              "sensitive": false
+            },
+            {
+              "kind": {
+                "kind": "reference",
+                "schema_id": "core.filter.http.payload_processing.json_body_field"
+              },
+              "description": "",
+              "examples": [],
+              "rules": [],
+              "sensitive": false
+            },
+            {
+              "kind": {
+                "kind": "reference",
+                "schema_id": "core.filter.http.payload_processing.json_rpc"
+              },
+              "description": "",
+              "examples": [],
+              "rules": [],
+              "sensitive": false
+            },
+            {
+              "kind": {
+                "kind": "reference",
+                "schema_id": "core.filter.http.security.basic_auth"
+              },
+              "description": "",
+              "examples": [],
+              "rules": [],
+              "sensitive": false
+            },
+            {
+              "kind": {
+                "kind": "reference",
+                "schema_id": "core.filter.http.security.cors"
+              },
+              "description": "",
+              "examples": [],
+              "rules": [],
+              "sensitive": false
+            },
+            {
+              "kind": {
+                "kind": "reference",
+                "schema_id": "core.filter.http.security.credential_injection"
+              },
+              "description": "",
+              "examples": [],
+              "rules": [],
+              "sensitive": false
+            },
+            {
+              "kind": {
+                "kind": "reference",
+                "schema_id": "core.filter.http.security.csrf"
+              },
+              "description": "",
+              "examples": [],
+              "rules": [],
+              "sensitive": false
+            },
+            {
+              "kind": {
+                "kind": "reference",
+                "schema_id": "core.filter.http.security.forwarded_headers"
+              },
+              "description": "",
+              "examples": [],
+              "rules": [],
+              "sensitive": false
+            },
+            {
+              "kind": {
+                "kind": "reference",
+                "schema_id": "core.filter.http.security.guardrails"
+              },
+              "description": "",
+              "examples": [],
+              "rules": [],
+              "sensitive": false
+            },
+            {
+              "kind": {
+                "kind": "reference",
+                "schema_id": "core.filter.http.security.ip_acl"
+              },
+              "description": "",
+              "examples": [],
+              "rules": [],
+              "sensitive": false
+            },
+            {
+              "kind": {
+                "kind": "reference",
+                "schema_id": "core.filter.http.security.peer_identity_trust"
+              },
+              "description": "",
+              "examples": [],
+              "rules": [],
+              "sensitive": false
+            },
+            {
+              "kind": {
+                "kind": "reference",
+                "schema_id": "core.filter.http.security.policy"
+              },
+              "description": "",
+              "examples": [],
+              "rules": [],
+              "sensitive": false
+            },
+            {
+              "kind": {
+                "kind": "reference",
+                "schema_id": "core.filter.http.traffic_management.circuit_breaker"
+              },
+              "description": "",
+              "examples": [],
+              "rules": [],
+              "sensitive": false
+            },
+            {
+              "kind": {
+                "kind": "reference",
+                "schema_id": "core.filter.http.traffic_management.endpoint_selector"
+              },
+              "description": "",
+              "examples": [],
+              "rules": [],
+              "sensitive": false
+            },
+            {
+              "kind": {
+                "kind": "reference",
+                "schema_id": "core.filter.http.traffic_management.grpc_detection"
+              },
+              "description": "",
+              "examples": [],
+              "rules": [],
+              "sensitive": false
+            },
+            {
+              "kind": {
+                "kind": "reference",
+                "schema_id": "core.filter.http.traffic_management.iterative_request_router"
+              },
+              "description": "",
+              "examples": [],
+              "rules": [],
+              "sensitive": false
+            },
+            {
+              "kind": {
+                "kind": "reference",
+                "schema_id": "core.filter.http.traffic_management.load_balancer"
+              },
+              "description": "",
+              "examples": [],
+              "rules": [],
+              "sensitive": false
+            },
+            {
+              "kind": {
+                "kind": "reference",
+                "schema_id": "core.filter.http.traffic_management.rate_limit"
+              },
+              "description": "",
+              "examples": [],
+              "rules": [],
+              "sensitive": false
+            },
+            {
+              "kind": {
+                "kind": "reference",
+                "schema_id": "core.filter.http.traffic_management.redirect"
+              },
+              "description": "",
+              "examples": [],
+              "rules": [],
+              "sensitive": false
+            },
+            {
+              "kind": {
+                "kind": "reference",
+                "schema_id": "core.filter.http.traffic_management.router"
+              },
+              "description": "",
+              "examples": [],
+              "rules": [],
+              "sensitive": false
+            },
+            {
+              "kind": {
+                "kind": "reference",
+                "schema_id": "core.filter.http.traffic_management.static_response"
+              },
+              "description": "",
+              "examples": [],
+              "rules": [],
+              "sensitive": false
+            },
+            {
+              "kind": {
+                "kind": "reference",
+                "schema_id": "core.filter.http.traffic_management.sticky_sessions"
+              },
+              "description": "",
+              "examples": [],
+              "rules": [],
+              "sensitive": false
+            },
+            {
+              "kind": {
+                "kind": "reference",
+                "schema_id": "core.filter.http.traffic_management.timeout"
+              },
+              "description": "",
+              "examples": [],
+              "rules": [],
+              "sensitive": false
+            },
+            {
+              "kind": {
+                "kind": "reference",
+                "schema_id": "core.filter.http.transformation.headers"
+              },
+              "description": "",
+              "examples": [],
+              "rules": [],
+              "sensitive": false
+            },
+            {
+              "kind": {
+                "kind": "reference",
+                "schema_id": "core.filter.http.transformation.path_rewrite"
+              },
+              "description": "",
+              "examples": [],
+              "rules": [],
+              "sensitive": false
+            },
+            {
+              "kind": {
+                "kind": "reference",
+                "schema_id": "core.filter.http.transformation.url_rewrite"
+              },
+              "description": "",
+              "examples": [],
+              "rules": [],
+              "sensitive": false
+            },
+            {
+              "kind": {
+                "kind": "reference",
+                "schema_id": "core.filter.tcp.observability.tcp_access_log"
+              },
+              "description": "",
+              "examples": [],
+              "rules": [],
+              "sensitive": false
+            },
+            {
+              "kind": {
+                "kind": "reference",
+                "schema_id": "core.filter.tcp.traffic_management.sni_router"
+              },
+              "description": "",
+              "examples": [],
+              "rules": [],
+              "sensitive": false
+            },
+            {
+              "kind": {
+                "kind": "reference",
+                "schema_id": "core.filter.tcp.traffic_management.tcp_load_balancer"
+              },
+              "description": "",
+              "examples": [],
+              "rules": [],
+              "sensitive": false
+            }
+          ],
+          "discriminator": null
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.filter.http.observability.access_log": {
+      "id": "core.filter.http.observability.access_log",
+      "title": "access_log",
+      "description": "Logs structured access records for each request and response.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "sample_rate",
+              "schema": {
+                "kind": {
+                  "kind": "number"
+                },
+                "description": "Fraction of requests to log (0.0, 1.0]. Defaults to 1.0.",
+                "default": 64,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "fields",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "string"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "request_headers",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "string"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Request header names allowed for `request_header.<name>` tokens.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "response_headers",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "string"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Response header names allowed for `response_header.<name>` tokens.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "conditions",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "core.type.AccessLogEmitConditions"
+                },
+                "description": "Emit-time conditions (AND across keys).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.filter.http.observability.request_id": {
+      "id": "core.filter.http.observability.request_id",
+      "title": "request_id",
+      "description": "Ensures every request carries a correlation ID.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "header_name",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Name of the header to read, generate, and forward.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.filter.http.observability.trace_context": {
+      "id": "core.filter.http.observability.trace_context",
+      "title": "trace_context",
+      "description": "Propagates W3C Trace Context headers (`traceparent`, `tracestate`).",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.filter.http.payload_processing.compression": {
+      "id": "core.filter.http.payload_processing.compression",
+      "title": "compression",
+      "description": "Enables Pingora's built-in response compression when present in a filter chain.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "level",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Default compression level for all algorithms.\nClamped to each algorithm's maximum (gzip: 9,\nbrotli: 11, zstd: 22).",
+                "default": 32,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "gzip",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "core.type.AlgorithmConfig"
+                },
+                "description": "Gzip algorithm settings.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "brotli",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "core.type.AlgorithmConfig"
+                },
+                "description": "Brotli algorithm settings.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "zstd",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "core.type.AlgorithmConfig"
+                },
+                "description": "Zstd algorithm settings.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "min_size_bytes",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Minimum body size in bytes; smaller responses skip compression.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "content_types",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "string"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "MIME type prefixes that qualify for compression.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.filter.http.payload_processing.json_body_field": {
+      "id": "core.filter.http.payload_processing.json_body_field",
+      "title": "json_body_field",
+      "description": "Extracts top-level fields from a JSON request body and promotes their values to request headers using [`StreamBuffer`] mode.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "field",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Single-field: top-level JSON field name to extract.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "header",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Single-field: request header name to promote into.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "fields",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "reference",
+                      "schema_id": "core.type.JsonBodyFieldMapping"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Multi-field: list of field-to-header mappings.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "max_body_bytes",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum request body size in bytes for `StreamBuffer` mode.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.filter.http.payload_processing.json_rpc": {
+      "id": "core.filter.http.payload_processing.json_rpc",
+      "title": "json_rpc",
+      "description": "Extracts JSON-RPC 2.0 envelope metadata from request bodies and promotes method, id, and kind to request headers and filter results for routing.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "batch_policy",
+              "schema": {
+                "kind": {
+                  "kind": "one_of",
+                  "variants": [
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "reject"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "first"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    }
+                  ],
+                  "discriminator": null
+                },
+                "description": "Batch handling policy (default: [`reject`]).\n\nControls whether JSON-RPC batch arrays are allowed. See\n[`BatchPolicy`] for security implications.\n\n[`reject`]: BatchPolicy::Reject",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "headers",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "core.type.JsonRpcHeaders"
+                },
+                "description": "Header names for metadata promotion.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "max_batch_size",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum number of items allowed in a JSON-RPC batch array.\n\nOnly enforced when [`batch_policy`] is [`First`]. Requests\nexceeding this limit are rejected with HTTP 400. This prevents\na single HTTP request from multiplexing an excessive number of\nJSON-RPC calls, which could bypass per-request rate limits.\n\nDefault: [`DEFAULT_MAX_BATCH_SIZE`] (100).\n\n[`batch_policy`]: JsonRpcConfig::batch_policy\n[`First`]: BatchPolicy::First",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "max_body_bytes",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum body size in bytes for `StreamBuffer`.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "on_invalid",
+              "schema": {
+                "kind": {
+                  "kind": "one_of",
+                  "variants": [
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "continue"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "reject"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "error"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    }
+                  ],
+                  "discriminator": null
+                },
+                "description": "Invalid input handling behavior.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.filter.http.security.basic_auth": {
+      "id": "core.filter.http.security.basic_auth",
+      "title": "basic_auth",
+      "description": "HTTP Basic Authentication filter (RFC 7617).",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "realm",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Realm string for the `WWW-Authenticate` challenge.",
+                "default": "Restricted",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "strip_authorization",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Whether to strip the `Authorization` header before forwarding.",
+                "default": true,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "credentials",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "reference",
+                      "schema_id": "core.type.InlineCredential"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Inline credential list.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "kv_store",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "KV store name for credential lookup.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.filter.http.security.cors": {
+      "id": "core.filter.http.security.cors",
+      "title": "cors",
+      "description": "Spec-compliant CORS filter implementing origin validation, preflight handling, and response header injection.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "allow_origins",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "string"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Allowed origins. Use `[\"*\"]` for any origin.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "allow_methods",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "string"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Allowed HTTP methods. Defaults to `[\"GET\", \"HEAD\", \"POST\"]`.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "allow_headers",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "string"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Allowed request headers.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "expose_headers",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "string"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Response headers exposed to the client.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "allow_credentials",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Whether to include `Access-Control-Allow-Credentials: true`.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "max_age",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Preflight cache duration in seconds.",
+                "default": 32,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "allow_private_network",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Whether to support Private Network Access.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "disallowed_origin_mode",
+              "schema": {
+                "kind": {
+                  "kind": "one_of",
+                  "variants": [
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "omit"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "reject"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    }
+                  ],
+                  "discriminator": null
+                },
+                "description": "Behavior when origin is not in the allow list.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "allow_null_origin",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Whether to allow `Origin: null`.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.filter.http.security.credential_injection": {
+      "id": "core.filter.http.security.credential_injection",
+      "title": "credential_injection",
+      "description": "Injects per-cluster API credentials into upstream requests.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "clusters",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "reference",
+                      "schema_id": "core.type.ClusterCredentialConfig"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Per-cluster credential injection rules.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.filter.http.security.csrf": {
+      "id": "core.filter.http.security.csrf",
+      "title": "csrf",
+      "description": "CSRF protection filter that validates request origins against a trusted allowlist.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "enable_sec_fetch_site",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Whether to also validate the `Sec-Fetch-Site` header.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "enforce_percentage",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Percentage of requests to enforce (0..=100).",
+                "default": 8,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "safe_methods",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "string"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "HTTP methods that bypass CSRF checks.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "trusted_origins",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "string"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Allowed origin values (scheme + host + optional port).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.filter.http.security.forwarded_headers": {
+      "id": "core.filter.http.security.forwarded_headers",
+      "title": "forwarded_headers",
+      "description": "Injects `X-Forwarded-For`, `X-Forwarded-Proto`, and `X-Forwarded-Host` headers into upstream requests.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "trusted_proxies",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "string"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "CIDR ranges of trusted proxies whose existing\nX-Forwarded-For values are preserved (appended to).\nUntrusted sources have the header overwritten.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "use_standard_header",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "When `true`, also inject the standard [RFC 7239]\n`Forwarded` header in addition to X-Forwarded-* headers.\n\n[RFC 7239]: https://datatracker.ietf.org/doc/html/rfc7239",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.filter.http.security.guardrails": {
+      "id": "core.filter.http.security.guardrails",
+      "title": "guardrails",
+      "description": "Rejects requests matching string, regex, or PII rules against headers and/or body content.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "action",
+              "schema": {
+                "kind": {
+                  "kind": "one_of",
+                  "variants": [
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "reject"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "flag"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    }
+                  ],
+                  "discriminator": null
+                },
+                "description": "What to do when a rule matches (default: reject).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "reject_oversized",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Reject a body that exactly reaches the inspection buffer limit\n(1 MiB) instead of inspecting it.\n\nBodies that *exceed* the limit are always rejected with 413 by the\nstreaming buffer regardless of this flag — there is no silent\ntruncation. This flag only governs a body sized exactly at the\nlimit, which is otherwise inspected as-is.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "rules",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "reference",
+                      "schema_id": "core.type.RuleConfig"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "List of rules to evaluate.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.filter.http.security.ip_acl": {
+      "id": "core.filter.http.security.ip_acl",
+      "title": "ip_acl",
+      "description": "IP-based access control filter.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "allow",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "string"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "IPs/CIDRs to allow. If non-empty, only these are permitted.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "deny",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "string"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "IPs/CIDRs to deny.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.filter.http.security.peer_identity_trust": {
+      "id": "core.filter.http.security.peer_identity_trust",
+      "title": "peer_identity_trust",
+      "description": "Validates that the downstream mTLS peer identity matches a configured trusted peer before allowing the request to continue.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "trusted_peers",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "reference",
+                      "schema_id": "core.type.TrustedPeerConfig"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Trusted peer entries.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.filter.http.security.policy": {
+      "id": "core.filter.http.security.policy",
+      "title": "policy",
+      "description": "Embeds the Praxis Policy Engine in-process to enforce multi-source JWT identity, APL route policy, RFC 8693 token exchange, PII scanning, audit emission, and (under `body_access: read_write`) request / response body rewriting.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "body_access",
+              "schema": {
+                "kind": {
+                  "kind": "one_of",
+                  "variants": [
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "read_only"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "read_write"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    }
+                  ],
+                  "discriminator": null
+                },
+                "description": "Body-access tier. `ReadOnly` (default) lets APL inspect request\nand response bodies for routing / policy decisions but discards\nany mutations. `ReadWrite` enables the CMF → JSON-RPC\nre-serialization round-trip so APL field mutators\n(e.g. `args.ssn: redact(!perm.view_ssn)`) rewrite the upstream\nbody and response. Pay the round-trip cost only when needed.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "config_path",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Filesystem path to the policy document.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "init_timeout_secs",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum time, in seconds, to wait for `PolicyEngine::initialize`\nat filter construction. Identity plugins fetch JWKS over HTTPS\nduring init; a reachable-but-unresponsive identity provider\nwould otherwise hang startup or hot-reload indefinitely. On\nexpiry, filter construction returns an error and the server\nfails fast.\n\n30s is generous for legitimate cold-cache JWKS fetches over the\npublic internet, while short enough that misbehavior is noticed\nduring the deploy.",
+                "default": 64,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "max_buffer_bytes",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum request/response body bytes buffered in `ReadWrite`\nmode. `ReadWrite` uses `StreamBuffer` to accumulate the whole\nbody before APL field mutators run; without a cap an oversized\npayload could exhaust memory. Ignored in `ReadOnly` mode, which\nstreams. The pipeline rejects an unbounded buffer at config\nload, so this always carries a concrete ceiling.",
+                "default": 10,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "allow_private_idp",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Allow policy-engine calls to private or loopback identity providers.\n\nDisabled by default to limit SSRF through policy-defined endpoints. This\ndoes not affect Praxis upstreams, which use\n`insecure_options.allow_private_endpoints`.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "require_protocol_metadata",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Fail-closed policy gate for misconfigured chains. When `true`\n(default), `on_request_body` rejects any request that reaches\nit without `mcp.method` filter-metadata. The metadata is set\nby the protocol classifier filter (available in the `praxis-ai` package), so\nits absence means either (a) the protocol classifier filter is missing from\nthe chain, or (b) it is ordered AFTER `policy` instead of\nbefore. Either is a misconfiguration that would silently\nbypass CMF/APL policy.\n\nSet to `false` only when intentionally fronting non-classified\ntraffic through the `policy` filter for identity-only\nenforcement (legacy behavior).\n\nOnly consulted when the loaded policy declares entity routes\n(tool/prompt/resource). A pure-L7 (`global`-only) or identity-only\npolicy never reaches this gate — `on_request_body` returns\n`BodyDone` before it, so the flag has no effect there.\n\nNote: JSON-RPC methods that legitimately carry no entity (e.g.\n`tools/list`, `initialize`, `prompts/list`) still pass —\n`require_protocol_metadata` only rejects when the metadata is\nmissing entirely.",
+                "default": true,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.filter.http.traffic_management.circuit_breaker": {
+      "id": "core.filter.http.traffic_management.circuit_breaker",
+      "title": "circuit_breaker",
+      "description": "Rejects requests to clusters whose circuit is open.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "clusters",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "reference",
+                      "schema_id": "core.type.ClusterCircuitBreakerConfig"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Per-cluster circuit breaker settings.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.filter.http.traffic_management.endpoint_selector": {
+      "id": "core.filter.http.traffic_management.endpoint_selector",
+      "title": "endpoint_selector",
+      "description": "Selects an upstream endpoint from a trusted mutation source.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "connection",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "core.type.EndpointConnectionConfig"
+                },
+                "description": "Optional connection tuning for selected upstreams.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "required",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Whether the destination header is required (fail-closed).\n\nWhen `true`, requests without a trusted destination header\nare rejected. Use for compositions where an external\nprocessor is expected to always supply a destination.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "source_header",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "The request header to read the upstream endpoint address from.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "status_on_required_failure",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "HTTP status code for required-mode routing failures.\n\nOnly used when `required: true`. Defaults to 500.\nCompositions with required external processing typically set 503.",
+                "default": 16,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "strip_header",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Whether to remove the source header after reading it.",
+                "default": true,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "tls",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "core.type.ClusterTls"
+                },
+                "description": "Optional TLS settings for selected upstreams.\n\nCertificates and keys are loaded and parsed once when the\nfilter is constructed, never on a request path.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.filter.http.traffic_management.grpc_detection": {
+      "id": "core.filter.http.traffic_management.grpc_detection",
+      "title": "grpc_detection",
+      "description": "Detects gRPC requests from the `content-type` header and promotes the variant to filter metadata and results for downstream routing.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.filter.http.traffic_management.iterative_request_router": {
+      "id": "core.filter.http.traffic_management.iterative_request_router",
+      "title": "iterative_request_router",
+      "description": "Framework-level filter for iterative sub-request execution.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "initial_step",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Name of the first step to execute.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "max_iterations",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum iterations before aborting (default 10, max 100).",
+                "default": 32,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "max_response_bytes",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum response body bytes per sub-request.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "max_stream_response_bytes",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Optional cumulative byte ceiling for one logical streamed response.\nThis is intentionally distinct from buffered per-step response limits.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "max_state_bytes",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum accumulated iteration state bytes.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "step_timeout_ms",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Per-step timeout in milliseconds. Defaults to `timeout_ms`.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "steps",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "reference",
+                      "schema_id": "core.type.StepConfig"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Named steps, each with filters and transition rules.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "timeout_ms",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Overall timeout in milliseconds (default 30000). This is an\nend-to-end deadline: a streamed final response (e.g. SSE / LLM\nstreaming) is also cut when the deadline expires, not only the step\nexchanges — raise it for routes whose streams legitimately outlive\nthe default.",
+                "default": 64,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.filter.http.traffic_management.load_balancer": {
+      "id": "core.filter.http.traffic_management.load_balancer",
+      "title": "load_balancer",
+      "description": "Selects an upstream endpoint using the cluster's configured strategy.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "clusters",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "reference",
+                      "schema_id": "core.type.Cluster"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Cluster definitions.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.filter.http.traffic_management.rate_limit": {
+      "id": "core.filter.http.traffic_management.rate_limit",
+      "title": "rate_limit",
+      "description": "Token bucket rate limiter that rejects excess traffic with 429.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "mode",
+              "schema": {
+                "kind": {
+                  "kind": "one_of",
+                  "variants": [
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "global"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "per_ip"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    }
+                  ],
+                  "discriminator": null
+                },
+                "description": "Whether to use a single global bucket or per-IP buckets.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "rate",
+              "schema": {
+                "kind": {
+                  "kind": "number"
+                },
+                "description": "Tokens replenished per second.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "burst",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum bucket capacity.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.filter.http.traffic_management.redirect": {
+      "id": "core.filter.http.traffic_management.redirect",
+      "title": "redirect",
+      "description": "Returns a redirect response without contacting any upstream.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "allowed_hosts",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "string"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Optional allowlist of permitted hostnames for `${host}` substitution.\n\nSupports exact matches and wildcard prefixes (`*.example.com`).\nWhen set, host values not matching any entry leave `${host}` unexpanded\nand log a warning. When absent or empty, any syntactically valid host\nis accepted (character-level validation still applies).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "location",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Location URL template. Supports `${path}`, `${query}`, `${host}`, and `${scheme}` placeholders.\n\n`${query}` expands to `?key=val` (with leading `?`) when a query string\nis present, or to an empty string when absent. `${host}` expands to the\nrequest `Host` header value (port stripped). `${scheme}` expands to the\ninferred scheme (`http` or `https`). Templates should use\n`${path}${query}` without a literal `?` separator.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "status",
+              "schema": {
+                "kind": {
+                  "kind": "enum",
+                  "values": [
+                    301,
+                    302,
+                    307,
+                    308
+                  ]
+                },
+                "description": "HTTP redirect status code (301, 302, 307, or 308).",
+                "default": 16,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.filter.http.traffic_management.router": {
+      "id": "core.filter.http.traffic_management.router",
+      "title": "router",
+      "description": "Routes requests to clusters based on path prefix and host header.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "json_alias_header",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Reserved for the unimplemented JSON alias feature; has no effect.\n\nKept so existing configs continue to parse. Any route that\nactually sets `json_aliases` is rejected at startup.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "json_alias_max_body_bytes",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Reserved for the unimplemented JSON alias feature; has no effect.\n\nKept so existing configs continue to parse. Any route that\nactually sets `json_aliases` is rejected at startup.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "routes",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "reference",
+                      "schema_id": "core.type.RouterRouteConfig"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Route table entries.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "multi_level_subdomain_matching",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Enable multi-level subdomain matching for wildcard hosts.\n\nWhen `false` (default), `*.example.com` matches only single-level\nsubdomains like `foo.example.com`. When `true`, it also matches\nmulti-level subdomains like `foo.bar.example.com` (suffix match).\n\nSome control planes (e.g. Kubernetes Gateway API) require this.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.filter.http.traffic_management.static_response": {
+      "id": "core.filter.http.traffic_management.static_response",
+      "title": "static_response",
+      "description": "Returns a fixed response without contacting any upstream.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "body",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Optional response body string.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "headers",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "reference",
+                      "schema_id": "core.type.HeaderEntry"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Response headers to include.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "status",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "HTTP status code to return.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.filter.http.traffic_management.sticky_sessions": {
+      "id": "core.filter.http.traffic_management.sticky_sessions",
+      "title": "sticky_sessions",
+      "description": "Sticky sessions HTTP filter.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "clusters",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "reference",
+                      "schema_id": "core.type.ClusterSessionConfig"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Per-cluster session persistence configurations.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.filter.http.traffic_management.timeout": {
+      "id": "core.filter.http.traffic_management.timeout",
+      "title": "timeout",
+      "description": "Enforces a maximum end-to-end latency from request receipt to response headers.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "timeout_ms",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum allowed elapsed time from request receipt to response headers,\nin milliseconds. Requests that exceed this limit receive a 504.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.filter.http.transformation.headers": {
+      "id": "core.filter.http.transformation.headers",
+      "title": "headers",
+      "description": "Adds, sets, or removes headers on upstream requests and downstream responses.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "request_add",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "reference",
+                      "schema_id": "core.type.HeaderPair"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Headers to append to the upstream request.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "request_remove",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "string"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Header names to remove from the upstream request.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "request_set",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "reference",
+                      "schema_id": "core.type.HeaderPair"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Headers to set on the upstream request (overwrites existing values).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "response_add",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "reference",
+                      "schema_id": "core.type.HeaderPair"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Headers to append to the downstream response.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "response_remove",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "string"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Header names to remove from the downstream response.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "response_set",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "reference",
+                      "schema_id": "core.type.HeaderPair"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Headers to set on the downstream response (overwrites existing values).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.filter.http.transformation.path_rewrite": {
+      "id": "core.filter.http.transformation.path_rewrite",
+      "title": "path_rewrite",
+      "description": "Rewrites the request path before forwarding to the upstream.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "strip_prefix",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Remove this prefix from the request path.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "add_prefix",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Prepend this prefix to the request path.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "replace",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "core.type.ReplaceConfig"
+                },
+                "description": "Regex find/replace on the request path.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "allow_rewrite_override",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "When `true`, suppresses the duplicate-rewrite validation\nerror if another rewrite filter precedes this one.\n\nConsumed by pipeline validation via the raw YAML config.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.filter.http.transformation.url_rewrite": {
+      "id": "core.filter.http.transformation.url_rewrite",
+      "title": "url_rewrite",
+      "description": "Rewrites request URLs using regex substitution and query parameter manipulation before the request reaches upstream.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "operations",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "reference",
+                      "schema_id": "core.type.OperationConfig"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Ordered list of rewrite operations to apply.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "allow_rewrite_override",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "When `true`, suppresses the duplicate-rewrite validation\nerror if another rewrite filter precedes this one.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.filter.tcp.observability.tcp_access_log": {
+      "id": "core.filter.tcp.observability.tcp_access_log",
+      "title": "tcp_access_log",
+      "description": "Logs TCP connection events.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.filter.tcp.traffic_management.sni_router": {
+      "id": "core.filter.tcp.traffic_management.sni_router",
+      "title": "sni_router",
+      "description": "Routes TCP connections by SNI hostname.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "default_upstream",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Fallback upstream when no route matches.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "routes",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "reference",
+                      "schema_id": "core.type.SniRouteEntry"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Route entries mapping server names to upstreams.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.filter.tcp.traffic_management.tcp_load_balancer": {
+      "id": "core.filter.tcp.traffic_management.tcp_load_balancer",
+      "title": "tcp_load_balancer",
+      "description": "Selects an upstream TCP endpoint using the cluster's configured strategy.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "clusters",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "reference",
+                      "schema_id": "core.type.Cluster"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Cluster definitions.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.root.config": {
+      "id": "core.root.config",
+      "title": "Praxis configuration",
+      "description": "The top-level Praxis configuration.",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "admin",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "core.type.AdminConfig"
+                },
+                "description": "Admin endpoint settings (address and verbosity).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "body_limits",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "core.type.BodyLimitsConfig"
+                },
+                "description": "Global hard ceilings on request and response body size.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "clusters",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "reference",
+                      "schema_id": "core.type.Cluster"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Cluster definitions referenced by filters.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "filter_chains",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "reference",
+                      "schema_id": "core.type.FilterChainConfig"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Named filter chains.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "insecure_options",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "core.type.InsecureOptions"
+                },
+                "description": "Consolidated security overrides. All default to `false`.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "listeners",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "reference",
+                      "schema_id": "core.type.Listener"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Proxy listeners to bind.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "metrics",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "core.type.MetricsConfig"
+                },
+                "description": "Optional Prometheus metric collection settings.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "runtime",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "core.type.RuntimeConfig"
+                },
+                "description": "Runtime configuration knobs.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "shutdown_timeout_secs",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Drain time for graceful shutdown.",
+                "default": 64,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "telemetry",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "core.type.TelemetryConfig"
+                },
+                "description": "OpenTelemetry tracing export settings.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.AccessLogEmitConditions": {
+      "id": "core.type.AccessLogEmitConditions",
+      "title": "AccessLogEmitConditions",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "min_duration_ms",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "status_classes",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "one_of",
+                      "variants": [
+                        {
+                          "kind": {
+                            "kind": "literal",
+                            "value": "1xx"
+                          },
+                          "description": "",
+                          "examples": [],
+                          "rules": [],
+                          "sensitive": false
+                        },
+                        {
+                          "kind": {
+                            "kind": "literal",
+                            "value": "2xx"
+                          },
+                          "description": "",
+                          "examples": [],
+                          "rules": [],
+                          "sensitive": false
+                        },
+                        {
+                          "kind": {
+                            "kind": "literal",
+                            "value": "3xx"
+                          },
+                          "description": "",
+                          "examples": [],
+                          "rules": [],
+                          "sensitive": false
+                        },
+                        {
+                          "kind": {
+                            "kind": "literal",
+                            "value": "4xx"
+                          },
+                          "description": "",
+                          "examples": [],
+                          "rules": [],
+                          "sensitive": false
+                        },
+                        {
+                          "kind": {
+                            "kind": "literal",
+                            "value": "5xx"
+                          },
+                          "description": "",
+                          "examples": [],
+                          "rules": [],
+                          "sensitive": false
+                        }
+                      ],
+                      "discriminator": null
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "paths",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "string"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.AdminConfig": {
+      "id": "core.type.AdminConfig",
+      "title": "AdminConfig",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "address",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Admin endpoint bind address.\n\nDefaults to disabled (`None`). When set, must be loopback unless\n`insecure_options.allow_public_admin: true` is configured at the\ntop level.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "verbose",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Include per-cluster detail in `/ready` response.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.AlgorithmConfig": {
+      "id": "core.type.AlgorithmConfig",
+      "title": "AlgorithmConfig",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "enabled",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Whether this algorithm is enabled.",
+                "default": true,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "level",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Compression level for this algorithm.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.BackoffConfig": {
+      "id": "core.type.BackoffConfig",
+      "title": "BackoffConfig",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "base_interval_ms",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Exponential base interval in milliseconds.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "max_interval_ms",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum capped interval in milliseconds.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.BodyLimitsConfig": {
+      "id": "core.type.BodyLimitsConfig",
+      "title": "BodyLimitsConfig",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "max_request_bytes",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum request body size in bytes.\n\nDefaults to 10 MiB. `None` (YAML `null`) disables the\nlimit and requires `insecure_options.allow_unbounded_body`.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "max_response_bytes",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum response body size in bytes.\n\nDefaults to 10 MiB. `None` (YAML `null`) disables the\nlimit and requires `insecure_options.allow_unbounded_body`.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.BranchChainConfig": {
+      "id": "core.type.BranchChainConfig",
+      "title": "BranchChainConfig",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "name",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Globally unique name for this branch.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "chains",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "one_of",
+                      "variants": [
+                        {
+                          "kind": {
+                            "kind": "object",
+                            "fields": [
+                              {
+                                "serialized_name": "name",
+                                "schema": {
+                                  "kind": {
+                                    "kind": "string"
+                                  },
+                                  "description": "Globally unique chain name.",
+                                  "examples": [],
+                                  "rules": [],
+                                  "sensitive": false
+                                },
+                                "required": true,
+                                "flattened": false
+                              },
+                              {
+                                "serialized_name": "filters",
+                                "schema": {
+                                  "kind": {
+                                    "kind": "array",
+                                    "items": {
+                                      "kind": {
+                                        "kind": "reference",
+                                        "schema_id": "core.type.FilterEntry"
+                                      },
+                                      "description": "",
+                                      "examples": [],
+                                      "rules": [],
+                                      "sensitive": false
+                                    },
+                                    "min_items": null,
+                                    "max_items": null
+                                  },
+                                  "description": "Ordered list of filters.",
+                                  "examples": [],
+                                  "rules": [],
+                                  "sensitive": false
+                                },
+                                "required": true,
+                                "flattened": false
+                              }
+                            ],
+                            "additional_properties": false
+                          },
+                          "description": "",
+                          "examples": [],
+                          "rules": [],
+                          "sensitive": false
+                        },
+                        {
+                          "kind": {
+                            "kind": "string"
+                          },
+                          "description": "",
+                          "examples": [],
+                          "rules": [],
+                          "sensitive": false
+                        }
+                      ],
+                      "discriminator": null
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Chains to execute when triggered. Named refs\nor inline definitions, concatenated in order.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "max_iterations",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum re-entrance iterations. Required when\n`rejoin` targets the branch point or an earlier\nfilter. Validation rejects backward rejoin\nwithout this field.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "on_result",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "core.type.BranchCondition"
+                },
+                "description": "Condition based on a filter's result output.\nWhen omitted, the branch always fires\n(unconditional branch).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "rejoin",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Where to resume in the parent pipeline after the branch.\n\n- `\"next\"` (default): continue after the branch point\n- `\"terminal\"` or `\"client\"`: stop the pipeline\n- `\"<name>\"`: skip to a named filter in the pipeline\n\nNamed targets work across chains because all listener\nchains are concatenated into one flat pipeline. Forward\ntargets become `SkipTo`; backward targets become\n`ReEnter` (which requires [`max_iterations`]).\n\n[`max_iterations`]: BranchChainConfig::max_iterations",
+                "default": "next",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.BranchCondition": {
+      "id": "core.type.BranchCondition",
+      "title": "BranchCondition",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "filter",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Filter TYPE name whose results to inspect.\n\nMust match the return value of [`HttpFilter::name()`] (e.g.,\n`\"guardrails\"`, `\"json_rpc\"`), NOT the user-assigned `name`\non [`FilterEntry`].\n\n[`HttpFilter::name()`]: https://docs.rs/praxis-filter/latest/praxis_filter/trait.HttpFilter.html#tymethod.name\n[`FilterEntry`]: super::FilterEntry",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "key",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Result key to check (default: \"status\").",
+                "default": "status",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "result",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Expected result value. Branch fires when the\nfilter's result for `key` equals this value.\n\nIn YAML this field is written as `result:`, not `value:`.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.CaConfig": {
+      "id": "core.type.CaConfig",
+      "title": "CaConfig",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "ca_path",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Path to the PEM CA certificate file.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "crl_paths",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "string"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Paths to PEM-encoded certificate revocation list (CRL) files.\n\nApplies only to **listener** client authentication: the client\nverifier checks presented client certificates against these CRLs\nand rejects revoked ones. Upstream (cluster) CRL checking is not\nimplemented, so `crl_paths` under `clusters[].tls.ca` is rejected\nat config validation rather than being silently ignored.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.CertKeyPair": {
+      "id": "core.type.CertKeyPair",
+      "title": "CertKeyPair",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "cert_path",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Path to the PEM certificate file.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "default",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Whether this certificate is the default fallback for unmatched SNI.\n\nAt most one certificate in a multi-cert config may set this to\n`true`. The default entry does not need `server_names`.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "key_path",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Path to the PEM private key file.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "server_names",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "string"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "SNI hostnames this certificate serves (listener only).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.Cluster": {
+      "id": "core.type.Cluster",
+      "title": "Cluster",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "name",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Unique name for the cluster.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "http",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "core.type.ClusterHttpOptions"
+                },
+                "description": "HTTP-specific cluster options.\n\nGrouped under `http:` so the shared cluster/upstream transport\ntypes stay protocol-agnostic; TCP load balancers ignore this\nblock entirely.\n\n```\n# use praxis_core::config::Cluster;\nlet yaml = r#\"\nname: \"api\"\nendpoints: [\"10.0.0.1:443\"]\nhttp:\n  authority: \"api.example.com\"\ntls:\n  sni: \"api.example.com\"\n\"#;\nlet cluster: Cluster = serde_yaml::from_str(yaml).unwrap();\nassert_eq!(cluster.http.authority.as_deref(), Some(\"api.example.com\"));\n```",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "connection_timeout_ms",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "TCP connection timeout in milliseconds.\n\nApplies to the TCP handshake only (before TLS). When\nexceeded, the connection attempt fails and the load\nbalancer may retry on the next endpoint. `None` (the\ndefault) uses Pingora's built-in timeout.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "endpoints",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "one_of",
+                      "variants": [
+                        {
+                          "kind": {
+                            "kind": "string"
+                          },
+                          "description": "",
+                          "examples": [],
+                          "rules": [],
+                          "sensitive": false
+                        },
+                        {
+                          "kind": {
+                            "kind": "object",
+                            "fields": [
+                              {
+                                "serialized_name": "address",
+                                "schema": {
+                                  "kind": {
+                                    "kind": "string"
+                                  },
+                                  "description": "Socket address as `host:port`.",
+                                  "examples": [],
+                                  "rules": [],
+                                  "sensitive": false
+                                },
+                                "required": true,
+                                "flattened": false
+                              },
+                              {
+                                "serialized_name": "weight",
+                                "schema": {
+                                  "kind": {
+                                    "kind": "integer"
+                                  },
+                                  "description": "Relative forwarding weight. Higher values receive proportionally more\ntraffic. Defaults to 1.",
+                                  "default": 32,
+                                  "examples": [],
+                                  "rules": [],
+                                  "sensitive": false
+                                },
+                                "required": false,
+                                "flattened": false
+                              },
+                              {
+                                "serialized_name": "metadata",
+                                "schema": {
+                                  "kind": {
+                                    "kind": "map",
+                                    "values": {
+                                      "kind": {
+                                        "kind": "string"
+                                      },
+                                      "description": "",
+                                      "examples": [],
+                                      "rules": [],
+                                      "sensitive": false
+                                    }
+                                  },
+                                  "description": "Arbitrary key-value metadata for subset-based load balancing.",
+                                  "examples": [],
+                                  "rules": [],
+                                  "sensitive": false
+                                },
+                                "required": false,
+                                "flattened": false
+                              },
+                              {
+                                "serialized_name": "priority",
+                                "schema": {
+                                  "kind": {
+                                    "kind": "integer"
+                                  },
+                                  "description": "Priority tier (0 = primary, 1 = first failover, etc.).",
+                                  "examples": [],
+                                  "rules": [],
+                                  "sensitive": false
+                                },
+                                "required": false,
+                                "flattened": false
+                              },
+                              {
+                                "serialized_name": "zone",
+                                "schema": {
+                                  "kind": {
+                                    "kind": "string"
+                                  },
+                                  "description": "Locality zone identifier for zone-aware routing.",
+                                  "examples": [],
+                                  "rules": [],
+                                  "sensitive": false
+                                },
+                                "required": false,
+                                "flattened": false
+                              }
+                            ],
+                            "additional_properties": false
+                          },
+                          "description": "",
+                          "examples": [],
+                          "rules": [],
+                          "sensitive": false
+                        }
+                      ],
+                      "discriminator": null
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "List of endpoints for the cluster. Each entry is either a plain\n`\"host:port\"` string or a `{ address, weight }` object.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "health_check",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "core.type.HealthCheckConfig"
+                },
+                "description": "Active health check configuration for this cluster.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "idle_timeout_ms",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Idle connection timeout in milliseconds.\n\nCloses pooled upstream connections that have been idle\nlonger than this duration. `None` uses Pingora's default.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "load_balancer_strategy",
+              "schema": {
+                "kind": {
+                  "kind": "one_of",
+                  "variants": [
+                    {
+                      "kind": {
+                        "kind": "one_of",
+                        "variants": [
+                          {
+                            "kind": {
+                              "kind": "literal",
+                              "value": "round_robin"
+                            },
+                            "description": "",
+                            "examples": [],
+                            "rules": [],
+                            "sensitive": false
+                          },
+                          {
+                            "kind": {
+                              "kind": "literal",
+                              "value": "least_connections"
+                            },
+                            "description": "",
+                            "examples": [],
+                            "rules": [],
+                            "sensitive": false
+                          },
+                          {
+                            "kind": {
+                              "kind": "literal",
+                              "value": "p2c"
+                            },
+                            "description": "",
+                            "examples": [],
+                            "rules": [],
+                            "sensitive": false
+                          },
+                          {
+                            "kind": {
+                              "kind": "literal",
+                              "value": "random"
+                            },
+                            "description": "",
+                            "examples": [],
+                            "rules": [],
+                            "sensitive": false
+                          }
+                        ],
+                        "discriminator": null
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    {
+                      "kind": {
+                        "kind": "one_of",
+                        "variants": [
+                          {
+                            "kind": {
+                              "kind": "object",
+                              "fields": [
+                                {
+                                  "serialized_name": "consistent_hash",
+                                  "schema": {
+                                    "kind": {
+                                      "kind": "reference",
+                                      "schema_id": "core.type.ConsistentHashOpts"
+                                    },
+                                    "description": "",
+                                    "examples": [],
+                                    "rules": [],
+                                    "sensitive": false
+                                  },
+                                  "required": true,
+                                  "flattened": false
+                                }
+                              ],
+                              "additional_properties": false
+                            },
+                            "description": "",
+                            "examples": [],
+                            "rules": [],
+                            "sensitive": false
+                          },
+                          {
+                            "kind": {
+                              "kind": "object",
+                              "fields": [
+                                {
+                                  "serialized_name": "maglev",
+                                  "schema": {
+                                    "kind": {
+                                      "kind": "reference",
+                                      "schema_id": "core.type.MaglevOpts"
+                                    },
+                                    "description": "",
+                                    "examples": [],
+                                    "rules": [],
+                                    "sensitive": false
+                                  },
+                                  "required": true,
+                                  "flattened": false
+                                }
+                              ],
+                              "additional_properties": false
+                            },
+                            "description": "",
+                            "examples": [],
+                            "rules": [],
+                            "sensitive": false
+                          },
+                          {
+                            "kind": {
+                              "kind": "object",
+                              "fields": [
+                                {
+                                  "serialized_name": "ring_hash",
+                                  "schema": {
+                                    "kind": {
+                                      "kind": "reference",
+                                      "schema_id": "core.type.RingHashOpts"
+                                    },
+                                    "description": "",
+                                    "examples": [],
+                                    "rules": [],
+                                    "sensitive": false
+                                  },
+                                  "required": true,
+                                  "flattened": false
+                                }
+                              ],
+                              "additional_properties": false
+                            },
+                            "description": "",
+                            "examples": [],
+                            "rules": [],
+                            "sensitive": false
+                          },
+                          {
+                            "kind": {
+                              "kind": "object",
+                              "fields": [
+                                {
+                                  "serialized_name": "subset",
+                                  "schema": {
+                                    "kind": {
+                                      "kind": "reference",
+                                      "schema_id": "core.type.SubsetOpts"
+                                    },
+                                    "description": "",
+                                    "examples": [],
+                                    "rules": [],
+                                    "sensitive": false
+                                  },
+                                  "required": true,
+                                  "flattened": false
+                                }
+                              ],
+                              "additional_properties": false
+                            },
+                            "description": "",
+                            "examples": [],
+                            "rules": [],
+                            "sensitive": false
+                          },
+                          {
+                            "kind": {
+                              "kind": "object",
+                              "fields": [
+                                {
+                                  "serialized_name": "zone_aware",
+                                  "schema": {
+                                    "kind": {
+                                      "kind": "reference",
+                                      "schema_id": "core.type.ZoneAwareOpts"
+                                    },
+                                    "description": "",
+                                    "examples": [],
+                                    "rules": [],
+                                    "sensitive": false
+                                  },
+                                  "required": true,
+                                  "flattened": false
+                                }
+                              ],
+                              "additional_properties": false
+                            },
+                            "description": "",
+                            "examples": [],
+                            "rules": [],
+                            "sensitive": false
+                          },
+                          {
+                            "kind": {
+                              "kind": "object",
+                              "fields": [
+                                {
+                                  "serialized_name": "priority",
+                                  "schema": {
+                                    "kind": {
+                                      "kind": "reference",
+                                      "schema_id": "core.type.PriorityOpts"
+                                    },
+                                    "description": "",
+                                    "examples": [],
+                                    "rules": [],
+                                    "sensitive": false
+                                  },
+                                  "required": true,
+                                  "flattened": false
+                                }
+                              ],
+                              "additional_properties": false
+                            },
+                            "description": "",
+                            "examples": [],
+                            "rules": [],
+                            "sensitive": false
+                          }
+                        ],
+                        "discriminator": null
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    }
+                  ],
+                  "discriminator": null
+                },
+                "description": "Load-balancing algorithm for this cluster. Defaults to `round_robin`.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "max_connections",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum concurrent in-flight requests to this cluster.\n\nWhen set, excess requests receive 503. Prevents a single\nslow upstream from consuming all available capacity.\n\n```\n# use praxis_core::config::Cluster;\nlet yaml = r#\"\nname: backend\nendpoints: [\"10.0.0.1:80\"]\nmax_connections: 100\n\"#;\nlet cluster: Cluster = serde_yaml::from_str(yaml).unwrap();\nassert_eq!(cluster.max_connections, Some(100));\n```",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "read_timeout_ms",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Per-read timeout in milliseconds.\n\nApplies to each individual read operation on an\nestablished upstream connection. A timeout fires a 502\nresponse to the client. Use [`total_connection_timeout_ms`]\nto bound the entire exchange instead.\n\n[`total_connection_timeout_ms`]: Cluster::total_connection_timeout_ms",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "tls",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "core.type.ClusterTls"
+                },
+                "description": "TLS settings for upstream connections.\n\nPresence implies TLS is enabled. Omit for plaintext HTTP.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "total_connection_timeout_ms",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Total connection timeout in milliseconds (TCP + TLS).\n\nBounds the combined TCP handshake and TLS negotiation.\nWhen exceeded, the connection attempt fails with a 502\nresponse. Prefer this over [`connection_timeout_ms`] for\nTLS-enabled clusters where the handshake dominates latency.\n\n[`connection_timeout_ms`]: Cluster::connection_timeout_ms",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "write_timeout_ms",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Per-write timeout in milliseconds.\n\nApplies to each individual write operation on an\nestablished upstream connection. A timeout fires a 502\nresponse to the client.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "retry_policy",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "core.type.RetryPolicy"
+                },
+                "description": "Optional retry policy for this cluster.\n\nWhen unset, the proxy retains the legacy connect-failure\nretry behavior (3 attempts, idempotent methods, 64 `KiB` body).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.ClusterCircuitBreakerConfig": {
+      "id": "core.type.ClusterCircuitBreakerConfig",
+      "title": "ClusterCircuitBreakerConfig",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "name",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Cluster name (must match a cluster in the load balancer).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "consecutive_failures",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Number of consecutive upstream failures before the\ncircuit trips to Open.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "half_open_timeout_secs",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Seconds a Half-Open probe may remain in-flight before\nthe circuit resets to Open and starts a new recovery\ncycle. Prevents indefinite stall when a probe request\nis dropped without a response. Defaults to 30 seconds.",
+                "default": 64,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "recovery_window_secs",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Seconds the circuit stays Open before transitioning\nto Half-Open.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.ClusterCredentialConfig": {
+      "id": "core.type.ClusterCredentialConfig",
+      "title": "ClusterCredentialConfig",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "name",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Cluster name this rule applies to.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "env_var",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Environment variable name containing the credential.\nResolved at filter construction time.\nMutually exclusive with `value`.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "header",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Header name to inject (e.g. `\"Authorization\"`, `\"x-api-key\"`).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "header_prefix",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Optional prefix prepended to the credential value\nbefore injection (e.g. `\"Bearer \"`).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "strip_client_credential",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Deprecated: injection always replaces any client-provided\nvalue for the header. Retained for config compatibility.",
+                "default": true,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "value",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Literal credential value. Mutually exclusive with `env_var`.\nWrapped in [`SecretString`] to prevent accidental logging.",
+                "examples": [],
+                "rules": [],
+                "sensitive": true
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.ClusterHttpOptions": {
+      "id": "core.type.ClusterHttpOptions",
+      "title": "ClusterHttpOptions",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "authority",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Override the upstream HTTP `Host` header.\n\nWhen set, the proxy rewrites the `Host` header sent to the\nupstream instead of forwarding the downstream value. Upstream\nconnections use HTTP/1.1; the `:authority` pseudo-header on\nthe downstream HTTP/2 side is not forwarded upstream. TLS SNI\nremains independent — configure `tls.sni` separately when\nneeded.\n\nMust be a valid HTTP authority: a hostname with an optional\nport, or a bracketed IPv6 address with an optional port. URI\nschemes, paths, userinfo, and fragments are rejected.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.ClusterSessionConfig": {
+      "id": "core.type.ClusterSessionConfig",
+      "title": "ClusterSessionConfig",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "name",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Cluster name this config applies to.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "persistence",
+              "schema": {
+                "kind": {
+                  "kind": "one_of",
+                  "variants": [
+                    {
+                      "kind": {
+                        "kind": "object",
+                        "fields": [
+                          {
+                            "serialized_name": "type",
+                            "schema": {
+                              "kind": {
+                                "kind": "literal",
+                                "value": "cookie"
+                              },
+                              "description": "",
+                              "examples": [],
+                              "rules": [],
+                              "sensitive": false
+                            },
+                            "required": true,
+                            "flattened": false
+                          },
+                          {
+                            "serialized_name": "cookie_name",
+                            "schema": {
+                              "kind": {
+                                "kind": "string"
+                              },
+                              "description": "Cookie name used to store the session ID.",
+                              "examples": [],
+                              "rules": [],
+                              "sensitive": false
+                            },
+                            "required": false,
+                            "flattened": false
+                          },
+                          {
+                            "serialized_name": "cookie_attributes",
+                            "schema": {
+                              "kind": {
+                                "kind": "reference",
+                                "schema_id": "core.type.CookieAttributes"
+                              },
+                              "description": "Cookie attributes for the `Set-Cookie` header.",
+                              "examples": [],
+                              "rules": [],
+                              "sensitive": false
+                            },
+                            "required": false,
+                            "flattened": false
+                          }
+                        ],
+                        "additional_properties": false
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    {
+                      "kind": {
+                        "kind": "object",
+                        "fields": [
+                          {
+                            "serialized_name": "type",
+                            "schema": {
+                              "kind": {
+                                "kind": "literal",
+                                "value": "header"
+                              },
+                              "description": "",
+                              "examples": [],
+                              "rules": [],
+                              "sensitive": false
+                            },
+                            "required": true,
+                            "flattened": false
+                          },
+                          {
+                            "serialized_name": "header_name",
+                            "schema": {
+                              "kind": {
+                                "kind": "string"
+                              },
+                              "description": "Header name to read the session key from.",
+                              "examples": [],
+                              "rules": [],
+                              "sensitive": false
+                            },
+                            "required": false,
+                            "flattened": false
+                          }
+                        ],
+                        "additional_properties": false
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    {
+                      "kind": {
+                        "kind": "object",
+                        "fields": [
+                          {
+                            "serialized_name": "type",
+                            "schema": {
+                              "kind": {
+                                "kind": "literal",
+                                "value": "learn"
+                              },
+                              "description": "",
+                              "examples": [],
+                              "rules": [],
+                              "sensitive": false
+                            },
+                            "required": true,
+                            "flattened": false
+                          },
+                          {
+                            "serialized_name": "cookie_name",
+                            "schema": {
+                              "kind": {
+                                "kind": "string"
+                              },
+                              "description": "Cookie name to observe in upstream responses.",
+                              "examples": [],
+                              "rules": [],
+                              "sensitive": false
+                            },
+                            "required": false,
+                            "flattened": false
+                          }
+                        ],
+                        "additional_properties": false
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    }
+                  ],
+                  "discriminator": "type"
+                },
+                "description": "Persistence mechanism (tagged enum discriminated by `type`).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": true
+            },
+            {
+              "serialized_name": "ttl_secs",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Idle timeout for session entries in seconds (sliding TTL).\nThe binding expires after this many seconds of inactivity.",
+                "default": 64,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "failover",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Re-pin to a healthy endpoint when the pinned one is unhealthy.",
+                "default": true,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "max_entries",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum number of session entries in the store.",
+                "examples": [],
+                "rules": [
+                  {
+                    "code": "core.max_entries.range",
+                    "target": "",
+                    "kind": "numeric_bounds",
+                    "parameters": {
+                      "max": 200000,
+                      "min": 1
+                    },
+                    "message": "value must be between 1 and 200000"
+                  }
+                ],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "eviction",
+              "schema": {
+                "kind": {
+                  "kind": "one_of",
+                  "variants": [
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "lru"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "ttl"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    }
+                  ],
+                  "discriminator": null
+                },
+                "description": "Eviction policy when at capacity.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.ClusterTls": {
+      "id": "core.type.ClusterTls",
+      "title": "ClusterTls",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "ca",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "core.type.CaConfig"
+                },
+                "description": "Custom CA.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "client_cert",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "core.type.CertKeyPair"
+                },
+                "description": "Client certificate for upstream mTLS.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "sni",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "SNI hostname.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "verify",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Verify upstream certificate.",
+                "default": true,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.ConsistentHashOpts": {
+      "id": "core.type.ConsistentHashOpts",
+      "title": "ConsistentHashOpts",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "header",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Name of the request header to use as the hash key.\n\nFalls back to the request URI path when the header is absent or when this field is `None`.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.CookieAttributes": {
+      "id": "core.type.CookieAttributes",
+      "title": "CookieAttributes",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "domain",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "`Domain` attribute.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "path",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "`Path` attribute.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "http_only",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "`HttpOnly` flag.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "secure",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "`Secure` flag.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "same_site",
+              "schema": {
+                "kind": {
+                  "kind": "one_of",
+                  "variants": [
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "Strict"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "Lax"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "None"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    }
+                  ],
+                  "discriminator": null
+                },
+                "description": "`SameSite` attribute.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.EndpointConnectionConfig": {
+      "id": "core.type.EndpointConnectionConfig",
+      "title": "EndpointConnectionConfig",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "connection_timeout_ms",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "TCP connection timeout in milliseconds.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "idle_timeout_ms",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Idle connection timeout in milliseconds.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "read_timeout_ms",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Per-read timeout in milliseconds.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "total_connection_timeout_ms",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Total TCP and TLS connection timeout in milliseconds.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "write_timeout_ms",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Per-write timeout in milliseconds.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.FilterChainConfig": {
+      "id": "core.type.FilterChainConfig",
+      "title": "FilterChainConfig",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "name",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Unique name for this filter chain.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "filters",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "reference",
+                      "schema_id": "core.type.FilterEntry"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Ordered list of filters in this chain.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.FilterEntry": {
+      "id": "core.type.FilterEntry",
+      "title": "FilterEntry",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "filter",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Filter type name (e.g. `\"router\"`, `\"load_balancer\"`, or a custom name).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "branch_chains",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "reference",
+                      "schema_id": "core.type.BranchChainConfig"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Optional branch chains evaluated after this filter\nbased on filter result conditions.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "conditions",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "one_of",
+                      "variants": [
+                        {
+                          "kind": {
+                            "kind": "object",
+                            "fields": [
+                              {
+                                "serialized_name": "when",
+                                "schema": {
+                                  "kind": {
+                                    "kind": "object",
+                                    "fields": [
+                                      {
+                                        "serialized_name": "path",
+                                        "schema": {
+                                          "kind": {
+                                            "kind": "string"
+                                          },
+                                          "description": "",
+                                          "examples": [],
+                                          "rules": [],
+                                          "sensitive": false
+                                        },
+                                        "required": false,
+                                        "flattened": false
+                                      },
+                                      {
+                                        "serialized_name": "path_prefix",
+                                        "schema": {
+                                          "kind": {
+                                            "kind": "string"
+                                          },
+                                          "description": "",
+                                          "examples": [],
+                                          "rules": [],
+                                          "sensitive": false
+                                        },
+                                        "required": false,
+                                        "flattened": false
+                                      },
+                                      {
+                                        "serialized_name": "methods",
+                                        "schema": {
+                                          "kind": {
+                                            "kind": "array",
+                                            "items": {
+                                              "kind": {
+                                                "kind": "string"
+                                              },
+                                              "description": "",
+                                              "examples": [],
+                                              "rules": [],
+                                              "sensitive": false
+                                            },
+                                            "min_items": null,
+                                            "max_items": null
+                                          },
+                                          "description": "",
+                                          "examples": [],
+                                          "rules": [],
+                                          "sensitive": false
+                                        },
+                                        "required": false,
+                                        "flattened": false
+                                      },
+                                      {
+                                        "serialized_name": "headers",
+                                        "schema": {
+                                          "kind": {
+                                            "kind": "map",
+                                            "values": {
+                                              "kind": {
+                                                "kind": "string"
+                                              },
+                                              "description": "",
+                                              "examples": [],
+                                              "rules": [],
+                                              "sensitive": false
+                                            }
+                                          },
+                                          "description": "",
+                                          "examples": [],
+                                          "rules": [],
+                                          "sensitive": false
+                                        },
+                                        "required": false,
+                                        "flattened": false
+                                      }
+                                    ],
+                                    "additional_properties": false
+                                  },
+                                  "description": "",
+                                  "examples": [],
+                                  "rules": [],
+                                  "sensitive": false
+                                },
+                                "required": true,
+                                "flattened": false
+                              }
+                            ],
+                            "additional_properties": false
+                          },
+                          "description": "",
+                          "examples": [],
+                          "rules": [],
+                          "sensitive": false
+                        },
+                        {
+                          "kind": {
+                            "kind": "object",
+                            "fields": [
+                              {
+                                "serialized_name": "unless",
+                                "schema": {
+                                  "kind": {
+                                    "kind": "object",
+                                    "fields": [
+                                      {
+                                        "serialized_name": "path",
+                                        "schema": {
+                                          "kind": {
+                                            "kind": "string"
+                                          },
+                                          "description": "",
+                                          "examples": [],
+                                          "rules": [],
+                                          "sensitive": false
+                                        },
+                                        "required": false,
+                                        "flattened": false
+                                      },
+                                      {
+                                        "serialized_name": "path_prefix",
+                                        "schema": {
+                                          "kind": {
+                                            "kind": "string"
+                                          },
+                                          "description": "",
+                                          "examples": [],
+                                          "rules": [],
+                                          "sensitive": false
+                                        },
+                                        "required": false,
+                                        "flattened": false
+                                      },
+                                      {
+                                        "serialized_name": "methods",
+                                        "schema": {
+                                          "kind": {
+                                            "kind": "array",
+                                            "items": {
+                                              "kind": {
+                                                "kind": "string"
+                                              },
+                                              "description": "",
+                                              "examples": [],
+                                              "rules": [],
+                                              "sensitive": false
+                                            },
+                                            "min_items": null,
+                                            "max_items": null
+                                          },
+                                          "description": "",
+                                          "examples": [],
+                                          "rules": [],
+                                          "sensitive": false
+                                        },
+                                        "required": false,
+                                        "flattened": false
+                                      },
+                                      {
+                                        "serialized_name": "headers",
+                                        "schema": {
+                                          "kind": {
+                                            "kind": "map",
+                                            "values": {
+                                              "kind": {
+                                                "kind": "string"
+                                              },
+                                              "description": "",
+                                              "examples": [],
+                                              "rules": [],
+                                              "sensitive": false
+                                            }
+                                          },
+                                          "description": "",
+                                          "examples": [],
+                                          "rules": [],
+                                          "sensitive": false
+                                        },
+                                        "required": false,
+                                        "flattened": false
+                                      }
+                                    ],
+                                    "additional_properties": false
+                                  },
+                                  "description": "",
+                                  "examples": [],
+                                  "rules": [],
+                                  "sensitive": false
+                                },
+                                "required": true,
+                                "flattened": false
+                              }
+                            ],
+                            "additional_properties": false
+                          },
+                          "description": "",
+                          "examples": [],
+                          "rules": [],
+                          "sensitive": false
+                        }
+                      ],
+                      "discriminator": null
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Ordered conditions that gate whether this filter runs on requests.\nEmpty means the filter always runs.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "name",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Optional user-assigned name for this filter entry.\nUsed as a rejoin target by branch chains.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "response_conditions",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "one_of",
+                      "variants": [
+                        {
+                          "kind": {
+                            "kind": "object",
+                            "fields": [
+                              {
+                                "serialized_name": "when",
+                                "schema": {
+                                  "kind": {
+                                    "kind": "object",
+                                    "fields": [
+                                      {
+                                        "serialized_name": "status",
+                                        "schema": {
+                                          "kind": {
+                                            "kind": "array",
+                                            "items": {
+                                              "kind": {
+                                                "kind": "integer"
+                                              },
+                                              "description": "",
+                                              "examples": [],
+                                              "rules": [],
+                                              "sensitive": false
+                                            },
+                                            "min_items": null,
+                                            "max_items": null
+                                          },
+                                          "description": "",
+                                          "examples": [],
+                                          "rules": [],
+                                          "sensitive": false
+                                        },
+                                        "required": false,
+                                        "flattened": false
+                                      },
+                                      {
+                                        "serialized_name": "headers",
+                                        "schema": {
+                                          "kind": {
+                                            "kind": "map",
+                                            "values": {
+                                              "kind": {
+                                                "kind": "string"
+                                              },
+                                              "description": "",
+                                              "examples": [],
+                                              "rules": [],
+                                              "sensitive": false
+                                            }
+                                          },
+                                          "description": "",
+                                          "examples": [],
+                                          "rules": [],
+                                          "sensitive": false
+                                        },
+                                        "required": false,
+                                        "flattened": false
+                                      }
+                                    ],
+                                    "additional_properties": false
+                                  },
+                                  "description": "",
+                                  "examples": [],
+                                  "rules": [],
+                                  "sensitive": false
+                                },
+                                "required": true,
+                                "flattened": false
+                              }
+                            ],
+                            "additional_properties": false
+                          },
+                          "description": "",
+                          "examples": [],
+                          "rules": [],
+                          "sensitive": false
+                        },
+                        {
+                          "kind": {
+                            "kind": "object",
+                            "fields": [
+                              {
+                                "serialized_name": "unless",
+                                "schema": {
+                                  "kind": {
+                                    "kind": "object",
+                                    "fields": [
+                                      {
+                                        "serialized_name": "status",
+                                        "schema": {
+                                          "kind": {
+                                            "kind": "array",
+                                            "items": {
+                                              "kind": {
+                                                "kind": "integer"
+                                              },
+                                              "description": "",
+                                              "examples": [],
+                                              "rules": [],
+                                              "sensitive": false
+                                            },
+                                            "min_items": null,
+                                            "max_items": null
+                                          },
+                                          "description": "",
+                                          "examples": [],
+                                          "rules": [],
+                                          "sensitive": false
+                                        },
+                                        "required": false,
+                                        "flattened": false
+                                      },
+                                      {
+                                        "serialized_name": "headers",
+                                        "schema": {
+                                          "kind": {
+                                            "kind": "map",
+                                            "values": {
+                                              "kind": {
+                                                "kind": "string"
+                                              },
+                                              "description": "",
+                                              "examples": [],
+                                              "rules": [],
+                                              "sensitive": false
+                                            }
+                                          },
+                                          "description": "",
+                                          "examples": [],
+                                          "rules": [],
+                                          "sensitive": false
+                                        },
+                                        "required": false,
+                                        "flattened": false
+                                      }
+                                    ],
+                                    "additional_properties": false
+                                  },
+                                  "description": "",
+                                  "examples": [],
+                                  "rules": [],
+                                  "sensitive": false
+                                },
+                                "required": true,
+                                "flattened": false
+                              }
+                            ],
+                            "additional_properties": false
+                          },
+                          "description": "",
+                          "examples": [],
+                          "rules": [],
+                          "sensitive": false
+                        }
+                      ],
+                      "discriminator": null
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Ordered conditions that gate whether this filter runs on responses.\nEvaluated against the upstream response (status, headers).\nEmpty means the filter always runs on responses.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "failure_mode",
+              "schema": {
+                "kind": {
+                  "kind": "one_of",
+                  "variants": [
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "closed"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "open"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    }
+                  ],
+                  "discriminator": null
+                },
+                "description": "Per-filter failure behaviour (`open` or `closed`).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "config",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "core.filter.entry.config"
+                },
+                "description": "",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": true
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.HeaderEntry": {
+      "id": "core.type.HeaderEntry",
+      "title": "HeaderEntry",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "name",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Header field name.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "value",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Header field value.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.HeaderPair": {
+      "id": "core.type.HeaderPair",
+      "title": "HeaderPair",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "name",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Header field name.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "value",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Header field value.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.HealthCheckConfig": {
+      "id": "core.type.HealthCheckConfig",
+      "title": "HealthCheckConfig",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "type",
+              "schema": {
+                "kind": {
+                  "kind": "one_of",
+                  "variants": [
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "http"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "tcp"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "grpc"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    }
+                  ],
+                  "discriminator": null
+                },
+                "description": "Probe type: [`Http`], [`Tcp`], or [`Grpc`].\n\n[`Http`]: HealthCheckType::Http\n[`Tcp`]: HealthCheckType::Tcp\n[`Grpc`]: HealthCheckType::Grpc",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "expected_status",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Expected HTTP status code for a healthy response.",
+                "default": 16,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "healthy_threshold",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Consecutive successes required to mark an endpoint healthy.",
+                "default": 32,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "interval_ms",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Probe interval in milliseconds.",
+                "default": 64,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "passive_healthy_threshold",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Consecutive successes to mark an endpoint healthy again\nvia passive observation. `None` disables passive recovery\n(active checks must recover it).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "passive_unhealthy_threshold",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Consecutive response failures (5xx or connect error) to\nmark an endpoint unhealthy via passive observation.\n`None` disables passive checking.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "path",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "HTTP path to probe (only used for `http` type).",
+                "default": "/",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "timeout_ms",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Probe timeout in milliseconds. Must be less than `interval_ms`.",
+                "default": 64,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "unhealthy_threshold",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Consecutive failures required to mark an endpoint unhealthy.",
+                "default": 32,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.InlineCredential": {
+      "id": "core.type.InlineCredential",
+      "title": "InlineCredential",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "username",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Username for authentication.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "password",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Literal password value.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "env_var",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Environment variable containing the password.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.InsecureOptions": {
+      "id": "core.type.InsecureOptions",
+      "title": "InsecureOptions",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "allow_open_security_filters",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Allow security-critical filters to use `failure_mode: open`,\ndemoting the validation error to a warning.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "allow_private_endpoints",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Allow cluster endpoints to resolve to loopback, link-local,\nor cloud metadata addresses.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "allow_private_health_checks",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Allow health checks to loopback/metadata addresses.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "allow_private_upstreams",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Allow upstream connections to resolve to private or reserved IP\naddresses at runtime. Without this flag, DNS-resolved upstream\naddresses in RFC 1918, loopback, link-local, CGNAT, and IPv6\nunique-local ranges are rejected to prevent DNS rebinding and\nSSRF attacks.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "allow_public_admin",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Allow admin endpoint on non-loopback addresses (`0.0.0.0`, LAN IPs, etc.).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "allow_root",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Allow running as root (UID 0).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "allow_tls_no_verify",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Allow disabling upstream TLS certificate verification (`tls.verify: false`).\n\nWithout this flag, setting `verify: false` on a cluster is a hard\nvalidation error. Enabling it demotes the error to a warning.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "allow_tls_without_sni",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Allow TLS without SNI hostname verification.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "allow_unbounded_body",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Allow startup without `body_limits.max_request_bytes` or\n`body_limits.max_response_bytes` configured. Without this\nflag, missing body limits are a hard validation error.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "csrf_log_only",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Run the CSRF filter in log-only mode: evaluate all rules\nbut log violations as warnings instead of rejecting requests.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "skip_pipeline_checks",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "core.type.SkipPipelineChecks"
+                },
+                "description": "Granular pipeline validation bypass flags.\n\nPrefer these over the blanket [`skip_pipeline_validation`]\nflag for targeted overrides.\n\n[`skip_pipeline_validation`]: InsecureOptions::skip_pipeline_validation",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "skip_pipeline_validation",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "**Deprecated.** Skip ALL pipeline ordering validation checks.\n\nPrefer [`skip_pipeline_checks`] for granular control. When this\nflag is `true`, [`effective_pipeline_checks`] returns\n[`SkipPipelineChecks::all`], overriding individual flags.\n\n[`skip_pipeline_checks`]: InsecureOptions::skip_pipeline_checks\n[`effective_pipeline_checks`]: InsecureOptions::effective_pipeline_checks",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.JsonAlias": {
+      "id": "core.type.JsonAlias",
+      "title": "JsonAlias",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "field",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Request JSON field whose string value is compared with `pattern`.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "match",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Exact or single-wildcard pattern for the configured field value.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "target",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Replacement value; omitted aliases preserve the original value.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.JsonBodyFieldMapping": {
+      "id": "core.type.JsonBodyFieldMapping",
+      "title": "JsonBodyFieldMapping",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "field",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Top-level JSON field name to extract.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "header",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Request header name to promote the extracted value into.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.JsonRpcHeaders": {
+      "id": "core.type.JsonRpcHeaders",
+      "title": "JsonRpcHeaders",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "id",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Header name for JSON-RPC id (e.g., `X-Json-Rpc-Id`).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "kind",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Header name for JSON-RPC kind (e.g., `X-Json-Rpc-Kind`).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "method",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Header name for JSON-RPC method (e.g., `X-Json-Rpc-Method`).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.Listener": {
+      "id": "core.type.Listener",
+      "title": "Listener",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "name",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Unique name for this listener.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "address",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Address to bind to (e.g. \"0.0.0.0:8080\").",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "cluster",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Cluster name for TCP load balancing.\n\nWhen set, the TCP listener routes connections via a load\nbalancer strategy across the named cluster's endpoints.\nMutually exclusive with `upstream`.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "downstream_read_timeout_ms",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Downstream read timeout in milliseconds for HTTP listeners.\n\nOnly applies to `protocol: http` listeners.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "filter_chains",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "string"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Named filter chains to apply to this listener.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "max_connections",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum concurrent connections for this listener.\n\nWhen set, new connections beyond this limit are\nrejected: HTTP returns 503, TCP closes the socket.\n`None` means unlimited.\n\n```\nuse praxis_core::config::Listener;\n\nlet listener: Listener = serde_yaml::from_str(\n    r#\"\nname: web\naddress: \"0.0.0.0:8080\"\nmax_connections: 10000\n\"#,\n)\n.unwrap();\nassert_eq!(listener.max_connections, Some(10000));\n```",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "protocol",
+              "schema": {
+                "kind": {
+                  "kind": "one_of",
+                  "variants": [
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "http"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "tcp"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    }
+                  ],
+                  "discriminator": null
+                },
+                "description": "Protocol this listener handles. Default: `http`.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "tcp_session_timeout_ms",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Session timeout in milliseconds for TCP forwarding sessions.\n\nWhen set, the entire `copy_bidirectional` call is wrapped in\na hard deadline. Active connections are terminated after this\nduration regardless of whether data is in flight. Only\napplies to `protocol: tcp` listeners. Defaults to 300,000 ms\n(5 minutes) for TCP listeners when not set.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "tcp_max_duration_secs",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum total session duration in seconds for TCP listeners.\n\nWhen set, the entire TCP session is capped at this duration\nregardless of activity. Only applies to `protocol: tcp` listeners.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "tls",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "core.type.ListenerTls"
+                },
+                "description": "TLS configuration for the listener.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "upstream",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Upstream address for TCP listeners (e.g. \"10.0.0.1:5432\").\n\nRequired for `protocol: tcp` unless `cluster` is set or filter\nchains provide routing. Ignored for HTTP listeners. Mutually\nexclusive with `cluster`.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.ListenerTls": {
+      "id": "core.type.ListenerTls",
+      "title": "ListenerTls",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "certificates",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "reference",
+                      "schema_id": "core.type.CertKeyPair"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Server certificates. At least one required.\n\nMultiple entries enable SNI-based cert selection.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "cipher_suites",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "one_of",
+                      "variants": [
+                        {
+                          "kind": {
+                            "kind": "literal",
+                            "value": "tls13_aes_128_gcm_sha256"
+                          },
+                          "description": "",
+                          "examples": [],
+                          "rules": [],
+                          "sensitive": false
+                        },
+                        {
+                          "kind": {
+                            "kind": "literal",
+                            "value": "tls13_aes_256_gcm_sha384"
+                          },
+                          "description": "",
+                          "examples": [],
+                          "rules": [],
+                          "sensitive": false
+                        },
+                        {
+                          "kind": {
+                            "kind": "literal",
+                            "value": "tls13_chacha20_poly1305_sha256"
+                          },
+                          "description": "",
+                          "examples": [],
+                          "rules": [],
+                          "sensitive": false
+                        },
+                        {
+                          "kind": {
+                            "kind": "literal",
+                            "value": "tls12_ecdhe_ecdsa_with_aes_128_gcm_sha256"
+                          },
+                          "description": "",
+                          "examples": [],
+                          "rules": [],
+                          "sensitive": false
+                        },
+                        {
+                          "kind": {
+                            "kind": "literal",
+                            "value": "tls12_ecdhe_ecdsa_with_aes_256_gcm_sha384"
+                          },
+                          "description": "",
+                          "examples": [],
+                          "rules": [],
+                          "sensitive": false
+                        },
+                        {
+                          "kind": {
+                            "kind": "literal",
+                            "value": "tls12_ecdhe_ecdsa_with_chacha20_poly1305_sha256"
+                          },
+                          "description": "",
+                          "examples": [],
+                          "rules": [],
+                          "sensitive": false
+                        },
+                        {
+                          "kind": {
+                            "kind": "literal",
+                            "value": "tls12_ecdhe_rsa_with_aes_128_gcm_sha256"
+                          },
+                          "description": "",
+                          "examples": [],
+                          "rules": [],
+                          "sensitive": false
+                        },
+                        {
+                          "kind": {
+                            "kind": "literal",
+                            "value": "tls12_ecdhe_rsa_with_aes_256_gcm_sha384"
+                          },
+                          "description": "",
+                          "examples": [],
+                          "rules": [],
+                          "sensitive": false
+                        },
+                        {
+                          "kind": {
+                            "kind": "literal",
+                            "value": "tls12_ecdhe_rsa_with_chacha20_poly1305_sha256"
+                          },
+                          "description": "",
+                          "examples": [],
+                          "rules": [],
+                          "sensitive": false
+                        }
+                      ],
+                      "discriminator": null
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Restrict accepted cipher suites to this list.\n\nWhen `None`, all provider cipher suites are accepted.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "client_ca",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "core.type.CaConfig"
+                },
+                "description": "CA for client certificate verification (mTLS).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "client_cert_mode",
+              "schema": {
+                "kind": {
+                  "kind": "one_of",
+                  "variants": [
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "none"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "request"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "require"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    }
+                  ],
+                  "discriminator": null
+                },
+                "description": "Client cert verification mode.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "hot_reload",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Certificate hot-reload via filesystem watching.\n\nDefaults to enabled for single-cert listeners (`None` is\ntreated as `true`). Set to `false` to disable. Certificate\nand key files are monitored for changes and reloaded without\nrestarting the proxy. Multi-cert (SNI) listeners always\ndisable hot-reload.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "min_version",
+              "schema": {
+                "kind": {
+                  "kind": "one_of",
+                  "variants": [
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "tls12"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "tls13"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    }
+                  ],
+                  "discriminator": null
+                },
+                "description": "Minimum TLS version accepted.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.LoggingConfig": {
+      "id": "core.type.LoggingConfig",
+      "title": "LoggingConfig",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "output",
+              "schema": {
+                "kind": {
+                  "kind": "one_of",
+                  "variants": [
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "stdout"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "stderr"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "file"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    }
+                  ],
+                  "discriminator": null
+                },
+                "description": "Log destination (`stdout`, `stderr`, or `file`).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "file_path",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Active log file path when `output` is `file`.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "non_blocking",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Use a background thread for log I/O.",
+                "default": true,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "buffer_size",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Non-blocking queue capacity in lines.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.MaglevOpts": {
+      "id": "core.type.MaglevOpts",
+      "title": "MaglevOpts",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "header",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Name of the request header to use as the hash key.\n\nFalls back to the request URI path when the header is absent or when this field is `None`.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.MetricLabelsConfig": {
+      "id": "core.type.MetricLabelsConfig",
+      "title": "MetricLabelsConfig",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "disabled",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "one_of",
+                      "variants": [
+                        {
+                          "kind": {
+                            "kind": "literal",
+                            "value": "cluster"
+                          },
+                          "description": "",
+                          "examples": [],
+                          "rules": [],
+                          "sensitive": false
+                        },
+                        {
+                          "kind": {
+                            "kind": "literal",
+                            "value": "endpoint"
+                          },
+                          "description": "",
+                          "examples": [],
+                          "rules": [],
+                          "sensitive": false
+                        },
+                        {
+                          "kind": {
+                            "kind": "literal",
+                            "value": "listener"
+                          },
+                          "description": "",
+                          "examples": [],
+                          "rules": [],
+                          "sensitive": false
+                        },
+                        {
+                          "kind": {
+                            "kind": "literal",
+                            "value": "method"
+                          },
+                          "description": "",
+                          "examples": [],
+                          "rules": [],
+                          "sensitive": false
+                        },
+                        {
+                          "kind": {
+                            "kind": "literal",
+                            "value": "route"
+                          },
+                          "description": "",
+                          "examples": [],
+                          "rules": [],
+                          "sensitive": false
+                        },
+                        {
+                          "kind": {
+                            "kind": "literal",
+                            "value": "status_class"
+                          },
+                          "description": "",
+                          "examples": [],
+                          "rules": [],
+                          "sensitive": false
+                        }
+                      ],
+                      "discriminator": null
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Dimensions to drop from every metric that carries them.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.MetricsConfig": {
+      "id": "core.type.MetricsConfig",
+      "title": "MetricsConfig",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "filter_duration",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Record per-filter hook duration histograms (`praxis_filter_duration_seconds`).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "labels",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "core.type.MetricLabelsConfig"
+                },
+                "description": "Label dimensions to emit on metrics.\n\nDisabling a dimension drops it from every metric that carries it,\nbounding total time-series cardinality in large deployments while\nkeeping the underlying metric available.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "route_templates",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "string"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Path templates that collapse dynamic segments in the `route` label.\n\nEach entry is a path with `{name}` placeholders, e.g.\n`/users/{id}/orders`. A request whose path matches a template is\nlabeled with the template instead of the router's path-match\npattern, keeping the label stable and bounded while staying more\nprecise than a prefix match.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.OperationConfig": {
+      "id": "core.type.OperationConfig",
+      "title": "OperationConfig",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "regex_replace",
+              "schema": {
+                "kind": {
+                  "kind": "one_of",
+                  "variants": [
+                    {
+                      "kind": {
+                        "kind": "string"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    {
+                      "kind": {
+                        "kind": "map",
+                        "values": {
+                          "kind": {
+                            "kind": "string"
+                          },
+                          "description": "",
+                          "examples": [],
+                          "rules": [],
+                          "sensitive": false
+                        }
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    {
+                      "kind": {
+                        "kind": "array",
+                        "items": {
+                          "kind": {
+                            "kind": "string"
+                          },
+                          "description": "",
+                          "examples": [],
+                          "rules": [],
+                          "sensitive": false
+                        },
+                        "min_items": null,
+                        "max_items": null
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    }
+                  ],
+                  "discriminator": null
+                },
+                "description": "",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "strip_query_params",
+              "schema": {
+                "kind": {
+                  "kind": "one_of",
+                  "variants": [
+                    {
+                      "kind": {
+                        "kind": "string"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    {
+                      "kind": {
+                        "kind": "map",
+                        "values": {
+                          "kind": {
+                            "kind": "string"
+                          },
+                          "description": "",
+                          "examples": [],
+                          "rules": [],
+                          "sensitive": false
+                        }
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    {
+                      "kind": {
+                        "kind": "array",
+                        "items": {
+                          "kind": {
+                            "kind": "string"
+                          },
+                          "description": "",
+                          "examples": [],
+                          "rules": [],
+                          "sensitive": false
+                        },
+                        "min_items": null,
+                        "max_items": null
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    }
+                  ],
+                  "discriminator": null
+                },
+                "description": "",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "add_query_params",
+              "schema": {
+                "kind": {
+                  "kind": "one_of",
+                  "variants": [
+                    {
+                      "kind": {
+                        "kind": "string"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    {
+                      "kind": {
+                        "kind": "map",
+                        "values": {
+                          "kind": {
+                            "kind": "string"
+                          },
+                          "description": "",
+                          "examples": [],
+                          "rules": [],
+                          "sensitive": false
+                        }
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    {
+                      "kind": {
+                        "kind": "array",
+                        "items": {
+                          "kind": {
+                            "kind": "string"
+                          },
+                          "description": "",
+                          "examples": [],
+                          "rules": [],
+                          "sensitive": false
+                        },
+                        "min_items": null,
+                        "max_items": null
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    }
+                  ],
+                  "discriminator": null
+                },
+                "description": "",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.PriorityOpts": {
+      "id": "core.type.PriorityOpts",
+      "title": "PriorityOpts",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "inner_strategy",
+              "schema": {
+                "kind": {
+                  "kind": "one_of",
+                  "variants": [
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "round_robin"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "least_connections"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "p2c"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "random"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    }
+                  ],
+                  "discriminator": null
+                },
+                "description": "Strategy to apply within each priority tier. Defaults to round-robin.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "overprovisioning_factor",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Overprovisioning factor as a percentage (e.g. 140 = 140%).\nTraffic shifts to the next tier when the current tier's healthy\ncapacity falls below `100 / overprovisioning_factor` of its total.\nDefaults to 140.",
+                "default": 32,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.ReplaceConfig": {
+      "id": "core.type.ReplaceConfig",
+      "title": "ReplaceConfig",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "pattern",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Regex pattern to match.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "replacement",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Replacement string (supports `$1`, `$name` capture groups).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.RetryBudgetConfig": {
+      "id": "core.type.RetryBudgetConfig",
+      "title": "RetryBudgetConfig",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "percent",
+              "schema": {
+                "kind": {
+                  "kind": "number"
+                },
+                "description": "Maximum retries as a percentage of active requests (0.0..=100.0).",
+                "examples": [],
+                "rules": [
+                  {
+                    "code": "core.budget_percent.range",
+                    "target": "",
+                    "kind": "numeric_bounds",
+                    "parameters": {
+                      "max": 100.0,
+                      "min": 0.0
+                    },
+                    "message": "value must be between 0 and 100"
+                  }
+                ],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "min_retries_per_second",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Floor on tokens per second even at low traffic.",
+                "default": 32,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.RetryPolicy": {
+      "id": "core.type.RetryPolicy",
+      "title": "RetryPolicy",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "max_retries",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum number of retry attempts after the initial try.\n\n`None` means inherit from the merge parent / use the legacy default.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "retriable_status_codes",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "integer"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [
+                      {
+                        "code": "core.http_status_code.range",
+                        "target": "",
+                        "kind": "numeric_bounds",
+                        "parameters": {
+                          "max": 599,
+                          "min": 100
+                        },
+                        "message": "value must be between 100 and 599"
+                      }
+                    ],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Explicit HTTP status codes that are retriable.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "retriable_conditions",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "one_of",
+                      "variants": [
+                        {
+                          "kind": {
+                            "kind": "literal",
+                            "value": "connect_failure"
+                          },
+                          "description": "",
+                          "examples": [],
+                          "rules": [],
+                          "sensitive": false
+                        },
+                        {
+                          "kind": {
+                            "kind": "literal",
+                            "value": "reset"
+                          },
+                          "description": "",
+                          "examples": [],
+                          "rules": [],
+                          "sensitive": false
+                        },
+                        {
+                          "kind": {
+                            "kind": "literal",
+                            "value": "refused_stream"
+                          },
+                          "description": "",
+                          "examples": [],
+                          "rules": [],
+                          "sensitive": false
+                        },
+                        {
+                          "kind": {
+                            "kind": "literal",
+                            "value": "status5xx"
+                          },
+                          "description": "",
+                          "examples": [],
+                          "rules": [],
+                          "sensitive": false
+                        }
+                      ],
+                      "discriminator": null
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Named retriable conditions (connect failure, reset, 5xx, ...).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "per_try_timeout_ms",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Independent timeout for a single upstream attempt, in milliseconds.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "request_timeout_ms",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Overall request deadline across all attempts, in milliseconds.\n\nWhen unset, the overall-timeout guard is skipped.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "backoff",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "core.type.BackoffConfig"
+                },
+                "description": "Exponential backoff between attempts.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "retry_budget",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "core.type.RetryBudgetConfig"
+                },
+                "description": "Token-bucket retry budget.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "retry_body_limit_bytes",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Max request body size eligible for replay (bytes). Defaults to 64 `KiB`.",
+                "examples": [],
+                "rules": [
+                  {
+                    "code": "core.retry_body_limit.range",
+                    "target": "",
+                    "kind": "numeric_bounds",
+                    "parameters": {
+                      "max": 65536,
+                      "min": 0
+                    },
+                    "message": "value must be between 0 and 65536"
+                  }
+                ],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "allow_non_idempotent",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Allow retries for non-idempotent methods (POST/PATCH) when true.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.RingHashOpts": {
+      "id": "core.type.RingHashOpts",
+      "title": "RingHashOpts",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "hash_function",
+              "schema": {
+                "kind": {
+                  "kind": "one_of",
+                  "variants": [
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "fnv1a"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "xxhash"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "murmur3"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    }
+                  ],
+                  "discriminator": null
+                },
+                "description": "Hash function to use for the ring. Defaults to FNV-1a.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "header",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Name of the request header to use as the hash key.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "virtual_nodes",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Number of virtual nodes per unit of endpoint weight. Defaults to 100.",
+                "default": 32,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.RouterRouteConfig": {
+      "id": "core.type.RouterRouteConfig",
+      "title": "RouterRouteConfig",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "path",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Exact path to match. Exactly one of `path` or `path_prefix`\nmust be set.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "path_prefix",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Path prefix to match; the longest matching prefix wins. Exactly\none of `path` or `path_prefix` must be set.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "cluster",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Name of the cluster to route matched requests to.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "headers",
+              "schema": {
+                "kind": {
+                  "kind": "map",
+                  "values": {
+                    "kind": {
+                      "kind": "string"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  }
+                },
+                "description": "Request headers to match. All specified headers must be present\nwith matching values (AND semantics, case-sensitive).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "host",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Host to match. If set, the route only applies to this host.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "json_aliases",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "reference",
+                      "schema_id": "core.type.JsonAlias"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Not implemented. Setting this is rejected at startup.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "retry_policy",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "core.type.RetryPolicy"
+                },
+                "description": "Optional per-route retry policy override.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.RuleConfig": {
+      "id": "core.type.RuleConfig",
+      "title": "RuleConfig",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "name",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Header name (required when `target` is [`Header`]).\n\n[`Header`]: RuleTargetKind::Header",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "contains",
+              "schema": {
+                "kind": {
+                  "kind": "one_of",
+                  "variants": [
+                    {
+                      "kind": {
+                        "kind": "string"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    {
+                      "kind": {
+                        "kind": "array",
+                        "items": {
+                          "kind": {
+                            "kind": "string"
+                          },
+                          "description": "",
+                          "examples": [],
+                          "rules": [],
+                          "sensitive": false
+                        },
+                        "min_items": null,
+                        "max_items": null
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    }
+                  ],
+                  "discriminator": null
+                },
+                "description": "",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "negate",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Invert the match: reject when the content does NOT\nmatch. For negated header rules, a missing header\nalso triggers rejection. Defaults to `false`.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "pattern",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Regex pattern match.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "target",
+              "schema": {
+                "kind": {
+                  "kind": "one_of",
+                  "variants": [
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "header"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "body"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    }
+                  ],
+                  "discriminator": null
+                },
+                "description": "What to inspect: header or body.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.RuntimeConfig": {
+      "id": "core.type.RuntimeConfig",
+      "title": "RuntimeConfig",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "global_queue_interval",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Tokio scheduler global queue check interval, in ticks.\n\nControls how often worker threads check the global task\nqueue. The default of 61 (a prime) reduces contention\nunder proxy workloads where most tasks are I/O-bound.\nSet to `null` to use the tokio default. Valid range is\nany positive `u32`.\n\n```\nuse praxis_core::config::RuntimeConfig;\n\nlet cfg = RuntimeConfig::default();\nassert_eq!(cfg.global_queue_interval, Some(61));\n\nlet cfg: RuntimeConfig = serde_yaml::from_str(\"global_queue_interval: 128\").unwrap();\nassert_eq!(cfg.global_queue_interval, Some(128));\n```",
+                "default": 32,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "log_overrides",
+              "schema": {
+                "kind": {
+                  "kind": "map",
+                  "values": {
+                    "kind": {
+                      "kind": "string"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  }
+                },
+                "description": "Per-module log level overrides.\n\n```\nuse praxis_core::config::RuntimeConfig;\n\nlet yaml = r#\"\nlog_overrides:\n  praxis_filter::pipeline: trace\n  praxis_protocol: debug\n\"#;\nlet cfg: RuntimeConfig = serde_yaml::from_str(yaml).unwrap();\nassert_eq!(cfg.log_overrides.len(), 2);\nassert_eq!(cfg.log_overrides[\"praxis_filter::pipeline\"], \"trace\");\n```",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "logging",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "core.type.LoggingConfig"
+                },
+                "description": "Process log destination and buffering.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "max_connections",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Process-wide maximum concurrent connections across all\nlisteners (both HTTP and TCP).\n\nWhen set, new connections beyond this limit are rejected\nwith HTTP 503 (or TCP close for non-HTTP listeners),\nregardless of per-listener limits. Connections are shed\nbefore filter pipeline execution. `None` (the default)\nmeans no global limit.\n\n```\nuse praxis_core::config::RuntimeConfig;\n\nlet cfg: RuntimeConfig = serde_yaml::from_str(\"max_connections: 10000\").unwrap();\nassert_eq!(cfg.max_connections, Some(10_000));\n\nlet cfg = RuntimeConfig::default();\nassert!(cfg.max_connections.is_none());\n```",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "max_memory_bytes",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum resident memory (RSS) in bytes before shedding load.\n\nWhen set, Praxis monitors process RSS and rejects new\nrequests with 503 when the threshold is exceeded. `None`\n(the default) disables memory pressure monitoring.\n\n```\nuse praxis_core::config::RuntimeConfig;\n\nlet cfg: RuntimeConfig = serde_yaml::from_str(\"max_memory_bytes: 1073741824\").unwrap();\nassert_eq!(cfg.max_memory_bytes, Some(1_073_741_824));\n\nlet cfg = RuntimeConfig::default();\nassert!(cfg.max_memory_bytes.is_none());\n```",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "subrequest_circuit_breaker",
+              "schema": {
+                "kind": {
+                  "kind": "reference",
+                  "schema_id": "core.type.SubRequestCircuitBreakerConfig"
+                },
+                "description": "Per-peer circuit breaker for the shared sub-request connector.\n\nWhen configured, the connector tracks consecutive failures\nper upstream `SocketAddr` and rejects sub-requests while\na peer's circuit is open. See\n[`SubRequestCircuitBreakerConfig`] for field descriptions.\n\n```\nuse praxis_core::config::RuntimeConfig;\n\nlet yaml = r#\"\nsubrequest_circuit_breaker:\n  consecutive_failures: 5\n  recovery_window_secs: 30\n\"#;\nlet cfg: RuntimeConfig = serde_yaml::from_str(yaml).unwrap();\nassert!(cfg.subrequest_circuit_breaker.is_some());\n\nlet cfg = RuntimeConfig::default();\nassert!(cfg.subrequest_circuit_breaker.is_none());\n```",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "subrequest_max_connections",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum concurrently active sub-request exchanges across\nall `iterative_request_router` instances.\n\nWhen set, a semaphore limits the number of in-flight\nexchanges. Requests that cannot acquire a permit within\ntheir step timeout produce an admission-timeout error.\n`None` (the default) means no concurrency limit.\n\n```\nuse praxis_core::config::RuntimeConfig;\n\nlet cfg: RuntimeConfig = serde_yaml::from_str(\"subrequest_max_connections: 256\").unwrap();\nassert_eq!(cfg.subrequest_max_connections, Some(256));\n\nlet cfg = RuntimeConfig::default();\nassert!(cfg.subrequest_max_connections.is_none());\n```",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "subrequest_pool_size",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum idle connections in the sub-request connection pool\nused by `iterative_request_router` step chains.\n\n```\nuse praxis_core::config::RuntimeConfig;\n\nlet cfg = RuntimeConfig::default();\nassert_eq!(cfg.subrequest_pool_size, Some(128));\n```",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "threads",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Number of worker threads per service.\n\n`0` (the default) auto-detects based on available CPU\ncores. Values above the CPU count are valid but yield\ndiminishing returns for I/O-bound workloads.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "upstream_ca_file",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Path to a PEM CA file used as the root certificate store for all upstream TLS connections.\n\nWhen set, this **replaces** the system trust store (not additive). If backends\nuse both a private CA and public CAs, create a combined PEM bundle containing\nall required root certificates.\n\n```\nuse praxis_core::config::RuntimeConfig;\n\nlet cfg: RuntimeConfig =\n    serde_yaml::from_str(\"upstream_ca_file: /etc/praxis/ca-bundle.pem\").unwrap();\nassert_eq!(\n    cfg.upstream_ca_file.as_deref(),\n    Some(\"/etc/praxis/ca-bundle.pem\")\n);\n\nlet cfg = RuntimeConfig::default();\nassert!(cfg.upstream_ca_file.is_none());\n```",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "upstream_keepalive_pool_size",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum number of idle upstream connections kept per worker\nthread, shared across all clusters.\n\nWhen a worker's pool is full, the oldest idle connection\nis evicted. Set to `null` to use Pingora's built-in\ndefault. This is a per-thread limit, not per-cluster.\n\n```\nuse praxis_core::config::RuntimeConfig;\n\nlet cfg = RuntimeConfig::default();\nassert_eq!(cfg.upstream_keepalive_pool_size, Some(64));\n\nlet cfg: RuntimeConfig = serde_yaml::from_str(\"upstream_keepalive_pool_size: 32\").unwrap();\nassert_eq!(cfg.upstream_keepalive_pool_size, Some(32));\n```",
+                "default": 64,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "work_stealing",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Allow work-stealing between worker threads of the same service.",
+                "default": true,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.SkipPipelineChecks": {
+      "id": "core.type.SkipPipelineChecks",
+      "title": "SkipPipelineChecks",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "conditional_security",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Skip check: security filters with request conditions (bypass risk).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "conflicting_cluster_selectors",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Skip check: multiple cluster-selecting filters before load balancer.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "duplicate_load_balancers",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Skip check: duplicate `load_balancer` filters.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "duplicate_rewrite_filters",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Skip check: multiple path rewriting filters.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "duplicate_routers",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Skip check: duplicate `router` filters.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "lb_without_router",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Skip check: `load_balancer` without a preceding router.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "misaligned_clusters",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Skip check: cluster references not matching load balancer config.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "unreachable_filters",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "Skip check: unconditional `static_response` blocking subsequent\nfilters.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.SniRouteEntry": {
+      "id": "core.type.SniRouteEntry",
+      "title": "SniRouteEntry",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "server_names",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "string"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Server name patterns (exact or wildcard like `*.example.com`).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "upstream",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Upstream address for matching connections.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.StepConfig": {
+      "id": "core.type.StepConfig",
+      "title": "StepConfig",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "name",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Step name (must be unique within the router).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "filters",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "reference",
+                      "schema_id": "core.type.FilterEntry"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Filters to execute for this step's sub-request.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "on_result",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "reference",
+                      "schema_id": "core.type.StepTransition"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Transition rules evaluated in order. Streaming header-safe failovers\nrun before body exposure; remaining rules run after step completion.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.StepTransition": {
+      "id": "core.type.StepTransition",
+      "title": "StepTransition",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "default",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "If true, this is the default (always-match) rule.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "filter",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Filter name whose results to check.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "key",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Result key to match.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "next",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Name of the step to transition to (mutually\nexclusive with `done`).",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "origin",
+              "schema": {
+                "kind": {
+                  "kind": "one_of",
+                  "variants": [
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "upstream"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "local"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "transport"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    }
+                  ],
+                  "discriminator": null
+                },
+                "description": "Where the response originated: `upstream`, `local`,\nor `transport`. When unset, any origin matches.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "status",
+              "schema": {
+                "kind": {
+                  "kind": "array",
+                  "items": {
+                    "kind": {
+                      "kind": "integer"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  },
+                  "min_items": null,
+                  "max_items": null
+                },
+                "description": "Response status codes to match (e.g., [502, 503, 504]).\nTransport failures are exposed as 502 and deadline expiry\nas 504.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "transport_error",
+              "schema": {
+                "kind": {
+                  "kind": "one_of",
+                  "variants": [
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "admission_timeout"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "circuit_open"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "connect"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "io"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "deadline_exceeded"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "response_too_large"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    }
+                  ],
+                  "discriminator": null
+                },
+                "description": "Transport error kind to match: `admission_timeout`,\n`circuit_open`, `connect`, `io`, `deadline_exceeded`,\nor `response_too_large`. `circuit_open` requires\n`runtime.subrequest_circuit_breaker` to be configured.\nOnly meaningful when `origin: transport`.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "value",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Result value to match.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "done",
+              "schema": {
+                "kind": {
+                  "kind": "boolean"
+                },
+                "description": "If true, return the current response to the client.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.SubRequestCircuitBreakerConfig": {
+      "id": "core.type.SubRequestCircuitBreakerConfig",
+      "title": "SubRequestCircuitBreakerConfig",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "consecutive_failures",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Consecutive failure threshold before the circuit opens.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "recovery_window_secs",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Seconds the circuit stays open before allowing a probe.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "half_open_timeout_secs",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Seconds a half-open probe may remain in-flight before\nthe circuit resets to open. Defaults to 30.",
+                "default": 64,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.SubsetOpts": {
+      "id": "core.type.SubsetOpts",
+      "title": "SubsetOpts",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "fallback_policy",
+              "schema": {
+                "kind": {
+                  "kind": "one_of",
+                  "variants": [
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "any_endpoint"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "no_endpoint"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    }
+                  ],
+                  "discriminator": null
+                },
+                "description": "Behavior when no endpoints match the selector.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "inner_strategy",
+              "schema": {
+                "kind": {
+                  "kind": "one_of",
+                  "variants": [
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "round_robin"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "least_connections"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "p2c"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "random"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    }
+                  ],
+                  "discriminator": null
+                },
+                "description": "Strategy to apply within the matching subset. Defaults to round-robin.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "selector",
+              "schema": {
+                "kind": {
+                  "kind": "map",
+                  "values": {
+                    "kind": {
+                      "kind": "string"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  }
+                },
+                "description": "Metadata key-value pairs that endpoints must match to be included\nin the active subset.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.TelemetryConfig": {
+      "id": "core.type.TelemetryConfig",
+      "title": "TelemetryConfig",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "batch_interval_secs",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Batch export interval in seconds.\n\nControls how frequently the batch span processor flushes pending spans\nto the OTLP collector. Defaults to 5 seconds when not set.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "batch_size",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Maximum number of spans per batch export.\n\nControls the maximum batch size for the batch span processor.\nDefaults to 512 when not set.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "environment",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Deployment environment resource attribute (`deployment.environment`).\n\nFalls back to `deployment.environment` in the `OTEL_RESOURCE_ATTRIBUTES`\nenv var when not set in config.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "otlp_endpoint",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "OTLP collector endpoint (e.g. `http://localhost:4317`).\n\nWhen set, enables the OTLP trace exporter (requires the `otel`\nfeature). Falls back to `OTEL_EXPORTER_OTLP_ENDPOINT` env var\nif not set in config.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "otlp_headers",
+              "schema": {
+                "kind": {
+                  "kind": "map",
+                  "values": {
+                    "kind": {
+                      "kind": "string"
+                    },
+                    "description": "",
+                    "examples": [],
+                    "rules": [],
+                    "sensitive": false
+                  }
+                },
+                "description": "Custom headers for the OTLP exporter (e.g. API keys).\n\nSent on every export request — as gRPC metadata for the default\n`grpc` protocol, or as HTTP headers for `http/protobuf`.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "sampling_rate",
+              "schema": {
+                "kind": {
+                  "kind": "number"
+                },
+                "description": "Head-based trace sampling rate between `0.0` (drop all) and `1.0`\n(sample all).\n\nWhen set, configures a `ParentBased(TraceIdRatioBased(rate))`\nsampler: root spans are sampled at the given rate while\nlocally-created child spans inherit their parent's sampling\ndecision.\n\nWhen `None` (the default), the `OTel` default sampler is used\n(`ParentBased(AlwaysOn)`), preserving backward compatibility.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "service_name",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "`OTel` `service.name` resource attribute.\n\nFalls back to `OTEL_SERVICE_NAME` env var when not set in config.\nDefaults to `\"praxis\"` when neither is set.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "service_version",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "`OTel` `service.version` resource attribute.\n\nFalls back to `service.version` in the `OTEL_RESOURCE_ATTRIBUTES`\nenv var when not set in config.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.TrustedPeerConfig": {
+      "id": "core.type.TrustedPeerConfig",
+      "title": "TrustedPeerConfig",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "cert_digest",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Lowercase hex-encoded SHA-256 certificate digest.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "organization",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "X.509 subject organization (`O=` field).\n\nWeaker than certificate digest — useful for bootstrap and\ncontrolled test configurations where cert digests are not\nknown ahead of time.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "serial_number",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "Certificate serial number.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    "core.type.ZoneAwareOpts": {
+      "id": "core.type.ZoneAwareOpts",
+      "title": "ZoneAwareOpts",
+      "description": "",
+      "node": {
+        "kind": {
+          "kind": "object",
+          "fields": [
+            {
+              "serialized_name": "inner_strategy",
+              "schema": {
+                "kind": {
+                  "kind": "one_of",
+                  "variants": [
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "round_robin"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "least_connections"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "p2c"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    },
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": "random"
+                      },
+                      "description": "",
+                      "examples": [],
+                      "rules": [],
+                      "sensitive": false
+                    }
+                  ],
+                  "discriminator": null
+                },
+                "description": "Strategy to apply within the selected zone group. Defaults to round-robin.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            },
+            {
+              "serialized_name": "local_zone",
+              "schema": {
+                "kind": {
+                  "kind": "string"
+                },
+                "description": "The zone of the proxy itself. Endpoints in this zone are preferred.",
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": true,
+              "flattened": false
+            },
+            {
+              "serialized_name": "min_local_healthy_pct",
+              "schema": {
+                "kind": {
+                  "kind": "integer"
+                },
+                "description": "Minimum percentage of healthy endpoints in the local zone before\ntraffic spills to remote zones. Defaults to 70.",
+                "default": 8,
+                "examples": [],
+                "rules": [],
+                "sensitive": false
+              },
+              "required": false,
+              "flattened": false
+            }
+          ],
+          "additional_properties": false
+        },
+        "description": "",
+        "examples": [],
+        "rules": [],
+        "sensitive": false
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    }
+  },
+  "roots": [
+    {
+      "name": "Config",
+      "schema": "core.root.config"
+    }
+  ],
+  "filters": [
+    {
+      "name": "access_log",
+      "protocol": "http",
+      "category": "observability",
+      "description": "Logs structured access records for each request and response.",
+      "config_schema": "core.filter.http.observability.access_log",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": false,
+        "response_headers": true,
+        "response_body": true,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: access_log\nsample_rate: 0.1   # optional; log ~10% of requests (default 1.0)\nfields:            # optional; replaces default ten fields when present\n  - method\n  - path\n  - status\n  - duration_ms\n  - request_header.user-agent\n  - trace_id\nrequest_headers: [user-agent]   # optional; pairs with request_header.* tokens\nresponse_headers: [content-type]\nconditions:                   # optional emit-time gates (AND across keys)\n  min_duration_ms: 1000\n  status_classes: [4xx, 5xx]  # OR within list\n  paths: [\"/api\"]             # OR within list; segment-boundary prefixes"
+        }
+      ],
+      "source": {
+        "path": "crates/filter/src/builtins/http/observability/access_log.rs",
+        "line": 562
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    {
+      "name": "request_id",
+      "protocol": "http",
+      "category": "observability",
+      "description": "Ensures every request carries a correlation ID.",
+      "config_schema": "core.filter.http.observability.request_id",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": false,
+        "response_headers": true,
+        "response_body": false,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: request_id\nheader_name: X-Correlation-ID   # optional"
+        }
+      ],
+      "source": {
+        "path": "crates/filter/src/builtins/http/observability/request_id.rs",
+        "line": 150
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    {
+      "name": "trace_context",
+      "protocol": "http",
+      "category": "observability",
+      "description": "Propagates W3C Trace Context headers (`traceparent`, `tracestate`).",
+      "config_schema": "core.filter.http.observability.trace_context",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": false,
+        "response_headers": false,
+        "response_body": false,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: trace_context"
+        }
+      ],
+      "source": {
+        "path": "crates/filter/src/builtins/http/observability/trace_context.rs",
+        "line": 191
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    {
+      "name": "compression",
+      "protocol": "http",
+      "category": "payload_processing",
+      "description": "Enables Pingora's built-in response compression when present in a filter chain.",
+      "config_schema": "core.filter.http.payload_processing.compression",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": false,
+        "response_headers": true,
+        "response_body": false,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: compression\nlevel: 6                        # default level for all algorithms\nmin_size_bytes: 256             # skip responses smaller than this\ngzip:\n  enabled: true\n  level: 6\nbrotli:\n  enabled: true\n  level: 4\nzstd:\n  enabled: true\n  level: 3\ncontent_types:\n  - \"text/\"\n  - \"application/json\"\n  - \"application/javascript\"\n  - \"application/xml\"\n  - \"application/wasm\""
+        }
+      ],
+      "source": {
+        "path": "crates/filter/src/builtins/http/payload_processing/compression.rs",
+        "line": 199
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    {
+      "name": "json_body_field",
+      "protocol": "http",
+      "category": "payload_processing",
+      "description": "Extracts top-level fields from a JSON request body and promotes their values to request headers using [`StreamBuffer`] mode.",
+      "config_schema": "core.filter.http.payload_processing.json_body_field",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": true,
+        "response_headers": false,
+        "response_body": false,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: json_body_field\nfield: model\nheader: X-Model"
+        },
+        {
+          "yaml": "filter: json_body_field\nfields:\n  - field: model\n    header: X-Model\n  - field: user_id\n    header: X-User-Id"
+        }
+      ],
+      "source": {
+        "path": "crates/filter/src/builtins/http/payload_processing/json_body_field/mod.rs",
+        "line": 165
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    {
+      "name": "json_rpc",
+      "protocol": "http",
+      "category": "payload_processing",
+      "description": "Extracts JSON-RPC 2.0 envelope metadata from request bodies and promotes method, id, and kind to request headers and filter results for routing.",
+      "config_schema": "core.filter.http.payload_processing.json_rpc",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": true,
+        "response_headers": false,
+        "response_body": false,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: json_rpc"
+        },
+        {
+          "yaml": "filter: json_rpc\nmax_body_bytes: 1048576\nbatch_policy: first\nmax_batch_size: 50\non_invalid: continue\nheaders:\n  method: X-Json-Rpc-Method\n  id: X-Json-Rpc-Id\n  kind: X-Json-Rpc-Kind"
+        }
+      ],
+      "source": {
+        "path": "crates/filter/src/builtins/http/payload_processing/json_rpc/mod.rs",
+        "line": 137
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    {
+      "name": "basic_auth",
+      "protocol": "http",
+      "category": "security",
+      "description": "HTTP Basic Authentication filter (RFC 7617).",
+      "config_schema": "core.filter.http.security.basic_auth",
+      "required_features": [
+        "basic-auth-filter"
+      ],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": false,
+        "response_headers": false,
+        "response_body": false,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: basic_auth\nrealm: \"Restricted\"\nstrip_authorization: true\ncredentials:\n  - username: admin\n    password: secret\n  - username: deploy\n    env_var: DEPLOY_PASSWORD"
+        }
+      ],
+      "source": {
+        "path": "crates/filter/src/builtins/http/security/basic_auth/filter.rs",
+        "line": 155
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    {
+      "name": "cors",
+      "protocol": "http",
+      "category": "security",
+      "description": "Spec-compliant CORS filter implementing origin validation, preflight handling, and response header injection.",
+      "config_schema": "core.filter.http.security.cors",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "security",
+        "request_headers": true,
+        "request_body": false,
+        "response_headers": true,
+        "response_body": false,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: cors\nallow_origins:\n  - \"https://app.example.com\"\n  - \"https://*.example.com\"\nallow_methods:\n  - GET\n  - POST\n  - PUT\nallow_headers:\n  - Content-Type\n  - Authorization\nexpose_headers:\n  - X-Request-ID\nmax_age: 3600\nallow_credentials: false"
+        }
+      ],
+      "source": {
+        "path": "crates/filter/src/builtins/http/security/cors/mod.rs",
+        "line": 294
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    {
+      "name": "credential_injection",
+      "protocol": "http",
+      "category": "security",
+      "description": "Injects per-cluster API credentials into upstream requests.",
+      "config_schema": "core.filter.http.security.credential_injection",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "security",
+        "request_headers": true,
+        "request_body": false,
+        "response_headers": true,
+        "response_body": false,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: credential_injection\nclusters:\n  - name: provider-a\n    header: Authorization\n    env_var: PROVIDER_A_API_KEY\n    header_prefix: \"Bearer \"\n    strip_client_credential: true\n  - name: internal\n    header: x-api-key\n    value: \"internal-secret\""
+        }
+      ],
+      "source": {
+        "path": "crates/filter/src/builtins/http/security/credential_injection/filter.rs",
+        "line": 150
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    {
+      "name": "csrf",
+      "protocol": "http",
+      "category": "security",
+      "description": "CSRF protection filter that validates request origins against a trusted allowlist.",
+      "config_schema": "core.filter.http.security.csrf",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "security",
+        "request_headers": true,
+        "request_body": false,
+        "response_headers": false,
+        "response_body": false,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: csrf\ntrusted_origins:\n  - \"https://app.example.com\"\n  - \"https://*.example.com\"\nenforce_percentage: 100\nenable_sec_fetch_site: true"
+        }
+      ],
+      "source": {
+        "path": "crates/filter/src/builtins/http/security/csrf/mod.rs",
+        "line": 204
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    {
+      "name": "forwarded_headers",
+      "protocol": "http",
+      "category": "security",
+      "description": "Injects `X-Forwarded-For`, `X-Forwarded-Proto`, and `X-Forwarded-Host` headers into upstream requests.",
+      "config_schema": "core.filter.http.security.forwarded_headers",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "security",
+        "request_headers": true,
+        "request_body": false,
+        "response_headers": false,
+        "response_body": false,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: forwarded_headers\ntrusted_proxies: [\"10.0.0.0/8\"]\nuse_standard_header: true"
+        }
+      ],
+      "source": {
+        "path": "crates/filter/src/builtins/http/security/forwarded_headers.rs",
+        "line": 249
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    {
+      "name": "guardrails",
+      "protocol": "http",
+      "category": "security",
+      "description": "Rejects requests matching string, regex, or PII rules against headers and/or body content.",
+      "config_schema": "core.filter.http.security.guardrails",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "security",
+        "request_headers": true,
+        "request_body": true,
+        "response_headers": false,
+        "response_body": false,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: guardrails\naction: flag            # or \"reject\" (default)\nrules:\n  # Detect PII in a header\n  - target: header\n    name: \"Authorization\"\n    contains: [ssn, credit_card, email]\n  # Detect PII in body\n  - target: body\n    contains: [ssn, credit_card, phone, email]\n  # Block SQL injection in body\n  - target: body\n    contains: \"DROP TABLE\"\n  # Block requests from bad bots\n  - target: header\n    name: \"User-Agent\"\n    pattern: \"bad-bot.*\"\n  # Require body to look like JSON (reject if NOT matching)\n  - target: body\n    pattern: \"^\\\\{.*\\\\}$\"\n    negate: true"
+        }
+      ],
+      "source": {
+        "path": "crates/filter/src/builtins/http/security/guardrails/filter.rs",
+        "line": 207
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    {
+      "name": "ip_acl",
+      "protocol": "http",
+      "category": "security",
+      "description": "IP-based access control filter.",
+      "config_schema": "core.filter.http.security.ip_acl",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "security",
+        "request_headers": true,
+        "request_body": false,
+        "response_headers": false,
+        "response_body": false,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: ip_acl\nallow:\n  - \"10.0.0.0/8\"\n  - \"192.168.0.0/16\""
+        }
+      ],
+      "source": {
+        "path": "crates/filter/src/builtins/http/security/ip_acl.rs",
+        "line": 126
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    {
+      "name": "peer_identity_trust",
+      "protocol": "http",
+      "category": "security",
+      "description": "Validates that the downstream mTLS peer identity matches a configured trusted peer before allowing the request to continue.",
+      "config_schema": "core.filter.http.security.peer_identity_trust",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "security",
+        "request_headers": true,
+        "request_body": false,
+        "response_headers": false,
+        "response_body": false,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: peer_identity_trust\ntrusted_peers:\n  - cert_digest: \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"\n  - cert_digest: \"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"\n    organization: example-org"
+        }
+      ],
+      "source": {
+        "path": "crates/filter/src/builtins/http/security/peer_identity_trust.rs",
+        "line": 161
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    {
+      "name": "policy",
+      "protocol": "http",
+      "category": "security",
+      "description": "Embeds the Praxis Policy Engine in-process to enforce multi-source JWT identity, APL route policy, RFC 8693 token exchange, PII scanning, audit emission, and (under `body_access: read_write`) request / response body rewriting.",
+      "config_schema": "core.filter.http.security.policy",
+      "required_features": [
+        "policy-engine"
+      ],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": true,
+        "response_headers": true,
+        "response_body": true,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: policy\nconfig_path: /etc/praxis/policy.yaml\nbody_access: read_write       # optional; default read_only\nrequire_protocol_metadata: true    # optional; default true\ninit_timeout_secs: 30         # optional; default 30\nmax_buffer_bytes: 10485760    # optional; default 10 MiB (read_write only)"
+        }
+      ],
+      "source": {
+        "path": "crates/filter/src/builtins/http/security/policy/filter.rs",
+        "line": 847
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    {
+      "name": "circuit_breaker",
+      "protocol": "http",
+      "category": "traffic_management",
+      "description": "Rejects requests to clusters whose circuit is open.",
+      "config_schema": "core.filter.http.traffic_management.circuit_breaker",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": false,
+        "response_headers": true,
+        "response_body": false,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: circuit_breaker\nclusters:\n  - name: backend\n    consecutive_failures: 5\n    recovery_window_secs: 30"
+        }
+      ],
+      "source": {
+        "path": "crates/filter/src/builtins/http/traffic_management/circuit_breaker/mod.rs",
+        "line": 223
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    {
+      "name": "endpoint_selector",
+      "protocol": "http",
+      "category": "traffic_management",
+      "description": "Selects an upstream endpoint from a trusted mutation source.",
+      "config_schema": "core.filter.http.traffic_management.endpoint_selector",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": false,
+        "response_headers": false,
+        "response_body": false,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: endpoint_selector\nsource_header: x-gateway-destination-endpoint\nstrip_header: true  # default true\nconnection:\n  connection_timeout_ms: 1000\n  total_connection_timeout_ms: 2000\ntls:\n  sni: inference.example.internal"
+        }
+      ],
+      "source": {
+        "path": "crates/filter/src/builtins/http/traffic_management/endpoint_selector.rs",
+        "line": 375
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    {
+      "name": "grpc_detection",
+      "protocol": "http",
+      "category": "traffic_management",
+      "description": "Detects gRPC requests from the `content-type` header and promotes the variant to filter metadata and results for downstream routing.",
+      "config_schema": "core.filter.http.traffic_management.grpc_detection",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": false,
+        "response_headers": false,
+        "response_body": false,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: grpc_detection"
+        }
+      ],
+      "source": {
+        "path": "crates/filter/src/builtins/http/traffic_management/grpc_detection/mod.rs",
+        "line": 63
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    {
+      "name": "iterative_request_router",
+      "protocol": "http",
+      "category": "traffic_management",
+      "description": "Framework-level filter for iterative sub-request execution.",
+      "config_schema": "core.filter.http.traffic_management.iterative_request_router",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": false,
+        "response_headers": false,
+        "response_body": false,
+        "terminal": true
+      },
+      "examples": [
+        {
+          "yaml": "filter: iterative_request_router\ninitial_step: model-call\nsteps:\n  - name: model-call\n    filters:\n      - filter: router\n        routes:\n          - cluster: llm-backend\n      - filter: load_balancer\n        clusters:\n          - name: llm-backend\n            endpoints: [\"10.0.0.1:8000\"]\n    on_result:\n      - default: true\n        done: true"
+        }
+      ],
+      "source": {
+        "path": "crates/filter/src/builtins/http/traffic_management/iterative_request_router/mod.rs",
+        "line": 311
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    {
+      "name": "load_balancer",
+      "protocol": "http",
+      "category": "traffic_management",
+      "description": "Selects an upstream endpoint using the cluster's configured strategy.",
+      "config_schema": "core.filter.http.traffic_management.load_balancer",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": false,
+        "response_headers": true,
+        "response_body": false,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: load_balancer\nclusters:\n  - name: backend\n    endpoints: [\"10.0.0.1:80\"]"
+        }
+      ],
+      "source": {
+        "path": "crates/filter/src/builtins/http/traffic_management/load_balancer/mod.rs",
+        "line": 154
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    {
+      "name": "rate_limit",
+      "protocol": "http",
+      "category": "traffic_management",
+      "description": "Token bucket rate limiter that rejects excess traffic with 429.",
+      "config_schema": "core.filter.http.traffic_management.rate_limit",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "security",
+        "request_headers": true,
+        "request_body": false,
+        "response_headers": true,
+        "response_body": false,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: rate_limit\nmode: per_ip        # \"per_ip\" or \"global\"\nrate: 100           # tokens per second\nburst: 200          # max bucket capacity"
+        }
+      ],
+      "source": {
+        "path": "crates/filter/src/builtins/http/traffic_management/rate_limit/mod.rs",
+        "line": 298
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    {
+      "name": "redirect",
+      "protocol": "http",
+      "category": "traffic_management",
+      "description": "Returns a redirect response without contacting any upstream.",
+      "config_schema": "core.filter.http.traffic_management.redirect",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": false,
+        "response_headers": false,
+        "response_body": false,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: redirect\nstatus: 301\nlocation: \"https://example.com${path}${query}\""
+        }
+      ],
+      "source": {
+        "path": "crates/filter/src/builtins/http/traffic_management/redirect.rs",
+        "line": 211
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    {
+      "name": "router",
+      "protocol": "http",
+      "category": "traffic_management",
+      "description": "Routes requests to clusters based on path prefix and host header.",
+      "config_schema": "core.filter.http.traffic_management.router",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": false,
+        "response_headers": false,
+        "response_body": false,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: router\nroutes:\n  - path_prefix: \"/\"\n    cluster: default"
+        }
+      ],
+      "source": {
+        "path": "crates/filter/src/builtins/http/traffic_management/router/mod.rs",
+        "line": 446
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    {
+      "name": "static_response",
+      "protocol": "http",
+      "category": "traffic_management",
+      "description": "Returns a fixed response without contacting any upstream.",
+      "config_schema": "core.filter.http.traffic_management.static_response",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": false,
+        "response_headers": false,
+        "response_body": false,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: static_response\nstatus: 200\nbody: \"OK\""
+        }
+      ],
+      "source": {
+        "path": "crates/filter/src/builtins/http/traffic_management/static_response.rs",
+        "line": 108
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    {
+      "name": "sticky_sessions",
+      "protocol": "http",
+      "category": "traffic_management",
+      "description": "Sticky sessions HTTP filter.",
+      "config_schema": "core.filter.http.traffic_management.sticky_sessions",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": false,
+        "response_headers": true,
+        "response_body": false,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: sticky_sessions\nclusters:\n  - name: app_backend\n    type: cookie\n    cookie_name: \"_praxis_route\"\n    ttl_secs: 3600\n    cookie_attributes:\n      path: \"/\"\n      http_only: true\n      secure: true\n      same_site: Lax\n    failover: true\n    max_entries: 100000\n    eviction: lru"
+        }
+      ],
+      "source": {
+        "path": "crates/filter/src/builtins/http/traffic_management/sticky_sessions/mod.rs",
+        "line": 331
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    {
+      "name": "timeout",
+      "protocol": "http",
+      "category": "traffic_management",
+      "description": "Enforces a maximum end-to-end latency from request receipt to response headers.",
+      "config_schema": "core.filter.http.traffic_management.timeout",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": false,
+        "response_headers": true,
+        "response_body": false,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: timeout\ntimeout_ms: 5000   # 5 seconds"
+        }
+      ],
+      "source": {
+        "path": "crates/filter/src/builtins/http/traffic_management/timeout.rs",
+        "line": 84
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    {
+      "name": "headers",
+      "protocol": "http",
+      "category": "transformation",
+      "description": "Adds, sets, or removes headers on upstream requests and downstream responses.",
+      "config_schema": "core.filter.http.transformation.headers",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": false,
+        "response_headers": true,
+        "response_body": false,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: headers\nrequest_add:\n  - name: X-Forwarded-By\n    value: praxis\nrequest_set:\n  - name: X-Custom-Auth\n    value: bearer-token\nrequest_remove:\n  - X-Internal-Only\nresponse_add:\n  - name: X-Frame-Options\n    value: DENY\nresponse_remove:\n  - X-Backend-Server\nresponse_set:\n  - name: Server\n    value: praxis"
+        }
+      ],
+      "source": {
+        "path": "crates/filter/src/builtins/http/transformation/header/mod.rs",
+        "line": 179
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    {
+      "name": "path_rewrite",
+      "protocol": "http",
+      "category": "transformation",
+      "description": "Rewrites the request path before forwarding to the upstream.",
+      "config_schema": "core.filter.http.transformation.path_rewrite",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": false,
+        "response_headers": false,
+        "response_body": false,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: path_rewrite\nstrip_prefix: \"/api/v1\""
+        }
+      ],
+      "source": {
+        "path": "crates/filter/src/builtins/http/transformation/path_rewrite/mod.rs",
+        "line": 130
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    {
+      "name": "url_rewrite",
+      "protocol": "http",
+      "category": "transformation",
+      "description": "Rewrites request URLs using regex substitution and query parameter manipulation before the request reaches upstream.",
+      "config_schema": "core.filter.http.transformation.url_rewrite",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": true,
+        "request_body": false,
+        "response_headers": false,
+        "response_body": false,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: url_rewrite\noperations:\n  - regex_replace:\n      pattern: \"^/api/v1/(.*)\"\n      replacement: \"/api/v2/$1\"\n  - strip_query_params:\n      - debug\n  - add_query_params:\n      source: gateway"
+        }
+      ],
+      "source": {
+        "path": "crates/filter/src/builtins/http/transformation/url_rewrite.rs",
+        "line": 181
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    {
+      "name": "tcp_access_log",
+      "protocol": "tcp",
+      "category": "observability",
+      "description": "Logs TCP connection events.",
+      "config_schema": "core.filter.tcp.observability.tcp_access_log",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": false,
+        "request_body": false,
+        "response_headers": false,
+        "response_body": false,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: tcp_access_log\n# no configurable parameters"
+        }
+      ],
+      "source": {
+        "path": "crates/filter/src/builtins/tcp/observability/tcp_access_log.rs",
+        "line": 57
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    {
+      "name": "sni_router",
+      "protocol": "tcp",
+      "category": "traffic_management",
+      "description": "Routes TCP connections by SNI hostname.",
+      "config_schema": "core.filter.tcp.traffic_management.sni_router",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": false,
+        "request_body": false,
+        "response_headers": false,
+        "response_body": false,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: sni_router\nroutes:\n  - server_names: [\"api.example.com\"]\n    upstream: \"10.0.0.1:443\"\n  - server_names: [\"*.example.com\"]\n    upstream: \"10.0.0.2:443\"\ndefault_upstream: \"10.0.0.3:443\""
+        }
+      ],
+      "source": {
+        "path": "crates/filter/src/builtins/tcp/traffic_management/sni_router.rs",
+        "line": 122
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    },
+    {
+      "name": "tcp_load_balancer",
+      "protocol": "tcp",
+      "category": "traffic_management",
+      "description": "Selects an upstream TCP endpoint using the cluster's configured strategy.",
+      "config_schema": "core.filter.tcp.traffic_management.tcp_load_balancer",
+      "required_features": [],
+      "capabilities": {
+        "security_class": "standard",
+        "request_headers": false,
+        "request_body": false,
+        "response_headers": false,
+        "response_body": false,
+        "terminal": false
+      },
+      "examples": [
+        {
+          "yaml": "filter: tcp_load_balancer\nclusters:\n  - name: db_pool\n    endpoints: [\"10.0.0.1:5432\", \"10.0.0.2:5432\"]"
+        }
+      ],
+      "source": {
+        "path": "crates/filter/src/builtins/tcp/traffic_management/tcp_load_balancer.rs",
+        "line": 131
+      },
+      "producer": {
+        "component": "core",
+        "package": "praxis-proxy-core",
+        "version": "0.5.4"
+      }
+    }
+  ],
+  "diagnostics": [
+    {
+      "severity": "warning",
+      "code": "unevaluable_default",
+      "target": "core.root.config.max_request_bytes",
+      "message": "default function `default_max_body_bytes` could not be evaluated safely"
+    },
+    {
+      "severity": "warning",
+      "code": "unevaluable_default",
+      "target": "core.root.config.max_response_bytes",
+      "message": "default function `default_max_body_bytes` could not be evaluated safely"
+    },
+    {
+      "severity": "warning",
+      "code": "unevaluable_default",
+      "target": "core.root.config.subrequest_pool_size",
+      "message": "default function `default_subrequest_pool_size` could not be evaluated safely"
+    },
+    {
+      "severity": "warning",
+      "code": "unevaluable_default",
+      "target": "core.filter.http.observability.request_id.header_name",
+      "message": "default function `default_header_name` could not be evaluated safely"
+    },
+    {
+      "severity": "warning",
+      "code": "unevaluable_default",
+      "target": "core.filter.http.payload_processing.compression.min_size_bytes",
+      "message": "default function `default_min_size` could not be evaluated safely"
+    },
+    {
+      "severity": "warning",
+      "code": "unevaluable_default",
+      "target": "core.filter.http.payload_processing.json_body_field.max_body_bytes",
+      "message": "default function `default_max_body_bytes` could not be evaluated safely"
+    },
+    {
+      "severity": "warning",
+      "code": "unevaluable_default",
+      "target": "core.filter.http.payload_processing.json_rpc.max_batch_size",
+      "message": "default function `default_max_batch_size` could not be evaluated safely"
+    },
+    {
+      "severity": "warning",
+      "code": "unevaluable_default",
+      "target": "core.filter.http.payload_processing.json_rpc.max_body_bytes",
+      "message": "default function `default_max_body_bytes` could not be evaluated safely"
+    },
+    {
+      "severity": "warning",
+      "code": "unevaluable_default",
+      "target": "core.filter.http.payload_processing.json_rpc.on_invalid",
+      "message": "default function `OnInvalidBehavior::default_continue` could not be evaluated safely"
+    },
+    {
+      "severity": "warning",
+      "code": "unevaluable_default",
+      "target": "core.filter.http.security.csrf.safe_methods",
+      "message": "default function `default_safe_methods` could not be evaluated safely"
+    },
+    {
+      "severity": "warning",
+      "code": "unevaluable_default",
+      "target": "core.filter.http.traffic_management.iterative_request_router.max_response_bytes",
+      "message": "default function `default_max_response_bytes` could not be evaluated safely"
+    },
+    {
+      "severity": "warning",
+      "code": "unevaluable_default",
+      "target": "core.filter.http.traffic_management.iterative_request_router.max_state_bytes",
+      "message": "default function `default_max_state_bytes` could not be evaluated safely"
+    },
+    {
+      "severity": "warning",
+      "code": "unevaluable_default",
+      "target": "core.filter.http.traffic_management.router.json_alias_header",
+      "message": "default function `default_json_alias_header` could not be evaluated safely"
+    },
+    {
+      "severity": "warning",
+      "code": "unevaluable_default",
+      "target": "core.filter.http.traffic_management.router.json_alias_max_body_bytes",
+      "message": "default function `default_json_alias_max_body_bytes` could not be evaluated safely"
+    }
+  ]
+}

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -13,6 +13,12 @@ publish = false
 [lints]
 workspace = true
 
+[features]
+default = []
+basic-auth-filter = ["praxis-filter/basic-auth-filter"]
+policy-engine = ["praxis-filter/policy-engine"]
+otel = ["praxis-filter/otel"]
+
 [dependencies]
 benchmarks = { workspace = true }
 chrono = { workspace = true }
@@ -20,7 +26,9 @@ clap = { workspace = true }
 nix = { workspace = true }
 plotters = { workspace = true }
 praxis = { workspace = true }
+praxis-config-catalog = { workspace = true, features = ["generator"] }
 praxis-core = { workspace = true }
+praxis-filter = { workspace = true }
 quote = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/xtask/src/config_catalog.rs
+++ b/xtask/src/config_catalog.rs
@@ -1,0 +1,1284 @@
+//! Generate the browser-facing Core configuration catalog.
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fs,
+    path::{Path, PathBuf},
+};
+
+use clap::Parser;
+use praxis_config_catalog::{
+    CatalogFormatVersion, CatalogFragment, ConfigSchema, ObjectField, Protocol, SchemaKind, SchemaNode, SecurityClass,
+};
+use syn::{GenericArgument, PathArguments, Type};
+
+/// Arguments for catalog generation.
+#[derive(Parser)]
+pub(crate) struct GenerateArgs {}
+
+/// Arguments for catalog linting.
+#[derive(Parser)]
+pub(crate) struct LintArgs {}
+
+/// Generate the tracked Core catalog artifact.
+pub(crate) fn generate(_args: GenerateArgs) {
+    let root = workspace_root();
+    let artifact = root.join("docs/catalog/config-catalog.json");
+    let bytes = render(&root);
+    if let Some(parent) = artifact.parent() {
+        fs::create_dir_all(parent).unwrap_or_else(|e| fail(parent, e));
+    }
+    fs::write(&artifact, bytes).unwrap_or_else(|e| fail(&artifact, e));
+    println!("wrote {}", artifact.display());
+}
+
+/// Ensure the tracked Core catalog equals a fresh generation.
+pub(crate) fn lint(_args: LintArgs) {
+    let root = workspace_root();
+    let artifact = root.join("docs/catalog/config-catalog.json");
+    let expected = render(&root);
+    match fs::read(&artifact) {
+        Ok(actual) if actual == expected => println!("configuration catalog is up to date"),
+        _ => {
+            eprintln!("configuration catalog is stale or missing: {}", artifact.display());
+            eprintln!("run: cargo xtask generate-config-catalog");
+            std::process::exit(1);
+        },
+    }
+}
+
+fn source_revision() -> Option<String> {
+    std::env::var("PRAXIS_SOURCE_REVISION")
+        .ok()
+        .filter(|revision| !revision.trim().is_empty())
+}
+
+fn render(root: &Path) -> Vec<u8> {
+    let shared = super::filter_docs::parse_shared_config_items(root);
+    let entries = super::filter_docs::discover_all_filters(root, &shared);
+    let (root_items, root_fields) = super::filter_docs::parse_root_config_source(root);
+    let registry = praxis_filter::FilterRegistry::with_builtins();
+    let mut fragment = CatalogFragment {
+        format_version: CatalogFormatVersion { major: 1, minor: 0 },
+        producer: praxis_config_catalog::ProducerInfo {
+            component: praxis_config_catalog::ProducerComponent::Core,
+            package: "praxis-proxy-core".to_owned(),
+            version: env!("CARGO_PKG_VERSION").to_owned(),
+            source_revision: source_revision(),
+        },
+        compatibility: praxis_config_catalog::CatalogCompatibility {
+            requires_format_major: 1,
+            requires_core: None,
+        },
+        feature_profile: feature_profile(root),
+        schemas: Default::default(),
+        roots: vec![praxis_config_catalog::RootConfigDescriptor {
+            name: "Config".to_owned(),
+            schema: "core.root.config".into(),
+        }],
+        filters: Vec::new(),
+        diagnostics: Vec::new(),
+    };
+    let mut matched_overrides = BTreeSet::new();
+    let mut root_builder = SchemaBuilder::new(
+        &mut fragment.schemas,
+        &mut fragment.diagnostics,
+        &root_items,
+        "core.root.config",
+        root,
+    );
+    let root_schema_fields = root_builder
+        .fields(&root_fields)
+        .unwrap_or_else(|e| panic!("cannot represent root Config: {e}"));
+    matched_overrides.extend(root_builder.matched_overrides);
+    fragment.schemas.insert(
+        "core.root.config".into(),
+        ConfigSchema {
+            id: "core.root.config".into(),
+            title: "Praxis configuration".to_owned(),
+            description: "The top-level Praxis configuration.".to_owned(),
+            shared: false,
+            node: SchemaNode {
+                kind: SchemaKind::Object {
+                    fields: root_schema_fields,
+                    additional_properties: false,
+                },
+                title: None,
+                description: String::new(),
+                default: None,
+                examples: Vec::new(),
+                rules: Vec::new(),
+                sensitive: false,
+            },
+            producer: None,
+        },
+    );
+    fragment.schemas.insert(
+        "core.filter.entry.config".into(),
+        ConfigSchema {
+            id: "core.filter.entry.config".into(),
+            title: "Filter configuration payload".to_owned(),
+            description:
+                "Discriminated filter payload; the selected filter supplies the referenced configuration schema."
+                    .to_owned(),
+            shared: false,
+            node: SchemaNode {
+                kind: SchemaKind::Object {
+                    fields: vec![
+                        ObjectField {
+                            serialized_name: "filter".into(),
+                            aliases: Vec::new(),
+                            schema: SchemaNode::simple(SchemaKind::String),
+                            required: true,
+                            flattened: false,
+                        },
+                        ObjectField {
+                            serialized_name: "config".into(),
+                            aliases: Vec::new(),
+                            schema: SchemaNode::map(SchemaNode::simple(SchemaKind::String)),
+                            required: true,
+                            flattened: false,
+                        },
+                    ],
+                    additional_properties: false,
+                },
+                title: None,
+                description: String::new(),
+                default: None,
+                examples: Vec::new(),
+                rules: Vec::new(),
+                sensitive: false,
+            },
+            producer: None,
+        },
+    );
+    for entry in entries {
+        let registry_names = registry.available_filters();
+        let active = entry
+            .required_feature
+            .as_deref()
+            .is_none_or(|feature| enabled_features(root).contains(feature));
+        if active && !registry_names.contains(&entry.filter.name.as_str()) {
+            panic!(
+                "catalog filter is not present in the built-in registry: {}",
+                entry.filter.name
+            );
+        }
+        let schema_id = praxis_config_catalog::SchemaId(format!(
+            "core.filter.{}.{}.{}",
+            entry.protocol, entry.category, entry.filter.name
+        ));
+        let mut schema_builder = SchemaBuilder::new(
+            &mut fragment.schemas,
+            &mut fragment.diagnostics,
+            &entry.filter.source_items,
+            &schema_id.0,
+            root,
+        );
+        let fields = schema_builder
+            .fields(&entry.filter.raw_fields)
+            .unwrap_or_else(|e| panic!("cannot represent filter {}: {e}", entry.filter.name));
+        matched_overrides.extend(schema_builder.matched_overrides);
+        fragment.schemas.insert(
+            schema_id.clone(),
+            ConfigSchema {
+                id: schema_id.clone(),
+                title: entry.filter.name.clone(),
+                description: entry.filter.description.clone(),
+                shared: false,
+                node: SchemaNode {
+                    kind: SchemaKind::Object {
+                        fields,
+                        additional_properties: false,
+                    },
+                    title: None,
+                    description: String::new(),
+                    default: None,
+                    examples: Vec::new(),
+                    rules: Vec::new(),
+                    sensitive: false,
+                },
+                producer: None,
+            },
+        );
+        let mut required_features = BTreeSet::new();
+        if let Some(feature) = entry.required_feature.as_ref() {
+            required_features.insert(feature.clone());
+        }
+        let filter_name = entry.filter.name.clone();
+        let source = entry.filter.source_path.as_deref().map(|path| {
+            let path = Path::new(path)
+                .strip_prefix(root)
+                .unwrap_or_else(|_| Path::new(path))
+                .to_string_lossy()
+                .replace('\\', "/");
+            praxis_config_catalog::SourceLocation {
+                line: source_line(entry.filter.source_path.as_deref()),
+                path,
+            }
+        });
+        let capabilities = filter_capabilities(&entry, &registry);
+        fragment.filters.push(praxis_config_catalog::FilterDescriptor {
+            name: filter_name.clone(),
+            protocol: if entry.protocol == "http" {
+                Protocol::Http
+            } else {
+                Protocol::Tcp
+            },
+            category: entry.category,
+            description: entry.filter.description,
+            config_schema: schema_id,
+            required_features,
+            capabilities,
+            examples: entry
+                .filter
+                .yaml_examples
+                .into_iter()
+                .map(|yaml| praxis_config_catalog::ConfigExample { yaml })
+                .collect(),
+            source,
+            producer: None,
+        });
+    }
+    let descriptor_names: BTreeSet<&str> = fragment.filters.iter().map(|filter| filter.name.as_str()).collect();
+    for name in registry.available_filters() {
+        if !descriptor_names.contains(name) {
+            panic!("registered filter is missing from the catalog: {name}");
+        }
+    }
+    if let Some(schema) = fragment.schemas.get_mut(&"core.filter.entry.config".into()) {
+        schema.node = SchemaNode::one_of(
+            fragment
+                .filters
+                .iter()
+                .map(|filter| SchemaNode::reference(filter.config_schema.0.clone()))
+                .collect(),
+        );
+    }
+    validate_examples(&fragment).unwrap_or_else(|error| panic!("invalid generated example: {error}"));
+    validate_overrides(SEMANTIC_OVERRIDES, &matched_overrides).unwrap_or_else(|error| panic!("{error}"));
+    praxis_config_catalog::generator::render(fragment)
+        .unwrap_or_else(|error| panic!("invalid generated catalog: {error}"))
+}
+
+fn validate_examples(fragment: &CatalogFragment) -> Result<(), String> {
+    for filter in &fragment.filters {
+        let schema = fragment
+            .schemas
+            .get(&filter.config_schema)
+            .ok_or_else(|| format!("example references missing schema {}", filter.config_schema))?;
+        for example in &filter.examples {
+            let mut value: serde_yaml::Value = serde_yaml::from_str(&example.yaml)
+                .map_err(|error| format!("invalid YAML example for {}: {error}", filter.name))?;
+            let serde_yaml::Value::Mapping(mapping) = &mut value else {
+                return Err(format!("example for {} must be a mapping", filter.name));
+            };
+            let key = serde_yaml::Value::String("filter".to_owned());
+            let declared = mapping.remove(&key).and_then(|value| value.as_str().map(str::to_owned));
+            if declared.as_deref() != Some(filter.name.as_str()) {
+                return Err(format!("example filter discriminator does not match {}", filter.name));
+            }
+            validate_yaml_node(&value, &schema.node, fragment, &filter.name)?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_yaml_node(
+    value: &serde_yaml::Value,
+    node: &SchemaNode,
+    fragment: &CatalogFragment,
+    target: &str,
+) -> Result<(), String> {
+    match &node.kind {
+        SchemaKind::Reference { schema_id } => {
+            let schema = fragment
+                .schemas
+                .get(schema_id)
+                .ok_or_else(|| format!("{target} references missing schema {schema_id}"))?;
+            return validate_yaml_node(value, &schema.node, fragment, target);
+        },
+        SchemaKind::Object {
+            fields,
+            additional_properties,
+        } => {
+            let serde_yaml::Value::Mapping(mapping) = value else {
+                return Err(format!("example for {target} must be an object"));
+            };
+            for field in fields {
+                let names = std::iter::once(&field.serialized_name).chain(field.aliases.iter());
+                let matched = names
+                    .filter_map(|name| mapping.get(serde_yaml::Value::String(name.clone())))
+                    .next();
+                if field.required && matched.is_none() {
+                    return Err(format!(
+                        "example for {target} is missing required field {}",
+                        field.serialized_name
+                    ));
+                }
+                if let Some(value) = matched {
+                    validate_yaml_node(value, &field.schema, fragment, target)?;
+                }
+            }
+            let flattened: Vec<&ObjectField> = fields.iter().filter(|field| field.flattened).collect();
+            if !flattened.is_empty() {
+                let known: BTreeSet<&str> = fields
+                    .iter()
+                    .flat_map(|field| {
+                        std::iter::once(field.serialized_name.as_str()).chain(field.aliases.iter().map(String::as_str))
+                    })
+                    .collect();
+                let remainder = mapping
+                    .iter()
+                    .filter(|(key, _)| key.as_str().is_some_and(|name| !known.contains(name)))
+                    .map(|(key, value)| (key.clone(), value.clone()))
+                    .collect();
+                let remainder = serde_yaml::Value::Mapping(remainder);
+                if !matches!(&remainder, serde_yaml::Value::Mapping(values) if values.is_empty())
+                    && !flattened
+                        .iter()
+                        .any(|field| validate_yaml_node(&remainder, &field.schema, fragment, target).is_ok())
+                {
+                    return Err(format!("example for {target} does not match flattened fields"));
+                }
+            }
+            if !additional_properties {
+                for key in mapping.keys() {
+                    let Some(name) = key.as_str() else {
+                        return Err(format!("example for {target} has a non-string field name"));
+                    };
+                    if flattened.is_empty()
+                        && !fields.iter().any(|field| {
+                            field.serialized_name == name || field.aliases.iter().any(|alias| alias == name)
+                        })
+                    {
+                        return Err(format!("example for {target} has unknown field {name}"));
+                    }
+                }
+            }
+        },
+        SchemaKind::Array {
+            items,
+            min_items,
+            max_items,
+        } => {
+            let serde_yaml::Value::Sequence(values) = value else {
+                return Err(format!("example for {target} must be an array"));
+            };
+            if min_items.is_some_and(|min| values.len() < min) || max_items.is_some_and(|max| values.len() > max) {
+                return Err(format!("example for {target} has an invalid array length"));
+            }
+            for value in values {
+                validate_yaml_node(value, items, fragment, target)?;
+            }
+        },
+        SchemaKind::Map { values } => {
+            let serde_yaml::Value::Mapping(mapping) = value else {
+                return Err(format!("example for {target} must be a map"));
+            };
+            for (key, value) in mapping {
+                if key.as_str().is_none() {
+                    return Err(format!("example for {target} has a non-string map key"));
+                }
+                validate_yaml_node(value, values, fragment, target)?;
+            }
+        },
+        SchemaKind::OneOf { variants, .. } => {
+            if !variants
+                .iter()
+                .any(|variant| validate_yaml_node(value, variant, fragment, target).is_ok())
+            {
+                return Err(format!("example for {target} matches no schema variant"));
+            }
+        },
+        SchemaKind::Any => return Err(format!("example for {target} uses unresolved Any")),
+        SchemaKind::Boolean => {
+            if !value.is_bool() {
+                return Err(format!("example for {target} must be a boolean"));
+            }
+        },
+        SchemaKind::Integer => {
+            if value.as_i64().is_none() && value.as_u64().is_none() {
+                return Err(format!("example for {target} must be an integer"));
+            }
+        },
+        SchemaKind::Number => {
+            if value.as_f64().is_none() {
+                return Err(format!("example for {target} must be a number"));
+            }
+        },
+        SchemaKind::String => {
+            if !value.is_string() {
+                return Err(format!("example for {target} must be a string"));
+            }
+        },
+        SchemaKind::Null => {
+            if !value.is_null() {
+                return Err(format!("example for {target} must be null"));
+            }
+        },
+        SchemaKind::Literal { value: expected } => {
+            let actual = serde_json::to_value(value).map_err(|error| error.to_string())?;
+            if &actual != expected {
+                return Err(format!("example for {target} does not match its literal value"));
+            }
+        },
+        SchemaKind::Enum { values } => {
+            let actual = serde_json::to_value(value).map_err(|error| error.to_string())?;
+            if !values.iter().any(|candidate| candidate == &actual) {
+                return Err(format!("example for {target} is not an allowed enum value"));
+            }
+        },
+    }
+    Ok(())
+}
+
+fn validate_overrides(table: &[SemanticOverride], matched: &BTreeSet<usize>) -> Result<(), String> {
+    let expected: BTreeSet<usize> = (0..table.len()).collect();
+    if matched != &expected {
+        let stale = expected
+            .difference(matched)
+            .map(|index| {
+                format!(
+                    "{}.{} ({})",
+                    table[*index].owner, table[*index].field, table[*index].reason
+                )
+            })
+            .collect::<Vec<_>>();
+        return Err(format!(
+            "stale or unmatched catalog semantic overrides: {}",
+            stale.join(", ")
+        ));
+    }
+    for (index, item) in table.iter().enumerate() {
+        if table.iter().enumerate().any(|(other, candidate)| {
+            other != index
+                && candidate.owner == item.owner
+                && candidate.field == item.field
+                && candidate.rust_type == item.rust_type
+        }) {
+            return Err(format!(
+                "ambiguous catalog semantic override: {}.{}",
+                item.owner, item.field
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn source_line(path: Option<&str>) -> Option<u32> {
+    let source = path.and_then(|path| fs::read_to_string(path).ok())?;
+    source.lines().enumerate().find_map(|(index, line)| {
+        line.contains("fn name(")
+            .then(|| u32::try_from(index.saturating_add(1)).ok())
+            .flatten()
+    })
+}
+
+struct SemanticOverride {
+    owner: &'static str,
+    field: &'static str,
+    rust_type: &'static str,
+    kind: &'static str,
+    reason: &'static str,
+}
+
+const SEMANTIC_OVERRIDES: &[SemanticOverride] = &[
+    SemanticOverride {
+        owner: "core.root.config",
+        field: "config",
+        rust_type: "serde_yaml :: Value",
+        kind: "filter_entry_config",
+        reason: "FilterEntry dispatches config by its filter discriminator",
+    },
+    SemanticOverride {
+        owner: "core.filter.http.observability.access_log",
+        field: "fields",
+        rust_type: "Option < Vec < serde_yaml :: Value > >",
+        kind: "field_names",
+        reason: "access-log field selectors are validated names",
+    },
+    SemanticOverride {
+        owner: "core.filter.http.transformation.url_rewrite",
+        field: "regex_replace",
+        rust_type: "Option < serde_yaml :: Value >",
+        kind: "query_operation",
+        reason: "URL rewrite accepts an object or sequence operation",
+    },
+    SemanticOverride {
+        owner: "core.filter.http.transformation.url_rewrite",
+        field: "strip_query_params",
+        rust_type: "Option < serde_yaml :: Value >",
+        kind: "query_operation",
+        reason: "URL rewrite accepts an object or sequence operation",
+    },
+    SemanticOverride {
+        owner: "core.filter.http.transformation.url_rewrite",
+        field: "add_query_params",
+        rust_type: "Option < serde_yaml :: Value >",
+        kind: "query_operation",
+        reason: "URL rewrite accepts an object or sequence operation",
+    },
+    SemanticOverride {
+        owner: "core.filter.http.security.guardrails",
+        field: "contains",
+        rust_type: "Option < ContainsValue >",
+        kind: "contains_value",
+        reason: "guardrail content target is one of the documented semantic values",
+    },
+];
+
+struct SchemaBuilder<'a> {
+    schemas: &'a mut BTreeMap<praxis_config_catalog::SchemaId, ConfigSchema>,
+    diagnostics: &'a mut Vec<praxis_config_catalog::CatalogDiagnostic>,
+    source: &'a super::filter_docs::ModuleItems,
+    owner: String,
+    root: &'a Path,
+    matched_overrides: BTreeSet<usize>,
+    visiting: BTreeSet<String>,
+}
+
+impl<'a> SchemaBuilder<'a> {
+    fn new(
+        schemas: &'a mut BTreeMap<praxis_config_catalog::SchemaId, ConfigSchema>,
+        diagnostics: &'a mut Vec<praxis_config_catalog::CatalogDiagnostic>,
+        source: &'a super::filter_docs::ModuleItems,
+        owner: &str,
+        root: &'a Path,
+    ) -> Self {
+        Self {
+            schemas,
+            diagnostics,
+            source,
+            owner: owner.to_owned(),
+            root,
+            matched_overrides: BTreeSet::new(),
+            visiting: BTreeSet::new(),
+        }
+    }
+
+    fn fields(&mut self, fields: &[super::filter_docs::RawField]) -> Result<Vec<ObjectField>, String> {
+        let mut names = BTreeSet::new();
+        fields
+            .iter()
+            .filter(|field| !field.skip)
+            .map(|field| {
+                if !names.insert(field.name.clone()) {
+                    return Err(format!(
+                        "flattened or renamed field collision on `{}` in {}",
+                        field.name, self.owner
+                    ));
+                }
+                Ok(ObjectField {
+                    serialized_name: field.name.clone(),
+                    aliases: field.aliases.clone(),
+                    schema: self.field_node(field)?,
+                    required: matches!(field.requirement_hint, super::filter_docs::RequirementHint::Normal)
+                        && field.has_default == false
+                        && !field.flatten
+                        && !is_option(&field.ty),
+                    flattened: field.flatten,
+                })
+            })
+            .collect()
+    }
+
+    fn field_node(&mut self, field: &super::filter_docs::RawField) -> Result<SchemaNode, String> {
+        let field_type_ast = &field.ty;
+        let field_type = quote::quote!(#field_type_ast).to_string();
+        let matches: Vec<(usize, &SemanticOverride)> = SEMANTIC_OVERRIDES
+            .iter()
+            .enumerate()
+            .filter(|(_, item)| item.owner == self.owner && item.field == field.name && item.rust_type == field_type)
+            .collect();
+        if matches.len() > 1 {
+            return Err(format!(
+                "ambiguous semantic overrides for {}.{}",
+                self.owner, field.name
+            ));
+        }
+        if let Some((index, item)) = matches.into_iter().next() {
+            self.matched_overrides.insert(index);
+            return Ok(match item.kind {
+                "filter_entry_config" => SchemaNode::reference("core.filter.entry.config".to_owned()),
+                "field_names" => SchemaNode::array(SchemaNode::simple(SchemaKind::String)),
+                "query_operation" => SchemaNode::one_of(vec![
+                    SchemaNode::simple(SchemaKind::String),
+                    SchemaNode::map(SchemaNode::simple(SchemaKind::String)),
+                    SchemaNode::array(SchemaNode::simple(SchemaKind::String)),
+                ]),
+                "contains_value" => SchemaNode::one_of(vec![
+                    SchemaNode::simple(SchemaKind::String),
+                    SchemaNode::array(SchemaNode::simple(SchemaKind::String)),
+                ]),
+                _ => {
+                    return Err(format!(
+                        "unsupported semantic override kind for {}.{}: {}",
+                        self.owner, field.name, item.kind
+                    ));
+                },
+            });
+        }
+        if field_type.contains("Value") {
+            return Err(format!(
+                "unresolved dynamic config type `{field_type}` at {}.{}",
+                self.owner, field.name
+            ));
+        }
+        let mut node = if let Some(kind) = custom_deserializer_kind(field) {
+            SchemaNode::simple(kind)
+        } else {
+            self.type_node(&field.ty)?
+        };
+        node.description = field.doc.clone();
+        if let Some(default_path) = field.default_path.as_ref() {
+            match evaluate_default(self.root, default_path) {
+                Some(value) => node.default = Some(value),
+                None => self.diagnostics.push(praxis_config_catalog::CatalogDiagnostic {
+                    severity: praxis_config_catalog::DiagnosticSeverity::Warning,
+                    code: "unevaluable_default".to_owned(),
+                    target: format!("{}.{}", self.owner, field.name),
+                    message: format!("default function `{default_path}` could not be evaluated safely"),
+                }),
+            }
+        }
+        if is_sensitive_type(&field.ty) {
+            node.sensitive = true;
+        }
+        Ok(node)
+    }
+
+    fn type_node(&mut self, ty: &Type) -> Result<SchemaNode, String> {
+        match ty {
+            Type::Reference(reference) => self.type_node(&reference.elem),
+            Type::Array(array) => Ok(SchemaNode::array(self.type_node(&array.elem)?)),
+            Type::Slice(slice) => Ok(SchemaNode::array(self.type_node(&slice.elem)?)),
+            Type::Tuple(tuple) if tuple.elems.is_empty() => Ok(SchemaNode::simple(SchemaKind::Null)),
+            Type::Tuple(_) => Err(format!("unsupported tuple type `{}`", quote::quote!(#ty))),
+            Type::Path(path) => self.path_node(path),
+            _ => Err(format!("unsupported Rust type `{}`", quote::quote!(#ty))),
+        }
+    }
+
+    fn path_node(&mut self, path: &syn::TypePath) -> Result<SchemaNode, String> {
+        let segment = path.path.segments.last().ok_or_else(|| "empty type path".to_owned())?;
+        let raw_name = segment.ident.to_string();
+        if self.source.has_ambiguous_alias(&raw_name) {
+            return Err(format!("ambiguous type alias `{raw_name}`"));
+        }
+        let name = self.source.resolve_type_alias(&raw_name).to_owned();
+        let name = name.rsplit("::").next().unwrap_or(&name).to_owned();
+        let args = type_args(&segment.arguments);
+        match name.as_str() {
+            "Condition" => Ok(condition_node(false)),
+            "ResponseCondition" => Ok(condition_node(true)),
+            "Option" | "Box" | "Arc" | "Rc" | "Cow" => args
+                .last()
+                .ok_or_else(|| format!("missing inner type for `{name}`"))
+                .and_then(|ty| self.type_node(ty)),
+            "Vec" | "VecDeque" | "SmallVec" => args
+                .last()
+                .ok_or_else(|| format!("missing item type for `{name}`"))
+                .and_then(|ty| self.type_node(ty))
+                .map(|items| SchemaNode::array(items)),
+            "BTreeMap" | "HashMap" | "IndexMap" => args
+                .first()
+                .filter(|key| matches!(key, Type::Path(path) if path.path.segments.last().is_some_and(|segment| segment.ident == "String")))
+                .ok_or_else(|| format!("non-string map key for `{name}`"))
+                .and_then(|_| {
+                    args.get(1)
+                        .ok_or_else(|| format!("missing map value type for `{name}`"))
+                })
+                .and_then(|ty| self.type_node(ty))
+                .map(SchemaNode::map),
+            "bool" => Ok(SchemaNode::simple(SchemaKind::Boolean)),
+            "f32" | "f64" => Ok(SchemaNode::simple(SchemaKind::Number)),
+            "i8" | "i16" | "i32" | "i64" | "i128" | "isize" | "u8" | "u16" | "u32" | "u64" | "u128" | "usize"
+            | "NonZeroI8" | "NonZeroI16" | "NonZeroI32" | "NonZeroI64" | "NonZeroI128" | "NonZeroIsize"
+            | "NonZeroU8" | "NonZeroU16" | "NonZeroU32" | "NonZeroU64" | "NonZeroU128" | "NonZeroUsize" => {
+                Ok(SchemaNode::simple(SchemaKind::Integer))
+            },
+            "str" | "String" | "PathBuf" | "Url" | "Uri" | "HeaderName" | "HeaderValue" | "IpAddr" | "Ipv4Addr"
+            | "Ipv6Addr" | "SocketAddr" | "SocketAddrV4" | "SocketAddrV6" | "Duration" | "Regex" | "SecretString" => {
+                Ok(SchemaNode::simple(SchemaKind::String))
+            },
+            "Value" => Err(format!("unresolved dynamic config type `{name}`")),
+            "HttpStatusCode" => Ok(bounded_node(
+                SchemaKind::Integer,
+                numeric_rule("core.http_status_code.range", 100, 599),
+            )),
+            "RetryBodyLimit" => Ok(bounded_node(
+                SchemaKind::Integer,
+                numeric_rule("core.retry_body_limit.range", 0, 65_536),
+            )),
+            "BudgetPercent" => Ok(bounded_number_node(
+                "core.budget_percent.range",
+                serde_json::Value::from(0.0_f64),
+                serde_json::Value::from(100.0_f64),
+            )),
+            "MaxEntries" => Ok(bounded_node(
+                SchemaKind::Integer,
+                numeric_rule("core.max_entries.range", 1, 200_000),
+            )),
+            _ if self.source.newtype_inner(&name).is_some() => {
+                let inner = self.source.newtype_inner(&name).expect("checked above").clone();
+                self.type_node(&inner)
+            },
+            _ if self.source.enum_info(&name).is_some() => self.enum_node(&name),
+            _ if self.source.struct_fields(&name).is_some() => self.struct_node(&name),
+            _ => Err(format!("unresolved config type `{name}`")),
+        }
+    }
+
+    fn struct_node(&mut self, name: &str) -> Result<SchemaNode, String> {
+        let id = format!("core.type.{name}");
+        if self.visiting.contains(name) {
+            return Ok(SchemaNode::reference(id));
+        }
+        let schema_id = praxis_config_catalog::SchemaId(id.clone());
+        if !self.schemas.contains_key(&schema_id) {
+            let fields = self
+                .source
+                .struct_fields(name)
+                .ok_or_else(|| format!("missing struct `{name}`"))?
+                .to_vec();
+            self.visiting.insert(name.to_owned());
+            let object = SchemaNode::object(self.fields(&fields)?);
+            self.visiting.remove(name);
+            self.schemas.insert(
+                schema_id.clone(),
+                ConfigSchema {
+                    id: schema_id.clone(),
+                    title: name.to_owned(),
+                    description: String::new(),
+                    shared: false,
+                    node: object,
+                    producer: None,
+                },
+            );
+        }
+        Ok(SchemaNode::reference(id))
+    }
+
+    fn enum_node(&mut self, name: &str) -> Result<SchemaNode, String> {
+        let info = self
+            .source
+            .enum_info(name)
+            .ok_or_else(|| format!("missing enum `{name}`"))?
+            .clone();
+        let variants = info
+            .variants
+            .iter()
+            .enumerate()
+            .map(|(index, label)| {
+                let shape = info
+                    .variant_shapes
+                    .get(index)
+                    .ok_or_else(|| format!("enum `{name}` has incomplete variant metadata"))?;
+                let fields = info.variant_fields.get(index).map(Vec::as_slice).unwrap_or(&[]);
+                if info.untagged {
+                    return self.untagged_variant_node(shape, fields);
+                }
+                if let Some(tag) = info.tag.as_ref() {
+                    return self.tagged_variant_node(tag, info.content.as_deref(), label, shape, fields);
+                }
+                self.externally_tagged_variant_node(label, shape, fields)
+            })
+            .collect::<Result<Vec<_>, String>>()?;
+        let discriminator = info.tag.clone();
+        Ok(SchemaNode::one_of_with_discriminator(variants, discriminator))
+    }
+
+    fn untagged_variant_node(
+        &mut self,
+        shape: &super::filter_docs::EnumVariantShape,
+        fields: &[super::filter_docs::RawField],
+    ) -> Result<SchemaNode, String> {
+        match shape {
+            super::filter_docs::EnumVariantShape::Unit => Ok(SchemaNode::literal(serde_json::Value::Null)),
+            super::filter_docs::EnumVariantShape::Unnamed(ty) => self.type_node(ty),
+            super::filter_docs::EnumVariantShape::Named => Ok(SchemaNode::object(self.fields(fields)?)),
+        }
+    }
+
+    fn externally_tagged_variant_node(
+        &mut self,
+        label: &str,
+        shape: &super::filter_docs::EnumVariantShape,
+        fields: &[super::filter_docs::RawField],
+    ) -> Result<SchemaNode, String> {
+        match shape {
+            super::filter_docs::EnumVariantShape::Unit => {
+                Ok(SchemaNode::literal(serde_json::Value::String(label.to_owned())))
+            },
+            super::filter_docs::EnumVariantShape::Unnamed(ty) => Ok(SchemaNode::object(vec![ObjectField {
+                serialized_name: label.to_owned(),
+                aliases: Vec::new(),
+                schema: self.type_node(ty)?,
+                required: true,
+                flattened: false,
+            }])),
+            super::filter_docs::EnumVariantShape::Named => Ok(SchemaNode::object(vec![ObjectField {
+                serialized_name: label.to_owned(),
+                aliases: Vec::new(),
+                schema: SchemaNode::object(self.fields(fields)?),
+                required: true,
+                flattened: false,
+            }])),
+        }
+    }
+
+    fn tagged_variant_node(
+        &mut self,
+        tag: &str,
+        content: Option<&str>,
+        label: &str,
+        shape: &super::filter_docs::EnumVariantShape,
+        fields: &[super::filter_docs::RawField],
+    ) -> Result<SchemaNode, String> {
+        let payload = match shape {
+            super::filter_docs::EnumVariantShape::Unit => None,
+            super::filter_docs::EnumVariantShape::Unnamed(ty) => Some(self.type_node(ty)?),
+            super::filter_docs::EnumVariantShape::Named => Some(SchemaNode::object(self.fields(fields)?)),
+        };
+        let mut object_fields = vec![ObjectField {
+            serialized_name: tag.to_owned(),
+            aliases: Vec::new(),
+            schema: SchemaNode::literal(serde_json::Value::String(label.to_owned())),
+            required: true,
+            flattened: false,
+        }];
+        if let Some(content) = content {
+            if let Some(payload) = payload {
+                object_fields.push(ObjectField {
+                    serialized_name: content.to_owned(),
+                    aliases: Vec::new(),
+                    schema: payload,
+                    required: true,
+                    flattened: false,
+                });
+            }
+        } else if let Some(SchemaNode {
+            kind: SchemaKind::Object { fields, .. },
+            ..
+        }) = payload
+        {
+            object_fields.extend(fields);
+        }
+        Ok(SchemaNode::object(object_fields))
+    }
+}
+
+fn numeric_rule(code: &str, min: i64, max: i64) -> praxis_config_catalog::PortableRule {
+    let mut parameters = BTreeMap::new();
+    parameters.insert("min".to_owned(), serde_json::Value::from(min));
+    parameters.insert("max".to_owned(), serde_json::Value::from(max));
+    praxis_config_catalog::PortableRule {
+        code: code.to_owned(),
+        target: String::new(),
+        kind: praxis_config_catalog::RuleKind::NumericBounds,
+        parameters,
+        message: format!("value must be between {min} and {max}"),
+    }
+}
+
+fn bounded_node(kind: SchemaKind, rule: praxis_config_catalog::PortableRule) -> SchemaNode {
+    let mut node = SchemaNode::simple(kind);
+    node.rules.push(rule);
+    node
+}
+
+fn bounded_number_node(code: &str, min: serde_json::Value, max: serde_json::Value) -> SchemaNode {
+    let mut parameters = BTreeMap::new();
+    parameters.insert("min".to_owned(), min);
+    parameters.insert("max".to_owned(), max);
+    let mut node = SchemaNode::simple(SchemaKind::Number);
+    node.rules.push(praxis_config_catalog::PortableRule {
+        code: code.to_owned(),
+        target: String::new(),
+        kind: praxis_config_catalog::RuleKind::NumericBounds,
+        parameters,
+        message: "value must be between 0 and 100".to_owned(),
+    });
+    node
+}
+
+fn evaluate_default(root: &Path, function: &str) -> Option<serde_json::Value> {
+    let files = [
+        root.join("crates/core/src"),
+        root.join("crates/filter/src"),
+        root.join("crates/tls/src"),
+    ];
+    for directory in files {
+        for path in super::filter_docs::collect_rs_files(&directory) {
+            let Ok(source) = fs::read_to_string(path) else { continue };
+            let marker = format!("fn {function}");
+            let Some(start) = source.find(&marker) else { continue };
+            let tail = &source[start..];
+            let body = &tail[..tail.find('}').unwrap_or(tail.len())];
+            if body.contains("true") {
+                return Some(serde_json::Value::Bool(true));
+            }
+            if body.contains("false") {
+                return Some(serde_json::Value::Bool(false));
+            }
+            if let Some(value) = body.split('"').nth(1) {
+                return Some(serde_json::Value::String(value.to_owned()));
+            }
+            if let Some(number) = body
+                .split(|character: char| !character.is_ascii_digit() && character != '-')
+                .find(|value| !value.is_empty() && *value != "-")
+            {
+                if let Ok(value) = number.parse::<i64>() {
+                    return Some(serde_json::Value::from(value));
+                }
+            }
+        }
+    }
+    None
+}
+
+fn condition_node(response: bool) -> SchemaNode {
+    let match_fields = if response {
+        vec![
+            ObjectField {
+                serialized_name: "status".into(),
+                aliases: Vec::new(),
+                schema: SchemaNode::array(SchemaNode::simple(SchemaKind::Integer)),
+                required: false,
+                flattened: false,
+            },
+            ObjectField {
+                serialized_name: "headers".into(),
+                aliases: Vec::new(),
+                schema: SchemaNode::map(SchemaNode::simple(SchemaKind::String)),
+                required: false,
+                flattened: false,
+            },
+        ]
+    } else {
+        vec![
+            ObjectField {
+                serialized_name: "path".into(),
+                aliases: Vec::new(),
+                schema: SchemaNode::simple(SchemaKind::String),
+                required: false,
+                flattened: false,
+            },
+            ObjectField {
+                serialized_name: "path_prefix".into(),
+                aliases: Vec::new(),
+                schema: SchemaNode::simple(SchemaKind::String),
+                required: false,
+                flattened: false,
+            },
+            ObjectField {
+                serialized_name: "methods".into(),
+                aliases: Vec::new(),
+                schema: SchemaNode::array(SchemaNode::simple(SchemaKind::String)),
+                required: false,
+                flattened: false,
+            },
+            ObjectField {
+                serialized_name: "headers".into(),
+                aliases: Vec::new(),
+                schema: SchemaNode::map(SchemaNode::simple(SchemaKind::String)),
+                required: false,
+                flattened: false,
+            },
+        ]
+    };
+    let match_schema = SchemaNode::object(match_fields);
+    SchemaNode::one_of(vec![
+        SchemaNode::object(vec![ObjectField {
+            serialized_name: "when".into(),
+            aliases: Vec::new(),
+            schema: match_schema.clone(),
+            required: true,
+            flattened: false,
+        }]),
+        SchemaNode::object(vec![ObjectField {
+            serialized_name: "unless".into(),
+            aliases: Vec::new(),
+            schema: match_schema,
+            required: true,
+            flattened: false,
+        }]),
+    ])
+}
+
+fn type_args(arguments: &PathArguments) -> Vec<&Type> {
+    let PathArguments::AngleBracketed(arguments) = arguments else {
+        return Vec::new();
+    };
+    arguments
+        .args
+        .iter()
+        .filter_map(|argument| match argument {
+            GenericArgument::Type(ty) => Some(ty),
+            _ => None,
+        })
+        .collect()
+}
+
+fn is_option(ty: &Type) -> bool {
+    matches!(ty, Type::Path(path) if path.path.segments.last().is_some_and(|segment| segment.ident == "Option"))
+}
+
+fn is_sensitive_type(ty: &Type) -> bool {
+    quote::quote!(#ty).to_string().to_ascii_lowercase().contains("secret")
+}
+
+fn custom_deserializer_kind(field: &super::filter_docs::RawField) -> Option<SchemaKind> {
+    match field.deserialize_with.as_deref() {
+        Some("deserialize_redirect_status") => Some(SchemaKind::Enum {
+            values: [301, 302, 307, 308].into_iter().map(serde_json::Value::from).collect(),
+        }),
+        _ => None,
+    }
+}
+
+fn filter_capabilities(
+    entry: &super::filter_docs::FilterEntry,
+    registry: &praxis_filter::FilterRegistry,
+) -> praxis_config_catalog::FilterCapabilities {
+    let source = entry
+        .filter
+        .source_path
+        .as_deref()
+        .and_then(|path| fs::read_to_string(path).ok())
+        .unwrap_or_default();
+    let is_http = entry.protocol == "http";
+    praxis_config_catalog::FilterCapabilities {
+        security_class: if registry.is_security_filter(&entry.filter.name) {
+            SecurityClass::Security
+        } else {
+            SecurityClass::Standard
+        },
+        request_headers: is_http && source.contains("fn on_request("),
+        request_body: is_http && source.contains("fn on_request_body("),
+        response_headers: is_http && source.contains("fn on_response("),
+        response_body: is_http && source.contains("fn on_response_body("),
+        terminal: praxis_core::config::TERMINAL_FILTERS.contains(&entry.filter.name.as_str()),
+    }
+}
+
+fn feature_profile(root: &Path) -> praxis_config_catalog::FeatureProfile {
+    let path = root.join("crates/filter/Cargo.toml");
+    let Ok(source) = fs::read_to_string(path) else {
+        return Default::default();
+    };
+    let mut in_features = false;
+    let mut available = BTreeSet::new();
+    let mut default_enabled = BTreeSet::new();
+    for line in source.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with('[') {
+            in_features = trimmed == "[features]";
+            continue;
+        }
+        if !in_features || trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        let Some((name, value)) = trimmed.split_once('=') else {
+            continue;
+        };
+        let name = name.trim().to_owned();
+        available.insert(name.clone());
+        if name == "default" {
+            default_enabled.extend(
+                value
+                    .trim()
+                    .trim_start_matches('[')
+                    .trim_end_matches(']')
+                    .split(',')
+                    .map(str::trim)
+                    .map(|feature| feature.trim_matches('"').to_owned())
+                    .filter(|feature| !feature.is_empty()),
+            );
+        }
+    }
+    praxis_config_catalog::FeatureProfile {
+        available,
+        default_enabled,
+    }
+}
+
+fn enabled_features(_root: &Path) -> BTreeSet<&'static str> {
+    [
+        ("basic-auth-filter", cfg!(feature = "basic-auth-filter")),
+        ("policy-engine", cfg!(feature = "policy-engine")),
+        ("otel", cfg!(feature = "otel")),
+    ]
+    .into_iter()
+    .filter_map(|(feature, enabled)| enabled.then_some(feature))
+    .collect()
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("xtask has workspace parent")
+        .to_path_buf()
+}
+fn fail(path: &Path, error: std::io::Error) -> ! {
+    panic!("{}: {error}", path.display())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generated_catalog_is_nonempty_and_valid() {
+        let bytes = render(&workspace_root());
+        let fragment: CatalogFragment = serde_json::from_slice(&bytes).expect("generated JSON should parse");
+        fragment.validate().expect("generated catalog should validate");
+        assert_eq!(fragment.roots.len(), 1);
+        assert!(!fragment.schemas.is_empty());
+        assert!(!fragment.filters.is_empty());
+    }
+
+    #[test]
+    fn generated_catalog_is_deterministic() {
+        assert_eq!(render(&workspace_root()), render(&workspace_root()));
+    }
+
+    #[test]
+    fn generated_catalog_emits_try_from_rules_and_enum_discriminators() {
+        let bytes = render(&workspace_root());
+        let fragment: CatalogFragment = serde_json::from_slice(&bytes).expect("generated JSON should parse");
+        let retry_policy = fragment
+            .schemas
+            .get(&"core.type.RetryPolicy".into())
+            .expect("retry policy schema");
+        let retry_limit = match &retry_policy.node.kind {
+            SchemaKind::Object { fields, .. } => fields
+                .iter()
+                .find(|field| field.serialized_name == "retry_body_limit_bytes")
+                .expect("retry body limit field"),
+            _ => panic!("retry policy must be an object"),
+        };
+        let SchemaKind::Integer = retry_limit.schema.kind else {
+            panic!("retry body limit must remain an integer")
+        };
+        assert_eq!(retry_limit.schema.rules.len(), 1);
+        assert_eq!(
+            retry_limit.schema.rules[0].kind,
+            praxis_config_catalog::RuleKind::NumericBounds
+        );
+
+        fn has_discriminator(node: &SchemaNode) -> bool {
+            match &node.kind {
+                SchemaKind::OneOf {
+                    variants,
+                    discriminator,
+                } => discriminator.is_some() || variants.iter().any(has_discriminator),
+                SchemaKind::Object { fields, .. } => fields.iter().any(|field| has_discriminator(&field.schema)),
+                SchemaKind::Array { items, .. } | SchemaKind::Map { values: items } => has_discriminator(items),
+                _ => false,
+            }
+        }
+        assert!(
+            fragment.schemas.values().any(|schema| has_discriminator(&schema.node)),
+            "at least one tagged enum must expose its discriminator"
+        );
+    }
+
+    #[test]
+    fn registry_and_feature_profile_are_catalog_parity_checked() {
+        let bytes = render(&workspace_root());
+        let fragment: CatalogFragment = serde_json::from_slice(&bytes).expect("generated JSON should parse");
+        let descriptors: BTreeSet<&str> = fragment.filters.iter().map(|filter| filter.name.as_str()).collect();
+        let registry = praxis_filter::FilterRegistry::with_builtins();
+        for name in registry.available_filters() {
+            assert!(
+                descriptors.contains(name),
+                "registered filter {name} has no generated catalog descriptor"
+            );
+        }
+        for filter in &fragment.filters {
+            assert!(
+                filter.required_features.is_subset(&fragment.feature_profile.available),
+                "{} requires a feature outside the generated profile",
+                filter.name
+            );
+        }
+    }
+
+    #[test]
+    fn semantic_override_validation_rejects_stale_and_ambiguous_entries() {
+        let stale = [SemanticOverride {
+            owner: "test",
+            field: "field",
+            rust_type: "Value",
+            kind: "test",
+            reason: "fixture",
+        }];
+        assert!(
+            validate_overrides(&stale, &BTreeSet::new()).is_err(),
+            "unmatched overrides must fail closed"
+        );
+        let ambiguous = [
+            SemanticOverride {
+                owner: "test",
+                field: "field",
+                rust_type: "Value",
+                kind: "test",
+                reason: "fixture",
+            },
+            SemanticOverride {
+                owner: "test",
+                field: "field",
+                rust_type: "Value",
+                kind: "test",
+                reason: "duplicate",
+            },
+        ];
+        assert!(
+            validate_overrides(&ambiguous, &BTreeSet::from([0, 1])).is_err(),
+            "ambiguous overrides must fail closed"
+        );
+    }
+
+    #[test]
+    fn example_validation_rejects_wrong_scalar_and_unknown_field() {
+        let fragment = CatalogFragment {
+            format_version: CatalogFormatVersion { major: 1, minor: 0 },
+            producer: praxis_config_catalog::ProducerInfo {
+                component: praxis_config_catalog::ProducerComponent::Core,
+                package: "test".to_owned(),
+                version: "1.0.0".to_owned(),
+                source_revision: None,
+            },
+            compatibility: praxis_config_catalog::CatalogCompatibility {
+                requires_format_major: 1,
+                requires_core: None,
+            },
+            feature_profile: Default::default(),
+            schemas: BTreeMap::new(),
+            roots: Vec::new(),
+            filters: Vec::new(),
+            diagnostics: Vec::new(),
+        };
+        let scalar = SchemaNode::simple(SchemaKind::Boolean);
+        assert!(
+            validate_yaml_node(
+                &serde_yaml::Value::String("true".to_owned()),
+                &scalar,
+                &fragment,
+                "test"
+            )
+            .is_err()
+        );
+        let object = SchemaNode::object(vec![ObjectField {
+            serialized_name: "known".to_owned(),
+            aliases: Vec::new(),
+            schema: SchemaNode::simple(SchemaKind::String),
+            required: false,
+            flattened: false,
+        }]);
+        let value: serde_yaml::Value = serde_yaml::from_str("unknown: value").expect("fixture YAML");
+        assert!(validate_yaml_node(&value, &object, &fragment, "test").is_err());
+    }
+}

--- a/xtask/src/filter_docs.rs
+++ b/xtask/src/filter_docs.rs
@@ -113,50 +113,56 @@ fn collect_stale_doc_paths(root: &Path, docs_dir: &Path, all_filters: &[FilterEn
 // ---------------------------------------------------------------------------
 
 /// A filter with its location metadata for output path construction.
-struct FilterEntry {
+pub(crate) struct FilterEntry {
     /// Protocol name (`http` or `tcp`).
-    protocol: String,
+    pub(crate) protocol: String,
     /// Category slug (e.g. `traffic_management`).
-    category: String,
+    pub(crate) category: String,
     /// Cargo feature required for the filter to be registered.
-    required_feature: Option<String>,
+    pub(crate) required_feature: Option<String>,
     /// Extracted filter information.
-    filter: FilterInfo,
+    pub(crate) filter: FilterInfo,
 }
 
 /// Information extracted for one filter.
 #[derive(Clone)]
-struct FilterInfo {
+pub(crate) struct FilterInfo {
     /// Filter name as returned by `fn name()` (e.g. `"rate_limit"`).
-    name: String,
+    pub(crate) name: String,
     /// First paragraph of the filter struct doc comment.
-    description: String,
+    pub(crate) description: String,
     /// First paragraphs from same-name filter variants.
-    extra_descriptions: Vec<String>,
+    pub(crate) extra_descriptions: Vec<String>,
     /// Additional notes extracted from config struct docs.
-    config_notes: Vec<String>,
+    pub(crate) config_notes: Vec<String>,
     /// Config fields in declaration order.
-    fields: Vec<FieldInfo>,
+    pub(crate) fields: Vec<FieldInfo>,
+    /// Structured config fields retained for machine-readable catalogs.
+    pub(crate) raw_fields: Vec<RawField>,
+    /// Source type table used to resolve nested config shapes.
+    pub(crate) source_items: ModuleItems,
+    /// Anchor source path for catalog provenance.
+    pub(crate) source_path: Option<String>,
     /// YAML configuration example from doc comments.
-    yaml_examples: Vec<String>,
+    pub(crate) yaml_examples: Vec<String>,
 }
 
 /// Information extracted for one config field.
 #[derive(Clone)]
-struct FieldInfo {
+pub(crate) struct FieldInfo {
     /// Field name.
-    name: String,
+    pub(crate) name: String,
     /// Human-readable type string.
-    type_str: String,
+    pub(crate) type_str: String,
     /// Doc comment text.
-    doc: String,
+    pub(crate) doc: String,
     /// Field presence requirement.
-    required: RequiredKind,
+    pub(crate) required: RequiredKind,
 }
 
 /// How a field must appear in YAML.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum RequiredKind {
+pub(crate) enum RequiredKind {
     /// Field must be present.
     Yes,
     /// Field may be omitted.
@@ -198,7 +204,8 @@ struct ConfigStruct {
 }
 
 /// Parsed items accumulated from source files belonging to one filter module.
-struct ModuleItems {
+#[derive(Clone)]
+pub(crate) struct ModuleItems {
     /// Module-level doc comments from files in the filter scope.
     module_docs: Vec<String>,
     /// Local config structs found (with `Deserialize` + `deny_unknown_fields`).
@@ -210,9 +217,15 @@ struct ModuleItems {
     structs: BTreeMap<String, ConfigStruct>,
     /// Enum definitions with `Deserialize` for variant rendering.
     enums: BTreeMap<String, EnumInfo>,
+    /// Single-field newtypes whose serde shape is their inner value.
+    newtypes: BTreeMap<String, syn::Type>,
     /// `serde(try_from)` aliases: public struct name to the raw struct
     /// whose fields describe the actual YAML shape.
     try_from_aliases: BTreeMap<String, String>,
+    /// Rust `use` and type aliases used by configuration fields.
+    type_aliases: BTreeMap<String, String>,
+    /// Aliases whose source paths disagree; these must fail closed.
+    ambiguous_aliases: BTreeSet<String>,
 }
 
 impl ModuleItems {
@@ -224,7 +237,10 @@ impl ModuleItems {
             struct_docs: Vec::new(),
             structs: BTreeMap::new(),
             enums: BTreeMap::new(),
+            newtypes: BTreeMap::new(),
             try_from_aliases: BTreeMap::new(),
+            type_aliases: BTreeMap::new(),
+            ambiguous_aliases: BTreeSet::new(),
         }
     }
 
@@ -236,33 +252,72 @@ impl ModuleItems {
             struct_docs: Vec::new(),
             structs: self.structs.clone(),
             enums: self.enums.clone(),
+            newtypes: self.newtypes.clone(),
             try_from_aliases: self.try_from_aliases.clone(),
+            type_aliases: self.type_aliases.clone(),
+            ambiguous_aliases: self.ambiguous_aliases.clone(),
         }
     }
 
     /// Resolve a struct name through any `serde(try_from)` alias to the
     /// struct whose fields describe the YAML shape.
-    fn resolve_alias<'a>(&'a self, name: &'a str) -> &'a str {
-        self.try_from_aliases.get(name).map_or(name, String::as_str)
+    pub(crate) fn resolve_alias<'a>(&'a self, name: &'a str) -> &'a str {
+        self.try_from_aliases
+            .get(name)
+            .or_else(|| self.type_aliases.get(name))
+            .map_or(name, String::as_str)
+    }
+
+    /// Resolve only Rust `use`/type aliases, preserving serde `try_from`
+    /// wrapper names so their portable constraints can be emitted.
+    pub(crate) fn resolve_type_alias<'a>(&'a self, name: &'a str) -> &'a str {
+        self.type_aliases.get(name).map_or(name, String::as_str)
+    }
+
+    /// Return whether a short type alias maps to more than one source path.
+    pub(crate) fn has_ambiguous_alias(&self, name: &str) -> bool {
+        self.ambiguous_aliases.contains(name)
+    }
+
+    /// Return a parsed struct by its Rust identifier.
+    pub(crate) fn struct_fields(&self, name: &str) -> Option<&[RawField]> {
+        self.structs
+            .get(self.resolve_alias(name))
+            .map(|config| config.fields.as_slice())
+    }
+
+    /// Return parsed enum metadata by its Rust identifier.
+    pub(crate) fn enum_info(&self, name: &str) -> Option<&EnumInfo> {
+        self.enums.get(self.resolve_alias(name))
+    }
+
+    /// Return the inner type of a serialized single-field newtype.
+    pub(crate) fn newtype_inner(&self, name: &str) -> Option<&syn::Type> {
+        self.newtypes.get(self.resolve_alias(name))
     }
 }
 
 /// Parsed enum metadata.
 #[derive(Clone)]
-struct EnumInfo {
+pub(crate) struct EnumInfo {
     /// YAML variant names.
-    variants: Vec<String>,
+    pub(crate) variants: Vec<String>,
     /// Whether serde tries variants by shape instead of by variant tag.
-    untagged: bool,
+    pub(crate) untagged: bool,
     /// Source shape for each variant.
-    variant_shapes: Vec<EnumVariantShape>,
+    pub(crate) variant_shapes: Vec<EnumVariantShape>,
     /// Named fields from struct-like variants.
-    fields: Vec<RawField>,
+    pub(crate) fields: Vec<RawField>,
+    /// Optional internally or adjacently tagged representation metadata.
+    pub(crate) tag: Option<String>,
+    pub(crate) content: Option<String>,
+    /// Fields grouped by variant for tagged rendering.
+    pub(crate) variant_fields: Vec<Vec<RawField>>,
 }
 
 /// Source shape for one enum variant.
 #[derive(Clone)]
-enum EnumVariantShape {
+pub(crate) enum EnumVariantShape {
     /// Unit variant, usually rendered as a scalar YAML value.
     Unit,
     /// Tuple variant with one wrapped type.
@@ -273,26 +328,32 @@ enum EnumVariantShape {
 
 /// A raw field before type rendering.
 #[derive(Clone)]
-struct RawField {
+pub(crate) struct RawField {
     /// Field name.
-    name: String,
+    pub(crate) name: String,
     /// Raw type from syn.
-    ty: syn::Type,
+    pub(crate) ty: syn::Type,
     /// Doc comment lines joined.
-    doc: String,
+    pub(crate) doc: String,
     /// Has `#[serde(default)]` or `#[serde(default = "...")]`.
-    has_default: bool,
+    pub(crate) has_default: bool,
     /// Custom serde deserializer from `#[serde(deserialize_with = "...")]`.
-    deserialize_with: Option<String>,
+    pub(crate) deserialize_with: Option<String>,
     /// Has `#[serde(flatten)]`.
-    flatten: bool,
+    pub(crate) flatten: bool,
     /// Additional requiredness hint from surrounding syntax.
-    requirement_hint: RequirementHint,
+    pub(crate) requirement_hint: RequirementHint,
+    /// Accepted serde aliases.
+    pub(crate) aliases: Vec<String>,
+    /// Whether serde skips this field during deserialization.
+    pub(crate) skip: bool,
+    /// Default function path, when present.
+    pub(crate) default_path: Option<String>,
 }
 
 /// Requiredness hint from the surrounding source shape.
 #[derive(Clone, Copy)]
-enum RequirementHint {
+pub(crate) enum RequirementHint {
     /// Use the field type and serde defaults to infer requiredness.
     Normal,
     /// Field came from one of several struct-like enum variants.
@@ -314,6 +375,13 @@ impl FilterInfo {
         append_unique(&mut self.config_notes, other.config_notes);
         append_unique_fields(&mut self.fields, other.fields);
         append_unique(&mut self.yaml_examples, other.yaml_examples);
+        if self.raw_fields.is_empty() {
+            self.raw_fields = other.raw_fields;
+            self.source_items = other.source_items;
+        }
+        if self.source_path.is_none() {
+            self.source_path = other.source_path;
+        }
     }
 }
 
@@ -322,7 +390,7 @@ impl FilterInfo {
 // ---------------------------------------------------------------------------
 
 /// Parse shared config types that built-in filters reference.
-fn parse_shared_config_items(root: &Path) -> ModuleItems {
+pub(crate) fn parse_shared_config_items(root: &Path) -> ModuleItems {
     let mut items = ModuleItems::new();
     for dir in &[root.join("crates/core/src/config"), root.join("crates/tls/src/config")] {
         for path in collect_rs_files(dir) {
@@ -342,8 +410,27 @@ fn parse_shared_config_items(root: &Path) -> ModuleItems {
     items
 }
 
+/// Extract the structured top-level Core `Config` fields and type table.
+pub(crate) fn parse_root_config_source(root: &Path) -> (ModuleItems, Vec<RawField>) {
+    let path = root.join("crates/core/src/config/mod.rs");
+    let Ok(source) = fs::read_to_string(path) else {
+        return (ModuleItems::new(), Vec::new());
+    };
+    let Ok(file) = syn::parse_file(&source) else {
+        return (ModuleItems::new(), Vec::new());
+    };
+    let mut items = parse_shared_config_items(root);
+    parse_file_items(&file, &mut items);
+    let fields = items
+        .configs
+        .iter()
+        .find(|config| config.name == "Config")
+        .map_or_else(Vec::new, |config| config.fields.clone());
+    (items, fields)
+}
+
 /// Discover all filters across all protocols and categories.
-fn discover_all_filters(root: &Path, shared_items: &ModuleItems) -> Vec<FilterEntry> {
+pub(crate) fn discover_all_filters(root: &Path, shared_items: &ModuleItems) -> Vec<FilterEntry> {
     let builtins = root.join("crates/filter/src/builtins");
     let feature_requirements = discover_feature_requirements(root);
     let mut entries = Vec::new();
@@ -403,7 +490,9 @@ fn extract_filters(category_dir: &Path, shared_items: &ModuleItems) -> Vec<Filte
                 };
                 parse_file_items(&file, &mut items);
             }
-            build_filter(&items, &anchor.name, anchor.config_type_name.as_deref())
+            let mut filter = build_filter(&items, &anchor.name, anchor.config_type_name.as_deref());
+            filter.source_path = Some(anchor.file.to_string_lossy().into_owned());
+            filter
         })
         .collect();
     merge_filter_variants(filters)
@@ -714,7 +803,7 @@ fn scope_files_recursive(dir: &Path, excluded: &HashSet<&Path>, out: &mut Vec<Pa
 }
 
 /// Recursively collect `.rs` files, skipping test files.
-fn collect_rs_files(dir: &Path) -> Vec<PathBuf> {
+pub(crate) fn collect_rs_files(dir: &Path) -> Vec<PathBuf> {
     let mut files = Vec::new();
     collect_rs_files_recursive(dir, &mut files);
     files.sort();
@@ -752,6 +841,14 @@ fn parse_file_items(file: &syn::File, out: &mut ModuleItems) {
     for item in &file.items {
         match item {
             syn::Item::Struct(s) => parse_struct(s, out),
+            syn::Item::Type(alias) => {
+                if let syn::Type::Path(path) = &*alias.ty
+                    && let Some(segment) = path.path.segments.last()
+                {
+                    register_type_alias(out, alias.ident.to_string(), segment.ident.to_string());
+                }
+            },
+            syn::Item::Use(use_item) => collect_use_aliases(&use_item.tree, String::new(), out),
             syn::Item::Enum(e)
                 if derives_deserialize(&e.attrs) || manual_deserialize.contains(&e.ident.to_string()) =>
             {
@@ -762,6 +859,52 @@ fn parse_file_items(file: &syn::File, out: &mut ModuleItems) {
             },
             _ => {},
         }
+    }
+}
+
+fn register_type_alias(out: &mut ModuleItems, alias: String, target: String) {
+    let target = target.rsplit("::").next().unwrap_or(&target).to_owned();
+    if let Some(existing) = out.type_aliases.get(&alias)
+        && existing != &target
+    {
+        out.ambiguous_aliases.insert(alias);
+        return;
+    }
+    out.type_aliases.insert(alias, target);
+}
+
+fn collect_use_aliases(tree: &syn::UseTree, prefix: String, out: &mut ModuleItems) {
+    match tree {
+        syn::UseTree::Path(path) => {
+            let next = if prefix.is_empty() {
+                path.ident.to_string()
+            } else {
+                format!("{prefix}::{}", path.ident)
+            };
+            collect_use_aliases(&path.tree, next, out);
+        },
+        syn::UseTree::Name(name) => {
+            let target = if prefix.is_empty() {
+                name.ident.to_string()
+            } else {
+                format!("{prefix}::{}", name.ident)
+            };
+            register_type_alias(out, name.ident.to_string(), target);
+        },
+        syn::UseTree::Rename(rename) => {
+            let target = if prefix.is_empty() {
+                rename.ident.to_string()
+            } else {
+                format!("{prefix}::{}", rename.ident)
+            };
+            register_type_alias(out, rename.rename.to_string(), target);
+        },
+        syn::UseTree::Group(group) => {
+            for item in &group.items {
+                collect_use_aliases(item, prefix.clone(), out);
+            }
+        },
+        syn::UseTree::Glob(_) => {},
     }
 }
 
@@ -820,6 +963,12 @@ fn parse_struct(s: &syn::ItemStruct, out: &mut ModuleItems) {
         if is_config_struct(s) {
             out.configs.push(config);
         }
+    } else if let syn::Fields::Unnamed(fields) = &s.fields
+        && fields.unnamed.len() == 1
+    {
+        if let Some(field) = fields.unnamed.first() {
+            out.newtypes.insert(s.ident.to_string(), field.ty.clone());
+        }
     }
     if !docs.is_empty() && is_filter_doc_candidate(s) {
         out.struct_docs.push((s.ident.to_string(), docs));
@@ -850,6 +999,7 @@ fn build_filter(items: &ModuleItems, name: &str, config_type: Option<&str>) -> F
     let cfg_notes = config.map_or_else(Vec::new, |c| config_notes(&c.doc));
     append_unique(&mut all_notes, cfg_notes);
     let fields = config.map_or_else(Vec::new, |c| build_fields(c, items));
+    let raw_fields = config.map_or_else(Vec::new, |c| c.fields.clone());
 
     FilterInfo {
         name: name.to_owned(),
@@ -857,6 +1007,9 @@ fn build_filter(items: &ModuleItems, name: &str, config_type: Option<&str>) -> F
         extra_descriptions: Vec::new(),
         config_notes: all_notes,
         fields,
+        raw_fields,
+        source_items: items.clone(),
+        source_path: None,
         yaml_examples,
     }
 }
@@ -1027,6 +1180,9 @@ fn parse_config_fields(s: &syn::ItemStruct) -> Option<Vec<RawField>> {
                 deserialize_with: serde_deserialize_with(&f.attrs),
                 flatten: has_serde_attr(&f.attrs, "flatten"),
                 requirement_hint: RequirementHint::Normal,
+                aliases: serde_aliases(&f.attrs),
+                skip: has_serde_attr(&f.attrs, "skip") || has_serde_attr(&f.attrs, "skip_deserializing"),
+                default_path: serde_default_path(&f.attrs),
                 ty: f.ty.clone(),
             })
             .collect(),
@@ -1070,6 +1226,43 @@ fn serde_field_name(field: &syn::Field) -> String {
         .find_map(serde_rename)
         .or_else(|| field.ident.as_ref().map(ToString::to_string))
         .unwrap_or_default()
+}
+
+fn serde_aliases(attrs: &[syn::Attribute]) -> Vec<String> {
+    attrs
+        .iter()
+        .filter(|attr| attr.path().is_ident("serde"))
+        .flat_map(|attr| {
+            let mut aliases = Vec::new();
+            let _ = attr.parse_nested_meta(|meta| {
+                if meta.path.is_ident("alias") {
+                    if let Ok(value) = meta.value()?.parse::<syn::LitStr>() {
+                        aliases.push(value.value());
+                    }
+                }
+                Ok(())
+            });
+            aliases
+        })
+        .collect()
+}
+
+fn serde_default_path(attrs: &[syn::Attribute]) -> Option<String> {
+    attrs.iter().find_map(|attr| {
+        if !attr.path().is_ident("serde") {
+            return None;
+        }
+        let mut path = None;
+        let _ = attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("default")
+                && let Ok(value) = meta.value()?.parse::<syn::LitStr>()
+            {
+                path = Some(value.value());
+            }
+            Ok(())
+        });
+        path
+    })
 }
 
 /// Return whether a serde attribute contains a given nested key.
@@ -1143,13 +1336,16 @@ fn extract_enum_info(e: &syn::ItemEnum) -> EnumInfo {
             }
         }
     }
-    let fields = variant_fields.into_iter().flatten().collect();
+    let fields = variant_fields.clone().into_iter().flatten().collect();
 
     EnumInfo {
         variants,
         untagged,
         variant_shapes,
         fields,
+        tag: e.attrs.iter().find_map(|attr| serde_lit_value(attr, "tag")),
+        content: e.attrs.iter().find_map(|attr| serde_lit_value(attr, "content")),
+        variant_fields,
     }
 }
 
@@ -1211,6 +1407,9 @@ fn parse_variant_fields(variant: &syn::Variant) -> Vec<RawField> {
             deserialize_with: serde_deserialize_with(&f.attrs),
             flatten: has_serde_attr(&f.attrs, "flatten"),
             requirement_hint: RequirementHint::Normal,
+            aliases: serde_aliases(&f.attrs),
+            skip: has_serde_attr(&f.attrs, "skip") || has_serde_attr(&f.attrs, "skip_deserializing"),
+            default_path: serde_default_path(&f.attrs),
             ty: f.ty.clone(),
         })
         .collect()
@@ -2454,6 +2653,9 @@ mod tests {
                 extra_descriptions: vec![],
                 config_notes: vec![],
                 fields: vec![],
+                raw_fields: vec![],
+                source_items: ModuleItems::new(),
+                source_path: None,
                 yaml_examples: vec![],
             },
         }];
@@ -2708,6 +2910,9 @@ mod tests {
                     doc: "Max time in milliseconds.".to_owned(),
                     required: RequiredKind::Yes,
                 }],
+                raw_fields: vec![],
+                source_items: ModuleItems::new(),
+                source_path: None,
                 yaml_examples: vec!["filter: timeout\ntimeout_ms: 5000".to_owned()],
             },
         }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -24,6 +24,7 @@
 #![allow(let_underscore_drop, reason = "development tooling")]
 
 mod benchmark;
+mod config_catalog;
 mod debug;
 mod echo;
 mod filter_docs;
@@ -78,6 +79,12 @@ enum Command {
 
     /// Check that filter doc files are up to date.
     LintFilterDocs(filter_docs::LintArgs),
+
+    /// Generate the machine-readable configuration catalog.
+    GenerateConfigCatalog(config_catalog::GenerateArgs),
+
+    /// Check the machine-readable configuration catalog is current.
+    LintConfigCatalog(config_catalog::LintArgs),
 }
 
 // -----------------------------------------------------------------------------
@@ -96,6 +103,8 @@ fn main() {
         Command::SyncExampleReadme(args) => sync_example_readme::run(&args),
         Command::GenerateFilterDocs(args) => filter_docs::generate(args),
         Command::LintFilterDocs(args) => filter_docs::lint(args),
+        Command::GenerateConfigCatalog(args) => config_catalog::generate(args),
+        Command::LintConfigCatalog(args) => config_catalog::lint(args),
     }
 }
 


### PR DESCRIPTION
### What does this PR do?

This PR:
* Adds a generator for a catalog of every filter and configuration from Praxis core. This generator can be consumed from other projects that rely on Praxis as well
* Commits the initial catalog

The idea behind this is that a UI/playground can use this as a source of truth for supported Praxis configuration, allowing users to have a visual design of their configuration

This is a WIP

### Which issue(s) does this relate to?
WIP
Fixes #

### Checklist

- [ ] Signed off all commits (`git commit -s`)
- [ ] Tests added or updated
- [ ] Documentation updated (if applicable)
- [ ] `make lint && make test && make test-integration` passes locally

### Does this introduce a breaking change?

<!-- If yes, describe the impact and migration
path. -->
