### PR TITLE
feat(filter): publish selected cluster application metadata in context

### DIFF
--- a/crates/filter/src/builtins/http/traffic_management/iterative_request_router/mod.rs
+++ b/crates/filter/src/builtins/http/traffic_management/iterative_request_router/mod.rs
@@ -71,6 +71,7 @@ use crate::{
     FilterEntry, FilterError, FilterPipeline, FilterRegistry, IterationState, NextIterationBody, RequestExtensions,
     StreamTermination, SubRequest, SubResponse,
     actions::{FilterAction, Rejection, StreamingResponseBody as _, StreamingTerminalResponse, TerminalResponse},
+    extensions::SelectedClusterApplication,
     factory::parse_filter_config,
     filter::{HttpFilter, HttpFilterContext},
     filtered_subrequest::{FilteredStreamingBody, SubrequestRuntime, normalize_response_status},
@@ -124,6 +125,21 @@ pub(super) fn strip_iteration_extensions(mut extensions: RequestExtensions) -> R
     extensions.remove::<IterationState>();
     extensions.remove::<NextIterationBody>();
     extensions
+}
+
+/// Drop any selected-cluster application metadata a prior step published, so a
+/// new step never inherits it through the threaded [`RequestExtensions`].
+///
+/// Called at each iteration boundary — the top of the run loop and the top of a
+/// streaming resume (`IrrStreamingSession::open_next`) — before the
+/// max-iteration and deadline guards can early-return the threaded extensions to
+/// the parent, and before the step's body hooks run (which precede its load
+/// balancer under a `StreamBuffer` pre-read). The step's load balancer
+/// republishes for the current step during `on_request`, so the terminal step's
+/// value survives while no early exit and no pre-selection hook observes a stale
+/// one.
+pub(super) fn clear_selected_application(extensions: &mut RequestExtensions) {
+    extensions.remove::<SelectedClusterApplication>();
 }
 
 // ---------------------------------------------------------------------------
@@ -459,6 +475,7 @@ impl IterativeRequestRouterFilter {
         let mut pending_bytes = 0_usize;
 
         loop {
+            clear_selected_application(&mut extensions);
             if state.iteration >= self.max_iterations {
                 ctx.extensions = extensions;
                 warn!(

--- a/crates/filter/src/builtins/http/traffic_management/iterative_request_router/streaming.rs
+++ b/crates/filter/src/builtins/http/traffic_management/iterative_request_router/streaming.rs
@@ -332,6 +332,9 @@ impl IrrStreamingSession {
             .take()
             .ok_or_else(|| -> FilterError { "iterative_request_router: next step missing".into() })?;
         self.current_step = next;
+        if let Some(extensions) = self.extensions.as_mut() {
+            super::clear_selected_application(extensions);
+        }
         let state = self.state.take().ok_or_else(|| -> FilterError {
             "iterative_request_router: iteration state missing between steps".into()
         })?;

--- a/crates/filter/src/builtins/http/traffic_management/iterative_request_router/tests.rs
+++ b/crates/filter/src/builtins/http/traffic_management/iterative_request_router/tests.rs
@@ -3628,3 +3628,260 @@ steps:
         other => panic!("expected TerminalResponse, got {other:?}"),
     }
 }
+
+// ---------------------------------------------------------------------------
+// Selected Cluster Application Isolation Across Steps
+//
+// A single `RequestExtensions` is threaded across steps, so a step must
+// not observe the cluster application metadata published by a prior step.
+// ---------------------------------------------------------------------------
+
+/// Shared slot recording the selected cluster application a probe filter
+/// observed from inside an IRR step, so the test can assert on it afterward.
+type ObservedApplication = std::sync::Arc<std::sync::Mutex<Option<(Option<String>, Option<String>)>>>;
+
+/// Records the selected cluster application it observes during the request
+/// body phase. Declares a `StreamBuffer` request body mode so its
+/// `on_request_body` hook runs before the step's `on_request` phase, i.e.
+/// before that step's load balancer selects and publishes.
+struct ApplicationProbeFilter {
+    observed: ObservedApplication,
+}
+
+#[async_trait::async_trait]
+impl crate::HttpFilter for ApplicationProbeFilter {
+    fn name(&self) -> &'static str {
+        "test_application_probe"
+    }
+
+    fn request_body_access(&self) -> crate::BodyAccess {
+        crate::BodyAccess::ReadOnly
+    }
+
+    fn request_body_mode(&self) -> crate::BodyMode {
+        crate::BodyMode::StreamBuffer { max_bytes: Some(65536) }
+    }
+
+    async fn on_request(
+        &self,
+        _ctx: &mut crate::HttpFilterContext<'_>,
+    ) -> Result<crate::FilterAction, crate::FilterError> {
+        Ok(crate::FilterAction::Continue)
+    }
+
+    async fn on_request_body(
+        &self,
+        ctx: &mut crate::HttpFilterContext<'_>,
+        _body: &mut Option<bytes::Bytes>,
+        _end_of_stream: bool,
+    ) -> Result<crate::FilterAction, crate::FilterError> {
+        let protocol = ctx.selected_application_protocol().map(str::to_owned);
+        let provider = ctx.selected_application_provider().map(str::to_owned);
+        *self.observed.lock().unwrap() = Some((protocol, provider));
+        Ok(crate::FilterAction::Continue)
+    }
+}
+
+/// Build an IRR filter whose registry includes a probe filter recording
+/// the selected cluster application into `observed`.
+fn irr_with_application_probe(yaml: &str, observed: &ObservedApplication) -> Box<dyn crate::HttpFilter> {
+    let observed = std::sync::Arc::clone(observed);
+    let mut registry = crate::FilterRegistry::with_builtins();
+    registry
+        .register(
+            "test_application_probe",
+            crate::FilterFactory::Http(std::sync::Arc::new(move |_| {
+                Ok(Box::new(ApplicationProbeFilter {
+                    observed: std::sync::Arc::clone(&observed),
+                }))
+            })),
+        )
+        .unwrap();
+    let value: serde_yaml::Value = serde_yaml::from_str(yaml).unwrap();
+    super::IterativeRequestRouterFilter::from_config_with_registry(&value, &registry).unwrap()
+}
+
+#[tokio::test]
+async fn iteration_streambuffer_step_body_hook_does_not_observe_prior_step_application() {
+    let (addr, backend) = spawn_raw_backend("HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok").await;
+    let yaml = format!(
+        "
+initial_step: tagged
+steps:
+  - name: tagged
+    filters:
+      - filter: router
+        routes:
+          - path_prefix: \"/\"
+            cluster: tagged_backend
+      - filter: load_balancer
+        clusters:
+          - name: tagged_backend
+            endpoints:
+              - \"{addr}\"
+            http:
+              application_protocol: openai_chat_completions
+              application_provider: vllm
+    on_result:
+      - default: true
+        next: untagged
+  - name: untagged
+    filters:
+      - filter: test_application_probe
+      - filter: router
+        routes:
+          - path_prefix: \"/\"
+            cluster: plain_backend
+      - filter: load_balancer
+        clusters:
+          - name: plain_backend
+            endpoints:
+              - \"{addr}\"
+    on_result:
+      - default: true
+        done: true
+"
+    );
+    let observed = ObservedApplication::default();
+    let filter = irr_with_application_probe(&yaml, &observed);
+    let client = make_client();
+    let req = crate::test_utils::make_request(http::Method::POST, "/chat");
+    let mut ctx = make_iteration_context(&req, &client, b"payload");
+
+    let action = filter.on_request(&mut ctx).await.unwrap();
+    backend.abort();
+
+    assert!(
+        matches!(action, crate::FilterAction::TerminalResponse(_)),
+        "the two-step run must reach a terminal response: {action:?}"
+    );
+    let (protocol, provider) = observed
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("the probe body hook must have run in the untagged step");
+    assert_eq!(
+        protocol, None,
+        "the untagged step's body hook must not observe the prior tagged step's application_protocol before selection"
+    );
+    assert_eq!(
+        provider, None,
+        "the untagged step's body hook must not observe the prior tagged step's application_provider before selection"
+    );
+}
+
+#[tokio::test]
+async fn iteration_selection_failure_does_not_leak_prior_step_application() {
+    let (addr, backend) = spawn_raw_backend("HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok").await;
+    let yaml = format!(
+        "
+initial_step: tagged
+steps:
+  - name: tagged
+    filters:
+      - filter: router
+        routes:
+          - path_prefix: \"/\"
+            cluster: tagged_backend
+      - filter: load_balancer
+        clusters:
+          - name: tagged_backend
+            endpoints:
+              - \"{addr}\"
+            http:
+              application_protocol: openai_chat_completions
+              application_provider: vllm
+    on_result:
+      - default: true
+        next: broken
+  - name: broken
+    filters:
+      - filter: router
+        routes:
+          - path_prefix: \"/\"
+            cluster: empty_backend
+      - filter: load_balancer
+        clusters:
+          - name: empty_backend
+            endpoints:
+              - address: \"{addr}\"
+                weight: 0
+    on_result:
+      - default: true
+        done: true
+"
+    );
+    let filter = irr_from_yaml(&yaml);
+    let client = make_client();
+    let req = crate::test_utils::make_request(http::Method::POST, "/chat");
+    let mut ctx = make_iteration_context(&req, &client, b"payload");
+
+    let err = filter.on_request(&mut ctx).await.unwrap_err();
+    backend.abort();
+
+    assert!(
+        err.to_string().contains("no available endpoints"),
+        "the second step's selection must fail: {err}"
+    );
+    assert_eq!(
+        ctx.selected_application_protocol(),
+        None,
+        "a step whose selection fails must not leak the prior step's application_protocol to the parent"
+    );
+    assert_eq!(
+        ctx.selected_application_provider(),
+        None,
+        "a step whose selection fails must not leak the prior step's application_provider to the parent"
+    );
+}
+
+#[tokio::test]
+async fn iteration_max_iterations_early_exit_does_not_leak_prior_step_application() {
+    let (addr, backend) = spawn_raw_backend("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n").await;
+    let yaml = format!(
+        "
+initial_step: tagged
+max_iterations: 1
+steps:
+  - name: tagged
+    filters:
+      - filter: router
+        routes:
+          - path_prefix: \"/\"
+            cluster: tagged_backend
+      - filter: load_balancer
+        clusters:
+          - name: tagged_backend
+            endpoints:
+              - \"{addr}\"
+            http:
+              application_protocol: openai_chat_completions
+              application_provider: vllm
+    on_result:
+      - status: [200]
+        next: tagged
+      - default: true
+        done: true
+"
+    );
+    let filter = irr_from_yaml(&yaml);
+    let client = make_client();
+    let req = crate::test_utils::make_request(http::Method::GET, "/loop");
+    let mut ctx = make_iteration_context(&req, &client, b"");
+
+    let action = filter.on_request(&mut ctx).await.unwrap();
+    backend.abort();
+
+    let is_508 = matches!(&action, crate::FilterAction::Reject(rej) if rej.status == 508);
+    assert!(is_508, "exhausted iterations must reject with 508: {action:?}");
+    assert_eq!(
+        ctx.selected_application_protocol(),
+        None,
+        "a max-iterations early exit must not leak the prior step's application_protocol to the parent"
+    );
+    assert_eq!(
+        ctx.selected_application_provider(),
+        None,
+        "a max-iterations early exit must not leak the prior step's application_provider to the parent"
+    );
+}

--- a/crates/filter/src/builtins/http/traffic_management/load_balancer/entry.rs
+++ b/crates/filter/src/builtins/http/traffic_management/load_balancer/entry.rs
@@ -45,6 +45,12 @@ pub(super) struct ClusterEntry {
     /// Pre-cached TLS material. `None` means plain TCP.
     pub(super) tls: Option<CachedClusterTls>,
 
+    /// Opaque application protocol tagged on the cluster, if any.
+    pub(super) application_protocol: Option<Arc<str>>,
+
+    /// Opaque application provider tagged on the cluster, if any.
+    pub(super) application_provider: Option<Arc<str>>,
+
     /// Resolved retry policy (legacy default when unset).
     pub(super) retry_policy: Arc<RetryPolicy>,
 
@@ -178,6 +184,8 @@ pub(super) fn build_cluster_entry(cluster: &Cluster) -> Result<ClusterEntry, Fil
         opts: Arc::new(ConnectionOptions::from(cluster)),
         strategy,
         tls,
+        application_protocol: cluster.http.application_protocol.clone(),
+        application_provider: cluster.http.application_provider.clone(),
         retry_policy,
         retry_state,
         merged_retry_memo: ArcSwap::from_pointee(None),

--- a/crates/filter/src/builtins/http/traffic_management/load_balancer/mod.rs
+++ b/crates/filter/src/builtins/http/traffic_management/load_balancer/mod.rs
@@ -198,6 +198,10 @@ impl HttpFilter for LoadBalancerFilter {
                 // outages are handled upstream by the session-affinity filter,
                 // which does not pin to a down endpoint.
                 ctx.upstream = Some(entry.build_upstream(pinned_addr, ctx));
+                ctx.publish_selected_application(
+                    entry.application_protocol.clone(),
+                    entry.application_provider.clone(),
+                );
                 return Ok(FilterAction::Continue);
             }
             debug!(
@@ -243,6 +247,7 @@ impl HttpFilter for LoadBalancerFilter {
         });
         ctx.attempted_endpoints.push(Arc::clone(&addr));
         ctx.upstream = Some(entry.build_upstream(addr, ctx));
+        ctx.publish_selected_application(entry.application_protocol.clone(), entry.application_provider.clone());
 
         Ok(FilterAction::Continue)
     }

--- a/crates/filter/src/builtins/http/traffic_management/load_balancer/tests.rs
+++ b/crates/filter/src/builtins/http/traffic_management/load_balancer/tests.rs
@@ -5,8 +5,9 @@
 
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
-use praxis_core::config::{
-    Cluster, ConsistentHashOpts, Endpoint, LoadBalancerStrategy, ParameterisedStrategy, SimpleStrategy,
+use praxis_core::{
+    config::{Cluster, ConsistentHashOpts, Endpoint, LoadBalancerStrategy, ParameterisedStrategy, SimpleStrategy},
+    health::{ClusterHealthEntry, ClusterHealthState, EndpointHealth, HealthRegistry},
 };
 
 use super::{LoadBalancerFilter, entry::build_cluster_entry, strategy::build_strategy};
@@ -583,12 +584,302 @@ async fn on_request_errors_when_cluster_has_no_endpoints() {
 }
 
 // -----------------------------------------------------------------------------
+// Selected Cluster Application Tests
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn on_request_publishes_selected_application_ordinary_path() {
+    let lb = LoadBalancerFilter::new(&[cluster_with_application(
+        "llm",
+        &["127.0.0.1:8080"],
+        Some("openai_chat_completions"),
+        Some("vllm"),
+    )]);
+    let req = crate::test_utils::make_request(http::Method::GET, "/");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.cluster = Some(Arc::from("llm"));
+
+    drop(lb.on_request(&mut ctx).await.unwrap());
+
+    assert_eq!(
+        ctx.selected_application_protocol(),
+        Some("openai_chat_completions"),
+        "ordinary selection should publish the selected cluster's application protocol"
+    );
+    assert_eq!(
+        ctx.selected_application_provider(),
+        Some("vllm"),
+        "ordinary selection should publish the selected cluster's application provider"
+    );
+}
+
+#[tokio::test]
+async fn on_request_publishes_selected_application_pinned_endpoint() {
+    let lb = LoadBalancerFilter::new(&[cluster_with_application(
+        "llm",
+        &["127.0.0.1:8080"],
+        Some("openai_responses"),
+        Some("openai"),
+    )]);
+    let req = crate::test_utils::make_request(http::Method::GET, "/");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.cluster = Some(Arc::from("llm"));
+    ctx.pinned_endpoint_address = Some(Arc::from("127.0.0.1:8080"));
+
+    drop(lb.on_request(&mut ctx).await.unwrap());
+
+    assert!(ctx.upstream.is_some(), "the pinned endpoint should have been used");
+    assert_eq!(
+        ctx.selected_application_protocol(),
+        Some("openai_responses"),
+        "the pinned-endpoint path should publish the selected cluster's application protocol"
+    );
+    assert_eq!(
+        ctx.selected_application_provider(),
+        Some("openai"),
+        "the pinned-endpoint path should publish the selected cluster's application provider"
+    );
+}
+
+#[tokio::test]
+async fn on_request_publishes_selected_application_panic_mode() {
+    let lb = LoadBalancerFilter::new(&[cluster_with_application(
+        "llm",
+        &["127.0.0.1:8080", "127.0.0.1:8081"],
+        Some("openai_chat_completions"),
+        Some("vllm"),
+    )]);
+    let registry = all_unhealthy_registry("llm", &["127.0.0.1:8080", "127.0.0.1:8081"]);
+    let req = crate::test_utils::make_request(http::Method::GET, "/");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.cluster = Some(Arc::from("llm"));
+    ctx.health_registry = Some(&registry);
+
+    drop(lb.on_request(&mut ctx).await.unwrap());
+
+    assert!(ctx.upstream.is_some(), "panic mode should still select an upstream");
+    assert_eq!(
+        ctx.selected_application_protocol(),
+        Some("openai_chat_completions"),
+        "panic-mode selection should publish the selected cluster's application protocol"
+    );
+    assert_eq!(
+        ctx.selected_application_provider(),
+        Some("vllm"),
+        "panic-mode selection should publish the selected cluster's application provider"
+    );
+}
+
+#[tokio::test]
+async fn on_request_leaves_application_absent_for_untagged_cluster() {
+    let lb = LoadBalancerFilter::new(&[test_cluster("web", &["127.0.0.1:8080"])]);
+    let req = crate::test_utils::make_request(http::Method::GET, "/");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.cluster = Some(Arc::from("web"));
+
+    drop(lb.on_request(&mut ctx).await.unwrap());
+
+    assert!(
+        ctx.upstream.is_some(),
+        "an untagged cluster should still select an upstream"
+    );
+    assert_eq!(
+        ctx.selected_application_protocol(),
+        None,
+        "an untagged cluster must not publish an application protocol"
+    );
+    assert_eq!(
+        ctx.selected_application_provider(),
+        None,
+        "an untagged cluster must not publish an application provider"
+    );
+}
+
+#[tokio::test]
+async fn on_request_leaves_application_absent_on_failed_selection() {
+    let lb = LoadBalancerFilter::new(&[cluster_with_application(
+        "empty",
+        &[],
+        Some("openai_chat_completions"),
+        Some("vllm"),
+    )]);
+    let req = crate::test_utils::make_request(http::Method::GET, "/");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.cluster = Some(Arc::from("empty"));
+
+    let result = lb.on_request(&mut ctx).await;
+
+    assert!(result.is_err(), "a cluster with no endpoints must fail selection");
+    assert_eq!(
+        ctx.selected_application_protocol(),
+        None,
+        "a failed selection must not publish an application protocol"
+    );
+    assert_eq!(
+        ctx.selected_application_provider(),
+        None,
+        "a failed selection must not publish an application provider"
+    );
+}
+
+#[tokio::test]
+async fn selected_application_survives_on_response() {
+    let lb = LoadBalancerFilter::new(&[cluster_with_application(
+        "llm",
+        &["127.0.0.1:8080"],
+        Some("openai_responses"),
+        Some("openai"),
+    )]);
+    let req = crate::test_utils::make_request(http::Method::GET, "/");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.cluster = Some(Arc::from("llm"));
+
+    drop(lb.on_request(&mut ctx).await.unwrap());
+    drop(lb.on_response(&mut ctx).await.unwrap());
+
+    assert_eq!(
+        ctx.selected_application_protocol(),
+        Some("openai_responses"),
+        "the response phase must observe the same application protocol published at selection"
+    );
+    assert_eq!(
+        ctx.selected_application_provider(),
+        Some("openai"),
+        "the response phase must observe the same application provider published at selection"
+    );
+}
+
+#[tokio::test]
+async fn transport_retry_does_not_change_selected_application() {
+    let lb = LoadBalancerFilter::new(&[cluster_with_application(
+        "llm",
+        &["127.0.0.1:8080", "127.0.0.1:8081"],
+        Some("openai_chat_completions"),
+        Some("vllm"),
+    )]);
+    let req = crate::test_utils::make_request(http::Method::GET, "/");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.cluster = Some(Arc::from("llm"));
+
+    drop(lb.on_request(&mut ctx).await.unwrap());
+
+    let reselector = ctx.endpoint_reselector.clone().expect("reselector should be set");
+    let attempted = ctx.attempted_endpoints.clone();
+    let next = reselector
+        .select_address(None, &attempted)
+        .expect("an alternate endpoint should be available for retry");
+    ctx.upstream = Some(reselector.build_upstream(next));
+
+    assert_eq!(
+        ctx.selected_application_protocol(),
+        Some("openai_chat_completions"),
+        "a transport retry must not change the published application protocol"
+    );
+    assert_eq!(
+        ctx.selected_application_provider(),
+        Some("vllm"),
+        "a transport retry must not change the published application provider"
+    );
+}
+
+#[tokio::test]
+async fn selected_application_survives_pipeline_drop() {
+    let req = crate::test_utils::make_request(http::Method::GET, "/");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.cluster = Some(Arc::from("llm"));
+
+    {
+        let lb = LoadBalancerFilter::new(&[cluster_with_application(
+            "llm",
+            &["127.0.0.1:8080"],
+            Some("openai_chat_completions"),
+            Some("vllm"),
+        )]);
+        drop(lb.on_request(&mut ctx).await.unwrap());
+    }
+
+    assert_eq!(
+        ctx.selected_application_protocol(),
+        Some("openai_chat_completions"),
+        "dropping the selecting pipeline (as a hot reload does) must not disturb this exchange's protocol"
+    );
+    assert_eq!(
+        ctx.selected_application_provider(),
+        Some("vllm"),
+        "dropping the selecting pipeline (as a hot reload does) must not disturb this exchange's provider"
+    );
+}
+
+#[tokio::test]
+async fn irr_style_reuse_untagged_step_clears_prior_application() {
+    let tagged_step = LoadBalancerFilter::new(&[cluster_with_application(
+        "llm",
+        &["127.0.0.1:8080"],
+        Some("openai_chat_completions"),
+        Some("vllm"),
+    )]);
+    let untagged_step = LoadBalancerFilter::new(&[test_cluster("web", &["127.0.0.1:9090"])]);
+    let req = crate::test_utils::make_request(http::Method::GET, "/");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    ctx.cluster = Some(Arc::from("llm"));
+    drop(tagged_step.on_request(&mut ctx).await.unwrap());
+    assert_eq!(
+        ctx.selected_application_protocol(),
+        Some("openai_chat_completions"),
+        "the first step must publish its tagged cluster's application protocol"
+    );
+
+    ctx.upstream = None;
+    ctx.cluster = Some(Arc::from("web"));
+    drop(untagged_step.on_request(&mut ctx).await.unwrap());
+
+    assert_eq!(
+        ctx.selected_application_protocol(),
+        None,
+        "a later untagged step reusing the same extensions must not observe the prior step's protocol"
+    );
+    assert_eq!(
+        ctx.selected_application_provider(),
+        None,
+        "a later untagged step reusing the same extensions must not observe the prior step's provider"
+    );
+}
+
+// -----------------------------------------------------------------------------
 // Test Utilities
 // -----------------------------------------------------------------------------
 
 /// Build a [`Cluster`] with default strategy for testing.
 fn test_cluster(name: &str, endpoints: &[&str]) -> Cluster {
     Cluster::with_defaults(name, endpoints.iter().map(|s| (*s).into()).collect())
+}
+
+/// Build a [`Cluster`] tagged with application protocol and/or provider.
+fn cluster_with_application(name: &str, endpoints: &[&str], protocol: Option<&str>, provider: Option<&str>) -> Cluster {
+    Cluster {
+        http: praxis_core::config::ClusterHttpOptions {
+            application_protocol: protocol.map(Arc::from),
+            application_provider: provider.map(Arc::from),
+            ..praxis_core::config::ClusterHttpOptions::default()
+        },
+        ..Cluster::with_defaults(name, endpoints.iter().map(|s| (*s).into()).collect())
+    }
+}
+
+/// Build a [`HealthRegistry`] whose every endpoint is marked unhealthy,
+/// forcing the load balancer into panic mode for `cluster`.
+fn all_unhealthy_registry(cluster: &str, endpoints: &[&str]) -> HealthRegistry {
+    let entry: ClusterHealthState = Arc::new(ClusterHealthEntry::new(
+        endpoints.iter().map(|_| EndpointHealth::new()).collect(),
+        endpoints.iter().map(|s| Arc::from(*s)).collect(),
+        None,
+        None,
+    ));
+    for ep in entry.endpoints() {
+        ep.mark_unhealthy();
+    }
+    Arc::new(HashMap::from([(Arc::from(cluster), entry)]))
 }
 
 /// Build a [`Cluster`] with a specific load balancer strategy.

--- a/crates/filter/src/context.rs
+++ b/crates/filter/src/context.rs
@@ -22,7 +22,7 @@ use crate::{
     FilterError, IterationState,
     body::BodyMode,
     condition::{ConditionError, HeaderSource},
-    extensions::RequestExtensions,
+    extensions::{RequestExtensions, SelectedClusterApplication},
     pipeline::body::merge_body_mode,
     results::FilterResultSet,
 };
@@ -495,6 +495,51 @@ impl HttpFilterContext<'_> {
     /// Upstream peer address, if selected.
     pub fn upstream_addr(&self) -> Option<&str> {
         self.upstream.as_ref().map(|u| &*u.address)
+    }
+
+    /// Opaque application protocol of the cluster selected for this exchange.
+    ///
+    /// Published by the load balancer after a successful upstream selection
+    /// and stable for the life of the exchange, so every phase (request,
+    /// response, response-body, logging) observes the same value. `None`
+    /// when no cluster was selected or the selected cluster declared no
+    /// `application_protocol`. The value is opaque to Praxis core; consuming
+    /// filters interpret it.
+    pub fn selected_application_protocol(&self) -> Option<&str> {
+        self.extensions
+            .get::<SelectedClusterApplication>()
+            .and_then(SelectedClusterApplication::protocol)
+    }
+
+    /// Opaque application provider of the cluster selected for this exchange.
+    ///
+    /// Companion to [`selected_application_protocol`]; identical lifecycle
+    /// and opacity, reflecting the selected cluster's `application_provider`.
+    ///
+    /// [`selected_application_protocol`]: Self::selected_application_protocol
+    pub fn selected_application_provider(&self) -> Option<&str> {
+        self.extensions
+            .get::<SelectedClusterApplication>()
+            .and_then(SelectedClusterApplication::provider)
+    }
+
+    /// Publish the selected cluster's opaque application metadata into the
+    /// request-scoped extensions.
+    ///
+    /// Called by the trusted built-in load balancer after a successful upstream
+    /// selection. Publication is authoritative: a tagged cluster replaces any
+    /// prior value, and an untagged cluster removes it. This matters because a
+    /// single [`RequestExtensions`] is threaded across `iterative_request_router`
+    /// steps; without the removal, a later step selecting an untagged cluster
+    /// would leave the previous step's protocol/provider visible and a consuming
+    /// filter could apply the wrong transformation.
+    pub(crate) fn publish_selected_application(&mut self, protocol: Option<Arc<str>>, provider: Option<Arc<str>>) {
+        match SelectedClusterApplication::new(protocol, provider) {
+            Some(app) => self.extensions.insert(app),
+            None => {
+                self.extensions.remove::<SelectedClusterApplication>();
+            },
+        }
     }
 
     /// Shared sub-request client, if set.
@@ -2230,6 +2275,130 @@ mod tests {
         assert!(
             ctx.stream_termination().is_some_and(StreamTermination::is_handled),
             "handled state should persist for the session"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Selected Cluster Application Tests
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn selected_application_absent_by_default() {
+        let req = crate::test_utils::make_request(Method::GET, "/");
+        let ctx = crate::test_utils::make_filter_context(&req);
+        assert!(
+            ctx.selected_application_protocol().is_none(),
+            "protocol should be absent before any selection"
+        );
+        assert!(
+            ctx.selected_application_provider().is_none(),
+            "provider should be absent before any selection"
+        );
+    }
+
+    #[test]
+    fn publish_selected_application_exposes_both_fields() {
+        let req = crate::test_utils::make_request(Method::GET, "/");
+        let mut ctx = crate::test_utils::make_filter_context(&req);
+        ctx.publish_selected_application(Some(Arc::from("openai_chat_completions")), Some(Arc::from("vllm")));
+        assert_eq!(
+            ctx.selected_application_protocol(),
+            Some("openai_chat_completions"),
+            "published protocol should be readable"
+        );
+        assert_eq!(
+            ctx.selected_application_provider(),
+            Some("vllm"),
+            "published provider should be readable"
+        );
+    }
+
+    #[test]
+    fn publish_selected_application_protocol_only() {
+        let req = crate::test_utils::make_request(Method::GET, "/");
+        let mut ctx = crate::test_utils::make_filter_context(&req);
+        ctx.publish_selected_application(Some(Arc::from("openai_responses")), None);
+        assert_eq!(
+            ctx.selected_application_protocol(),
+            Some("openai_responses"),
+            "published protocol should be readable"
+        );
+        assert!(
+            ctx.selected_application_provider().is_none(),
+            "an unpublished provider should stay absent"
+        );
+    }
+
+    #[test]
+    fn publish_selected_application_provider_only() {
+        let req = crate::test_utils::make_request(Method::GET, "/");
+        let mut ctx = crate::test_utils::make_filter_context(&req);
+        ctx.publish_selected_application(None, Some(Arc::from("openai")));
+        assert!(
+            ctx.selected_application_protocol().is_none(),
+            "an unpublished protocol should stay absent"
+        );
+        assert_eq!(
+            ctx.selected_application_provider(),
+            Some("openai"),
+            "published provider should be readable"
+        );
+    }
+
+    #[test]
+    fn publish_selected_application_is_noop_when_both_absent() {
+        let req = crate::test_utils::make_request(Method::GET, "/");
+        let mut ctx = crate::test_utils::make_filter_context(&req);
+        ctx.publish_selected_application(None, None);
+        assert!(
+            ctx.selected_application_protocol().is_none(),
+            "publishing nothing must leave the protocol absent"
+        );
+        assert!(
+            ctx.selected_application_provider().is_none(),
+            "publishing nothing must leave the provider absent"
+        );
+        assert!(
+            ctx.extensions.get::<SelectedClusterApplication>().is_none(),
+            "an untagged cluster must not insert an extension value"
+        );
+    }
+
+    #[test]
+    fn publish_selected_application_untagged_clears_prior_selection() {
+        let req = crate::test_utils::make_request(Method::GET, "/");
+        let mut ctx = crate::test_utils::make_filter_context(&req);
+        ctx.publish_selected_application(Some(Arc::from("openai_chat_completions")), Some(Arc::from("vllm")));
+        ctx.publish_selected_application(None, None);
+        assert!(
+            ctx.selected_application_protocol().is_none(),
+            "a later untagged selection must clear the prior protocol so a reused context cannot leak stale metadata"
+        );
+        assert!(
+            ctx.selected_application_provider().is_none(),
+            "a later untagged selection must clear the prior provider so a reused context cannot leak stale metadata"
+        );
+        assert!(
+            ctx.extensions.get::<SelectedClusterApplication>().is_none(),
+            "an untagged re-selection must remove the extension value entirely"
+        );
+    }
+
+    #[test]
+    fn publish_selected_application_replaces_prior_selection() {
+        let req = crate::test_utils::make_request(Method::GET, "/");
+        let mut ctx = crate::test_utils::make_filter_context(&req);
+        ctx.publish_selected_application(Some(Arc::from("openai_chat_completions")), Some(Arc::from("vllm")));
+        ctx.publish_selected_application(Some(Arc::from("anthropic_messages")), Some(Arc::from("bedrock")));
+        assert_eq!(
+            ctx.selected_application_protocol(),
+            Some("anthropic_messages"),
+            "a later tagged selection must overwrite the prior protocol"
+        );
+        assert_eq!(
+            ctx.selected_application_provider(),
+            Some("bedrock"),
+            "a later tagged selection must overwrite the prior provider"
         );
     }
 }

--- a/crates/filter/src/extensions.rs
+++ b/crates/filter/src/extensions.rs
@@ -22,6 +22,7 @@
 use std::{
     any::Any,
     collections::{BTreeMap, BTreeSet, HashMap},
+    sync::Arc,
 };
 
 // -----------------------------------------------------------------------------
@@ -97,6 +98,59 @@ impl AuthenticatedIdentity {
     /// serializing them outside Praxis.
     pub fn custom_claims(&self) -> &BTreeMap<String, String> {
         &self.custom_claims
+    }
+}
+
+// -----------------------------------------------------------------------------
+// SelectedClusterApplication
+// -----------------------------------------------------------------------------
+
+/// Opaque application metadata of the cluster the load balancer selected
+/// for this exchange.
+///
+/// Published once by the trusted built-in load balancer after a successful
+/// upstream selection and read-only thereafter, so request, response,
+/// response-body, and logging filters all observe the same values for the
+/// life of the exchange. Absent when no cluster was selected or the
+/// selected cluster tagged neither field.
+///
+/// The identifiers are opaque to Praxis core — consuming filters interpret
+/// them; Praxis defines no enum of known protocols or providers. The type
+/// is deliberately crate-private with read-only getters: only the load
+/// balancer constructs it (via
+/// [`HttpFilterContext::publish_selected_application`]), and external
+/// filters read it through
+/// [`HttpFilterContext::selected_application_protocol`] and
+/// [`HttpFilterContext::selected_application_provider`] rather than naming
+/// the type. The identifiers come straight from the resolved cluster entry.
+///
+/// [`HttpFilterContext::publish_selected_application`]: crate::HttpFilterContext::publish_selected_application
+/// [`HttpFilterContext::selected_application_protocol`]: crate::HttpFilterContext::selected_application_protocol
+/// [`HttpFilterContext::selected_application_provider`]: crate::HttpFilterContext::selected_application_provider
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct SelectedClusterApplication {
+    /// Opaque application protocol of the selected cluster, if tagged.
+    protocol: Option<Arc<str>>,
+    /// Opaque application provider of the selected cluster, if tagged.
+    provider: Option<Arc<str>>,
+}
+
+impl SelectedClusterApplication {
+    /// Build selected-application metadata from a resolved cluster's
+    /// identifiers, or `None` when the cluster tagged neither field, so the
+    /// extension is inserted only when there is something to read.
+    pub(crate) fn new(protocol: Option<Arc<str>>, provider: Option<Arc<str>>) -> Option<Self> {
+        (protocol.is_some() || provider.is_some()).then_some(Self { protocol, provider })
+    }
+
+    /// Opaque application protocol of the selected cluster, if tagged.
+    pub(crate) fn protocol(&self) -> Option<&str> {
+        self.protocol.as_deref()
+    }
+
+    /// Opaque application provider of the selected cluster, if tagged.
+    pub(crate) fn provider(&self) -> Option<&str> {
+        self.provider.as_deref()
     }
 }
 
@@ -214,6 +268,46 @@ mod tests {
     fn default_is_empty() {
         let ext = RequestExtensions::default();
         assert!(ext.get::<String>().is_none(), "default should contain no values");
+    }
+
+    // -------------------------------------------------------------------------
+    // SelectedClusterApplication Tests
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn selected_cluster_application_absent_when_both_fields_absent() {
+        assert!(
+            SelectedClusterApplication::new(None, None).is_none(),
+            "an untagged cluster must not produce a metadata value"
+        );
+    }
+
+    #[test]
+    fn selected_cluster_application_present_with_protocol_only() {
+        let app = SelectedClusterApplication::new(Some(Arc::from("openai_chat_completions")), None)
+            .expect("a protocol-only cluster should produce a value");
+        assert_eq!(
+            app.protocol(),
+            Some("openai_chat_completions"),
+            "protocol should read back"
+        );
+        assert!(app.provider().is_none(), "an absent provider should read back as None");
+    }
+
+    #[test]
+    fn selected_cluster_application_present_with_provider_only() {
+        let app = SelectedClusterApplication::new(None, Some(Arc::from("vllm")))
+            .expect("a provider-only cluster should produce a value");
+        assert!(app.protocol().is_none(), "an absent protocol should read back as None");
+        assert_eq!(app.provider(), Some("vllm"), "provider should read back");
+    }
+
+    #[test]
+    fn selected_cluster_application_exposes_both_fields() {
+        let app = SelectedClusterApplication::new(Some(Arc::from("openai_responses")), Some(Arc::from("openai")))
+            .expect("a fully tagged cluster should produce a value");
+        assert_eq!(app.protocol(), Some("openai_responses"), "protocol should read back");
+        assert_eq!(app.provider(), Some("openai"), "provider should read back");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Publish the **selected** cluster's `application_protocol` and `application_provider` into `HttpFilterContext` as a typed, framework-owned, read-only extension after a successful load balancer selection. Consuming filters read them via `selected_application_protocol()` and `selected_application_provider()`; the identifiers stay opaque to Praxis core.

Publication is authoritative: a tagged cluster replaces any prior value and an untagged cluster removes it.

The `iterative_request_router` threads one `RequestExtensions` across steps, so it clears the metadata at each step boundary (the outer run loop and streaming resume) before any early exit and before a step's body hooks run. A step therefore never observes a prior step's value and no early exit leaks it to the parent, while the terminal successful step's republished value is retained.

## Changes

- `extensions.rs`: `SelectedClusterApplication` typed extension and accessors.
- `context.rs`: `publish_selected_application()`, `selected_application_protocol()`, `selected_application_provider()`.
- `load_balancer`: publish selection metadata after a successful upstream selection.
- `iterative_request_router`: clear metadata at step boundaries (outer run loop and streaming resume) before early exits and before body hooks run.
- Tests: unit and IRR boundary tests, including a deterministic `max_iterations` rejection test asserting the parent sees no application metadata.

## Testing

- `cargo build --workspace --all-targets` — passes.
- `make lint` — passes.
- Filter lib tests pass.

Closes #1136
Part of #1134
