### PR TITLE
fix(json_rpc): strip configured promotion headers to prevent client forgery

### DIFF
--- a/crates/filter/src/builtins/http/payload_processing/json_rpc/mod.rs
+++ b/crates/filter/src/builtins/http/payload_processing/json_rpc/mod.rs
@@ -284,7 +284,10 @@ fn strip_promotion_headers(
     .into_iter()
     .flatten()
     {
-        if let Ok(header_name) = http::header::HeaderName::from_bytes(name.as_bytes()) {
+match http::header::HeaderName::from_bytes(name.as_bytes()) {
+    Ok(header_name) => headers_to_remove.push(header_name),
+    Err(_) => warn!(header = %name, "cannot strip promotion header: invalid header name"),
+}
             headers_to_remove.push(header_name);
         }
     }

--- a/crates/filter/src/builtins/http/payload_processing/json_rpc/mod.rs
+++ b/crates/filter/src/builtins/http/payload_processing/json_rpc/mod.rs
@@ -288,7 +288,11 @@ match http::header::HeaderName::from_bytes(name.as_bytes()) {
     Ok(header_name) => headers_to_remove.push(header_name),
     Err(_) => warn!(header = %name, "cannot strip promotion header: invalid header name"),
 }
-            headers_to_remove.push(header_name);
+        {
+match http::header::HeaderName::from_bytes(name.as_bytes()) {
+    Ok(header_name) => headers_to_remove.push(header_name),
+    Err(_) => warn!(header = %name, "cannot strip promotion header: invalid header name"),
+        }
         }
     }
 }

--- a/crates/filter/src/builtins/http/payload_processing/json_rpc/mod.rs
+++ b/crates/filter/src/builtins/http/payload_processing/json_rpc/mod.rs
@@ -285,10 +285,10 @@ fn strip_promotion_headers(
     .flatten()
     {
         {
-match http::header::HeaderName::from_bytes(name.as_bytes()) {
-    Ok(header_name) => headers_to_remove.push(header_name),
-    Err(_) => warn!(header = %name, "cannot strip promotion header: invalid header name"),
-        }
+            match http::header::HeaderName::from_bytes(name.as_bytes()) {
+                Ok(header_name) => headers_to_remove.push(header_name),
+                Err(_) => warn!(header = %name, "cannot strip promotion header: invalid header name"),
+            }
         }
     }
 }

--- a/crates/filter/src/builtins/http/payload_processing/json_rpc/mod.rs
+++ b/crates/filter/src/builtins/http/payload_processing/json_rpc/mod.rs
@@ -168,6 +168,14 @@ impl HttpFilter for JsonRpcFilter {
             return Ok(FilterAction::Continue);
         }
 
+        // Strip any client-supplied copies of the configured promotion
+        // headers unconditionally at end-of-stream, *before* attempting
+        // to parse the body. This prevents header forgery regardless of
+        // whether the body is valid JSON-RPC: a non-JSON-RPC request (or
+        // a parse failure with `on_invalid: continue`) must not pass
+        // through client-supplied classifier headers. (#1057)
+        strip_promotion_headers(&self.config, &mut ctx.request_headers_to_remove);
+
         let Some(chunk) = body.as_ref() else {
             return Ok(FilterAction::Continue);
         };
@@ -254,6 +262,31 @@ fn promote_checked(
         );
     } else {
         headers.push((std::borrow::Cow::Owned(header_name.clone()), value.clone()));
+    }
+}
+
+/// Strip client-supplied copies of the configured promotion headers.
+///
+/// Pushes each configured header name onto the remove list so that
+/// any client-supplied values are discarded before the promoted
+/// (body-derived) values are added. The mutation pipeline applies
+/// removes before adds, so the promoted values replace — not
+/// coexist with — forged client copies.
+fn strip_promotion_headers(
+    config: &JsonRpcConfig,
+    headers_to_remove: &mut Vec<http::header::HeaderName>,
+) {
+    for name in [
+        config.headers.method.as_ref(),
+        config.headers.id.as_ref(),
+        config.headers.kind.as_ref(),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        if let Ok(header_name) = http::header::HeaderName::from_bytes(name.as_bytes()) {
+            headers_to_remove.push(header_name);
+        }
     }
 }
 

--- a/crates/filter/src/builtins/http/payload_processing/json_rpc/mod.rs
+++ b/crates/filter/src/builtins/http/payload_processing/json_rpc/mod.rs
@@ -284,10 +284,6 @@ fn strip_promotion_headers(
     .into_iter()
     .flatten()
     {
-match http::header::HeaderName::from_bytes(name.as_bytes()) {
-    Ok(header_name) => headers_to_remove.push(header_name),
-    Err(_) => warn!(header = %name, "cannot strip promotion header: invalid header name"),
-}
         {
 match http::header::HeaderName::from_bytes(name.as_bytes()) {
     Ok(header_name) => headers_to_remove.push(header_name),

--- a/crates/filter/src/builtins/http/payload_processing/json_rpc/tests.rs
+++ b/crates/filter/src/builtins/http/payload_processing/json_rpc/tests.rs
@@ -1270,3 +1270,167 @@ fn root_scalars_are_not_json_rpc() {
         assert!(out.is_none(), "root scalar {root} is not JSON-RPC");
     }
 }
+
+// -----------------------------------------------------------------------------
+// Header Forgery Prevention Tests (#1057)
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn strips_forged_headers_on_valid_json_rpc() {
+    // A classified JSON-RPC request must remove any client-supplied copies
+    // of the promotion headers before adding the body-derived values.
+    let filter = make_filter();
+    let req = crate::test_utils::make_request(http::Method::POST, "/rpc");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let json = br#"{"jsonrpc":"2.0","method":"service/invoke","id":"req-123"}"#;
+    let mut body = Some(Bytes::from_static(json));
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(matches!(action, FilterAction::Release));
+
+    // The configured header names should appear in the remove list so
+    // client-supplied copies are stripped before the promoted values
+    // are added.
+    let remove_names: Vec<&str> = ctx
+        .request_headers_to_remove
+        .iter()
+        .map(|h| h.as_str())
+        .collect();
+    assert!(
+        remove_names.contains(&"x-json-rpc-method"),
+        "X-Json-Rpc-Method should be in the remove list: {remove_names:?}"
+    );
+    assert!(
+        remove_names.contains(&"x-json-rpc-id"),
+        "X-Json-Rpc-Id should be in the remove list: {remove_names:?}"
+    );
+    assert!(
+        remove_names.contains(&"x-json-rpc-kind"),
+        "X-Json-Rpc-Kind should be in the remove list: {remove_names:?}"
+    );
+
+    // Promoted values should still be present in extra_request_headers.
+    assert_promoted_header(&ctx, "X-Json-Rpc-Method", "service/invoke");
+    assert_promoted_header(&ctx, "X-Json-Rpc-Id", "req-123");
+    assert_promoted_header(&ctx, "X-Json-Rpc-Kind", "request");
+}
+
+#[tokio::test]
+async fn strips_forged_headers_on_non_json_rpc_body() {
+    // A non-JSON-RPC request must strip the configured promotion headers
+    // even though the classifier does not promote anything. Without this,
+    // a forged X-Json-Rpc-Method passes through unchanged.
+    let filter = make_filter();
+    let req = crate::test_utils::make_request(http::Method::POST, "/test");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from_static(b"not json at all"));
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "non-JSON body should continue"
+    );
+
+    // Even though no promotion happened, the remove list should contain
+    // the configured header names to strip any client-supplied forgeries.
+    let remove_names: Vec<&str> = ctx
+        .request_headers_to_remove
+        .iter()
+        .map(|h| h.as_str())
+        .collect();
+    assert!(
+        remove_names.contains(&"x-json-rpc-method"),
+        "non-JSON-RPC request must still strip X-Json-Rpc-Method: {remove_names:?}"
+    );
+    assert!(
+        remove_names.contains(&"x-json-rpc-id"),
+        "non-JSON-RPC request must still strip X-Json-Rpc-Id: {remove_names:?}"
+    );
+    assert!(
+        remove_names.contains(&"x-json-rpc-kind"),
+        "non-JSON-RPC request must still strip X-Json-Rpc-Kind: {remove_names:?}"
+    );
+
+    // No promotion should have occurred.
+    assert!(
+        ctx.extra_request_headers.is_empty(),
+        "non-JSON body should not promote any headers"
+    );
+}
+
+#[tokio::test]
+async fn strips_forged_headers_on_none_body() {
+    // Even with no body at all, configured headers should be stripped.
+    let filter = make_filter();
+    let req = crate::test_utils::make_request(http::Method::POST, "/test");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body: Option<Bytes> = None;
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(matches!(action, FilterAction::Continue));
+
+    let remove_names: Vec<&str> = ctx
+        .request_headers_to_remove
+        .iter()
+        .map(|h| h.as_str())
+        .collect();
+    assert!(
+        remove_names.contains(&"x-json-rpc-method"),
+        "None body must still strip configured headers: {remove_names:?}"
+    );
+}
+
+#[tokio::test]
+async fn strips_forged_headers_with_custom_header_names() {
+    // Custom header names configured by the operator should also be
+    // stripped from inbound requests.
+    let filter = JsonRpcFilter {
+        config: super::config::JsonRpcConfig {
+            batch_policy: BatchPolicy::Reject,
+            headers: JsonRpcHeaders {
+                id: Some("X-Custom-Id".to_owned()),
+                kind: Some("X-Custom-Kind".to_owned()),
+                method: Some("X-Custom-Method".to_owned()),
+            },
+            max_batch_size: DEFAULT_MAX_BATCH_SIZE,
+            max_body_bytes: 1_048_576,
+            on_invalid: OnInvalidBehavior::Continue,
+        },
+        max_body_bytes: 1_048_576,
+    };
+    let req = crate::test_utils::make_request(http::Method::POST, "/test");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from_static(b"not json"));
+    let _action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    let remove_names: Vec<&str> = ctx
+        .request_headers_to_remove
+        .iter()
+        .map(|h| h.as_str())
+        .collect();
+    assert!(
+        remove_names.contains(&"x-custom-method"),
+        "custom method header should be stripped: {remove_names:?}"
+    );
+    assert!(
+        remove_names.contains(&"x-custom-id"),
+        "custom id header should be stripped: {remove_names:?}"
+    );
+    assert!(
+        remove_names.contains(&"x-custom-kind"),
+        "custom kind header should be stripped: {remove_names:?}"
+    );
+}
+
+#[tokio::test]
+async fn no_strip_before_end_of_stream() {
+    // Pre-EOS calls should not strip headers (the strip happens at EOS).
+    let filter = make_filter();
+    let req = crate::test_utils::make_request(http::Method::POST, "/rpc");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let json = br#"{"jsonrpc":"2.0","method":"service/invoke","id":"req-123"}"#;
+    let mut partial = Some(Bytes::from_static(json));
+    let _action = filter.on_request_body(&mut ctx, &mut partial, false).await.unwrap();
+
+    assert!(
+        ctx.request_headers_to_remove.is_empty(),
+        "pre-EOS should not modify the remove list"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #1057 — JSON-RPC classifier promotes to non-reserved `X-Json-Rpc-*` headers (client-spoofable).

## Problem

The `json_rpc` classifier promotes envelope metadata (method/id/kind) into request headers (`X-Json-Rpc-Method`, `X-Json-Rpc-Id`, `X-Json-Rpc-Kind`) that sit outside the reserved `x-praxis-*` / `x-ext-*` namespace. This allowed two attack vectors:

1. **Non-JSON-RPC requests** (or parse failures with `on_invalid: continue`) returned `Continue` without touching headers, so client-supplied forged `X-Json-Rpc-*` headers passed through unchanged.
2. **Classified requests** used `Add` semantics via `extra_request_headers`, so client-supplied copies coexisted with the promoted body-derived values.

If routing or an upstream keys on these headers, a client could forge the classification.

## Fix

At end-of-stream, **unconditionally** push the configured promotion header names onto `ctx.request_headers_to_remove` *before* attempting to parse the body. The mutation pipeline applies removes before adds, so:

- On **non-JSON-RPC requests**: forged headers are stripped, no promoted headers are added → upstream sees nothing
- On **classified requests**: forged headers are stripped, then body-derived headers are added → upstream sees only the real values

This approach is **non-breaking** — default header names (`X-Json-Rpc-*`) are unchanged, and custom operator-configured header names are also protected.

## Changes

- `crates/filter/src/builtins/http/payload_processing/json_rpc/mod.rs`
  - Added `strip_promotion_headers()` helper that pushes configured header names to the remove list
  - Call it unconditionally at EOS in `on_request_body`, before body parsing

- `crates/filter/src/builtins/http/payload_processing/json_rpc/tests.rs`
  - 5 new tests covering both attack vectors, custom header names, None body, and pre-EOS non-stripping

## Testing

All 81 json_rpc unit tests pass (76 existing + 5 new), zero regressions.