### PR TITLE
feat(server): add server composition API (#1085)

### DIFF
--- a/crates/server/src/composition.rs
+++ b/crates/server/src/composition.rs
@@ -1,0 +1,611 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Praxis Contributors
+
+//! Data-only server composition for embedding Praxis.
+//!
+//! [`ServerComposition`] describes how a downstream binary customizes an
+//! embedded Praxis server without reaching into its lifecycle. It is passed
+//! to [`run_server_with_composition`] and carries three things:
+//!
+//! 1. **Registry construction** — how the filter [`FilterRegistry`] is built. The factory runs once at startup and
+//!    receives a [`RegistryContext`] exposing the server-owned [`SubRequestClient`], the one runtime handle a
+//!    downstream registry commonly needs while wiring its filters.
+//! 2. **Pipeline-extension factories** — each produces a fresh [`PipelineExtension`] per listener pipeline. Factories
+//!    receive an immutable [`ExtensionContext`] and must be synchronous and side-effect-free; they run again on every
+//!    hot reload.
+//! 3. **Read-only pipeline validators** — each inspects a built pipeline via a [`ValidatorContext`] and may reject it,
+//!    but cannot mutate it.
+//!
+//! The composition never exposes mutable pipelines, watchers, listeners, or
+//! publication handles: it is a description consumed by the server, not a hook
+//! into a running one.
+//!
+//! [`run_server_with_composition`]: crate::run_server_with_composition
+//! [`SubRequestClient`]: praxis_core::subrequest::SubRequestClient
+
+use std::{fmt, sync::Arc};
+
+use praxis_core::{
+    config::{Config, FilterEntry, Listener},
+    subrequest::SubRequestClient,
+};
+use praxis_filter::{FilterPipeline, FilterRegistry, PipelineExtension};
+
+// -----------------------------------------------------------------------------
+// Function Types
+// -----------------------------------------------------------------------------
+
+/// Builds the filter registry once at startup from immutable server context.
+///
+/// [`FnOnce`] because [`FilterRegistry`] is not `Clone`: the registry is
+/// constructed a single time, wrapped in an `Arc`, and reused across reloads.
+type RegistryFactory = Box<dyn FnOnce(&RegistryContext<'_>) -> Result<FilterRegistry, CompositionError>>;
+
+/// Produces a fresh [`PipelineExtension`] for one listener pipeline.
+///
+/// `Send + Sync` because the factory is carried into the hot-reload watcher
+/// thread and invoked again for each rebuilt pipeline.
+type ExtensionFactory =
+    Box<dyn Fn(&ExtensionContext<'_>) -> Result<Box<dyn PipelineExtension>, CompositionError> + Send + Sync>;
+
+/// Validates a built pipeline read-only, rejecting it on error.
+///
+/// `Send + Sync` for the same reason as [`ExtensionFactory`].
+type PipelineValidator = Box<dyn Fn(&ValidatorContext<'_>) -> Result<(), CompositionError> + Send + Sync>;
+
+// -----------------------------------------------------------------------------
+// CompositionError
+// -----------------------------------------------------------------------------
+
+/// Error returned by a registry factory, extension factory, or validator.
+///
+/// A factory or validator that returns this rejects pipeline construction, both
+/// at startup and on reload, exactly like a built-in validation failure.
+#[derive(Debug)]
+pub struct CompositionError {
+    /// Human-readable description of what went wrong.
+    message: String,
+}
+
+impl CompositionError {
+    /// Create a composition error with the given message.
+    #[must_use]
+    pub fn new<S: Into<String>>(message: S) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+
+    /// The error message.
+    #[must_use]
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+impl fmt::Display for CompositionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for CompositionError {}
+
+impl From<String> for CompositionError {
+    fn from(message: String) -> Self {
+        Self::new(message)
+    }
+}
+
+impl From<&str> for CompositionError {
+    fn from(message: &str) -> Self {
+        Self::new(message)
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Contexts
+// -----------------------------------------------------------------------------
+
+/// Immutable server context handed to the registry factory at startup.
+///
+/// Deliberately narrow: it exposes the server-owned [`SubRequestClient`], not
+/// general server state, so a downstream registry can wire the shared
+/// sub-request client into its filters while it is being built.
+///
+/// [`SubRequestClient`]: praxis_core::subrequest::SubRequestClient
+pub struct RegistryContext<'ctx> {
+    /// The server-owned shared sub-request client.
+    subrequest_client: &'ctx SubRequestClient,
+}
+
+impl<'ctx> RegistryContext<'ctx> {
+    /// Construct a registry context.
+    pub(crate) fn new(subrequest_client: &'ctx SubRequestClient) -> Self {
+        Self { subrequest_client }
+    }
+
+    /// The server-owned shared sub-request client.
+    #[must_use]
+    pub fn subrequest_client(&self) -> &SubRequestClient {
+        self.subrequest_client
+    }
+}
+
+/// Immutable context handed to a pipeline-extension factory per listener.
+pub struct ExtensionContext<'ctx> {
+    /// The full effective configuration.
+    config: &'ctx Config,
+    /// The listener whose pipeline is being built.
+    listener: &'ctx Listener,
+    /// The server-owned shared sub-request client.
+    subrequest_client: &'ctx SubRequestClient,
+}
+
+impl<'ctx> ExtensionContext<'ctx> {
+    /// Construct an extension context.
+    pub(crate) fn new(
+        config: &'ctx Config,
+        listener: &'ctx Listener,
+        subrequest_client: &'ctx SubRequestClient,
+    ) -> Self {
+        Self {
+            config,
+            listener,
+            subrequest_client,
+        }
+    }
+
+    /// The full effective configuration.
+    #[must_use]
+    pub fn config(&self) -> &Config {
+        self.config
+    }
+
+    /// The listener whose pipeline is being built.
+    #[must_use]
+    pub fn listener(&self) -> &Listener {
+        self.listener
+    }
+
+    /// The server-owned shared sub-request client.
+    #[must_use]
+    pub fn subrequest_client(&self) -> &SubRequestClient {
+        self.subrequest_client
+    }
+}
+
+/// Read-only context handed to a pipeline validator after a pipeline is built.
+///
+/// A validator may inspect the configuration, the listener, the flattened
+/// filter entries, and the completed pipeline, but cannot mutate any of them.
+pub struct ValidatorContext<'ctx> {
+    /// The full effective configuration.
+    config: &'ctx Config,
+    /// The listener whose pipeline was built.
+    listener: &'ctx Listener,
+    /// The flattened filter entries after chain concatenation.
+    entries: &'ctx [FilterEntry],
+    /// The completed, ordering-validated pipeline.
+    pipeline: &'ctx FilterPipeline,
+}
+
+impl<'ctx> ValidatorContext<'ctx> {
+    /// Construct a validator context.
+    pub(crate) fn new(
+        config: &'ctx Config,
+        listener: &'ctx Listener,
+        entries: &'ctx [FilterEntry],
+        pipeline: &'ctx FilterPipeline,
+    ) -> Self {
+        Self {
+            config,
+            listener,
+            entries,
+            pipeline,
+        }
+    }
+
+    /// The full effective configuration.
+    #[must_use]
+    pub fn config(&self) -> &Config {
+        self.config
+    }
+
+    /// The listener whose pipeline was built.
+    #[must_use]
+    pub fn listener(&self) -> &Listener {
+        self.listener
+    }
+
+    /// The flattened filter entries after chain concatenation.
+    #[must_use]
+    pub fn entries(&self) -> &[FilterEntry] {
+        self.entries
+    }
+
+    /// The completed, ordering-validated pipeline.
+    #[must_use]
+    pub fn pipeline(&self) -> &FilterPipeline {
+        self.pipeline
+    }
+}
+
+// -----------------------------------------------------------------------------
+// PipelineComposition
+// -----------------------------------------------------------------------------
+
+/// The reload-durable half of a [`ServerComposition`].
+///
+/// Holds the pipeline-extension factories and validators, wrapped in `Arc`s so
+/// they can be cheaply carried into the hot-reload watcher and applied on every
+/// rebuild. Cloning shares the same factories. The default value applies no
+/// extensions and no validators, which is what the standard non-embedded server
+/// uses.
+#[derive(Clone, Default)]
+pub(crate) struct PipelineComposition {
+    /// Factories producing a fresh extension per listener pipeline.
+    extension_factories: Arc<[ExtensionFactory]>,
+    /// Read-only validators run against each built pipeline.
+    validators: Arc<[PipelineValidator]>,
+}
+
+impl PipelineComposition {
+    /// Apply every extension factory to `pipeline` for the given context.
+    ///
+    /// Each factory produces a fresh [`PipelineExtension`]; a factory error
+    /// rejects the pipeline.
+    pub(crate) fn apply_extensions(
+        &self,
+        pipeline: &mut FilterPipeline,
+        ctx: &ExtensionContext<'_>,
+    ) -> Result<(), CompositionError> {
+        for factory in self.extension_factories.iter() {
+            pipeline.add_pipeline_extension(factory(ctx)?);
+        }
+        Ok(())
+    }
+
+    /// Run every validator against the built pipeline.
+    ///
+    /// A validator error rejects the pipeline.
+    pub(crate) fn validate(&self, ctx: &ValidatorContext<'_>) -> Result<(), CompositionError> {
+        for validator in self.validators.iter() {
+            validator(ctx)?;
+        }
+        Ok(())
+    }
+}
+
+// -----------------------------------------------------------------------------
+// ServerComposition
+// -----------------------------------------------------------------------------
+
+/// A data-only description of how to compose an embedded Praxis server.
+///
+/// Construct one with [`ServerComposition::standard`] (built-in and
+/// auto-discovered filters), [`ServerComposition::with_registry`] (a
+/// pre-built registry), or [`ServerComposition::with_registry_factory`] (a
+/// registry built from server context), then layer on pipeline extensions and
+/// validators. Pass it to [`run_server_with_composition`].
+///
+/// ```
+/// use praxis::{CompositionError, PipelineExtension, RequestExtensions, ServerComposition};
+///
+/// // A pipeline-scoped resource a downstream filter retrieves per request.
+/// #[derive(Clone)]
+/// struct ModelRegistry;
+///
+/// impl PipelineExtension for ModelRegistry {
+///     fn prepare(&self, extensions: &mut RequestExtensions) {
+///         extensions.insert(self.clone());
+///     }
+/// }
+///
+/// let composition = ServerComposition::standard()
+///     // A fresh extension is produced for each listener pipeline.
+///     .add_pipeline_extension_factory(|_ctx| Ok(Box::new(ModelRegistry)))
+///     // A read-only validator that rejects pipelines it disapproves of.
+///     .add_pipeline_validator(|ctx| {
+///         if ctx.listener().name.is_empty() {
+///             Err(CompositionError::new("listener requires a name"))
+///         } else {
+///             Ok(())
+///         }
+///     });
+/// # let _ = composition;
+/// // praxis::run_server_with_composition(config, composition, config_path, log_level);
+/// ```
+///
+/// [`run_server_with_composition`]: crate::run_server_with_composition
+pub struct ServerComposition {
+    /// Builds the filter registry once at startup.
+    registry_factory: RegistryFactory,
+    /// Factories producing a fresh extension per listener pipeline.
+    extension_factories: Vec<ExtensionFactory>,
+    /// Read-only validators run against each built pipeline.
+    validators: Vec<PipelineValidator>,
+}
+
+impl ServerComposition {
+    /// A composition using built-in and auto-discovered external filters.
+    ///
+    /// This is the registry the standard `praxis` binary uses; it ignores the
+    /// registry context. Equivalent to the behavior of [`run_server`].
+    ///
+    /// [`run_server`]: crate::run_server
+    #[must_use]
+    pub fn standard() -> Self {
+        Self::with_registry_factory(|_ctx| Ok(crate::build_full_registry()))
+    }
+
+    /// A composition wrapping an already-built [`FilterRegistry`].
+    ///
+    /// Equivalent to the behavior of [`run_server_with_registry`]; the registry
+    /// context is ignored.
+    ///
+    /// [`run_server_with_registry`]: crate::run_server_with_registry
+    #[must_use]
+    pub fn with_registry(registry: FilterRegistry) -> Self {
+        Self::with_registry_factory(move |_ctx| Ok(registry))
+    }
+
+    /// A composition whose registry is built from server context at startup.
+    ///
+    /// The factory receives a [`RegistryContext`] exposing the server-owned
+    /// [`SubRequestClient`] and runs exactly once. Returning an error aborts
+    /// startup.
+    ///
+    /// [`SubRequestClient`]: praxis_core::subrequest::SubRequestClient
+    #[must_use]
+    pub fn with_registry_factory<F>(factory: F) -> Self
+    where
+        F: FnOnce(&RegistryContext<'_>) -> Result<FilterRegistry, CompositionError> + 'static,
+    {
+        Self {
+            registry_factory: Box::new(factory),
+            extension_factories: Vec::new(),
+            validators: Vec::new(),
+        }
+    }
+
+    /// Register a pipeline-extension factory.
+    ///
+    /// The factory is invoked once per listener pipeline (at startup and on
+    /// every reload), producing a fresh [`PipelineExtension`]. It must be
+    /// synchronous and side-effect-free; returning an error rejects the
+    /// pipeline.
+    #[must_use]
+    pub fn add_pipeline_extension_factory<F>(mut self, factory: F) -> Self
+    where
+        F: Fn(&ExtensionContext<'_>) -> Result<Box<dyn PipelineExtension>, CompositionError> + Send + Sync + 'static,
+    {
+        self.extension_factories.push(Box::new(factory));
+        self
+    }
+
+    /// Register a read-only pipeline validator.
+    ///
+    /// The validator is invoked once per built pipeline (at startup and on
+    /// every reload) with a [`ValidatorContext`]. Returning an error rejects
+    /// the pipeline.
+    #[must_use]
+    pub fn add_pipeline_validator<F>(mut self, validator: F) -> Self
+    where
+        F: Fn(&ValidatorContext<'_>) -> Result<(), CompositionError> + Send + Sync + 'static,
+    {
+        self.validators.push(Box::new(validator));
+        self
+    }
+
+    /// Split into the startup-only registry factory and the reload-durable
+    /// pipeline composition.
+    pub(crate) fn into_parts(self) -> (RegistryFactory, PipelineComposition) {
+        (
+            self.registry_factory,
+            PipelineComposition {
+                extension_factories: Arc::from(self.extension_factories),
+                validators: Arc::from(self.validators),
+            },
+        )
+    }
+}
+
+impl Default for ServerComposition {
+    fn default() -> Self {
+        Self::standard()
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[cfg(test)]
+#[expect(clippy::allow_attributes, reason = "blanket test suppressions")]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::too_many_lines,
+    reason = "tests"
+)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use praxis_core::subrequest::SubRequestConnector;
+    use praxis_filter::RequestExtensions;
+
+    use super::*;
+
+    /// A marker resource inserted into per-request extensions.
+    #[derive(Clone, PartialEq, Eq, Debug)]
+    struct Marker(u8);
+
+    impl PipelineExtension for Marker {
+        fn prepare(&self, extensions: &mut RequestExtensions) {
+            extensions.insert(self.clone());
+        }
+    }
+
+    #[test]
+    fn composition_error_display_is_the_message() {
+        let err = CompositionError::new("boom");
+        assert_eq!(err.to_string(), "boom", "Display should render the message verbatim");
+        assert_eq!(err.message(), "boom", "message() should return the message");
+    }
+
+    #[test]
+    fn composition_error_converts_from_str_and_string() {
+        let from_str: CompositionError = "slice".into();
+        let from_string: CompositionError = String::from("owned").into();
+        assert_eq!(from_str.message(), "slice");
+        assert_eq!(from_string.message(), "owned");
+    }
+
+    #[test]
+    fn default_composition_has_no_extensions_or_validators() {
+        let (_factory, pipeline) = ServerComposition::default().into_parts();
+        assert!(
+            pipeline.extension_factories.is_empty(),
+            "the standard composition applies no extensions"
+        );
+        assert!(
+            pipeline.validators.is_empty(),
+            "the standard composition applies no validators"
+        );
+    }
+
+    #[test]
+    fn with_registry_factory_receives_the_subrequest_client() {
+        let client = empty_subrequest_client();
+        let observed = Arc::new(AtomicUsize::new(0));
+        let observed_in_factory = Arc::clone(&observed);
+        let composition = ServerComposition::with_registry_factory(move |ctx| {
+            // Record the client's address: the connector is opaque, so we prove
+            // the exact server-owned client is exposed rather than a value copy.
+            observed_in_factory.store(std::ptr::from_ref(ctx.subrequest_client()).addr(), Ordering::SeqCst);
+            Ok(FilterRegistry::with_builtins())
+        });
+        let (factory, _pipeline) = composition.into_parts();
+        let ctx = RegistryContext::new(&client);
+        factory(&ctx).expect("standard registry build should succeed");
+        assert_eq!(
+            observed.load(Ordering::SeqCst),
+            std::ptr::from_ref(&client).addr(),
+            "the factory must observe the server-owned client"
+        );
+    }
+
+    #[test]
+    fn apply_extensions_runs_each_factory_and_injects_resources() {
+        let client = empty_subrequest_client();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls_in_factory = Arc::clone(&calls);
+        let composition = ServerComposition::standard().add_pipeline_extension_factory(move |_ctx| {
+            calls_in_factory.fetch_add(1, Ordering::SeqCst);
+            let ext: Box<dyn PipelineExtension> = Box::new(Marker(7));
+            Ok(ext)
+        });
+        let (_factory, pipeline_composition) = composition.into_parts();
+
+        let config = single_listener_config();
+        let listener = &config.listeners[0];
+        let mut pipeline = empty_pipeline();
+        let ext_ctx = ExtensionContext::new(&config, listener, &client);
+        pipeline_composition
+            .apply_extensions(&mut pipeline, &ext_ctx)
+            .expect("extension application should succeed");
+
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "the factory should run exactly once here"
+        );
+
+        let mut request_extensions = RequestExtensions::new();
+        pipeline.prepare_extensions(&mut request_extensions);
+        assert_eq!(
+            request_extensions.get::<Marker>(),
+            Some(&Marker(7)),
+            "the produced extension must inject its resource per request"
+        );
+    }
+
+    #[test]
+    fn apply_extensions_propagates_factory_errors() {
+        let client = empty_subrequest_client();
+        let composition = ServerComposition::standard()
+            .add_pipeline_extension_factory(|_ctx| Err(CompositionError::new("factory refused")));
+        let (_factory, pipeline_composition) = composition.into_parts();
+
+        let config = single_listener_config();
+        let listener = &config.listeners[0];
+        let mut pipeline = empty_pipeline();
+        let ext_ctx = ExtensionContext::new(&config, listener, &client);
+        let err = pipeline_composition
+            .apply_extensions(&mut pipeline, &ext_ctx)
+            .expect_err("a failing factory must reject");
+        assert_eq!(err.message(), "factory refused");
+    }
+
+    #[test]
+    fn validate_propagates_validator_errors() {
+        let composition = ServerComposition::standard()
+            .add_pipeline_validator(|_ctx| Err(CompositionError::new("validator refused")));
+        let (_factory, pipeline_composition) = composition.into_parts();
+
+        let config = single_listener_config();
+        let listener = &config.listeners[0];
+        let pipeline = empty_pipeline();
+        let validator_ctx = ValidatorContext::new(&config, listener, &[], &pipeline);
+        let err = pipeline_composition
+            .validate(&validator_ctx)
+            .expect_err("a failing validator must reject");
+        assert_eq!(err.message(), "validator refused");
+    }
+
+    #[test]
+    fn validate_passes_when_every_validator_accepts() {
+        let composition = ServerComposition::standard().add_pipeline_validator(|_ctx| Ok(()));
+        let (_factory, pipeline_composition) = composition.into_parts();
+
+        let config = single_listener_config();
+        let listener = &config.listeners[0];
+        let pipeline = empty_pipeline();
+        let validator_ctx = ValidatorContext::new(&config, listener, &[], &pipeline);
+        assert!(
+            pipeline_composition.validate(&validator_ctx).is_ok(),
+            "an accepting validator must not reject"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Test Utilities
+    // -------------------------------------------------------------------------
+
+    fn empty_subrequest_client() -> SubRequestClient {
+        SubRequestClient::new(SubRequestConnector::new(8, None))
+    }
+
+    fn empty_pipeline() -> FilterPipeline {
+        FilterPipeline::build(&mut [], &FilterRegistry::with_builtins()).unwrap()
+    }
+
+    fn single_listener_config() -> Config {
+        Config::from_yaml(
+            r#"
+listeners:
+  - name: web
+    address: "127.0.0.1:8080"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: static_response
+        status: 200
+"#,
+        )
+        .unwrap()
+    }
+}

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -27,6 +27,7 @@
 //!
 //! [`FilterPipeline`]: praxis_filter::FilterPipeline
 
+mod composition;
 pub(crate) mod pipelines;
 #[cfg(feature = "config-reload")]
 pub(crate) mod reload;
@@ -38,12 +39,16 @@ pub(crate) mod startup_checks;
 mod version;
 #[cfg(feature = "config-reload")]
 pub(crate) mod watcher;
+pub use composition::{CompositionError, ExtensionContext, RegistryContext, ServerComposition, ValidatorContext};
 pub use pipelines::{build_subrequest_client, resolve_pipelines};
 pub use praxis_core::{
     config::load_config,
     logging::{TracingGuard, init_tracing},
 };
-pub use server::{check_root_privilege, fatal, resolve_config_path, run_server, run_server_with_registry};
+pub use praxis_filter::{PipelineExtension, RequestExtensions};
+pub use server::{
+    check_root_privilege, fatal, resolve_config_path, run_server, run_server_with_composition, run_server_with_registry,
+};
 #[cfg(feature = "admin-api")]
 pub use version::process_version_info;
 

--- a/crates/server/src/pipelines.rs
+++ b/crates/server/src/pipelines.rs
@@ -30,6 +30,8 @@ use praxis_core::{
 use praxis_filter::{FilterPipeline, FilterRegistry};
 use praxis_protocol::ListenerPipelines;
 
+use crate::composition::{ExtensionContext, PipelineComposition, ValidatorContext};
+
 // -----------------------------------------------------------------------------
 // Sub-request client construction
 // -----------------------------------------------------------------------------
@@ -73,9 +75,11 @@ pub fn build_subrequest_client(config: &Config) -> SubRequestClient {
 
 /// Build a [`FilterPipeline`] for each listener by resolving named chains.
 ///
-/// This is the config-to-runtime bridge. After it returns, the concept
-/// of "chains" no longer exists — each listener has a flat pipeline of
-/// filters in execution order.
+/// This is the config-to-runtime bridge used by the CLI validate/dump path and
+/// by callers that need no downstream composition: it applies no pipeline
+/// extensions and no validators. Embedded servers that customize per-listener
+/// pipelines go through [`run_server_with_composition`](crate::run_server_with_composition)
+/// instead.
 ///
 /// # Errors
 ///
@@ -84,11 +88,7 @@ pub fn build_subrequest_client(config: &Config) -> SubRequestClient {
 /// resolution error, body limit conflict, or pipeline ordering violation).
 ///
 /// [`FilterPipeline`]: praxis_filter::FilterPipeline
-#[expect(
-    clippy::too_many_arguments,
-    clippy::too_many_lines,
-    reason = "pipeline wiring passes multiple registries and validates each listener inline"
-)]
+#[expect(clippy::too_many_arguments, reason = "pipeline wiring passes multiple registries")]
 pub fn resolve_pipelines(
     config: &Config,
     registry: &FilterRegistry,
@@ -96,6 +96,56 @@ pub fn resolve_pipelines(
     kv_stores: &praxis_core::kv::KvStoreRegistry,
     session_stores: &Arc<praxis_filter::SessionStoreRegistry>,
     subrequest_client: &SubRequestClient,
+) -> Result<ListenerPipelines, Box<dyn std::error::Error + Send + Sync>> {
+    resolve_pipelines_with_composition(
+        config,
+        registry,
+        health_registry,
+        kv_stores,
+        session_stores,
+        subrequest_client,
+        &PipelineComposition::default(),
+    )
+}
+
+/// Build a [`FilterPipeline`] for each listener, applying a downstream
+/// [`ServerComposition`]'s pipeline extensions and read-only validators.
+///
+/// This is the config-to-runtime bridge. After it returns, the concept
+/// of "chains" no longer exists — each listener has a flat pipeline of
+/// filters in execution order.
+///
+/// For each listener pipeline, after the built-in resources are configured, a
+/// fresh [`PipelineExtension`] is produced from each of `composition`'s
+/// factories and attached, then each of `composition`'s validators inspects the
+/// completed pipeline. A factory or validator error rejects that pipeline (and
+/// therefore the whole build), exactly like a built-in validation failure. Both
+/// hooks run again on every hot reload, so downstream extensions are never lost
+/// across a reload.
+///
+/// # Errors
+///
+/// Returns an error when pipeline construction fails (unknown filter chain
+/// referenced by listener, filter instantiation failure, branch chain
+/// resolution error, body limit conflict, pipeline ordering violation, or a
+/// composition factory/validator rejecting the pipeline).
+///
+/// [`FilterPipeline`]: praxis_filter::FilterPipeline
+/// [`PipelineExtension`]: praxis_filter::PipelineExtension
+/// [`ServerComposition`]: crate::ServerComposition
+#[expect(
+    clippy::too_many_arguments,
+    clippy::too_many_lines,
+    reason = "pipeline wiring passes multiple registries and validates each listener inline"
+)]
+pub(crate) fn resolve_pipelines_with_composition(
+    config: &Config,
+    registry: &FilterRegistry,
+    health_registry: &praxis_core::health::HealthRegistry,
+    kv_stores: &praxis_core::kv::KvStoreRegistry,
+    session_stores: &Arc<praxis_filter::SessionStoreRegistry>,
+    subrequest_client: &SubRequestClient,
+    composition: &PipelineComposition,
 ) -> Result<ListenerPipelines, Box<dyn std::error::Error + Send + Sync>> {
     let chains: HashMap<&str, &[_]> = config
         .filter_chains
@@ -117,6 +167,14 @@ pub fn resolve_pipelines(
 
         validate_terminal_position(&entries, &listener.name)?;
 
+        // Snapshot the complete flattened entries before build_with_chains()
+        // drains conditions and branch chains out of them (via mem::take). The
+        // built-in ordering checks read those from the built pipeline's filters,
+        // but downstream validators only see this snapshot, so it must retain
+        // the full configuration or conditional filters and branch chains would
+        // appear absent.
+        let entry_snapshot = entries.clone();
+
         let mut pipeline =
             FilterPipeline::build_with_chains(&mut entries, registry, &chains, &config.insecure_options)?;
         configure_pipeline(
@@ -126,6 +184,13 @@ pub fn resolve_pipelines(
             kv_stores,
             session_stores,
             subrequest_client,
+        )?;
+
+        // Attach a fresh downstream extension per listener pipeline. Runs at
+        // startup and on every reload, so extensions survive reloads.
+        composition.apply_extensions(
+            &mut pipeline,
+            &ExtensionContext::new(config, listener, subrequest_client),
         )?;
 
         let unsupported = pipeline.filters_unsupported_by(listener.protocol);
@@ -141,6 +206,11 @@ pub fn resolve_pipelines(
         }
 
         validate_pipeline(&pipeline, &entries, &listener.name, &config.insecure_options)?;
+
+        // Read-only downstream validation against the completed pipeline. The
+        // validator sees the pristine flattened entries, not the husks left by
+        // build_with_chains.
+        composition.validate(&ValidatorContext::new(config, listener, &entry_snapshot, &pipeline))?;
 
         pipelines.insert(listener.name.clone(), Arc::new(pipeline));
     }
@@ -263,9 +333,23 @@ fn validate_pipeline(
     reason = "tests"
 )]
 mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
     use praxis_core::health::HealthRegistry;
+    use praxis_filter::{PipelineExtension, RequestExtensions};
 
     use super::*;
+    use crate::composition::{CompositionError, ServerComposition};
+
+    /// A marker resource a composed extension injects into per-request state.
+    #[derive(Clone, PartialEq, Eq, Debug)]
+    struct Marker(u8);
+
+    impl PipelineExtension for Marker {
+        fn prepare(&self, extensions: &mut RequestExtensions) {
+            extensions.insert(self.clone());
+        }
+    }
 
     #[test]
     fn resolve_pipelines_builds_for_each_listener() {
@@ -857,6 +941,195 @@ filter_chains:
     }
 
     // -------------------------------------------------------------------------
+    // Server composition (issue #1085)
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn composition_runs_extension_factory_once_per_listener() {
+        let config = two_listener_config();
+        let registry = FilterRegistry::with_builtins();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls_in_factory = Arc::clone(&calls);
+        let (_registry_factory, composition) = ServerComposition::standard()
+            .add_pipeline_extension_factory(move |_ctx| {
+                calls_in_factory.fetch_add(1, Ordering::SeqCst);
+                let ext: Box<dyn PipelineExtension> = Box::new(Marker(9));
+                Ok(ext)
+            })
+            .into_parts();
+
+        let pipelines = resolve_pipelines_with_composition(
+            &config,
+            &registry,
+            &empty_health_registry(),
+            &empty_kv_stores(),
+            &empty_session_stores(),
+            &empty_subrequest_client(),
+            &composition,
+        )
+        .unwrap();
+
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            2,
+            "the factory must run exactly once per listener pipeline"
+        );
+
+        // Each listener pipeline carries its own fresh extension.
+        for name in ["web", "api"] {
+            let pipeline = pipelines.get(name).expect("listener pipeline exists").load();
+            let mut request_extensions = RequestExtensions::new();
+            pipeline.prepare_extensions(&mut request_extensions);
+            assert_eq!(
+                request_extensions.get::<Marker>(),
+                Some(&Marker(9)),
+                "listener '{name}' pipeline must inject the composed extension per request"
+            );
+        }
+    }
+
+    #[test]
+    fn composition_factory_error_rejects_pipeline_build() {
+        let config = valid_config();
+        let registry = FilterRegistry::with_builtins();
+        let (_registry_factory, composition) = ServerComposition::standard()
+            .add_pipeline_extension_factory(|_ctx| Err(CompositionError::new("factory refused")))
+            .into_parts();
+
+        let result = resolve_pipelines_with_composition(
+            &config,
+            &registry,
+            &empty_health_registry(),
+            &empty_kv_stores(),
+            &empty_session_stores(),
+            &empty_subrequest_client(),
+            &composition,
+        );
+        let err = result
+            .err()
+            .expect("a failing extension factory must reject the whole build")
+            .to_string();
+        assert!(
+            err.contains("factory refused"),
+            "the build error must surface the factory message: {err}"
+        );
+    }
+
+    #[test]
+    fn composition_validator_error_rejects_pipeline_build() {
+        let config = valid_config();
+        let registry = FilterRegistry::with_builtins();
+        let (_registry_factory, composition) = ServerComposition::standard()
+            .add_pipeline_validator(|_ctx| Err(CompositionError::new("validator refused")))
+            .into_parts();
+
+        let result = resolve_pipelines_with_composition(
+            &config,
+            &registry,
+            &empty_health_registry(),
+            &empty_kv_stores(),
+            &empty_session_stores(),
+            &empty_subrequest_client(),
+            &composition,
+        );
+        let err = result
+            .err()
+            .expect("a failing validator must reject the whole build")
+            .to_string();
+        assert!(
+            err.contains("validator refused"),
+            "the build error must surface the validator message: {err}"
+        );
+    }
+
+    #[test]
+    fn composition_validator_sees_flattened_entries_and_pipeline() {
+        let config = valid_config();
+        let registry = FilterRegistry::with_builtins();
+        let observed = Arc::new(AtomicUsize::new(0));
+        let observed_in_validator = Arc::clone(&observed);
+        let (_registry_factory, composition) = ServerComposition::standard()
+            .add_pipeline_validator(move |ctx| {
+                // valid_config()'s single chain has a router + load_balancer.
+                observed_in_validator.store(ctx.entries().len(), Ordering::SeqCst);
+                assert_eq!(ctx.pipeline().len(), ctx.entries().len());
+                assert_eq!(ctx.listener().name, "web");
+                Ok(())
+            })
+            .into_parts();
+
+        resolve_pipelines_with_composition(
+            &config,
+            &registry,
+            &empty_health_registry(),
+            &empty_kv_stores(),
+            &empty_session_stores(),
+            &empty_subrequest_client(),
+            &composition,
+        )
+        .unwrap();
+        assert_eq!(
+            observed.load(Ordering::SeqCst),
+            2,
+            "the validator must see the flattened filter entries (router + load_balancer)"
+        );
+    }
+
+    #[test]
+    fn composition_validator_sees_entry_conditions_and_branch_chains() {
+        // Regression for the entries snapshot: build_with_chains() drains
+        // conditions, response_conditions, and branch_chains out of the entries
+        // via mem::take while constructing the pipeline. If the validator were
+        // handed those consumed entries, conditional filters would look
+        // unconditional and branch chains would vanish. Assert every gated
+        // field is still visible, not merely that the entry count matches.
+        const REQUEST_CONDITION: usize = 1 << 0;
+        const RESPONSE_CONDITION: usize = 1 << 1;
+        const BRANCH_CHAIN: usize = 1 << 2;
+
+        let config = config_with_conditions_and_branch();
+        let registry = FilterRegistry::with_builtins();
+        let seen = Arc::new(AtomicUsize::new(0));
+        let seen_in_validator = Arc::clone(&seen);
+        let (_registry_factory, composition) = ServerComposition::standard()
+            .add_pipeline_validator(move |ctx| {
+                let mut bits = 0;
+                for entry in ctx.entries() {
+                    if !entry.conditions.is_empty() {
+                        bits |= REQUEST_CONDITION;
+                    }
+                    if !entry.response_conditions.is_empty() {
+                        bits |= RESPONSE_CONDITION;
+                    }
+                    if entry.branch_chains.as_ref().is_some_and(|chains| !chains.is_empty()) {
+                        bits |= BRANCH_CHAIN;
+                    }
+                }
+                seen_in_validator.store(bits, Ordering::SeqCst);
+                Ok(())
+            })
+            .into_parts();
+
+        resolve_pipelines_with_composition(
+            &config,
+            &registry,
+            &empty_health_registry(),
+            &empty_kv_stores(),
+            &empty_session_stores(),
+            &empty_subrequest_client(),
+            &composition,
+        )
+        .unwrap();
+
+        assert_eq!(
+            seen.load(Ordering::SeqCst),
+            REQUEST_CONDITION | RESPONSE_CONDITION | BRANCH_CHAIN,
+            "the validator must see request conditions, response conditions, and branch chains \
+             on the flattened entries, not the husks left by build_with_chains"
+        );
+    }
+
+    // -------------------------------------------------------------------------
     // Test Utilities
     // -------------------------------------------------------------------------
 
@@ -906,6 +1179,75 @@ filter_chains:
         clusters:
           - name: backend
             endpoints: ["10.0.0.1:80"]
+"#,
+        )
+        .unwrap()
+    }
+
+    /// Two-listener config for verifying per-listener composition behavior.
+    fn two_listener_config() -> Config {
+        Config::from_yaml(
+            r#"
+listeners:
+  - name: web
+    address: "127.0.0.1:8080"
+    filter_chains: [main]
+  - name: api
+    address: "127.0.0.1:8081"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: static_response
+        status: 200
+"#,
+        )
+        .unwrap()
+    }
+
+    /// Single-listener config whose chain carries request conditions,
+    /// response conditions, and an (unconditional) branch chain. Used to prove
+    /// the validator snapshot survives `build_with_chains()`, which drains all
+    /// three off the entries while building the pipeline.
+    fn config_with_conditions_and_branch() -> Config {
+        Config::from_yaml(
+            r#"
+listeners:
+  - name: web
+    address: "127.0.0.1:8080"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: headers
+        request_add:
+          - name: "X-Conditional-Request"
+            value: "on"
+        conditions:
+          - when:
+              path_prefix: "/api/"
+      - filter: headers
+        response_set:
+          - name: "X-Conditional-Response"
+            value: "on"
+        response_conditions:
+          - when:
+              status: [200]
+      - filter: headers
+        request_add:
+          - name: "X-Branch-Parent"
+            value: "on"
+        branch_chains:
+          - name: utility_branch
+            chains:
+              - name: utility_inline
+                filters:
+                  - filter: headers
+                    request_add:
+                      - name: "X-Branch-Applied"
+                        value: "on"
+      - filter: static_response
+        status: 200
 "#,
         )
         .unwrap()

--- a/crates/server/src/reload.rs
+++ b/crates/server/src/reload.rs
@@ -15,12 +15,15 @@ use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
 
 #[cfg(test)]
+use crate::pipelines::resolve_pipelines;
+#[cfg(test)]
 use crate::reload_diagnostics::{
     collect_escalated_flags, detect_compression_additions, diff_named_items, find_chains_with_compression,
     is_stateful_recursive,
 };
 use crate::{
-    pipelines::resolve_pipelines,
+    composition::PipelineComposition,
+    pipelines::resolve_pipelines_with_composition,
     reload_diagnostics::{
         log_config_change_audit, log_restart_required_changes, warn_insecure_option_escalations,
         warn_stateful_filter_reset,
@@ -60,6 +63,7 @@ pub(crate) fn reload_pipelines(
     session_stores: &Arc<praxis_filter::SessionStoreRegistry>,
     subrequest_client: &praxis_core::subrequest::SubRequestClient,
     log_level: Option<&Arc<praxis_core::logging::LogLevelState>>,
+    composition: &PipelineComposition,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     info!("building new pipelines from reloaded config");
 
@@ -81,13 +85,14 @@ pub(crate) fn reload_pipelines(
         new_ceiling,
     );
 
-    let new_pipelines = match resolve_pipelines(
+    let new_pipelines = match resolve_pipelines_with_composition(
         new_config,
         registry,
         &health_registry,
         kv_stores,
         session_stores,
         &updated_client,
+        composition,
     ) {
         Ok(p) => p,
         Err(e) => {
@@ -344,11 +349,26 @@ fn spawn_health_check_thread(
     reason = "tests"
 )]
 mod tests {
-    use std::collections::HashMap;
+    use std::{
+        collections::HashMap,
+        sync::atomic::{AtomicUsize, Ordering},
+    };
 
     use praxis_core::config::{InsecureOptions, SkipPipelineChecks};
+    use praxis_filter::{CircuitBreakerFilter, FilterFactory, PipelineExtension, RequestExtensions};
 
     use super::*;
+    use crate::composition::ServerComposition;
+
+    /// A marker resource a composed extension injects into per-request state.
+    #[derive(Clone, PartialEq, Eq, Debug)]
+    struct ReloadMarker(u8);
+
+    impl PipelineExtension for ReloadMarker {
+        fn prepare(&self, extensions: &mut RequestExtensions) {
+            extensions.insert(self.clone());
+        }
+    }
 
     #[test]
     fn valid_reload_swaps_pipeline() {
@@ -386,6 +406,7 @@ filter_chains:
             &empty_session_stores(),
             &empty_subrequest_client(),
             None,
+            &PipelineComposition::default(),
         );
 
         assert!(result.is_ok(), "valid reload should succeed");
@@ -569,6 +590,7 @@ filter_chains:
             &session_stores,
             &subrequest_client,
             None,
+            &PipelineComposition::default(),
         )
         .unwrap();
 
@@ -622,6 +644,7 @@ filter_chains:
             &empty_session_stores(),
             &empty_subrequest_client(),
             None,
+            &PipelineComposition::default(),
         );
         assert!(result.is_err(), "invalid filter should return Err");
 
@@ -647,6 +670,7 @@ filter_chains:
             &empty_session_stores(),
             &empty_subrequest_client(),
             None,
+            &PipelineComposition::default(),
         )
         .unwrap();
 
@@ -674,6 +698,7 @@ filter_chains:
             &empty_session_stores(),
             &empty_subrequest_client(),
             None,
+            &PipelineComposition::default(),
         )
         .unwrap();
 
@@ -716,6 +741,7 @@ filter_chains:
             &empty_session_stores(),
             &empty_subrequest_client(),
             None,
+            &PipelineComposition::default(),
         );
         assert!(
             !old_token.is_cancelled(),
@@ -757,6 +783,7 @@ filter_chains:
             &empty_session_stores(),
             &empty_subrequest_client(),
             None,
+            &PipelineComposition::default(),
         );
         assert!(result.is_ok(), "reload with new listener should succeed");
         assert!(
@@ -1390,6 +1417,7 @@ filter_chains:
             &empty_session_stores(),
             &empty_subrequest_client(),
             None,
+            &PipelineComposition::default(),
         )
         .unwrap();
 
@@ -1483,6 +1511,7 @@ filter_chains:
             &empty_session_stores(),
             &empty_subrequest_client(),
             None,
+            &PipelineComposition::default(),
         )
         .unwrap();
 
@@ -1504,6 +1533,7 @@ filter_chains:
             &empty_session_stores(),
             &empty_subrequest_client(),
             None,
+            &PipelineComposition::default(),
         )
         .unwrap();
 
@@ -1555,6 +1585,7 @@ filter_chains:
             &empty_session_stores(),
             &empty_subrequest_client(),
             None,
+            &PipelineComposition::default(),
         )
         .unwrap();
 
@@ -1562,6 +1593,132 @@ filter_chains:
         assert!(
             new_registry.get("backend").unwrap().endpoints()[1].is_healthy(),
             "changed health_check config must reset endpoint state"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Server composition (issue #1085)
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn reload_reuses_provided_registry_including_custom_filters() {
+        // The registry carries a custom filter name unknown to the built-ins.
+        // If reload rebuilt a built-ins-only registry instead of reusing the one
+        // handed to it, resolving a config that references the custom filter
+        // would fail with "unknown filter type". A successful reload proves the
+        // custom registry survives reload.
+        let mut registry = FilterRegistry::with_builtins();
+        registry
+            .register(
+                "my_custom_breaker",
+                FilterFactory::Http(Arc::new(|cfg: &serde_yaml::Value| {
+                    CircuitBreakerFilter::from_config(cfg)
+                })),
+            )
+            .unwrap();
+
+        let config = valid_config();
+        let health_registry: HealthRegistry = Arc::new(HashMap::new());
+        let live = resolve_pipelines(
+            &config,
+            &registry,
+            &health_registry,
+            &empty_kv_stores(),
+            &empty_session_stores(),
+            &empty_subrequest_client(),
+        )
+        .unwrap();
+        let shutdown = Arc::new(Mutex::new(CancellationToken::new()));
+        let meta = praxis_protocol::http::pingora::health::new_listener_meta_store(
+            praxis_protocol::http::pingora::health::listener_meta_from_config(&config),
+        );
+        let cluster_meta = praxis_protocol::http::pingora::health::new_cluster_meta_store(
+            praxis_protocol::http::pingora::health::cluster_meta_from_config(&config),
+        );
+
+        let new_config = Config::from_yaml(
+            r#"
+insecure_options:
+  skip_pipeline_validation: true
+listeners:
+  - name: web
+    address: "127.0.0.1:8080"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: my_custom_breaker
+        clusters:
+          - name: backend
+            consecutive_failures: 3
+            recovery_window_secs: 30
+      - filter: static_response
+        status: 200
+"#,
+        )
+        .unwrap();
+
+        reload_pipelines(
+            &new_config,
+            &config,
+            &registry,
+            &live,
+            &meta,
+            &cluster_meta,
+            &shutdown,
+            &empty_kv_stores(),
+            &empty_session_stores(),
+            &empty_subrequest_client(),
+            None,
+            &PipelineComposition::default(),
+        )
+        .expect("reload must reuse the custom registry and resolve the custom filter");
+    }
+
+    #[test]
+    fn reload_preserves_downstream_extensions() {
+        let (live, old_config, registry, shutdown, meta, cluster_meta) = setup_live_pipelines();
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls_in_factory = Arc::clone(&calls);
+        let (_registry_factory, composition) = ServerComposition::standard()
+            .add_pipeline_extension_factory(move |_ctx| {
+                calls_in_factory.fetch_add(1, Ordering::SeqCst);
+                let ext: Box<dyn PipelineExtension> = Box::new(ReloadMarker(3));
+                Ok(ext)
+            })
+            .into_parts();
+
+        let new_config = valid_config();
+        reload_pipelines(
+            &new_config,
+            &old_config,
+            &registry,
+            &live,
+            &meta,
+            &cluster_meta,
+            &shutdown,
+            &empty_kv_stores(),
+            &empty_session_stores(),
+            &empty_subrequest_client(),
+            None,
+            &composition,
+        )
+        .unwrap();
+
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "the extension factory must run for the listener pipeline on reload"
+        );
+
+        let pipeline = live.get("web").unwrap().load();
+        let mut request_extensions = RequestExtensions::new();
+        pipeline.prepare_extensions(&mut request_extensions);
+        assert_eq!(
+            request_extensions.get::<ReloadMarker>(),
+            Some(&ReloadMarker(3)),
+            "the reloaded pipeline must still carry the downstream extension"
         );
     }
 

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -28,7 +28,8 @@ use crate::startup_checks::warn_admin_configured_without_feature;
 #[cfg(feature = "experimental")]
 use crate::startup_checks::warn_experimental_features;
 use crate::{
-    pipelines::resolve_pipelines,
+    composition::{PipelineComposition, RegistryContext, ServerComposition},
+    pipelines::resolve_pipelines_with_composition,
     startup_checks::{
         enforce_root_check, warn_insecure_key_permissions, warn_insecure_log_file_permissions, warn_insecure_options,
     },
@@ -96,7 +97,7 @@ pub fn resolve_config_path(explicit: Option<&str>) -> Option<PathBuf> {
 #[expect(clippy::allow_attributes, reason = "lint is platform/config-dependent")]
 #[allow(clippy::needless_pass_by_value, reason = "server owns config")]
 pub fn run_server(config: Config, config_path: Option<PathBuf>, log_level: Option<Arc<LogLevelState>>) -> ! {
-    run_server_with_registry(config, crate::build_full_registry(), config_path, log_level)
+    run_server_with_composition(config, ServerComposition::standard(), config_path, log_level)
 }
 
 /// Build filter pipelines from the given registry, register protocols and run the server.
@@ -113,6 +114,37 @@ pub fn run_server(config: Config, config_path: Option<PathBuf>, log_level: Optio
 pub fn run_server_with_registry(
     config: Config,
     registry: FilterRegistry,
+    config_path: Option<PathBuf>,
+    log_level: Option<Arc<LogLevelState>>,
+) -> ! {
+    run_server_with_composition(
+        config,
+        ServerComposition::with_registry(registry),
+        config_path,
+        log_level,
+    )
+}
+
+/// Build filter pipelines from a [`ServerComposition`], register protocols and
+/// run the server.
+///
+/// This is the composition-aware entry point that owns the full server
+/// lifecycle; [`run_server`] and [`run_server_with_registry`] are thin
+/// convenience wrappers over it. The composition describes how the downstream
+/// filter registry is built, which pipeline extensions are attached to each
+/// per-listener pipeline, and which read-only validators gate pipeline
+/// construction. The same composition is carried into the hot-reload watcher so
+/// downstream extensions and validators are re-applied on every reload.
+///
+/// Assumes tracing is already initialized. Blocks until the process is
+/// terminated; never returns.
+///
+/// Config is owned for the server's lifetime (never returns).
+#[expect(clippy::allow_attributes, reason = "lint is platform/config-dependent")]
+#[allow(clippy::needless_pass_by_value, reason = "server owns config")]
+pub fn run_server_with_composition(
+    config: Config,
+    composition: ServerComposition,
     config_path: Option<PathBuf>,
     log_level: Option<Arc<LogLevelState>>,
 ) -> ! {
@@ -136,7 +168,7 @@ pub fn run_server_with_registry(
         .map(|_| praxis_protocol::http::pingora::health::install_prometheus_admin_recorder());
 
     let health_registry = build_health_registry(&config.clusters);
-    let state = build_server_state(&config, &registry, &health_registry, log_level);
+    let (state, registry) = build_server_state(&config, composition, &health_registry, log_level);
 
     info!("initializing server");
     let mut server = PingoraServerRuntime::new(&config);
@@ -189,34 +221,47 @@ struct ServerState {
     health_shutdown: Arc<Mutex<CancellationToken>>,
     /// Runtime log-level overlay state for admin API and reload.
     log_level: Option<Arc<LogLevelState>>,
+    /// Downstream pipeline extensions and validators, re-applied on reload.
+    pipeline_composition: PipelineComposition,
 }
 
 /// Build filter pipelines, health checks, and registries.
+///
+/// Returns the assembled [`ServerState`] together with the [`FilterRegistry`]
+/// built from the composition. The registry is handed to the caller so it can
+/// be carried into the reload watcher (which rebuilds pipelines from the same
+/// registry).
 #[expect(
     clippy::too_many_lines,
     reason = "pipeline resolution, health spawn, and state assembly"
 )]
 fn build_server_state(
     config: &Config,
-    registry: &FilterRegistry,
+    composition: ServerComposition,
     health_registry: &HealthRegistry,
     log_level: Option<Arc<LogLevelState>>,
-) -> ServerState {
+) -> (ServerState, FilterRegistry) {
     info!("building filter pipelines");
     let kv_stores = praxis_core::kv::KvStoreRegistry::new();
     // Shared with the CLI --validate/--dump path (commands.rs) so both build an
     // identical connector, including the circuit breaker (issue #994).
     let subrequest_client = crate::pipelines::build_subrequest_client(config);
 
+    // Build the downstream registry once, from immutable server context, then
+    // reuse it across reloads. The factory is synchronous and side-effect-free.
+    let (registry_factory, pipeline_composition) = composition.into_parts();
+    let registry = registry_factory(&RegistryContext::new(&subrequest_client)).unwrap_or_else(|e| fatal(&e));
+
     let session_stores = Arc::new(praxis_filter::SessionStoreRegistry::new());
 
-    let pipelines = resolve_pipelines(
+    let pipelines = resolve_pipelines_with_composition(
         config,
-        registry,
+        &registry,
         health_registry,
         &kv_stores,
         &session_stores,
         &subrequest_client,
+        &pipeline_composition,
     )
     .unwrap_or_else(|e| fatal(&e));
     let listener_meta = praxis_protocol::http::pingora::health::new_listener_meta_store(
@@ -233,7 +278,7 @@ fn build_server_state(
         spawn_circuit_eviction_task(subrequest_client.clone());
     }
 
-    ServerState {
+    let state = ServerState {
         pipelines: Arc::new(pipelines),
         listener_meta,
         cluster_meta,
@@ -242,7 +287,9 @@ fn build_server_state(
         subrequest_client,
         health_shutdown,
         log_level,
-    }
+        pipeline_composition,
+    };
+    (state, registry)
 }
 
 // -----------------------------------------------------------------------------
@@ -307,6 +354,7 @@ fn spawn_watcher(
         shutdown: CancellationToken::new(),
         subrequest_client: state.subrequest_client,
         log_level: state.log_level,
+        pipeline_composition: state.pipeline_composition,
     });
     Some(handle)
 }

--- a/crates/server/src/watcher.rs
+++ b/crates/server/src/watcher.rs
@@ -24,7 +24,7 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
-use crate::reload::reload_pipelines;
+use crate::{composition::PipelineComposition, reload::reload_pipelines};
 
 // -----------------------------------------------------------------------------
 // Constants
@@ -93,6 +93,10 @@ pub(crate) struct WatcherParams {
 
     /// Filter registry for building new pipelines.
     pub(crate) registry: Arc<FilterRegistry>,
+
+    /// Downstream pipeline composition (extension factories and validators),
+    /// re-applied on every reload so downstream extensions survive reloads.
+    pub(crate) pipeline_composition: PipelineComposition,
 
     /// Token for clean watcher shutdown.
     pub(crate) shutdown: CancellationToken,
@@ -211,6 +215,7 @@ async fn run_event_loop(rx: &mut mpsc::Receiver<()>, params: WatcherParams) {
         &params.session_stores,
         &params.subrequest_client,
         params.log_level.as_ref(),
+        &params.pipeline_composition,
     );
     // A change seen while backing off is remembered rather than dropped,
     // and retried when the window expires. The filesystem will not
@@ -259,6 +264,7 @@ async fn run_event_loop(rx: &mut mpsc::Receiver<()>, params: WatcherParams) {
             &params.session_stores,
             &params.subrequest_client,
             params.log_level.as_ref(),
+            &params.pipeline_composition,
         );
         update_reload_backoff(ok, &mut consecutive_failures, &mut last_failure);
         // Cleared on success; a failed attempt stays pending so the timer
@@ -312,6 +318,7 @@ fn handle_reload(
     session_stores: &Arc<praxis_filter::SessionStoreRegistry>,
     subrequest_client: &praxis_core::subrequest::SubRequestClient,
     log_level: Option<&Arc<praxis_core::logging::LogLevelState>>,
+    composition: &PipelineComposition,
 ) -> bool {
     let content = match praxis_core::config::read_config_file(config_path) {
         Ok(c) => c,
@@ -366,6 +373,7 @@ fn handle_reload(
         session_stores,
         subrequest_client,
         log_level,
+        composition,
     ) {
         Ok(()) => {
             *current_config = new_config;
@@ -962,6 +970,7 @@ mod tests {
             &session_stores,
             &subrequest_client,
             None,
+            &PipelineComposition::default(),
         );
 
         assert!(!ok, "an unparseable config must report failure");
@@ -987,6 +996,7 @@ mod tests {
             &session_stores,
             &subrequest_client,
             None,
+            &PipelineComposition::default(),
         );
         assert!(recovered, "a subsequent valid config must reload");
     }
@@ -1038,6 +1048,7 @@ mod tests {
                 praxis_core::subrequest::SubRequestConnector::new(8, None),
             ),
             log_level: None,
+            pipeline_composition: PipelineComposition::default(),
         });
 
         std::thread::sleep(Duration::from_millis(100));
@@ -1094,6 +1105,7 @@ mod tests {
                 praxis_core::subrequest::SubRequestConnector::new(8, None),
             ),
             log_level: None,
+            pipeline_composition: PipelineComposition::default(),
         });
 
         std::thread::sleep(Duration::from_millis(WATCHER_STARTUP_MS));
@@ -1158,6 +1170,7 @@ mod tests {
                 praxis_core::subrequest::SubRequestConnector::new(8, None),
             ),
             log_level: None,
+            pipeline_composition: PipelineComposition::default(),
         });
 
         std::thread::sleep(Duration::from_millis(WATCHER_STARTUP_MS));
@@ -1252,6 +1265,7 @@ mod tests {
                 praxis_core::subrequest::SubRequestConnector::new(8, None),
             ),
             log_level: None,
+            pipeline_composition: PipelineComposition::default(),
         });
 
         let deadline = Instant::now() + Duration::from_secs(2);
@@ -1328,6 +1342,7 @@ mod tests {
                 praxis_core::subrequest::SubRequestConnector::new(8, None),
             ),
             log_level: None,
+            pipeline_composition: PipelineComposition::default(),
         });
 
         std::thread::sleep(Duration::from_millis(WATCHER_STARTUP_MS));
@@ -1406,6 +1421,7 @@ mod tests {
                 praxis_core::subrequest::SubRequestConnector::new(8, None),
             ),
             log_level: None,
+            pipeline_composition: PipelineComposition::default(),
         });
 
         tracing::info!("waiting for startup pre-check reload (mismatched hash triggers swap)");
@@ -1483,6 +1499,7 @@ mod tests {
                 praxis_core::subrequest::SubRequestConnector::new(8, None),
             ),
             log_level: None,
+            pipeline_composition: PipelineComposition::default(),
         });
 
         std::thread::sleep(Duration::from_millis(WATCHER_STARTUP_MS));
@@ -1655,6 +1672,7 @@ mod tests {
                 praxis_core::subrequest::SubRequestConnector::new(8, None),
             ),
             log_level: None,
+            pipeline_composition: PipelineComposition::default(),
         });
 
         std::thread::sleep(Duration::from_millis(WATCHER_STARTUP_MS));


### PR DESCRIPTION
## Summary

Introduces `ServerComposition`, a **data-only** description of how an embedding server customizes the downstream request path, plus `run_server_with_composition` as the single server-lifecycle owner. `run_server` and `run_server_with_registry` become thin wrappers over it, so existing entry points are unchanged.

Closes #1085.

## What a composition carries

Three hooks, each handed narrow, immutable, server-owned context:

- **Registry factory** — builds the `FilterRegistry` from a `RegistryContext` exposing only the server-owned `SubRequestClient`. The server, not the embedder, owns the sub-request client's lifecycle.
- **Pipeline-extension factories** — mint a *fresh* `Box<dyn PipelineExtension>` per candidate listener pipeline via `ExtensionContext` (config + listener + sub-request client). One extension instance never leaks across pipelines.
- **Read-only validators** — inspect the config, listener, flattened filter entries, and the built pipeline through `ValidatorContext` without mutating any of them.

## Lifecycle & reload

Extensions and validators run at startup **and on every hot reload** — the composition is carried into the reload watcher — so downstream customization survives config reloads rather than being silently dropped on the first swap.

## Validator correctness

Validators receive an **immutable snapshot of the flattened filter entries captured before `build_with_chains` runs**. `build_with_chains` drains `conditions`, `response_conditions`, and `branch_chains` out of the entries as it moves them into the built pipeline; taking the snapshot first means conditional filters and branch chains stay visible to downstream validation instead of appearing empty. A regression test asserts request conditions, response conditions, and branch chains are all still observable via the validator context.

## Testing

- `cargo test -p praxis-proxy` — all unit, binary, and doctests green
- `make lint` — clippy (workspace all-features + `-p praxis-proxy --no-default-features`), nightly `fmt --check`, machete, and xtask lints all pass
- `make doc` — clean with `-D warnings`
